### PR TITLE
Fix the crash issue when accessing geolocation APIs.

### DIFF
--- a/cameo.gyp
+++ b/cameo.gyp
@@ -66,6 +66,8 @@
         'src/runtime/browser/devtools/remote_debugging_server.h',
         'src/runtime/browser/runtime.cc',
         'src/runtime/browser/runtime.h',
+        'src/runtime/browser/geolocation/cameo_access_token_store.cc',
+        'src/runtime/browser/geolocation/cameo_access_token_store.h',
         'src/runtime/browser/runtime_context.cc',
         'src/runtime/browser/runtime_context.h',
         'src/runtime/browser/runtime_file_select_helper.cc',

--- a/cameo_tests.gypi
+++ b/cameo_tests.gypi
@@ -93,6 +93,7 @@
       'src/runtime/browser/cameo_runtime_browsertest.cc',
       'src/runtime/browser/cameo_switches_browsertest.cc',
       'src/runtime/browser/devtools/cameo_devtools_browsertest.cc',
+      'src/runtime/browser/geolocation/cameo_geolocation_browsertest.cc',
       'src/test/base/cameo_test_launcher.cc',
       'src/test/base/in_process_browser_test.cc',
       'src/test/base/in_process_browser_test.h',

--- a/src/runtime/browser/cameo_content_browser_client.cc
+++ b/src/runtime/browser/cameo_content_browser_client.cc
@@ -5,6 +5,7 @@
 #include "cameo/src/runtime/browser/cameo_content_browser_client.h"
 
 #include "cameo/src/runtime/browser/cameo_browser_main_parts.h"
+#include "cameo/src/runtime/browser/geolocation/cameo_access_token_store.h"
 #include "cameo/src/runtime/browser/runtime_context.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "content/public/browser/web_contents.h"
