### PR TITLE
Use WaitForLoadStop for identifying root cause

### DIFF
--- a/src/runtime/browser/devtools/cameo_devtools_browsertest.cc
+++ b/src/runtime/browser/devtools/cameo_devtools_browsertest.cc
@@ -33,8 +33,13 @@ IN_PROC_BROWSER_TEST_F(CameoDevToolsTest, RemoteDebugging) {
   Runtime* debugging_host =
       Runtime::Create(runtime()->runtime_context(), localhost_url);
 
+  content::WaitForLoadStop(debugging_host->web_contents());
+  string16 real_title = debugging_host->web_contents()->GetTitle();
+  LOG(INFO) << " The real title is: " << UTF16ToUTF8(real_title);
+
   string16 expected_title = ASCIIToUTF16("Cameo Remote Debugging");
-  content::TitleWatcher title_watcher(debugging_host->web_contents(),
-      expected_title);
-  EXPECT_EQ(expected_title, title_watcher.WaitAndGetTitle());
+  EXPECT_EQ(expected_title, real_title);
+//  content::TitleWatcher title_watcher(debugging_host->web_contents(),
+//      expected_title);
+//  EXPECT_EQ(expected_title, title_watcher.WaitAndGetTitle());
 }


### PR DESCRIPTION
Please don't merge this pull request.

This pull request is to help identify the root cause why CameoDevToolsTest.RemoteDebugging is failed on linux trybots.

See #63 about the failure test.
