### PR TITLE
Add Cameo extension subsystem

### DIFF
--- a/cameo.gyp
+++ b/cameo.gyp
@@ -53,6 +53,9 @@
       'include_dirs': [
         '..',
       ],
+      'includes': [
+        'src/extensions/extensions.gypi',
+      ],
       'sources': [
         'src/runtime/app/cameo_main_delegate.cc',
         'src/runtime/app/cameo_main_delegate.h',

--- a/src/extensions/README
+++ b/src/extensions/README
@@ -1,0 +1,3 @@
+Message posting extension mechanism for Cameo. Extensions consists of
+JavaScript API code (loaded into the Web contents), a function to handle
+messages from JavaScript and to post messages back to JavaScript.

--- a/src/extensions/browser/cameo_extension.cc
+++ b/src/extensions/browser/cameo_extension.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/extensions/browser/cameo_extension.h"
+
+namespace cameo {
+namespace extensions {
+
+CameoExtension::CameoExtension(CameoExtension::Poster* poster,
+                               const std::string& name,
+                               CameoExtension::HandlerThread thread)
+    : poster_(poster), name_(name), thread_(thread) {}
+
+CameoExtension::~CameoExtension() {}
+
+void CameoExtension::PostMessage(const int32_t render_view_id,
+                                 const std::string& msg) {
+  poster_->PostMessage(render_view_id, name_, msg);
+}
+
+}  // namespace extensions
+}  // namespace cameo

--- a/src/extensions/browser/cameo_extension.h
+++ b/src/extensions/browser/cameo_extension.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_H_
+#define CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_H_
+
+#include <stdint.h>
+#include <string>
+
+namespace cameo {
+namespace extensions {
+
+// Message exchanging interface to be implemented by Cameo
+// extensions. Currently the same extension is shared by all the
+// RenderViews of the process, distinguished by an id.
+class CameoExtension {
+ public:
+  // Interface used by CameoExtension to post messages, this is
+  // implemented by Cameo itself, extensions should not care about
+  // this.
+  class Poster {
+   public:
+    virtual void PostMessage(const int32_t render_view_id,
+                             const std::string& extension,
+                             const std::string& msg) = 0;
+   protected:
+    virtual ~Poster() {}  // So the client can't delete it.
+  };
+
+  // Defines the possible threads can be used to run the handler function.
+  enum HandlerThread {
+    HANDLER_THREAD_FILE,
+    HANDLER_THREAD_UI
+  };
+
+  CameoExtension(Poster* poster,
+                 const std::string& name,
+                 HandlerThread thread);
+  virtual ~CameoExtension();
+
+  // Returns the JavaScript API code that will be executed in the
+  // renderer process. It allows the extension provide a function or
+  // object based interface on top of the message passing.
+  virtual const char* GetJavaScriptAPI() = 0;
+
+  // Allow the extension to handle messages sent from JavaScript code
+  // running in renderer process, |render_view_id| identifies which
+  // RenderView send the message. Extensions should keep track of it
+  // to post messages back correctly.
+  //
+  // Note this function will be called in the thread the extension was
+  // registered, see CameoExtensionHost::RegisterExtension().
+  virtual void HandleMessage(const int32_t render_view_id,
+                             const std::string& msg) = 0;
+
+  // Function to be used by extensions to post messages back to
+  // JavaScript in the renderer process. |render_view_id| will be used
+  // to route the message to the right RenderView.
+  void PostMessage(const int32_t render_view_id, const std::string& msg);
+
+  std::string name() const { return name_; }
+  HandlerThread thread() const { return thread_; }
+
+ private:
+  Poster* poster_;
+
+  // Name of extension, used for dispatching messages.
+  std::string name_;
+
+  // Thread that will be used for handling messages of this extension.
+  HandlerThread thread_;
+};
+
+}  // namespace extensions
+}  // namespace cameo
+
+#endif  // CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_H_

--- a/src/extensions/browser/cameo_extension_host.cc
+++ b/src/extensions/browser/cameo_extension_host.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/extensions/browser/cameo_extension_host.h"
+
+#include "cameo/src/extensions/common/cameo_extension_messages.h"
+#include <string>
+
+using content::BrowserThread;
+
+namespace cameo {
+namespace extensions {
+
+CameoExtensionHost::CameoExtensionHost() : channel_(NULL) {}
+
+CameoExtensionHost::~CameoExtensionHost() {
+  ExtensionMap::iterator it = extensions_.begin();
+  for (; it != extensions_.end(); ++it)
+    delete it->second.extension;
+}
+
+static BrowserThread::ID BrowserThreadFromHandlerThread(
+    CameoExtension::HandlerThread thread) {
+  switch (thread) {
+    case CameoExtension::HANDLER_THREAD_FILE:
+      return BrowserThread::FILE;
+    case CameoExtension::HANDLER_THREAD_UI:
+      return BrowserThread::UI;
+  }
+  NOTREACHED();
+  return BrowserThread::FILE;
+}
+
+bool CameoExtensionHost::RegisterExtension(CameoExtension* extension) {
+  std::string name = extension->name();
+  if (extensions_.find(name) != extensions_.end())
+    return false;
+
+  ExtensionEntry entry;
+  entry.extension = extension;
+  entry.thread = BrowserThreadFromHandlerThread(extension->thread());
+  extensions_[name] = entry;
+  Send(new CameoViewMsg_RegisterExtension(name, extension->GetJavaScriptAPI()));
+  return true;
+}
+
+void CameoExtensionHost::OnFilterAdded(IPC::Channel* channel) {
+  channel_ = channel;
+}
+
+bool CameoExtensionHost::OnMessageReceived(const IPC::Message& message) {
+  CHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::IO));
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP(CameoExtensionHost, message)
+    IPC_MESSAGE_HANDLER_GENERIC(CameoViewHostMsg_PostMessage,
+                                OnPostMessage(message))
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+  return handled;
+}
+
+bool CameoExtensionHost::Send(IPC::Message* message) {
+  if (!BrowserThread::CurrentlyOn(BrowserThread::IO)) {
+    BrowserThread::PostTask(
+        BrowserThread::IO,
+        FROM_HERE,
+        base::Bind(base::IgnoreResult(&CameoExtensionHost::Send), this,
+                   message));
+    return true;
+  }
+
+  if (channel_)
+    return channel_->Send(message);
+
+  delete message;
+  return false;
+}
+
+void CameoExtensionHost::PostMessage(const int32_t render_view_id,
+                                     const std::string& extension,
+                                     const std::string& msg) {
+  // FIXME(cmarcelo): Can we check the validity of id?
+  Send(new CameoViewMsg_PostMessage(render_view_id, extension, msg));
+}
+
+void CameoExtensionHost::OnPostMessage(const IPC::Message& message) {
+  CameoViewHostMsg_PostMessage::Param param;
+  if (!CameoViewHostMsg_PostMessage::Read(&message, &param))
+    return;
+  const std::string& extension = param.a;
+  const std::string& msg = param.b;
+  ExtensionMap::iterator it = extensions_.find(extension);
+  if (it != extensions_.end()) {
+    CameoExtension* cameo_extension = it->second.extension;
+    BrowserThread::PostTask(
+        it->second.thread,
+        FROM_HERE,
+        base::Bind(&CameoExtension::HandleMessage,
+                   base::Unretained(cameo_extension),
+                   message.routing_id(), msg));
+  }
+}
+
+}  // namespace extensions
+}  // namespace cameo

