### PR TITLE
Differentiate app by app ID on Windows

### DIFF
--- a/cameo.gyp
+++ b/cameo.gyp
@@ -95,6 +95,8 @@
         'src/runtime/browser/ui/native_app_window_win.h',
         'src/runtime/browser/ui/native_app_window_gtk.cc',
         'src/runtime/browser/ui/native_app_window_gtk.h',
+        'src/runtime/browser/ui/taskbar_util_win.cc',
+        'src/runtime/browser/ui/taskbar_util.h',
         'src/runtime/common/cameo_content_client.cc',
         'src/runtime/common/cameo_content_client.h',
         'src/runtime/common/cameo_paths.cc',

--- a/cameo_tests.gypi
+++ b/cameo_tests.gypi
@@ -104,6 +104,11 @@
           '../base/allocator/allocator.gyp:allocator',
         ],
       }],
+      ['OS=="win"', {
+        'sources': [
+          'src/runtime/browser/ui/taskbar_util_browsertest.cc',
+        ],
+      }],  # OS=="win"
     ],
   }], # cameo_browser_tests target
 }

--- a/src/runtime/app/cameo_main_delegate.cc
+++ b/src/runtime/app/cameo_main_delegate.cc
@@ -8,9 +8,11 @@
 #include "base/logging.h"
 #include "base/path_service.h"
 #include "cameo/src/runtime/browser/cameo_content_browser_client.h"
+#include "cameo/src/runtime/browser/ui/taskbar_util.h"
 #include "cameo/src/runtime/common/cameo_paths.h"
 #include "cameo/src/runtime/renderer/cameo_content_renderer_client.h"
 #include "content/public/browser/browser_main_runner.h"
+#include "content/public/common/content_switches.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/ui_base_paths.h"
 
