### PR TITLE
Override some behavior of cpplint in depot_tools for cameo specific

### DIFF
--- a/tools/lint.py
+++ b/tools/lint.py
@@ -105,42 +105,50 @@ def do_cpp_lint(changeset, repo, args):
       origin_error(filename, linenum, category, confidence, message)
   cpplint.Error = MyError
 
+  origin_FileInfo = cpplint.FileInfo
+  class MyFileInfo(origin_FileInfo):
+    def RepositoryName(self):
+      ''' Origin FileInfo find the first .git and take it as project root,
+          it's not the case for cameo, header in cameo should have guard
+          relevant to root dir of chromium project, which is one level
+          upper of the origin output of RepositoryName.
+      '''
+      repo_name = origin_FileInfo.RepositoryName(self)
+      if repo == "cameo" and not repo_name.startswith('cameo'):
+        return 'cameo/%s' % repo_name
+      else:
+        return repo_name
+  cpplint.FileInfo = MyFileInfo
+
   print '_____ do cpp lint'
   if len(changeset) == 0:
     print 'changeset is empty except python files'
     return
-  # pass the build/header_guard check
-  if repo == 'cameo':
-    os.rename('.git', '.git.rename')
   # Following code is referencing depot_tools/gcl.py: CMDlint
-  try:
-    # Process cpplints arguments if any.
-    filenames = cpplint.ParseArguments(args + changeset)
+  # Process cpplints arguments if any.
+  filenames = cpplint.ParseArguments(args + changeset)
 
-    white_list = gcl.GetCodeReviewSetting("LINT_REGEX")
-    if not white_list:
-      white_list = gcl.DEFAULT_LINT_REGEX
-    white_regex = re.compile(white_list)
-    black_list = gcl.GetCodeReviewSetting("LINT_IGNORE_REGEX")
-    if not black_list:
-      black_list = gcl.DEFAULT_LINT_IGNORE_REGEX
-    black_regex = re.compile(black_list)
-    extra_check_functions = [cpplint_chromium.CheckPointerDeclarationWhitespace]
-    # pylint: disable=W0212
-    cpplint_state = cpplint._cpplint_state
-    for filename in filenames:
-      if white_regex.match(filename):
-        if black_regex.match(filename):
-          print "Ignoring file %s" % filename
-        else:
-          cpplint.ProcessFile(filename, cpplint_state.verbose_level,
-                              extra_check_functions)
+  white_list = gcl.GetCodeReviewSetting("LINT_REGEX")
+  if not white_list:
+    white_list = gcl.DEFAULT_LINT_REGEX
+  white_regex = re.compile(white_list)
+  black_list = gcl.GetCodeReviewSetting("LINT_IGNORE_REGEX")
+  if not black_list:
+    black_list = gcl.DEFAULT_LINT_IGNORE_REGEX
+  black_regex = re.compile(black_list)
+  extra_check_functions = [cpplint_chromium.CheckPointerDeclarationWhitespace]
+  # pylint: disable=W0212
+  cpplint_state = cpplint._cpplint_state
+  for filename in filenames:
+    if white_regex.match(filename):
+      if black_regex.match(filename):
+        print "Ignoring file %s" % filename
       else:
-        print "Skipping file %s" % filename
-    print "Total errors found: %d\n" % cpplint_state.error_count
-  finally:
-    if repo == 'cameo':
-      os.rename('.git.rename', '.git')
+        cpplint.ProcessFile(filename, cpplint_state.verbose_level,
+                            extra_check_functions)
+    else:
+      print "Skipping file %s" % filename
+  print "Total errors found: %d\n" % cpplint_state.error_count
 
 def do_py_lint(changeset):
   print '_____ do python lint'


### PR DESCRIPTION
Find the way to do this.
The pull request is for Header guard checker for cameo.
1. We should ignore header guard in *_messages.h, because they will be included with different macros for multiple times, so they don't need header guard.
2. Header path in cameo should count to the root dir of chromium, which is supported by a work around previously.(the work around is to rename .git folder in cameo), Now I've overwrite the logic to get project root dir.