--- a/src/extensions/browser/cameo_extension_host.h
+++ b/src/extensions/browser/cameo_extension_host.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_HOST_H_
+#define CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_HOST_H_
+
+#include <map>
+#include <string>
+#include "cameo/src/extensions/browser/cameo_extension.h"
+#include "content/public/browser/browser_thread.h"
+#include "ipc/ipc_channel_proxy.h"
+#include "ipc/ipc_sender.h"
+
+namespace cameo {
+namespace extensions {
+
+// Manages the set of extensions used by the browser process. Mediates
+// the message exchange between extensions and the renderer process.
+class CameoExtensionHost : public IPC::ChannelProxy::MessageFilter,
+                           public IPC::Sender,
+                           public CameoExtension::Poster {
+ public:
+  CameoExtensionHost();
+  virtual ~CameoExtensionHost();
+
+  // Takes |extension| ownership and register it with the renderer
+  // process so can be used by JavaScript code. Returns false if
+  // extension couldn't be registered because another one with the
+  // same name exists, otherwise returns true.
+  bool RegisterExtension(CameoExtension* extension);
+
+  // MessageFilter implementation.
+  virtual void OnFilterAdded(IPC::Channel* channel) OVERRIDE;
+  virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
+
+  // Sender implementation.
+  virtual bool Send(IPC::Message* message) OVERRIDE;
+
+  // CameoExtension::Poster implementation.
+  virtual void PostMessage(const int32_t render_view_id,
+                           const std::string& extension,
+                           const std::string& msg);
+
+ private:
+  // Called when a message was received from renderer process, handles
+  // the dispatching to the right extension.
+  void OnPostMessage(const IPC::Message& message);
+
+  struct ExtensionEntry {
+    CameoExtension* extension;
+    content::BrowserThread::ID thread;
+  };
+  typedef std::map<std::string, ExtensionEntry> ExtensionMap;
+  ExtensionMap extensions_;
+
+  IPC::Channel* channel_;
+
+  // FIXME(cmarcelo): Add peer_handle_ so we can kill process if we
+  // get a wrong message.
+};
+
+}  // namespace extensions
+}  // namespace cameo
+
+#endif  // CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_HOST_H_

