### PR TITLE
[Place Holder] Upgrade chromium base to 28.0.1500.36

### DIFF
--- a/DEPS.cameo
+++ b/DEPS.cameo
@@ -6,8 +6,8 @@
 # Usually it's major.minor.build.patch
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
-chromium_version = 'Trunk'
-chromium_cameo_point = 'c3e6fe7c1fc75d4385f1d1f06d6e211249779692'
+chromium_version = '28.0.1500.36'
+chromium_cameo_point = 'd8d1dc3503653401d5bd7edfa158067799ae7991'
 deps_cameo = {
   'src': 'ssh://git@github.com/otcshare/chromium-cameo.git@%s' % chromium_cameo_point,
 }

--- a/src/runtime/browser/runtime_url_request_context_getter.cc
+++ b/src/runtime/browser/runtime_url_request_context_getter.cc
@@ -114,6 +114,7 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
     net::HttpCache::DefaultBackend* main_backend =
         new net::HttpCache::DefaultBackend(
             net::DISK_CACHE,
+            net::CACHE_BACKEND_DEFAULT,
             cache_path,
             0,
             BrowserThread::GetMessageLoopProxyForThread(

--- a/src/test/base/in_process_browser_test.cc
+++ b/src/test/base/in_process_browser_test.cc
@@ -28,7 +28,7 @@
 #include "content/public/test/test_launcher.h"
 #include "content/public/test/test_navigation_observer.h"
 #include "content/public/test/test_utils.h"
-#include "net/test/test_server.h"
+#include "net/test/spawned_test_server.h"
 
 using cameo::RuntimeList;
 using cameo::RuntimeRegistry;


### PR DESCRIPTION
Please merge #78 before this one.

This pull request is for integrate upstream beta channel chromium according to https://github.com/otcshare/cameo/wiki/Rebasing-Strategy .
The rebased beta chromium is already pushed at https://github.com/otcshare/chromium-cameo/commits/trunk, and previous chromium cameo used which is lkgr is backed up at https://github.com/otcshare/chromium-cameo/commits/trunk_history_28_0_1490_0 .

For this time, trybot will fail at sync code stage for sure. Because the change will make many dependencies checkout switch from git to svn. But for the next time we rebase chromium, trybot will work.

After this pull request merged, we will clobber all cameo slaves of build/trybot, that will take some time (1-2 days), meanwhile, trybot / buildbot will stop serving during that time.
