### PR TITLE
Enable WebRTC on Cameo

### DIFF
--- a/cameo.gyp
+++ b/cameo.gyp
@@ -71,6 +71,8 @@
         'src/runtime/browser/geolocation/cameo_access_token_store.h',
         'src/runtime/browser/image_util.cc',
         'src/runtime/browser/image_util.h',
+        'src/runtime/browser/media/media_capture_devices_dispatcher.cc',
+        'src/runtime/browser/media/media_capture_devices_dispatcher.h',
         'src/runtime/browser/runtime.cc',
         'src/runtime/browser/runtime.h',
         'src/runtime/browser/runtime_context.cc',

--- a/src/runtime/browser/cameo_content_browser_client.cc
+++ b/src/runtime/browser/cameo_content_browser_client.cc
@@ -7,6 +7,7 @@
 #include "cameo/src/extensions/browser/cameo_extension_host.h"
 #include "cameo/src/runtime/browser/cameo_browser_main_parts.h"
 #include "cameo/src/runtime/browser/geolocation/cameo_access_token_store.h"
+#include "cameo/src/runtime/browser/media/media_capture_devices_dispatcher.h"
 #include "cameo/src/runtime/browser/runtime_context.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "content/public/browser/render_process_host.h"
@@ -85,6 +86,10 @@ void CameoContentBrowserClient::RenderProcessHostCreated(
   // we want a clearer lifetime, tied to the browser process or the
   // render process host.
   host->GetChannel()->AddFilter(extension_host);
+}
+
+content::MediaObserver* CameoContentBrowserClient::GetMediaObserver() {
+  return CameoMediaCaptureDevicesDispatcher::GetInstance();
 }
 
 }  // namespace cameo

--- a/src/runtime/browser/cameo_content_browser_client.h
+++ b/src/runtime/browser/cameo_content_browser_client.h
@@ -47,6 +47,7 @@ class CameoContentBrowserClient : public content::ContentBrowserClient {
       content::WebContents* web_contents) OVERRIDE;
   virtual void RenderProcessHostCreated(
       content::RenderProcessHost* host) OVERRIDE;
+  virtual content::MediaObserver* GetMediaObserver() OVERRIDE;
 
  private:
   net::URLRequestContextGetter* url_request_context_getter_;