--- a/src/extensions/common/cameo_extension_messages.cc
+++ b/src/extensions/common/cameo_extension_messages.cc
@@ -1,0 +1,6 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#define IPC_MESSAGE_IMPL
+#include "cameo/src/extensions/common/cameo_extension_messages.h"

--- a/src/extensions/common/cameo_extension_messages.h
+++ b/src/extensions/common/cameo_extension_messages.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <string>
+#include "ipc/ipc_message_macros.h"
+
+#define IPC_MESSAGE_START ExtensionMsgStart
+
+IPC_MESSAGE_ROUTED2(CameoViewHostMsg_PostMessage,  // NOLINT(*)
+                    std::string /* target extension */,
+                    std::string /* contents */)
+
+IPC_MESSAGE_ROUTED2(CameoViewMsg_PostMessage,  // NOLINT(*)
+                    std::string /* source extension */,
+                    std::string /* contents */)
+
+IPC_MESSAGE_CONTROL2(CameoViewMsg_RegisterExtension,  // NOLINT(*)
+                    std::string /* extension */,
+                    std::string /* JS API code for extension */)

--- a/src/extensions/extensions.gypi
+++ b/src/extensions/extensions.gypi
@@ -1,0 +1,14 @@
+{
+  'sources': [
+    'browser/cameo_extension.cc',
+    'browser/cameo_extension.h',
+    'browser/cameo_extension_host.cc',
+    'browser/cameo_extension_host.h',
+    'common/cameo_extension_messages.cc',
+    'common/cameo_extension_messages.h',
+    'renderer/cameo_extension_render_view_handler.cc',
+    'renderer/cameo_extension_render_view_handler.h',
+    'renderer/cameo_extension_renderer_controller.cc',
+    'renderer/cameo_extension_renderer_controller.h',
+  ],
+}