@@ -28,6 +30,14 @@ CameoMainDelegate::~CameoMainDelegate() {
 
 bool CameoMainDelegate::BasicStartupComplete(int* exit_code) {
   SetContentClient(content_client_.get());
+#if defined(OS_WIN)
+  CommandLine* command_line = CommandLine::ForCurrentProcess();
+  std::string process_type =
+          command_line->GetSwitchValueASCII(switches::kProcessType);
+  // Only set the id for browser process
+  if (process_type.empty())
+    SetTaskbarGroupIdForProcess();
+#endif
   return false;
 }
 

--- a/src/runtime/browser/ui/taskbar_util.h
+++ b/src/runtime/browser/ui/taskbar_util.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_RUNTIME_BROWSER_UI_TASKBAR_UTIL_H_
+#define CAMEO_SRC_RUNTIME_BROWSER_UI_TASKBAR_UTIL_H_
+
+namespace cameo {
+
+// Set the ID for current process so that the icons of different apps
+// on status bar will show in different group.
+void SetTaskbarGroupIdForProcess();
+
+}  // namespace cameo
+
+#endif  // CAMEO_SRC_RUNTIME_BROWSER_UI_TASKBAR_UTIL_H_

--- a/src/runtime/browser/ui/taskbar_util_browsertest.cc
+++ b/src/runtime/browser/ui/taskbar_util_browsertest.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <string>
+#include "base/command_line.h"
+#include "base/utf_string_conversions.h"
+#include "cameo/src/runtime/browser/ui/taskbar_util.h"
+#include "cameo/src/test/base/in_process_browser_test.h"
+
+#if defined(OS_WIN)
+#include <shobjidl.h>  // NOLINT(build/include_order)
+#endif
+
+class CameoTaskbarGroupingTest : public InProcessBrowserTest {
+ public:
+  bool TestForTaskbarGrouping(const std::string& url,
+                              const std::string& expected_id) {
+    CommandLine::ForCurrentProcess()->AppendArg(url);
+    cameo::SetTaskbarGroupIdForProcess();
+
+    bool result = true;
+#if defined(OS_WIN)
+    PWSTR user_model_id;
+    ::GetCurrentProcessExplicitAppUserModelID(&user_model_id);
+    result = (ASCIIToWide(expected_id) == user_model_id);
+    CoTaskMemFree(user_model_id);
+#endif
+
+    return result;
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(CameoTaskbarGroupingTest,
+                       UrlWithoutSlashEnd) {
+  EXPECT_TRUE(TestForTaskbarGrouping("http://127.0.0.1",
+                                     "nffebnloiadhkgeddojeojiaeklddbjj"));
+}
+
+IN_PROC_BROWSER_TEST_F(CameoTaskbarGroupingTest,
+                       UrlWithSlashEnd) {
+  EXPECT_TRUE(TestForTaskbarGrouping("http://127.0.0.1/",
+                                     "nffebnloiadhkgeddojeojiaeklddbjj"));
+}
+
+IN_PROC_BROWSER_TEST_F(CameoTaskbarGroupingTest,
+                       WindowsFilePathLowerCaseDriver) {
+  EXPECT_TRUE(TestForTaskbarGrouping("c:\\fake-path\\index.html",
+                                     "dpamcaeplfebmidmjpbghhhohfkpmnig"));
+}
+
+IN_PROC_BROWSER_TEST_F(CameoTaskbarGroupingTest,
+                       WindowsFilePathUpperCaseDriver) {
+  EXPECT_TRUE(TestForTaskbarGrouping("C:\\fake-path\\index.html",
+                                     "dpamcaeplfebmidmjpbghhhohfkpmnig"));
+}
+
+IN_PROC_BROWSER_TEST_F(CameoTaskbarGroupingTest,
+                       FilePathUrl) {
+  EXPECT_TRUE(TestForTaskbarGrouping("file:///C:/fake-path/index.html",
+                                     "dpamcaeplfebmidmjpbghhhohfkpmnig"));
+}

--- a/src/runtime/browser/ui/taskbar_util_win.cc
+++ b/src/runtime/browser/ui/taskbar_util_win.cc
@@ -1,0 +1,66 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/runtime/browser/ui/taskbar_util.h"
+
+#include <string>
+#include "base/command_line.h"
+#include "base/string_util.h"
+#include "base/string_number_conversions.h"
+#include "base/utf_string_conversions.h"
+#include "content/public/common/content_switches.h"
+#include "crypto/sha2.h"
+#include "googleurl/src/gurl.h"
+
+#if defined(OS_WIN)
+#include <shobjidl.h>  // NOLINT(build/include_order)
+#endif
+
+namespace cameo {
+
+const size_t kIdSize = 16;
+
+// Converts a normal hexadecimal string into the alphabet.
+// We use the characters 'a'-'p' instead of '0'-'f' to avoid ever having a
+// completely numeric host, since some software interprets that as an IP
+// address.
+void ConvertHexadecimalToIDAlphabet(std::string* id) {
+  for (size_t i = 0; i < id->size(); ++i) {
+    int val;
+    if (base::HexStringToInt(base::StringPiece(id->begin() + i,
+                                               id->begin() + i + 1),
+                             &val)) {
+      (*id)[i] = val + 'a';
+    } else {
+      (*id)[i] = 'a';
+    }
+  }
+}
+
+// Generates an ID from arbitrary input. The same input string will
+// always generate the same output ID.
+void GenerateId(const std::string& input, std::string* output) {
+  DCHECK(output);
+  uint8 hash[kIdSize];
+  crypto::SHA256HashString(input, hash, sizeof(hash));
+  *output = StringToLowerASCII(base::HexEncode(hash, sizeof(hash)));
+  ConvertHexadecimalToIDAlphabet(output);
+}
+
+void SetTaskbarGroupIdForProcess() {
+  CommandLine* command_line = CommandLine::ForCurrentProcess();
+  const CommandLine::StringVector& args = command_line->GetArgs();
+
+  if (args.empty())
+    return;
+
+  GURL url(args[0]);
+  if (url.is_valid() && url.has_scheme()) {
+    std::string appid;
+    GenerateId(url.spec(), &appid);
+    ::SetCurrentProcessExplicitAppUserModelID(ASCIIToWide(appid).c_str());
+  }
+}
+
+}  // namespace cameo


### PR DESCRIPTION
Make icons of different apps show in different group in Windows7 taskbar.

BUG=https://github.com/otcshare/cameo/issues/77
