### PR TITLE
[TestUtils] Fix that browsertest will hang sometimes at trybots

### DIFF
--- a/src/test/base/cameo_test_utils.cc
+++ b/src/test/base/cameo_test_utils.cc
@@ -4,6 +4,8 @@
 
 #include "cameo/src/test/base/cameo_test_utils.h"
 
+#include <set>
+
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "base/logging.h"
@@ -19,6 +21,7 @@
 #include "content/public/browser/notification_source.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/content_switches.h"
+#include "content/public/common/result_codes.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_navigation_observer.h"
 #include "content/public/test/test_utils.h"
@@ -76,6 +79,73 @@ void NavigateToURL(cameo::Runtime* runtime, const GURL& url) {
   navigation_observer.WaitForObservation(
       base::Bind(&content::RunThisRunLoop, base::Unretained(&run_loop)),
       content::GetQuitTaskForRunLoop(&run_loop));
+}
+
+class ChildProcessFilter : public base::ProcessFilter {
+ public:
+  explicit ChildProcessFilter(base::ProcessId parent_pid)
+      : parent_pids_(&parent_pid, (&parent_pid) + 1) {}
+
+  explicit ChildProcessFilter(const std::vector<base::ProcessId>& parent_pids)
+      : parent_pids_(parent_pids.begin(), parent_pids.end()) {}
+
+  virtual bool Includes(const base::ProcessEntry& entry) const OVERRIDE {
+    return parent_pids_.find(entry.parent_pid()) != parent_pids_.end();
+  }
+
+ private:
+  const std::set<base::ProcessId> parent_pids_;
+
+  DISALLOW_COPY_AND_ASSIGN(ChildProcessFilter);
+};
+
+const base::FilePath::StringType GetRunningRuntimeExecutableName() {
+  const CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  return cmd_line->GetProgram().BaseName().value();
+}
+
+CameoProcessList GetRunningCameoProcesses(base::ProcessId runtime_pid) {
+  const base::FilePath::StringType executable_name =
+      GetRunningRuntimeExecutableName();
+  CameoProcessList result;
+  if (runtime_pid == static_cast<base::ProcessId>(-1))
+    return result;
+
+  ChildProcessFilter filter(runtime_pid);
+  base::NamedProcessIterator it(executable_name, &filter);
+  while (const base::ProcessEntry* process_entry = it.NextProcessEntry()) {
+    result.push_back(process_entry->pid());
+  }
+
+#if defined(OS_POSIX) && !defined(OS_MACOSX)
+  // On Unix we might be running with a zygote process for the renderers.
+  // Because of that we sweep the list of processes again and pick those which
+  // are children of one of the processes that we've already seen.
+  {
+    ChildProcessFilter filter(result);
+    base::NamedProcessIterator it(executable_name, &filter);
+    while (const base::ProcessEntry* process_entry = it.NextProcessEntry())
+      result.push_back(process_entry->pid());
+  }
+#endif  // defined(OS_POSIX) && !defined(OS_MACOSX)
+
+  return result;
+}
+
+void TerminateAllCameoProcesses(const CameoProcessList& process_pids) {
+  CameoProcessList::const_iterator it;
+  for (it = process_pids.begin(); it != process_pids.end(); ++it) {
+    DLOG(INFO) << "Killing child processes: " << *it;
+    base::ProcessHandle handle;
+    if (!base::OpenProcessHandle(*it, &handle)) {
+      // Ignore processes for which we can't open the handle. We don't
+      // guarantee that all processes will terminate, only try to do so.
+      continue;
+    }
+
+    base::KillProcess(handle, content::RESULT_CODE_KILLED, true);
+    base::CloseProcessHandle(handle);
+  }
 }
 
 }  // namespace cameo_test_utils

--- a/src/test/base/cameo_test_utils.h
+++ b/src/test/base/cameo_test_utils.h
@@ -6,9 +6,11 @@
 #define CAMEO_SRC_TEST_BASE_CAMEO_TEST_UTILS_H_
 
 #include <string>
+#include <vector>
 
 #include "base/compiler_specific.h"
 #include "base/files/file_path.h"
+#include "base/process_util.h"
 #include "googleurl/src/gurl.h"
 
 namespace cameo {
@@ -19,6 +21,8 @@ class CommandLine;
 
 // A set of utilities for test code that launches separate processes.
 namespace cameo_test_utils {
+
+typedef std::vector<base::ProcessId> CameoProcessList;
 
 // Appends browser switches to provided |command_line| to be used
 // when running under tests.
@@ -39,6 +43,13 @@ base::FilePath GetTestFilePath(const base::FilePath& dir,
 // Navigate a specified URL in the given Runtime. It will block until the
 // navigation completes.
 void NavigateToURL(cameo::Runtime* runtime, const GURL& url);
+
+// Returns a vector of PIDs of all cameo processes (main and renderers etc)
+// based on |runtime_pid|, the PID of the main runtime process.
+CameoProcessList GetRunningCameoProcesses(base::ProcessId runtime_pid);
+
+// Attempts to terminate all cameo processes in |process_list|.
+void TerminateAllCameoProcesses(const CameoProcessList& process_pids);
 
 }  // namespace cameo_test_utils
 

--- a/src/test/base/in_process_browser_test.cc
+++ b/src/test/base/in_process_browser_test.cc
@@ -133,5 +133,8 @@ bool InProcessBrowserTest::CreateDataPathDir() {
 }
 
 void InProcessBrowserTest::QuitAllRuntimes() {
+  cameo_test_utils::CameoProcessList processes =
+      cameo_test_utils::GetRunningCameoProcesses(base::GetCurrentProcId());
   RuntimeRegistry::Get()->CloseAll();
+  cameo_test_utils::TerminateAllCameoProcesses(processes);
 }


### PR DESCRIPTION
The hung process is the render process of one of the test cases.
The stack trace shows that it hangs on a dead lock of tc_malloc.

The root cause of the deadlock is not found yet.
A guess will be that some thread get the lock but not existed in
the forked process.

The solution is referencing upstream issue:
https://code.google.com/p/chromium/issues/detail?id=177218

BUG=https://github.com/otcshare/build-infrastructure/issues/107