--- a/src/extensions/renderer/cameo_extension_render_view_handler.cc
+++ b/src/extensions/renderer/cameo_extension_render_view_handler.cc
@@ -1,0 +1,88 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/extensions/renderer/cameo_extension_render_view_handler.h"
+
+#include "cameo/src/extensions/common/cameo_extension_messages.h"
+#include "cameo/src/extensions/renderer/cameo_extension_renderer_controller.h"
+#include "content/public/renderer/render_view.h"
+#include "third_party/WebKit/Source/WebKit/chromium/public/WebFrame.h"
+#include "third_party/WebKit/Source/WebKit/chromium/public/WebView.h"
+#include "v8/include/v8.h"
+
+namespace cameo {
+namespace extensions {
+
+CameoExtensionRenderViewHandler::CameoExtensionRenderViewHandler(
+    content::RenderView* render_view,
+    CameoExtensionRendererController* controller)
+    : content::RenderViewObserver(render_view),
+      content::RenderViewObserverTracker<CameoExtensionRenderViewHandler>(
+          render_view),
+      controller_(controller) {
+  CHECK(controller);
+}
+
+CameoExtensionRenderViewHandler*
+CameoExtensionRenderViewHandler::GetForCurrentContext() {
+  WebKit::WebFrame* webframe = WebKit::WebFrame::frameForCurrentContext();
+  if (!webframe) return NULL;
+
+  WebKit::WebView* webview = webframe->view();
+  if (!webview) return NULL;  // Can happen during closing.
+
+  content::RenderView* render_view = content::RenderView::FromWebView(webview);
+  return CameoExtensionRenderViewHandler::Get(render_view);
+}
+
+bool CameoExtensionRenderViewHandler::PostMessageToExtension(
+    const std::string& extension, const std::string& msg) {
+  return Send(new CameoViewHostMsg_PostMessage(routing_id(), extension, msg));
+}
+
+void CameoExtensionRenderViewHandler::DidClearWindowObject(
+    WebKit::WebFrame* frame) {
+  controller_->InstallJavaScriptAPIs(frame);
+}
+
+bool CameoExtensionRenderViewHandler::OnMessageReceived(
+    const IPC::Message& message) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP(CameoExtensionRenderViewHandler, message)
+    IPC_MESSAGE_HANDLER(CameoViewMsg_PostMessage, OnPostMessage)
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+  return handled;
+}
+
+void CameoExtensionRenderViewHandler::OnPostMessage(
+    const std::string& extension, const std::string& msg) {
+  if (!controller_->ContainsExtension(extension))
+    return;
+
+  WebKit::WebFrame* frame = render_view()->GetWebView()->mainFrame();
+
+  v8::HandleScope handle_scope;
+  const int argc = 2;
+  v8::Handle<v8::Value> argv[argc] = {
+    v8::String::New(extension.c_str()),
+    v8::String::New(msg.c_str())
+  };
+
+  v8::Handle<v8::Context> context = frame->mainWorldScriptContext();
+  v8::Context::Scope context_scope(context);
+
+  // FIXME(cmarcelo): The way we are doing this, onpostmessage is exposed
+  // and could be changed. An alternative design would be to expose those
+  // things in a more controlled way during DidClearWindowObject instead of
+  // using v8::Extension.
+  v8::Handle<v8::Value> cameo =
+      context->Global()->Get(v8::String::New("cameo"));
+  v8::Handle<v8::Value> callback =
+      cameo.As<v8::Object>()->Get(v8::String::New("onpostmessage"));
+  callback.As<v8::Function>()->Call(context->Global(), argc, argv);
+}
+
+}  // namespace extensions
+}  // namespace cameo

--- a/src/extensions/renderer/cameo_extension_render_view_handler.h
+++ b/src/extensions/renderer/cameo_extension_render_view_handler.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_EXTENSIONS_RENDERER_CAMEO_EXTENSION_RENDER_VIEW_HANDLER_H_
+#define CAMEO_SRC_EXTENSIONS_RENDERER_CAMEO_EXTENSION_RENDER_VIEW_HANDLER_H_
+
+#include <string>
+#include "content/public/renderer/render_view_observer.h"
+#include "content/public/renderer/render_view_observer_tracker.h"
+
+namespace cameo {
+namespace extensions {
+
+class CameoExtensionRendererController;
+
+// This helper object is associated with each RenderView and handles
+// the message exchange between browser process and the JavaScript
+// code.
+class CameoExtensionRenderViewHandler
+    : public content::RenderViewObserver,
+      public
+      content::RenderViewObserverTracker<CameoExtensionRenderViewHandler> {
+ public:
+  CameoExtensionRenderViewHandler(content::RenderView* render_view,
+                          CameoExtensionRendererController* controller);
+
+  // Get the handler for the current context. Used in v8::Extension.
+  // This convenience is one of the reasons to have this helper class.
+  static CameoExtensionRenderViewHandler* GetForCurrentContext();
+
+  bool PostMessageToExtension(const std::string& extension,
+                              const std::string& msg);
+
+  // RenderViewObserver implementation.
+  virtual void DidClearWindowObject(WebKit::WebFrame* frame) OVERRIDE;
+  virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
+
+ private:
+  // Called when we receive a message from the browser process,
+  // dispatches it to JavaScript environment.
+  void OnPostMessage(const std::string& extension, const std::string& msg);
+
+  CameoExtensionRendererController* controller_;
+};
+
+}  // namespace extensions
+}  // namespace cameo
+
+#endif  // CAMEO_SRC_EXTENSIONS_RENDERER_CAMEO_EXTENSION_RENDER_VIEW_HANDLER_H_

