### PR TITLE
Add FILES.cfg and TESTS file for cameo

### DIFF
--- a/tools/build/linux/FILES.cfg
+++ b/tools/build/linux/FILES.cfg
@@ -1,0 +1,42 @@
+# -*- python -*-
+# ex: set syntax=python:
+
+# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a buildbot configuration file containing a tagged list of files
+# processed by the stage/archive scripts. The known tags are:
+#
+# filename: Name of the file in the build output directory.
+# arch:     List of CPU architectures for which this file should be processed
+#           (values are based on the strings returned by python's
+#           platform.architecture() function).  Leave unspecified for
+#           architecture neutral files.
+# buildtype: List of build types for which this file should be processed.
+# archive: The name of the archive file to store filename in. If not specified,
+#          filename is added to the default archive (e.g. platform.zip). If
+#          archive == filename, filename is archived directly, not zipped.
+# direct_archive: Force a file to be archived as-is, bypassing zip creation.
+#                 NOTE: This flag will not apply if more than one file has the
+#                 same 'archive' name, which will create a zip of all the
+#                 files instead.
+# filegroup: List of named groups to which this file belongs (e.g. 'symbols'
+#            for symbol processing, 'tests' for running tests, etc.).
+# optional: List of buildtypes for which the file might not exist, and it's not
+#           considered an error.
+
+FILES = [
+  {
+    'filename': 'cameo',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'cameo.pak',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'libffmpegsumo.so',
+    'buildtype': ['dev', 'official'],
+  },
+]

--- a/tools/build/linux/TESTS
+++ b/tools/build/linux/TESTS
@@ -1,0 +1,2 @@
+cameo_browsertest
+cameo_unittest

--- a/tools/build/win/FILES.cfg
+++ b/tools/build/win/FILES.cfg
@@ -1,0 +1,85 @@
+# -*- python -*-
+# ex: set syntax=python:
+
+# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a buildbot configuration file containing a tagged list of files
+# processed by the stage/archive scripts. The known tags are:
+#
+# filename: Name of the file in the build output directory.
+# arch:     List of CPU architectures for which this file should be processed
+#           Leave this unspecified to prcoess for all architectures.
+#           Acceptable values are 64bit, 32bit and arm.
+# buildtype: List of build types for which this file should be processed.
+# archive: The name of the archive file to store filename in. If not specified,
+#          filename is added to the default archive (e.g. platform.zip). If
+#          archive == filename, filename is archived directly, not zipped.
+# direct_archive: Force a file to be archived as-is, bypassing zip creation.
+#                 NOTE: This flag will not apply if more than one file has the
+#                 same 'archive' name, which will create a zip of all the
+#                 files instead.
+# filegroup: List of named groups to which this file belongs.
+#            default: Legacy "default archive". TODO(mmoss): These should
+#                     be updated to specify an 'archive' name and then this
+#                     filegroup and the related archive_utils.ParseLegacyList()
+#                     should go away.
+#            symsrc: Files to upload to the symbol server.
+# optional: List of buildtypes for which the file might not exist, and it's not
+#           considered an error.
+FILES = [
+  {
+    'filename': 'cameo.exe',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'ffmpegsumo.dll',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'cameo.pak',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'icudt.dll',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'wow_helper.exe',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'D3DCompiler_46.dll',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'libEGL.dll',
+    'buildtype': ['dev', 'official'],
+  },
+  {
+    'filename': 'libGLESv2.dll',
+    'buildtype': ['dev', 'official'],
+  },
+# syms files
+  {
+    'filename': 'cameo.exe.pdb',
+    'buildtype': ['dev', 'official'],
+    'archive': 'cameo-win32-syms.zip',
+  },
+  {
+    'filename': 'ffmpegsumo.dll.pdb',
+    'buildtype': ['dev', 'official'],
+    'archive': 'cameo-win32-syms.zip',
+  },
+  {
+    'filename': 'libEGL.dll.pdb',
+    'buildtype': ['dev', 'official'],
+    'archive': 'cameo-win32-syms.zip',
+  },
+  {
+    'filename': 'libGLESv2.dll.pdb',
+    'buildtype': ['dev', 'official'],
+    'archive': 'cameo-win32-syms.zip',
+  },
+]

--- a/tools/build/win/TESTS
+++ b/tools/build/win/TESTS
@@ -1,0 +1,2 @@
+cameo_browsertest.exe
+cameo_unittest.exe


### PR DESCRIPTION
FILES.cfg is listing the binaries and symbols for cameo project.
TESTS is listing the files needed to run cameo tests.
Currently only support Windows and Linux.

The files will be used by buildbot for archive and test.
