### PR TITLE
Fix lint.py will fail for py files when not called from repo root

### DIFF
--- a/tools/lint.py
+++ b/tools/lint.py
@@ -173,8 +173,8 @@ def do_lint(repo, base, args):
     base = get_tracking_remote()
   changes_py, changes_others = get_change_file_list(base)
   do_cpp_lint(changes_others, repo, args)
-  os.chdir(previous_cwd)
   do_py_lint(changes_py)
+  os.chdir(previous_cwd)
   return 1
 
 from optparse import OptionParser, BadOptionError


### PR DESCRIPTION
It's because the file path got from git diff is related to repo root.
So the work dir should be repo root before trying to do pylint.

BUG=https://github.com/otcshare/cameo/issues/31
