### PR TITLE
Support fullscreen when launch and Support HTML5 fullscreen API.

### DIFF
--- a/src/runtime/browser/runtime.h
+++ b/src/runtime/browser/runtime.h
@@ -135,6 +135,17 @@ class Runtime : public content::WebContentsDelegate,
   // Currently open color chooser. Non-NULL after OpenColorChooser is called and
   // before DidEndColorChooser is called.
   scoped_ptr<content::ColorChooser> color_chooser_;
+
+  // Fullscreen options.
+  enum FullscreenOptions {
+    NO_FULLSCREEN = 0,
+    // Fullscreen entered by launch with "--fullscreen".
+    FULLSCREEN_FOR_LAUNCH = 1,
+    // Fullscreen entered by HTML requestFullscreen.
+    FULLSCREEN_FOR_TAB = 1 << 1,
+  };
+
+  unsigned int fullscreen_options_;
 };
 
 }  // namespace cameo

--- a/src/runtime/browser/ui/native_app_window_win.cc
+++ b/src/runtime/browser/ui/native_app_window_win.cc
@@ -5,6 +5,8 @@
 #include "cameo/src/runtime/browser/ui/native_app_window_win.h"
 
 #include "cameo/src/runtime/browser/runtime.h"
+#include "cameo/src/runtime/common/cameo_notification_types.h"
+#include "content/public/browser/notification_service.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/web_contents.h"
@@ -41,6 +43,9 @@ NativeAppWindowWin::NativeAppWindowWin(
   gfx::Rect window_bounds = create_params.bounds;
   window_->SetBounds(window_bounds);
   window_->CenterWindow(window_bounds.size());
+
+  if (create_params.state == ui::SHOW_STATE_FULLSCREEN)
+    SetFullscreen(true);
 
   // TODO(hmin): Need to configure the maximum and minimum size of this window.
   window_->AddObserver(this);
@@ -99,6 +104,11 @@ void NativeAppWindowWin::SetFullscreen(bool fullscreen) {
     return;
   is_fullscreen_ = fullscreen;
   window_->SetFullscreen(is_fullscreen_);
+
+  content::NotificationService::current()->Notify(
+      cameo::NOTIFICATION_FULLSCREEN_CHANGED,
+      content::Source<NativeAppWindow>(this),
+      content::NotificationService::NoDetails());
 }
 
 void NativeAppWindowWin::Restore() {

--- a/src/runtime/common/cameo_notification_types.h
+++ b/src/runtime/common/cameo_notification_types.h
@@ -21,6 +21,9 @@ enum NotificationType {
   // containing the affected Runtime. No details is provided.
   NOTIFICATION_RUNTIME_CLOSED,
 
+  // Notify that fullscreen state of a NativeAppWindow is changed.
+  NOTIFICATION_FULLSCREEN_CHANGED,
+
   NOTIFICATION_CAMEO_END,
 };
 

--- a/src/runtime/common/cameo_switches.cc
+++ b/src/runtime/common/cameo_switches.cc
@@ -13,4 +13,6 @@ const char kCameoDataPath[] = "data-path";
 // Specifies the icon file for the app window.
 const char kAppIcon[] = "app-icon";
 
+// Specifies the window whether launched with fullscreen mode.
+const char kFullscreen[] = "fullscreen";
 }  // namespace switches

--- a/src/runtime/common/cameo_switches.h
+++ b/src/runtime/common/cameo_switches.h
@@ -12,6 +12,7 @@ extern const char kCameoDataPath[];
 
 extern const char kAppIcon[];
 
+extern const char kFullscreen[];
 }  // namespace switches
 
 #endif  // CAMEO_SRC_RUNTIME_COMMON_CAMEO_SWITCHES_H_

--- a/src/test/data/fullscreen.html
+++ b/src/test/data/fullscreen.html
@@ -1,0 +1,44 @@
+<html>
+<body>
+<script>
+function doFullscreenClick() {
+  var e = document.createEvent("MouseEvents");
+  e.initMouseEvent("click", true, true, window,
+      0, 0, 0, 0, 0, false, false, false, false, 0, null);
+  var elem = document.getElementById("Launchbutton");
+  elem.dispatchEvent(e);
+}
+
+function doExitFullscreenClick() {
+  var e = document.createEvent("MouseEvents");
+  e.initMouseEvent("click", true, true, window,
+      0, 0, 0, 0, 0, false, false, false, false, 0, null);
+  var elem = document.getElementById("Exitbutton");
+  elem.dispatchEvent(e);
+}
+
+function toggleFullScreen(element) {
+  if (element.requestFullScreen) {
+    element.requestFullScreen();
+  } else if(element.mozRequestFullScreen) {
+    element.mozRequestFullScreen();
+  } else if(element.webkitRequestFullScreen) {
+    element.webkitRequestFullScreen();
+  }
+}
+
+function exitFullScreen(element) {
+  if (element.exitFullScreen) {
+    element.exitFullScreen();
+  } else if(element.mozCancelFullScreen) {
+    element.mozCancelFullScreen();
+  } else if(element.webkitCancelFullScreen) {
+    element.webkitCancelFullScreen();
+  }
+}
+
+</script>
+<button id="Launchbutton" onclick="toggleFullScreen(document.documentElement);">Launch Fullscreen</button>
+<button id="Exitbutton" onclick="exitFullScreen(document);">Exit Fullscreen</button>
+</body>
+</html>


### PR DESCRIPTION
This patch has two
1. Launch fullscreen application with "--fullscreen" flag.
2. HTML5 fullscreen API support.

Know issues:
o fullscreen with "--fullscreen" flag: this feature need developer to
  take case application exit logic, because there doesn't exist default
  close button for user in fullscreen mode, which need developer to
  provide exit button in the web application.
o HTML5 fullscreen API: there doesn't exist "exist bubble" to exit
  fullscreen mode because it's a more kind of browser feature,
  but keep the "esc" keyboard button for exit.

BUG=https://github.com/otcshare/cameo/issues/76
TEST=CameoRuntimeTest.LaunchWithFullscreenWindow
