### PR TITLE
geolocation test: set the timeout to avoid browser test fails

### DIFF
--- a/src/test/data/geolocation/simple.html
+++ b/src/test/data/geolocation/simple.html
@@ -15,6 +15,9 @@
 
       window.onload = function() {
         if (navigator.geolocation) {
+          var options = {
+            timeout: 5000
+          };
           navigator.geolocation.getCurrentPosition(function(position) {
             document.getElementById("output").innerHTML =
                 "Position latitude: " + position.coords.latitude +
@@ -29,7 +32,8 @@
             //   1: permission denied
             //   2: position unavailable (error response from locaton provider)
             //   3: timed out
-          });
+          },
+          options);
         } else {
           console.log("navigator.geolocation is not available.");
           sendResult(-1);


### PR DESCRIPTION
When geolocation network provider is not reachable, geolocation
getCurrentPosition takes long time to timeout. It might get browser test to
timeout (30 secs) first and mark failure.

Set the getCurrentPosition timeout as 5 secs to avoid this to happen.
