### PR TITLE
Implement dynamically-loadable extensions

### DIFF
--- a/src/extensions/browser/cameo_extension.cc
+++ b/src/extensions/browser/cameo_extension.cc
@@ -7,8 +7,7 @@
 namespace cameo {
 namespace extensions {
 
-CameoExtension::CameoExtension(const std::string& name)
-    : name_(name) {}
+CameoExtension::CameoExtension() {}
 
 CameoExtension::~CameoExtension() {}
 

--- a/src/extensions/browser/cameo_extension.h
+++ b/src/extensions/browser/cameo_extension.h
@@ -22,7 +22,7 @@ class CameoExtensionWrapper;
 // keep separated state for each execution.
 class CameoExtension {
  public:
-  explicit CameoExtension(const std::string& name);
+  explicit CameoExtension();
   virtual ~CameoExtension();
 
   // Returns the JavaScript API code that will be executed in the
@@ -61,6 +61,9 @@ class CameoExtension {
   virtual Context* CreateContext(const PostMessageCallback& post_message) = 0;
 
   std::string name() const { return name_; }
+
+ protected:
+  void set_name(const std::string& name) { name_ = name; }
 
  private:
   friend class CameoExtensionWrapper;

--- a/src/extensions/browser/cameo_extension_external.cc
+++ b/src/extensions/browser/cameo_extension_external.cc
@@ -1,0 +1,114 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/src/extensions/browser/cameo_extension_external.h"
+
+#include "base/files/file_path.h"
+#include "base/logging.h"
+#include "base/scoped_native_library.h"
+#include "cameo/src/extensions/browser/cameo_extension.h"
+
+namespace cameo {
+namespace extensions {
+
+#include "cameo/src/extensions/public/cameo_extension_public.h"
+
+static const int32_t kImplementedAPIVersion = 1;
+
+CameoExternalExtension::CameoExternalExtension(
+      const base::FilePath& library_path)
+      : CameoExtension::CameoExtension()
+      , library_(new base::ScopedNativeLibrary(library_path))
+      , wrapped_(0) {
+  if (!library_->is_valid())
+    return;
+
+  typedef CCameoExtension* (*EntryPoint)(int32_t api_version);
+  EntryPoint initialize = reinterpret_cast<EntryPoint>(
+        library_->GetFunctionPointer("cameo_extension_init"));
+  if (!initialize)
+    return;
+
+  wrapped_ = initialize(kImplementedAPIVersion);
+  if (wrapped_)
+    set_name(wrapped_->name);
+}
+
+CameoExternalExtension::~CameoExternalExtension() {
+  if (wrapped_->shutdown)
+    wrapped_->shutdown(wrapped_);
+  delete library_;
+}
+
+bool CameoExternalExtension::is_valid() {
+  if (!library_)
+    return false;
+  if (!library_->is_valid())
+    return false;
+
+  if (!wrapped_)
+    return false;
+  if (wrapped_->api_version != kImplementedAPIVersion)
+    return false;
+  if (!wrapped_->get_javascript)
+    return false;
+  if (!wrapped_->context_create)
+    return false;
+
+  return true;
+}
+
+const char* CameoExternalExtension::GetJavaScriptAPI() {
+  return wrapped_->get_javascript(wrapped_);
+}
+
+CameoExtension::Context* CameoExternalExtension::CreateContext(
+      const CameoExtension::PostMessageCallback& post_message) {
+  CCameoExtensionContext* context = wrapped_->context_create(wrapped_);
+  if (!context)
+    return NULL;
+
+  return new ExternalContext(this, post_message, context);
+}
+
+CameoExternalExtension::ExternalContext::ExternalContext(
+      CameoExternalExtension* extension,
+      const CameoExtension::PostMessageCallback& post_message,
+      CCameoExtensionContext* context)
+      : CameoExtension::Context(post_message)
+      , context_(context) {
+  context->internal_data = this;
+  context->api = GetAPIWrappers();
+}
+
+const CCameoExtensionContextAPI*
+      CameoExternalExtension::ExternalContext::GetAPIWrappers() {
+  static const CCameoExtensionContextAPI api = {
+    .post_message = &PostMessageWrapper
+  };
+
+  return &api;
+}
+
+void CameoExternalExtension::ExternalContext::PostMessageWrapper(
+      CCameoExtensionContext* context, const char* msg) {
+  CameoExternalExtension::ExternalContext* self =
+        reinterpret_cast<CameoExternalExtension::ExternalContext*>(
+              context->internal_data);
+  self->PostMessage(msg);
+}
+
+void CameoExternalExtension::ExternalContext::HandleMessage(
+      const std::string& msg) {
+  if (context_->handle_message)
+    context_->handle_message(context_, msg.c_str());
+}
+
+CameoExternalExtension::ExternalContext::~ExternalContext() {
+  if (context_->destroy)
+    context_->destroy(context_);
+}
+
+}  // namespace extensions
+}  // namespace cameo

--- a/src/extensions/browser/cameo_extension_external.h
+++ b/src/extensions/browser/cameo_extension_external.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_EXTERNAL_H_
+#define CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_EXTERNAL_H_
+
+#include <string>
+#include "cameo/src/extensions/browser/cameo_extension.h"
+
+namespace base {
+class FilePath;
+class ScopedNativeLibrary;
+};
+
+namespace cameo {
+namespace extensions {
+
+typedef struct CCameoExtension_ CCameoExtension;
+typedef struct CCameoExtensionContext_ CCameoExtensionContext;
+typedef struct CCameoExtensionContextAPI_ CCameoExtensionContextAPI;
+
+// CameoExternalExtension bridges an extension contained in a shared
+// library. See extensions/public/cameo_extension_public.h for details
+// of how this library should be implemented.
+// Note that POD are used in the borders to keep compatibility with the C
+// ABI.
+class CameoExternalExtension : public CameoExtension {
+ public:
+  explicit CameoExternalExtension(const base::FilePath& library_path);
+  virtual ~CameoExternalExtension();
+
+  virtual const char* GetJavaScriptAPI();
+
+  virtual CameoExtension::Context* CreateContext(
+      const CameoExtension::PostMessageCallback& post_message);
+
+  bool is_valid();
+
+ private:
+  class ExternalContext : public CameoExtension::Context {
+   private:
+     CCameoExtensionContext* context_;
+
+     static const CCameoExtensionContextAPI* GetAPIWrappers();
+     static void PostMessageWrapper(CCameoExtensionContext* context,
+                                    const char* message);
+   public:
+     ExternalContext(
+        CameoExternalExtension* external,
+        const CameoExtension::PostMessageCallback& post_message,
+        CCameoExtensionContext* context);
+    ~ExternalContext();
+
+    virtual void HandleMessage(const std::string& msg) OVERRIDE;
+  };
+
+  base::ScopedNativeLibrary* library_;
+  CCameoExtension* wrapped_;
+
+  DISALLOW_COPY_AND_ASSIGN(CameoExternalExtension);
+};
+
+}  // namespace extensions
+}  // namespace cameo
+
+#endif  // CAMEO_SRC_EXTENSIONS_BROWSER_CAMEO_EXTENSION_EXTERNAL_H_

--- a/src/extensions/browser/cameo_extension_web_contents_handler.cc
+++ b/src/extensions/browser/cameo_extension_web_contents_handler.cc
@@ -68,9 +68,17 @@ class CameoExtensionRunner {
 
   void CreateContext() {
     CHECK(CalledOnExtensionThread());
-    context_.reset(extension_->CreateContext(
-        base::Bind(&CameoExtensionRunner::PostMessage,
-                   base::Unretained(this))));
+
+    CameoExtension::Context* context = extension_->CreateContext(base::Bind(
+          &CameoExtensionRunner::PostMessage, base::Unretained(this)));
+    if (!context) {
+      VLOG(0) << "Could not create context for extension \"" <<
+            extension_->name() << "\". Destroying extension thread.";
+      delete this;
+      return;
+    }
+
+    context_.reset(context);
   }
 
   void DestroyContext() {

--- a/src/extensions/extensions.gypi
+++ b/src/extensions/extensions.gypi
@@ -1,6 +1,8 @@
 {
   'sources': [
     'browser/cameo_extension.cc',
+    'browser/cameo_extension_external.cc',
+    'browser/cameo_extension_external.h',
     'browser/cameo_extension.h',
     'browser/cameo_extension_service.cc',
     'browser/cameo_extension_service.h',
@@ -8,9 +10,10 @@
     'browser/cameo_extension_web_contents_handler.h',
     'common/cameo_extension_messages.cc',
     'common/cameo_extension_messages.h',
-    'renderer/cameo_extension_render_view_handler.cc',
-    'renderer/cameo_extension_render_view_handler.h',
+    'public/cameo_extension_public.h',
     'renderer/cameo_extension_renderer_controller.cc',
     'renderer/cameo_extension_renderer_controller.h',
+    'renderer/cameo_extension_render_view_handler.cc',
+    'renderer/cameo_extension_render_view_handler.h',
   ],
 }

--- a/src/extensions/public/cameo_extension_public.h
+++ b/src/extensions/public/cameo_extension_public.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_SRC_EXTENSIONS_PUBLIC_CAMEO_EXTENSION_PUBLIC_H_
+#define CAMEO_SRC_EXTENSIONS_PUBLIC_CAMEO_EXTENSION_PUBLIC_H_
+
+// Extensions should #define WANT_IMPLEMENTATION before including this
+// file. Also, please note the comments below for implementation details
+// that extension implmentors should be aware of.
+#ifdef WANT_IMPLEMENTATION
+#include <assert.h>
+#endif  // WANT_IMPLEMENTATION
+
+#include <stdint.h>
+
+typedef struct CCameoExtension_           CCameoExtension;
+typedef struct CCameoExtensionContext_    CCameoExtensionContext;
+typedef struct CCameoExtensionContextAPI_ CCameoExtensionContextAPI;
+
+typedef void (*ExtensionShutdownCallback)(CCameoExtension* extension);
+typedef const char* (*ExtensionGetJavaScriptCallback)(
+      CCameoExtension* extension);
+typedef CCameoExtensionContext* (*ExtensionContextCreateCallback)(
+      CCameoExtension* extension);
+
+typedef void (*ExtensionContextDestroyCallback)(
+      CCameoExtensionContext* context);
+typedef void (*ExtensionContextHandleMessageCallback)(
+      CCameoExtensionContext* context, const char* message);
+
+typedef void (*ExtensionContextPostMessageCallback)(
+      CCameoExtensionContext* context, const char* message);
+
+struct CCameoExtension_ {
+  int32_t api_version;
+
+  // Version 1
+  const char* name;
+
+  ExtensionGetJavaScriptCallback get_javascript;
+  ExtensionShutdownCallback shutdown;
+  ExtensionContextCreateCallback context_create;
+};
+
+struct CCameoExtensionContextAPI_ {
+  // Version 1
+  ExtensionContextPostMessageCallback post_message;
+};
+
+struct CCameoExtensionContext_ {
+  void* internal_data;
+  const CCameoExtensionContextAPI* api;
+
+  // Version 1 */
+  ExtensionContextDestroyCallback destroy;
+  ExtensionContextHandleMessageCallback handle_message;
+};
+
+#ifdef WANT_IMPLEMENTATION
+// This function should be implemented and exported in the shared
+// object. The ``api_version'' parameter will contain the maximum
+// version supported by Cameo.
+// On a successful invocation, this function should return a pointer
+// to a CCameoExtension structure, with the fields:
+// - api_version, filled with the API version the extension implements.
+// - name, with the extension name (used by cameo.postMessage() and
+//   friends).
+// - get_javascript, filled with a pointer to a function that returns
+//   the JavaScript shim to be available in all page contexts.
+// - shutdown, filled with a pointer to a function that is called
+//   whenever this extension is shut down (e.g. Cameo terminating). NULL
+//   is fine.
+// - context_create, filled with a pointer to a function that creates
+//   an extension context (see comment below).
+CCameoExtension* cameo_extension_init(int32_t api_version);
+
+// A CCameoExtension structure holds the global state for a extension.
+// Due to the multithreaded way Cameo is written, one should not
+// store mutable state there. That's the reason CCameoExtensionContext
+// exists: so each page context has its own state and there's no need
+// to worry about race conditions while keeping state between contexts.
+//
+// The first two fields of a context (internal_data and api) should not
+// be tampered with. The following fields, though, should be filled:
+// - destroy, with a pointer to a function that will be called whenever
+//   a particular context is about to be destroyed.
+// - handle_message, with a pointer to a function that will be called
+//   whenever a message arrives from the JavaScript side.
+//
+// To post a message to the JavaScript side, one can simply call
+// cameo_extension_context_post_message(), defined below. Cameo will
+// handle all the multithreading details so it is safe to call this
+// whenever necessary.
+
+static void cameo_extension_context_post_message(
+      CCameoExtensionContext* context, const char* message) {
+  assert(context);
+  assert(context->api);
+  assert(context->api->post_message);
+  assert(message);
+
+  context->api->post_message(context, message);
+}
+#endif  // WANT_IMPLEMENTATION
+
+#endif  // CAMEO_SRC_EXTENSIONS_PUBLIC_CAMEO_EXTENSION_PUBLIC_H_

--- a/src/runtime/browser/cameo_browser_main_parts.cc
+++ b/src/runtime/browser/cameo_browser_main_parts.cc
@@ -8,8 +8,10 @@
 
 #include "base/bind.h"
 #include "base/command_line.h"
+#include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
 #include "base/strings/string_number_conversions.h"
+#include "cameo/src/extensions/browser/cameo_extension_external.h"
 #include "cameo/src/extensions/browser/cameo_extension_service.h"
 #include "cameo/src/runtime/browser/devtools/remote_debugging_server.h"
 #include "cameo/src/runtime/browser/runtime.h"
@@ -21,6 +23,8 @@
 #include "net/base/net_util.h"
 
 namespace cameo {
+
+using extensions::CameoExternalExtension;
 
 CameoBrowserMainParts::CameoBrowserMainParts(
     const content::MainFunctionParams& parameters)
@@ -53,11 +57,41 @@ void CameoBrowserMainParts::PostMainMessageLoopStart() {
 void CameoBrowserMainParts::PreEarlyInitialization() {
 }
 
+void CameoBrowserMainParts::RegisterExternalExtensions() {
+  if (!startup_url_.SchemeIsFile()) {
+    VLOG(0) << "Unsupported scheme for external extensions: " <<
+          startup_url_.scheme();
+    return;
+  }
+
+  base::FilePath where(startup_url_.path());
+  where.Append("extensions");
+  // FIXME(leandro): Use GetNativeLibraryName() to obtain the proper
+  // extension for the current platform.
+  const base::FilePath::StringType pattern = FILE_PATH_LITERAL("*.so");
+  base::FileEnumerator libraries(where, false, base::FileEnumerator::FILES,
+        pattern);
+
+  for (base::FilePath extension_path = libraries.Next();
+        !extension_path.empty(); extension_path = libraries.Next()) {
+    CameoExternalExtension* extension =
+          new CameoExternalExtension(extension_path);
+
+    if (extension->is_valid()) {
+      extension_service_->RegisterExtension(extension);
+    } else {
+      delete extension;
+    }
+  }
+}
+
 void CameoBrowserMainParts::PreMainMessageLoopRun() {
   runtime_context_.reset(new RuntimeContext);
   runtime_registry_.reset(new RuntimeRegistry);
   extension_service_.reset(
       new extensions::CameoExtensionService(runtime_registry_.get()));
+
+  RegisterExternalExtensions();
 
   CommandLine* command_line = CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kRemoteDebuggingPort)) {

--- a/src/runtime/browser/cameo_browser_main_parts.h
+++ b/src/runtime/browser/cameo_browser_main_parts.h
@@ -41,6 +41,8 @@ class CameoBrowserMainParts : public content::BrowserMainParts {
   }
 
  private:
+  void RegisterExternalExtensions();
+
   scoped_ptr<RuntimeContext> runtime_context_;
 
   // An application wide instance to manage all Runtime instances.


### PR DESCRIPTION
This basically wraps the C++ CameoExtension API in a simple C API. This not only avoids name mangling problems, but also allows creating plugins without Cameo and Chromium source code; except, of course, for the cameo_extension_public.h header file.

Dynamically-loadable extensions to allow running applications such as the Brackets editor should follow soon.