@@ -44,8 +45,9 @@ content::BrowserMainParts* CameoContentBrowserClient::CreateBrowserMainParts(
 net::URLRequestContextGetter* CameoContentBrowserClient::CreateRequestContext(
     content::BrowserContext* browser_context,
     content::ProtocolHandlerMap* protocol_handlers) {
-  return static_cast<RuntimeContext*>(browser_context)->
+  url_request_context_getter_ = static_cast<RuntimeContext*>(browser_context)->
       CreateRequestContext(protocol_handlers);
+  return url_request_context_getter_;
 }
 
 net::URLRequestContextGetter*
@@ -57,6 +59,10 @@ CameoContentBrowserClient::CreateRequestContextForStoragePartition(
   return static_cast<RuntimeContext*>(browser_context)->
       CreateRequestContextForStoragePartition(
           partition_path, in_memory, protocol_handlers);
+}
+
+content::AccessTokenStore* CameoContentBrowserClient::CreateAccessTokenStore() {
+  return new CameoAccessTokenStore(url_request_context_getter_);
 }
 
 content::WebContentsViewDelegate*

--- a/src/runtime/browser/cameo_content_browser_client.h
+++ b/src/runtime/browser/cameo_content_browser_client.h
@@ -21,6 +21,7 @@ class URLRequestContextGetter;
 
 namespace cameo {
 
+class CameoBrowserMainParts;
 class RuntimeContext;
 
 class CameoContentBrowserClient : public content::ContentBrowserClient {
@@ -41,10 +42,13 @@ class CameoContentBrowserClient : public content::ContentBrowserClient {
       const base::FilePath& partition_path,
       bool in_memory,
       content::ProtocolHandlerMap* protocol_handlers) OVERRIDE;
+  virtual content::AccessTokenStore* CreateAccessTokenStore() OVERRIDE;
   virtual content::WebContentsViewDelegate* GetWebContentsViewDelegate(
       content::WebContents* web_contents) OVERRIDE;
 
  private:
+  net::URLRequestContextGetter* url_request_context_getter_;
+
   DISALLOW_COPY_AND_ASSIGN(CameoContentBrowserClient);
 };
 

--- a/src/runtime/browser/geolocation/cameo_access_token_store.cc
+++ b/src/runtime/browser/geolocation/cameo_access_token_store.cc
@@ -1,0 +1,35 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/runtime/browser/geolocation/cameo_access_token_store.h"
+
+#include "base/bind.h"
+#include "base/message_loop.h"
+
+CameoAccessTokenStore::CameoAccessTokenStore(
+    net::URLRequestContextGetter* request_context)
+    : request_context_(request_context) {
+}
+
+CameoAccessTokenStore::~CameoAccessTokenStore() {
+}
+
+void CameoAccessTokenStore::LoadAccessTokens(
+    const LoadAccessTokensCallbackType& callback) {
+  MessageLoop::current()->PostTask(
+      FROM_HERE,
+      base::Bind(&CameoAccessTokenStore::DidLoadAccessTokens,
+                 request_context_, callback));
+}
+
+void CameoAccessTokenStore::DidLoadAccessTokens(
+    net::URLRequestContextGetter* request_context,
+    const LoadAccessTokensCallbackType& callback) {
+  AccessTokenSet access_token_set;
+  callback.Run(access_token_set, request_context);
+}
+
+void CameoAccessTokenStore::SaveAccessToken(
+    const GURL& server_url, const string16& access_token) {
+}

--- a/src/runtime/browser/geolocation/cameo_access_token_store.h
+++ b/src/runtime/browser/geolocation/cameo_access_token_store.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_RUNTIME_BROWSER_GEOLOCATION_CAMEO_ACCESS_TOKEN_STORE_H_
+#define CAMEO_SRC_RUNTIME_BROWSER_GEOLOCATION_CAMEO_ACCESS_TOKEN_STORE_H_
+
+#include "content/public/browser/access_token_store.h"
+
+class CameoAccessTokenStore : public content::AccessTokenStore {
+ public:
+  explicit CameoAccessTokenStore(net::URLRequestContextGetter* request_context);
+
+ private:
+  virtual ~CameoAccessTokenStore();
+
+  // AccessTokenStore
+  virtual void LoadAccessTokens(
+      const LoadAccessTokensCallbackType& callback) OVERRIDE;
+
+  virtual void SaveAccessToken(
+      const GURL& server_url, const string16& access_token) OVERRIDE;
+
+  static void DidLoadAccessTokens(
+      net::URLRequestContextGetter* request_context,
+      const LoadAccessTokensCallbackType& callback);
+
+  net::URLRequestContextGetter* request_context_;
+
+  DISALLOW_COPY_AND_ASSIGN(CameoAccessTokenStore);
+};
+
+#endif  // CAMEO_SRC_RUNTIME_BROWSER_GEOLOCATION_CAMEO_ACCESS_TOKEN_STORE_H_

--- a/src/runtime/browser/geolocation/cameo_geolocation_browsertest.cc
+++ b/src/runtime/browser/geolocation/cameo_geolocation_browsertest.cc
@@ -1,0 +1,96 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#if defined(TOOLKIT_GTK)
+#include <gtk/gtk.h>
+#endif
+
+#include "base/command_line.h"
+#include "base/file_util.h"
+#include "base/path_service.h"
+#include "base/string_util.h"
+#include "base/utf_string_conversions.h"
+#include "cameo/src/runtime/browser/runtime.h"
+#include "cameo/src/runtime/browser/runtime_registry.h"
+#include "cameo/src/runtime/common/cameo_notification_types.h"
+#include "cameo/src/test/base/cameo_test_utils.h"
+#include "cameo/src/test/base/in_process_browser_test.h"
+#include "content/public/browser/navigation_controller.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/browser/notification_details.h"
+#include "content/public/browser/notification_observer.h"
+#include "content/public/browser/notification_registrar.h"
+#include "content/public/browser/notification_service.h"
+#include "content/public/browser/notification_source.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
+#include "net/base/net_util.h"
+#include "testing/gmock/include/gmock/gmock.h"
+
+using cameo::NativeAppWindow;
+using cameo::Runtime;
+using cameo::RuntimeRegistry;
+using cameo::RuntimeList;
+using content::WebContents;
+using testing::_;
+
+// A mock observer to listen runtime registry changes.
+class MockRuntimeRegistryObserver : public cameo::RuntimeRegistryObserver {
+ public:
+  MockRuntimeRegistryObserver() {}
+  virtual ~MockRuntimeRegistryObserver() {}
+
+  MOCK_METHOD1(OnRuntimeAdded, void(Runtime* runtime));
+  MOCK_METHOD1(OnRuntimeRemoved, void(Runtime* runtime));
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(MockRuntimeRegistryObserver);
+};
+
+class CameoRuntimeTest : public InProcessBrowserTest {
+ public:
+  CameoRuntimeTest() {}
+  virtual ~CameoRuntimeTest() {
+    original_runtimes_.clear();
+    notification_observer_.reset();
+  }
+
+  // SetUpOnMainThread is called after BrowserMainRunner was initialized and
+  // just before RunTestOnMainThread (aka. TestBody).
+  virtual void SetUpOnMainThread() OVERRIDE {
+    notification_observer_.reset(
+        new content::WindowedNotificationObserver(
+          cameo::NOTIFICATION_RUNTIME_OPENED,
+          content::NotificationService::AllSources()));
+    const RuntimeList& runtimes = RuntimeRegistry::Get()->runtimes();
+    for (RuntimeList::const_iterator it = runtimes.begin();
+         it != runtimes.end(); ++it)
+      original_runtimes_.push_back(*it);
+  }
+
+ private:
+  RuntimeList original_runtimes_;
+  scoped_ptr<content::WindowedNotificationObserver> notification_observer_;
+};
+
+IN_PROC_BROWSER_TEST_F(CameoRuntimeTest, LoadGeolocationPage) {
+  GURL url = cameo_test_utils::GetTestURL(
+      base::FilePath(), base::FilePath().AppendASCII(
+          "geolocation/simple.html"));
+  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  cameo_test_utils::NavigateToURL(runtime(), url);
+  int error_code;
+  ASSERT_TRUE(content::ExecuteScriptAndExtractInt(
+      runtime()->web_contents(),
+      "console.log('wait for result...');",
+      &error_code));
+  EXPECT_NE(error_code, -1);
+  content::RunAllPendingInMessageLoop();
+  EXPECT_EQ(len, RuntimeRegistry::Get()->runtimes().size());
+  runtime()->Close();
+  content::RunAllPendingInMessageLoop();
+  EXPECT_EQ(len - 1, RuntimeRegistry::Get()->runtimes().size());
+}

--- a/src/test/data/geolocation/simple.html
+++ b/src/test/data/geolocation/simple.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <p>Simple geolocation test</p>
+    <div id="output"></div>
+    <script>
+      // error_code can be:
+      // -1: not initilized
+      // -2: success
+      // other: error.code (see below)
+      function sendResult(error_code) {
+        console.log("error code: " + error_code);
+        window.domAutomationController.send(error_code);
+      }
+
+      window.onload = function() {
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(function(position) {
+            document.getElementById("output").innerHTML =
+                "Position latitude: " + position.coords.latitude +
+                " longitude: " + position.coords.longitude;
+            sendResult(-2);
+          }, function(error) {
+            document.getElementById("output").innerHTML =
+                "Error occurred. Error code: " + error.code;
+            sendResult(error.code);
+            // error.code can be:
+            //   0: unknown error
+            //   1: permission denied
+            //   2: position unavailable (error response from locaton provider)
+            //   3: timed out
+          });
+        } else {
+          console.log("navigator.geolocation is not available.");
+          sendResult(-1);
+        }
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Implement a dummy AccessTokenStore to avoid returning NULL pointer.

Initialize the geolocation browser test with simple case which uses
navigator.geolocation.getCurrentPosition API.

BUG=https://github.com/otcshare/cameo/issues/34