--- a/src/runtime/browser/media/media_capture_devices_dispatcher.cc
+++ b/src/runtime/browser/media/media_capture_devices_dispatcher.cc
@@ -1,0 +1,171 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/runtime/browser/media/media_capture_devices_dispatcher.h"
+
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/media_devices_monitor.h"
+#include "content/public/common/media_stream_request.h"
+
+using content::BrowserThread;
+using content::MediaStreamDevices;
+
+namespace {
+
+const content::MediaStreamDevice* FindDefaultDeviceWithId(
+    const content::MediaStreamDevices& devices,
+    const std::string& device_id) {
+  if (devices.empty()) {
+    return NULL;
+  }
+  content::MediaStreamDevices::const_iterator iter = devices.begin();
+  for (; iter != devices.end(); ++iter) {
+    if (iter->id == device_id) {
+      return &(*iter);
+    }
+  }
+
+  return &(*devices.begin());
+};
+
+}  // namespace
+
+
+CameoMediaCaptureDevicesDispatcher*
+    CameoMediaCaptureDevicesDispatcher::GetInstance() {
+  return Singleton<CameoMediaCaptureDevicesDispatcher>::get();
+}
+
+CameoMediaCaptureDevicesDispatcher::CameoMediaCaptureDevicesDispatcher()
+    : devices_enumerated_(false) {}
+
+CameoMediaCaptureDevicesDispatcher::~CameoMediaCaptureDevicesDispatcher() {}
+
+void CameoMediaCaptureDevicesDispatcher::AddObserver(Observer* observer) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  if (!observers_.HasObserver(observer))
+    observers_.AddObserver(observer);
+}
+
+void CameoMediaCaptureDevicesDispatcher::RemoveObserver(Observer* observer) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  observers_.RemoveObserver(observer);
+}
+
+const MediaStreamDevices&
+CameoMediaCaptureDevicesDispatcher::GetAudioCaptureDevices() {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  if (!devices_enumerated_) {
+    BrowserThread::PostTask(
+        BrowserThread::IO, FROM_HERE,
+        base::Bind(&content::EnsureMonitorCaptureDevices));
+    devices_enumerated_ = true;
+  }
+  return audio_devices_;
+}
+
+const MediaStreamDevices&
+CameoMediaCaptureDevicesDispatcher::GetVideoCaptureDevices() {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  if (!devices_enumerated_) {
+    BrowserThread::PostTask(
+        BrowserThread::IO, FROM_HERE,
+        base::Bind(&content::EnsureMonitorCaptureDevices));
+    devices_enumerated_ = true;
+  }
+  return video_devices_;
+}
+
+void CameoMediaCaptureDevicesDispatcher::GetRequestedDevice(
+    const std::string& requested_device_id,
+    bool audio,
+    bool video,
+    content::MediaStreamDevices* devices) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  DCHECK(audio || video);
+
+  if (audio) {
+    const content::MediaStreamDevices& audio_devices = GetAudioCaptureDevices();
+    const content::MediaStreamDevice* const device =
+        FindDefaultDeviceWithId(audio_devices, requested_device_id);
+    if (device)
+      devices->push_back(*device);
+  }
+  if (video) {
+    const content::MediaStreamDevices& video_devices = GetVideoCaptureDevices();
+    const content::MediaStreamDevice* const device =
+        FindDefaultDeviceWithId(video_devices, requested_device_id);
+    if (device)
+      devices->push_back(*device);
+  }
+}
+
+void CameoMediaCaptureDevicesDispatcher::OnAudioCaptureDevicesChanged(
+    const content::MediaStreamDevices& devices) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
+  BrowserThread::PostTask(
+      BrowserThread::UI, FROM_HERE,
+      base::Bind(
+          &CameoMediaCaptureDevicesDispatcher::UpdateAudioDevicesOnUIThread,
+          base::Unretained(this), devices));
+}
+
+void CameoMediaCaptureDevicesDispatcher::OnVideoCaptureDevicesChanged(
+    const content::MediaStreamDevices& devices) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
+  BrowserThread::PostTask(
+      BrowserThread::UI, FROM_HERE,
+      base::Bind(
+          &CameoMediaCaptureDevicesDispatcher::UpdateVideoDevicesOnUIThread,
+          base::Unretained(this), devices));
+}
+
+void CameoMediaCaptureDevicesDispatcher::OnMediaRequestStateChanged(
+    int render_process_id,
+    int render_view_id,
+    const content::MediaStreamDevice& device,
+    content::MediaRequestState state) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
+  BrowserThread::PostTask(
+      BrowserThread::UI, FROM_HERE,
+      base::Bind(
+          &CameoMediaCaptureDevicesDispatcher::UpdateMediaReqStateOnUIThread,
+          base::Unretained(this), render_process_id, render_view_id, device,
+          state));
+}
+
+void CameoMediaCaptureDevicesDispatcher::OnAudioStreamPlayingChanged(
+    int render_process_id, int render_view_id, int stream_id, bool playing) {
+}
+
+void CameoMediaCaptureDevicesDispatcher::UpdateAudioDevicesOnUIThread(
+    const content::MediaStreamDevices& devices) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  devices_enumerated_ = true;
+  audio_devices_ = devices;
+  FOR_EACH_OBSERVER(Observer, observers_,
+                    OnUpdateAudioDevices(audio_devices_));
+}
+
+void CameoMediaCaptureDevicesDispatcher::UpdateVideoDevicesOnUIThread(
+    const content::MediaStreamDevices& devices) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  devices_enumerated_ = true;
+  video_devices_ = devices;
+  FOR_EACH_OBSERVER(Observer, observers_,
+                    OnUpdateVideoDevices(video_devices_));
+}
+
+void CameoMediaCaptureDevicesDispatcher::UpdateMediaReqStateOnUIThread(
+    int render_process_id,
+    int render_view_id,
+    const content::MediaStreamDevice& device,
+    content::MediaRequestState state) {
+  FOR_EACH_OBSERVER(Observer, observers_,
+                    OnRequestUpdate(render_process_id,
+                                    render_view_id,
+                                    device,
+                                    state));
+}