--- a/src/extensions/renderer/cameo_extension_renderer_controller.cc
+++ b/src/extensions/renderer/cameo_extension_renderer_controller.cc
@@ -1,0 +1,124 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/extensions/renderer/cameo_extension_renderer_controller.h"
+
+#include "cameo/src/extensions/common/cameo_extension_messages.h"
+#include "cameo/src/extensions/renderer/cameo_extension_render_view_handler.h"
+#include "content/public/renderer/render_thread.h"
+#include "third_party/WebKit/Source/WebKit/chromium/public/WebFrame.h"
+#include "third_party/WebKit/Source/WebKit/chromium/public/WebScriptSource.h"
+#include "v8/include/v8.h"
+
+namespace cameo {
+namespace extensions {
+
+class CameoExtensionV8Wrapper : public v8::Extension {
+ public:
+  CameoExtensionV8Wrapper();
+
+  // v8::Extension implementation.
+  virtual v8::Handle<v8::FunctionTemplate> GetNativeFunction(
+      v8::Handle<v8::String> name);
+
+ private:
+  static v8::Handle<v8::Value> PostMessage(const v8::Arguments& args);
+};
+
+// FIXME(cmarcelo): Implement this in C++ instead of JS. Tie it to the
+// window object lifetime.
+static const char* const kCameoExtensionV8WrapperAPI =
+    "var cameo = cameo || {};"
+    "cameo.postMessage = function(extension, msg) {"
+    "  native function PostMessage();"
+    "  PostMessage(extension, msg);"
+    "};"
+    "cameo._message_listeners = {};"
+    "cameo.setMessageListener = function(extension, callback) {"
+    "  if (callback === undefined)"
+    "    delete cameo._message_listeners[extension];"
+    "  else"
+    "    cameo._message_listeners[extension] = callback;"
+    "};"
+    "cameo.onpostmessage = function(extension, msg) {"
+    "  var listener = cameo._message_listeners[extension];"
+    "  if (listener !== undefined)"
+    "    listener(msg);"
+    "};";
+
+CameoExtensionV8Wrapper::CameoExtensionV8Wrapper()
+    : v8::Extension("cameo", kCameoExtensionV8WrapperAPI) {
+}
+
+v8::Handle<v8::FunctionTemplate>
+CameoExtensionV8Wrapper::GetNativeFunction(v8::Handle<v8::String> name) {
+  if (name->Equals(v8::String::New("PostMessage")))
+    return v8::FunctionTemplate::New(PostMessage);
+  return v8::Handle<v8::FunctionTemplate>();
+}
+
+v8::Handle<v8::Value> CameoExtensionV8Wrapper::PostMessage(
+    const v8::Arguments& args) {
+  if (args.Length() != 2)
+    return v8::False();
+
+  std::string extension(*v8::String::Utf8Value(args[0]));
+  std::string msg(*v8::String::Utf8Value(args[1]));
+
+  CameoExtensionRenderViewHandler* handler =
+      CameoExtensionRenderViewHandler::GetForCurrentContext();
+  if (!handler->PostMessageToExtension(extension, msg))
+    return v8::False();
+  return v8::True();
+}
+
+CameoExtensionRendererController::CameoExtensionRendererController() {
+  content::RenderThread* thread = content::RenderThread::Get();
+  thread->AddObserver(this);
+  thread->RegisterExtension(new CameoExtensionV8Wrapper);
+}
+
+CameoExtensionRendererController::~CameoExtensionRendererController() {
+  content::RenderThread::Get()->RemoveObserver(this);
+}
+
+void CameoExtensionRendererController::RenderViewCreated(
+    content::RenderView* render_view) {
+  // RenderView will own this object.
+  new CameoExtensionRenderViewHandler(render_view, this);
+}
+
+bool CameoExtensionRendererController::OnControlMessageReceived(
+    const IPC::Message& message) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP(CameoExtensionRendererController, message)
+    IPC_MESSAGE_HANDLER(CameoViewMsg_RegisterExtension, OnRegisterExtension)
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+  return handled;
+}
+
+void CameoExtensionRendererController::OnRegisterExtension(
+    const std::string& extension, const std::string& api) {
+  extension_apis_[extension] = api;
+}
+
+bool CameoExtensionRendererController::ContainsExtension(
+    const std::string& extension) const {
+  return extension_apis_.find(extension) != extension_apis_.end();
+}
+
+void CameoExtensionRendererController::InstallJavaScriptAPIs(
+    WebKit::WebFrame* frame) {
+  ExtensionAPIMap::const_iterator it = extension_apis_.begin();
+  for (; it != extension_apis_.end(); ++it) {
+    const std::string& api_code = it->second;
+    if (!api_code.empty())
+      frame->executeScript(WebKit::WebScriptSource(
+          WebKit::WebString::fromUTF8(api_code)));
+  }
+}
+
+}  // namespace extensions
+}  // namespace cameo

