### PR TITLE
Add build target for buildbot

### DIFF
--- a/cameo.gyp
+++ b/cameo.gyp
@@ -262,5 +262,14 @@
         }],  # toolkit_uses_gtk==1
       ],
     },
+    {
+      'target_name': 'cameo_builder',
+      'type': 'none',
+      'dependencies': [
+        'cameo',
+        'cameo_browsertest',
+        'cameo_unittest',
+      ],
+    },
   ],
 }


### PR DESCRIPTION
The target cameo_builder is including cameo, cameo_browsertest and
cameo_unittest.
