### PR TITLE
Differentiate app by app ID on Windows

### DIFF
--- a/cameo.gyp
+++ b/cameo.gyp
@@ -95,6 +95,8 @@
         'src/runtime/browser/ui/native_app_window_win.h',
         'src/runtime/browser/ui/native_app_window_gtk.cc',
         'src/runtime/browser/ui/native_app_window_gtk.h',
+        'src/runtime/browser/ui/taskbar_util.cc',
+        'src/runtime/browser/ui/taskbar_util.h',
         'src/runtime/common/cameo_content_client.cc',
         'src/runtime/common/cameo_content_client.h',
         'src/runtime/common/cameo_paths.cc',

--- a/src/runtime/app/cameo_main_delegate.cc
+++ b/src/runtime/app/cameo_main_delegate.cc
@@ -8,6 +8,7 @@
 #include "base/logging.h"
 #include "base/path_service.h"
 #include "cameo/src/runtime/browser/cameo_content_browser_client.h"
+#include "cameo/src/runtime/browser/ui/taskbar_util.h"
 #include "cameo/src/runtime/common/cameo_paths.h"
 #include "cameo/src/runtime/renderer/cameo_content_renderer_client.h"
 #include "content/public/browser/browser_main_runner.h"
@@ -28,6 +29,9 @@ CameoMainDelegate::~CameoMainDelegate() {
 
 bool CameoMainDelegate::BasicStartupComplete(int* exit_code) {
   SetContentClient(content_client_.get());
+#if defined(OS_WIN)
+  SetTaskbarGroupIdForProcess();
+#endif
   return false;
 }
 

--- a/src/runtime/browser/ui/taskbar_util.cc
+++ b/src/runtime/browser/ui/taskbar_util.cc
@@ -1,0 +1,67 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/runtime/browser/ui/taskbar_util.h"
+
+#include "base/command_line.h"
+#include "base/string_util.h"
+#include "base/string_number_conversions.h"
+#include "base/utf_string_conversions.h"
+#include "crypto/sha2.h"
+#include "googleurl/src/gurl.h"
+
+#if defined(OS_WIN)
+#include <shobjidl.h>
+#endif
+
+namespace cameo{
+
+#if defined(OS_WIN)
+const size_t kIdSize = 16;
+
+// Converts a normal hexadecimal string into the alphabet.
+// We use the characters 'a'-'p' instead of '0'-'f' to avoid ever having a
+// completely numeric host, since some software interprets that as an IP
+// address.
+void ConvertHexadecimalToIDAlphabet(std::string* id) {
+  for (size_t i = 0; i < id->size(); ++i) {
+    int val;
+    if (base::HexStringToInt(base::StringPiece(id->begin() + i,
+                                               id->begin() + i + 1),
+                             &val)) {
+      (*id)[i] = val + 'a';
+    } else {
+      (*id)[i] = 'a';
+    }
+  }
+}
+
+// Generates an ID from arbitrary input. The same input string will
+// always generate the same output ID.
+void GenerateId(const std::string& input, std::string* output) {
+  DCHECK(output);
+  uint8 hash[kIdSize];
+  crypto::SHA256HashString(input, hash, sizeof(hash));
+  *output = StringToLowerASCII(base::HexEncode(hash, sizeof(hash)));
+  ConvertHexadecimalToIDAlphabet(output);
+}
+#endif
+
+void SetTaskbarGroupIdForProcess() {
+  const CommandLine& command_line = *CommandLine::ForCurrentProcess();
+  if (command_line.argv().size() < 2)
+    return;
+
+  std::string arg;
+  GURL url(command_line.argv().at(1));
+  if (url.is_valid()) {
+    std::string appid;
+    GenerateId(url.spec(), &appid);
+#if defined(OS_WIN)
+    ::SetCurrentProcessExplicitAppUserModelID(ASCIIToWide(appid).c_str());
+#endif
+  }
+}
+
+}  // namespace cameo

--- a/src/runtime/browser/ui/taskbar_util.h
+++ b/src/runtime/browser/ui/taskbar_util.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_RUNTIME_BROWSER_UI_TASKBAR_UTIL_H_
+#define CAMEO_SRC_RUNTIME_BROWSER_UI_TASKBAR_UTIL_H_
+
+namespace cameo {
+
+// Set the ID for current process so that the icons of different apps
+// on status bar will show in different group.
+void SetTaskbarGroupIdForProcess();
+
+}  // namespace cameo
+
+#endif  // CAMEO_SRC_RUNTIME_BROWSER_UI_TASKBAR_UTIL_H_


### PR DESCRIPTION
Make icons of different apps show in different group in window7 taskbar.

BUG=https://github.com/otcshare/cameo/issues/77
