### PR TITLE
Fix FindDepotToolsInPath not working in some cases

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -15,6 +15,9 @@ def TryAddDepotToolsToPythonPath():
 def FindDepotToolsInPath():
   paths = os.getenv('PATH').split(os.path.pathsep)
   for path in paths:
+    if os.path.basename(path) == '':
+      # path is end with os.path.pathsep
+      path = os.path.dirname(path)
     if os.path.basename(path) == 'depot_tools':
       return path
   return None


### PR DESCRIPTION
When depot tools' path in PATH is like '/home/project/depot_tools/',
FindDepotToolsInPath will not detect it because os.path.basename will
get empty string.

Fix this by getting its parent if its basename is empty.

BUG=https://github.com/otcshare/cameo/issues/29