--- a/src/runtime/browser/media/media_capture_devices_dispatcher.h
+++ b/src/runtime/browser/media/media_capture_devices_dispatcher.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_RUNTIME_BROWSER_MEDIA_MEDIA_CAPTURE_DEVICES_DISPATCHER_H_
+#define CAMEO_SRC_RUNTIME_BROWSER_MEDIA_MEDIA_CAPTURE_DEVICES_DISPATCHER_H_
+
+#include <string>
+
+#include "base/callback.h"
+#include "base/memory/scoped_ptr.h"
+#include "base/memory/singleton.h"
+#include "base/observer_list.h"
+#include "content/public/browser/media_observer.h"
+#include "content/public/common/media_stream_request.h"
+
+// This singleton is used to receive updates about media events from the content
+// layer. Based on chrome/browser/media/media_capture_devices_dispatcher.[h|cc].
+class CameoMediaCaptureDevicesDispatcher : public content::MediaObserver {
+ public:
+  class Observer {
+   public:
+    // Handle an information update consisting of a up-to-date audio capture
+    // device lists. This happens when a microphone is plugged in or unplugged.
+    virtual void OnUpdateAudioDevices(
+        const content::MediaStreamDevices& devices) {}
+
+    // Handle an information update consisting of a up-to-date video capture
+    // device lists. This happens when a camera is plugged in or unplugged.
+    virtual void OnUpdateVideoDevices(
+        const content::MediaStreamDevices& devices) {}
+
+    // Handle an information update related to a media stream request.
+    virtual void OnRequestUpdate(
+        int render_process_id,
+        int render_view_id,
+        const content::MediaStreamDevice& device,
+        const content::MediaRequestState state) {}
+
+    virtual ~Observer() {}
+  };
+
+  static CameoMediaCaptureDevicesDispatcher* GetInstance();
+
+  // Methods for observers. Called on UI thread.
+  // Observers should add themselves on construction and remove themselves
+  // on destruction.
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+  const content::MediaStreamDevices& GetAudioCaptureDevices();
+  const content::MediaStreamDevices& GetVideoCaptureDevices();
+
+  // Helper for picking the device that was requested for an OpenDevice request.
+  // If the device requested is not available it will revert to using the first
+  // available one instead or will return an empty list if no devices of the
+  // requested kind are present.
+  void GetRequestedDevice(const std::string& requested_device_id,
+                          bool audio,
+                          bool video,
+                          content::MediaStreamDevices* devices);
+
+  // Overridden from content::MediaObserver:
+  virtual void OnAudioCaptureDevicesChanged(
+      const content::MediaStreamDevices& devices) OVERRIDE;
+  virtual void OnVideoCaptureDevicesChanged(
+      const content::MediaStreamDevices& devices) OVERRIDE;
+  virtual void OnMediaRequestStateChanged(
+      int render_process_id,
+      int render_view_id,
+      const content::MediaStreamDevice& device,
+      content::MediaRequestState state) OVERRIDE;
+  virtual void OnAudioStreamPlayingChanged(
+      int render_process_id,
+      int render_view_id,
+      int stream_id,
+      bool playing) OVERRIDE;
+
+ private:
+  friend struct DefaultSingletonTraits<CameoMediaCaptureDevicesDispatcher>;
+
+  CameoMediaCaptureDevicesDispatcher();
+  virtual ~CameoMediaCaptureDevicesDispatcher();
+
+  // Called by the MediaObserver() functions, executed on UI thread.
+  void UpdateAudioDevicesOnUIThread(const content::MediaStreamDevices& devices);
+  void UpdateVideoDevicesOnUIThread(const content::MediaStreamDevices& devices);
+  void UpdateMediaReqStateOnUIThread(
+      int render_process_id,
+      int render_view_id,
+      const content::MediaStreamDevice& device,
+      content::MediaRequestState state);
+
+  // A list of cached audio capture devices.
+  content::MediaStreamDevices audio_devices_;
+
+  // A list of cached video capture devices.
+  content::MediaStreamDevices video_devices_;
+
+  // A list of observers for the device update notifications.
+  ObserverList<Observer> observers_;
+
+  // Flag to indicate if device enumeration has been done/doing.
+  // Only accessed on UI thread.
+  bool devices_enumerated_;
+};
+
+#endif  // CAMEO_SRC_RUNTIME_BROWSER_MEDIA_MEDIA_CAPTURE_DEVICES_DISPATCHER_H_

--- a/src/runtime/browser/runtime.h
+++ b/src/runtime/browser/runtime.h
@@ -101,6 +101,10 @@ class Runtime : public content::WebContentsDelegate,
   virtual void EnumerateDirectory(content::WebContents* web_contents,
                                   int request_id,
                                   const base::FilePath& path) OVERRIDE;
+  virtual void RequestMediaAccessPermission(
+      content::WebContents* web_contents,
+      const content::MediaStreamRequest& request,
+      const content::MediaResponseCallback& callback) OVERRIDE;
 
   // Overridden from content::WebContentsObserver.
   virtual void DidUpdateFaviconURL(int32 page_id,

--- a/src/test/data/webrtc/getusermedia.html
+++ b/src/test/data/webrtc/getusermedia.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>getUserMedia Test</title>
+</head>
+<body>
+<div id="result">
+</div>
+<script>
+navigator.webkitGetUserMedia({audio:true, video:true}, successCallback, failedCallback); 
+
+function log(msg) {
+    var element = document.getElementById("result");
+    element.innerHTML = msg;
+}
+
+function failedCallback() {
+    log("Failed - Error callback is called.");
+}
+
+function successCallback(stream) {
+    log("Passed - Success callback is called.");
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Currently, getUserMedia can't work on Cameo, because Runtime didn't
implement the method WebContentsDelegate::RequestMediaAccessPermission.

I am implementing this feature like what CEF3 is doing, the infobar
dialog will not be popped up, when user calls getUserMedia function to
request Web Camera or Microphone.
And a test getUserMedia.html is added to verify this function, it is
needed to run manualy, beacuse it will be failed if your testing machine
have no real web camera or microphone devices.

BUG: https://github.com/otcshare/cameo/issues/73