--- a/src/extensions/renderer/cameo_extension_renderer_controller.h
+++ b/src/extensions/renderer/cameo_extension_renderer_controller.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_EXTENSIONS_RENDERER_CAMEO_EXTENSION_RENDERER_CONTROLLER_H_
+#define CAMEO_SRC_EXTENSIONS_RENDERER_CAMEO_EXTENSION_RENDERER_CONTROLLER_H_
+
+#include <map>
+#include <string>
+#include "base/compiler_specific.h"
+#include "content/public/renderer/render_process_observer.h"
+
+namespace content {
+class RenderView;
+}
+
+namespace WebKit {
+class WebFrame;
+}
+
+namespace cameo {
+namespace extensions {
+
+// Renderer controller for Cameo extensions keeps track of the
+// extensions registered into the system. It also watches for new
+// render views to attach the extensions handlers to them.
+class CameoExtensionRendererController : public content::RenderProcessObserver {
+ public:
+  CameoExtensionRendererController();
+  virtual ~CameoExtensionRendererController();
+
+  // To be called by client code when a render view is created. Will
+  // attach extension handlers to them.
+  void RenderViewCreated(content::RenderView* render_view);
+
+  // RenderProcessObserver implementation.
+  virtual bool OnControlMessageReceived(const IPC::Message& message) OVERRIDE;
+
+ private:
+  friend class CameoExtensionRenderViewHandler;
+
+  // Called when browser process send a message with a new extension
+  // to be registered, and its corresponding JavaScript API.
+  void OnRegisterExtension(const std::string& extension,
+                           const std::string& api);
+
+  // Returns whether the extension was already registered in the
+  // controller.
+  bool ContainsExtension(const std::string& extension) const;
+
+  // Installs the extensions' JavaScript API code into the given frame.
+  void InstallJavaScriptAPIs(WebKit::WebFrame* frame);
+
+  typedef std::map<std::string, std::string> ExtensionAPIMap;
+  ExtensionAPIMap extension_apis_;
+};
+
+}  // namespace extensions
+}  // namespace cameo
+
+#endif  // CAMEO_SRC_EXTENSIONS_RENDERER_CAMEO_EXTENSION_RENDERER_CONTROLLER_H_

--- a/src/runtime/browser/cameo_content_browser_client.cc
+++ b/src/runtime/browser/cameo_content_browser_client.cc
@@ -4,10 +4,12 @@
 
 #include "cameo/src/runtime/browser/cameo_content_browser_client.h"
 
