### PR TITLE
Use our own resource_ids files

### DIFF
--- a/cameo.gyp
+++ b/cameo.gyp
@@ -197,6 +197,7 @@
         {
           'action_name': 'cameo_resources',
           'variables': {
+            'grit_resource_ids': 'src/runtime/resources/resource_ids',
             'grit_grd_file': 'src/runtime/resources/cameo_resources.grd',
           },
           'includes': [ '../build/grit_action.gypi' ],

--- a/src/runtime/resources/resource_ids
+++ b/src/runtime/resources/resource_ids
@@ -1,0 +1,17 @@
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Check src/tools/gritsettings/resource_ids for details. As of today,
+# ids after 31000 are reserved to projects using Chromium, which is
+# our case.
+
+{
+  "SRCDIR": "../../../..",
+
+  "cameo/src/runtime/resources/cameo_resources.grd": {
+    "includes": [31000],
+    "structures": [31500],
+    "messages": [32000],
+  },
+}


### PR DESCRIPTION
Instead of changing the file in Chromium, we can pass our own
file. Reduces the number of necessary changes on top of Chromium for
the Runtime.