+#include "cameo/src/extensions/browser/cameo_extension_host.h"
 #include "cameo/src/runtime/browser/cameo_browser_main_parts.h"
 #include "cameo/src/runtime/browser/geolocation/cameo_access_token_store.h"
 #include "cameo/src/runtime/browser/runtime_context.h"
 #include "content/public/browser/browser_main_parts.h"
+#include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_view_delegate.h"
 #include "content/public/common/main_function_params.h"
@@ -69,6 +71,20 @@ content::WebContentsViewDelegate*
 CameoContentBrowserClient::GetWebContentsViewDelegate(
     content::WebContents* web_contents) {
   return NULL;
+}
+
+void CameoContentBrowserClient::RenderProcessHostCreated(
+    content::RenderProcessHost* host) {
+
+  extensions::CameoExtensionHost* extension_host =
+      new extensions::CameoExtensionHost;
+
+  // Register the extensions here.
+
+  // FIXME(cmarcelo): CameoExtensionHost shouldn't be a MessageFilter,
+  // we want a clearer lifetime, tied to the browser process or the
+  // render process host.
+  host->GetChannel()->AddFilter(extension_host);
 }
 
 }  // namespace cameo

--- a/src/runtime/browser/cameo_content_browser_client.h
+++ b/src/runtime/browser/cameo_content_browser_client.h
@@ -45,6 +45,8 @@ class CameoContentBrowserClient : public content::ContentBrowserClient {
   virtual content::AccessTokenStore* CreateAccessTokenStore() OVERRIDE;
   virtual content::WebContentsViewDelegate* GetWebContentsViewDelegate(
       content::WebContents* web_contents) OVERRIDE;
+  virtual void RenderProcessHostCreated(
+      content::RenderProcessHost* host) OVERRIDE;
 
  private:
   net::URLRequestContextGetter* url_request_context_getter_;

--- a/src/runtime/renderer/cameo_content_renderer_client.cc
+++ b/src/runtime/renderer/cameo_content_renderer_client.cc
@@ -4,6 +4,8 @@
 
 #include "cameo/src/runtime/renderer/cameo_content_renderer_client.h"
 
+#include "cameo/src/extensions/renderer/cameo_extension_renderer_controller.h"
+
 namespace cameo {
 
 namespace {
@@ -24,6 +26,12 @@ CameoContentRendererClient::~CameoContentRendererClient() {
 }
 
 void CameoContentRendererClient::RenderThreadStarted() {
+  extension_controller_.reset(new extensions::CameoExtensionRendererController);
+}
+
+void CameoContentRendererClient::RenderViewCreated(
+    content::RenderView* render_view) {
+  extension_controller_->RenderViewCreated(render_view);
 }
 
 }  // namespace cameo

--- a/src/runtime/renderer/cameo_content_renderer_client.h
+++ b/src/runtime/renderer/cameo_content_renderer_client.h
@@ -12,6 +12,10 @@
 
 namespace cameo {
 
+namespace extensions {
+class CameoExtensionRendererController;
+}
+
 class CameoContentRendererClient : public content::ContentRendererClient {
  public:
   static CameoContentRendererClient* Get();
@@ -21,8 +25,12 @@ class CameoContentRendererClient : public content::ContentRendererClient {
 
   // ContentRendererClient implementation.
   virtual void RenderThreadStarted() OVERRIDE;
+  virtual void RenderViewCreated(content::RenderView* render_view) OVERRIDE;
 
  private:
+  scoped_ptr<extensions::CameoExtensionRendererController>
+      extension_controller_;
+
   DISALLOW_COPY_AND_ASSIGN(CameoContentRendererClient);
 };
 


### PR DESCRIPTION
The Cameo extension subsystem is a set of classes that can be used by
Browser and Renderer processes to run native code that respects a
certain interface.

The interface is minimal and exposes message passing between the
extension and the JS code running in the Renderer process. Extensions
currently are run in the Browser process, either on the FILE or UI
threads.

A more detailed design document is available at
https://github.com/otcshare/cameo/wiki/Message-passing-extensions

BUG=https://github.com/otcshare/cameo/issues/65
