### PR TITLE
Enable download function on Runtime

### DIFF
--- a/cameo.gyp
+++ b/cameo.gyp
@@ -77,6 +77,8 @@
         'runtime/browser/runtime.h',
         'runtime/browser/runtime_context.cc',
         'runtime/browser/runtime_context.h',
+        'runtime/browser/runtime_download_manager_delegate.cc',
+        'runtime/browser/runtime_download_manager_delegate.h',
         'runtime/browser/runtime_file_select_helper.cc',
         'runtime/browser/runtime_file_select_helper.h',
         'runtime/browser/runtime_network_delegate.cc',

--- a/cameo_tests.gypi
+++ b/cameo_tests.gypi
@@ -89,6 +89,7 @@
       'HAS_OUT_OF_PROC_TEST_RUNNER',
     ],
     'sources': [
+      'runtime/browser/cameo_download_browsertest.cc',
       'runtime/browser/cameo_form_input_browsertest.cc',
       'runtime/browser/cameo_runtime_browsertest.cc',
       'runtime/browser/cameo_switches_browsertest.cc',

--- a/runtime/browser/cameo_download_browsertest.cc
+++ b/runtime/browser/cameo_download_browsertest.cc
@@ -1,0 +1,83 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/file_util.h"
+#include "base/files/file_path.h"
+#include "base/string_util.h"
+#include "base/utf_string_conversions.h"
+#include "cameo/runtime/browser/runtime.h"
+#include "cameo/runtime/browser/runtime_download_manager_delegate.h"
+#include "cameo/runtime/browser/ui/color_chooser.h"
+#include "cameo/test/base/cameo_test_utils.h"
+#include "cameo/test/base/in_process_browser_test.h"
+#include "content/browser/download/download_manager_impl.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/download_test_observer.h"
+#include "content/public/test/test_utils.h"
+
+using cameo::Runtime;
+using cameo::RuntimeDownloadManagerDelegate;
+using content::DownloadItem;
+using content::DownloadManager;
+using content::DownloadManagerImpl;
+using content::DownloadTestObserver;
+using content::DownloadTestObserverTerminal;
+using content::BrowserContext;
+
+namespace {
+
+static DownloadManagerImpl* DownloadManagerForCameo(Runtime* runtime) {
+  return static_cast<DownloadManagerImpl*>(
+      BrowserContext::GetDownloadManager(
+          runtime->web_contents()->GetBrowserContext()));
+}
+
+class CameoDownloadBroswerTest : public InProcessBrowserTest {
+ public:
+  virtual void SetUpOnMainThread() OVERRIDE {
+    ASSERT_TRUE(downloads_directory_.CreateUniqueTempDir());
+
+    DownloadManagerImpl* manager = DownloadManagerForCameo(runtime());
+    RuntimeDownloadManagerDelegate* delegate =
+        static_cast<RuntimeDownloadManagerDelegate*>(manager->GetDelegate());
+    delegate->SetDownloadBehaviorForTesting(downloads_directory_.path());
+  }
+
+  // Create a DownloadTestObserverTerminal that will wait for the
+  // specified number of downloads to finish.
+  DownloadTestObserver* CreateWaiter(Runtime* runtime, int num_downloads) {
+    DownloadManager* download_manager = DownloadManagerForCameo(runtime);
+    return new DownloadTestObserverTerminal(download_manager, num_downloads,
+        DownloadTestObserver::ON_DANGEROUS_DOWNLOAD_FAIL);
+  }
+
+ private:
+  // Location of the downloads directory for these tests
+  base::ScopedTempDir downloads_directory_;
+};
+
+IN_PROC_BROWSER_TEST_F(CameoDownloadBroswerTest, FileDownload) {
+  GURL url = cameo_test_utils::GetTestURL(
+      base::FilePath().AppendASCII("download"),
+      base::FilePath().AppendASCII("test.lib"));
+  scoped_ptr<DownloadTestObserver> observer(CreateWaiter(runtime(), 1));
+  cameo_test_utils::NavigateToURL(runtime(), url);
+  observer->WaitForFinished();
+  EXPECT_EQ(1u, observer->NumDownloadsSeenInState(DownloadItem::COMPLETE));
+  std::vector<DownloadItem*> downloads;
+  DownloadManagerForCameo(runtime())->GetAllDownloads(&downloads);
+  ASSERT_EQ(1u, downloads.size());
+  ASSERT_EQ(DownloadItem::COMPLETE, downloads[0]->GetState());
+  base::FilePath file(downloads[0]->GetFullPath());
+  ASSERT_TRUE(file_util::ContentsEqual(
+      file, cameo_test_utils::GetTestFilePath(
+          base::FilePath().AppendASCII("download"),
+          base::FilePath().AppendASCII("test.lib"))));
+}
+
+}  // namespace

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -7,6 +7,7 @@
 #include "base/command_line.h"
 #include "base/logging.h"
 #include "base/path_service.h"
+#include "cameo/runtime/browser/runtime_download_manager_delegate.h"
 #include "cameo/runtime/browser/runtime_url_request_context_getter.h"
 #include "cameo/runtime/common/cameo_paths.h"
 #include "cameo/runtime/common/cameo_switches.h"
@@ -16,6 +17,7 @@
 #include "content/public/common/content_switches.h"
 
 using content::BrowserThread;
+using content::DownloadManager;
 
 namespace cameo {
 
@@ -77,7 +79,14 @@ bool RuntimeContext::IsOffTheRecord() const {
 }
 
 content::DownloadManagerDelegate* RuntimeContext::GetDownloadManagerDelegate() {
-  return NULL;
+  content::DownloadManager* manager = BrowserContext::GetDownloadManager(this);
+
+  if (!download_manager_delegate_) {
+    download_manager_delegate_ = new RuntimeDownloadManagerDelegate();
+    download_manager_delegate_->SetDownloadManager(manager);
+  }
+
+  return download_manager_delegate_.get();
 }
 
 net::URLRequestContextGetter* RuntimeContext::GetRequestContext() {

--- a/runtime/browser/runtime_context.h
+++ b/runtime/browser/runtime_context.h
@@ -22,6 +22,7 @@ class DownloadManagerDelegate;
 
 namespace cameo {
 
+class RuntimeDownloadManagerDelegate;
 class RuntimeURLRequestContextGetter;
 
 class RuntimeContext : public content::BrowserContext {
@@ -66,6 +67,7 @@ class RuntimeContext : public content::BrowserContext {
   void InitWhileIOAllowed();
 
   scoped_ptr<RuntimeResourceContext> resource_context_;
+  scoped_refptr<RuntimeDownloadManagerDelegate> download_manager_delegate_;
   scoped_refptr<RuntimeURLRequestContextGetter> url_request_getter_;
 
   DISALLOW_COPY_AND_ASSIGN(RuntimeContext);

--- a/runtime/browser/runtime_download_manager_delegate.cc
+++ b/runtime/browser/runtime_download_manager_delegate.cc
@@ -1,0 +1,202 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cameo/runtime/browser/runtime_download_manager_delegate.h"
+
+#if defined(TOOLKIT_GTK)
+#include <gtk/gtk.h>
+#endif
+
+#if defined(OS_WIN)
+#include <windows.h>
+#include <commdlg.h>
+#endif
+
+#include <string>
+
+#include "base/bind.h"
+#include "base/command_line.h"
+#include "base/file_util.h"
+#include "base/logging.h"
+#include "base/string_util.h"
+#include "base/utf_string_conversions.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/download_manager.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_view.h"
+#include "content/shell/shell_switches.h"
+#include "content/shell/webkit_test_controller.h"
+#include "net/base/net_util.h"
+
+using content::BrowserThread;
+
+namespace cameo {
+
+RuntimeDownloadManagerDelegate::RuntimeDownloadManagerDelegate()
+    : download_manager_(NULL),
+      suppress_prompting_(false) {
+  // Balanced in Shutdown();
+  AddRef();
+}
+
+RuntimeDownloadManagerDelegate::~RuntimeDownloadManagerDelegate() {}
+
+void RuntimeDownloadManagerDelegate::SetDownloadManager(
+    content::DownloadManager* download_manager) {
+  download_manager_ = download_manager;
+}
+
+void RuntimeDownloadManagerDelegate::Shutdown() {
+  Release();
+}
+
+bool RuntimeDownloadManagerDelegate::DetermineDownloadTarget(
+    content::DownloadItem* download,
+    const content::DownloadTargetCallback& callback) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  // This assignment needs to be here because even at the call to
+  // SetDownloadManager, the system is not fully initialized.
+  if (default_download_path_.empty()) {
+    default_download_path_ = download_manager_->GetBrowserContext()->GetPath().
+        Append(FILE_PATH_LITERAL("Downloads"));
+  }
+
+  if (!download->GetForcedFilePath().empty()) {
+    callback.Run(download->GetForcedFilePath(),
+                 content::DownloadItem::TARGET_DISPOSITION_OVERWRITE,
+                 content::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS,
+                 download->GetForcedFilePath());
+    return true;
+  }
+
+  base::FilePath generated_name = net::GenerateFileName(
+      download->GetURL(),
+      download->GetContentDisposition(),
+      EmptyString(),
+      download->GetSuggestedFilename(),
+      download->GetMimeType(),
+      "download");
+
+  BrowserThread::PostTask(
+      BrowserThread::FILE,
+      FROM_HERE,
+      base::Bind(
+          &RuntimeDownloadManagerDelegate::GenerateFilename,
+          this, download->GetId(), callback, generated_name,
+          default_download_path_));
+  return true;
+}
+
+bool RuntimeDownloadManagerDelegate::ShouldOpenDownload(
+      content::DownloadItem* item,
+      const content::DownloadOpenDelayedCallback& callback) {
+  return true;
+}
+
+void RuntimeDownloadManagerDelegate::GenerateFilename(
+    int32 download_id,
+    const content::DownloadTargetCallback& callback,
+    const base::FilePath& generated_name,
+    const base::FilePath& suggested_directory) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::FILE));
+  if (!file_util::PathExists(suggested_directory))
+    file_util::CreateDirectory(suggested_directory);
+
+  base::FilePath suggested_path(suggested_directory.Append(generated_name));
+  BrowserThread::PostTask(
+      BrowserThread::UI,
+      FROM_HERE,
+      base::Bind(
+          &RuntimeDownloadManagerDelegate::OnDownloadPathGenerated,
+          this, download_id, callback, suggested_path));
+}
+
+void RuntimeDownloadManagerDelegate::OnDownloadPathGenerated(
+    int32 download_id,
+    const content::DownloadTargetCallback& callback,
+    const base::FilePath& suggested_path) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  if (suppress_prompting_) {
+    // Testing exit.
+    callback.Run(suggested_path,
+                 content::DownloadItem::TARGET_DISPOSITION_OVERWRITE,
+                 content::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS,
+                 suggested_path.AddExtension(FILE_PATH_LITERAL(".crdownload")));
+    return;
+  }
+
+  ChooseDownloadPath(download_id, callback, suggested_path);
+}
+
+void RuntimeDownloadManagerDelegate::ChooseDownloadPath(
+    int32 download_id,
+    const content::DownloadTargetCallback& callback,
+    const base::FilePath& suggested_path) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  content::DownloadItem* item = download_manager_->GetDownload(download_id);
+  if (!item || (item->GetState() != content::DownloadItem::IN_PROGRESS))
+    return;
+
+  base::FilePath result;
+#if defined(OS_WIN) && !defined(USE_AURA)
+  std::wstring file_part = base::FilePath(suggested_path).BaseName().value();
+  wchar_t file_name[MAX_PATH];
+  base::wcslcpy(file_name, file_part.c_str(), arraysize(file_name));
+  OPENFILENAME save_as;
+  ZeroMemory(&save_as, sizeof(save_as));
+  save_as.lStructSize = sizeof(OPENFILENAME);
+  save_as.hwndOwner = item->GetWebContents()->GetView()->GetNativeView();
+  save_as.lpstrFile = file_name;
+  save_as.nMaxFile = arraysize(file_name);
+
+  std::wstring directory;
+  if (!suggested_path.empty())
+    directory = suggested_path.DirName().value();
+
+  save_as.lpstrInitialDir = directory.c_str();
+  save_as.Flags = OFN_OVERWRITEPROMPT | OFN_EXPLORER | OFN_ENABLESIZING |
+                  OFN_NOCHANGEDIR | OFN_PATHMUSTEXIST;
+
+  if (GetSaveFileName(&save_as))
+    result = base::FilePath(std::wstring(save_as.lpstrFile));
+#elif defined(TOOLKIT_GTK)
+  GtkWidget* dialog;
+  gfx::NativeWindow parent_window;
+  std::string base_name = base::FilePath(suggested_path).BaseName().value();
+
+  parent_window = item->GetWebContents()->GetView()->GetTopLevelNativeWindow();
+  dialog = gtk_file_chooser_dialog_new("Save File",
+                                       parent_window,
+                                       GTK_FILE_CHOOSER_ACTION_SAVE,
+                                       GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+                                       GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
+                                       NULL);
+  gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog),
+                                                 TRUE);
+  gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog),
+                                    base_name.c_str());
+
+  if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
+    char* filename;
+    filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+    result = base::FilePath(filename);
+  }
+  gtk_widget_destroy(dialog);
+#else
+  NOTIMPLEMENTED();
+#endif
+
+  callback.Run(result, content::DownloadItem::TARGET_DISPOSITION_PROMPT,
+               content::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS, result);
+}
+
+void RuntimeDownloadManagerDelegate::SetDownloadBehaviorForTesting(
+    const base::FilePath& default_download_path) {
+  default_download_path_ = default_download_path;
+  suppress_prompting_ = true;
+}
+
+}  // namespace cameo

--- a/runtime/browser/runtime_download_manager_delegate.h
+++ b/runtime/browser/runtime_download_manager_delegate.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAMEO_RUNTIME_BROWSER_RUNTIME_DOWNLOAD_MANAGER_DELEGATE_H_
+#define CAMEO_RUNTIME_BROWSER_RUNTIME_DOWNLOAD_MANAGER_DELEGATE_H_
+
+#include "base/compiler_specific.h"
+#include "base/memory/ref_counted.h"
+#include "content/public/browser/download_manager_delegate.h"
+
+namespace cameo {
+
+class RuntimeDownloadManagerDelegate
+    : public content::DownloadManagerDelegate,
+      public base::RefCountedThreadSafe<RuntimeDownloadManagerDelegate> {
+ public:
+  RuntimeDownloadManagerDelegate();
+
+  void SetDownloadManager(content::DownloadManager* manager);
+
+  virtual void Shutdown() OVERRIDE;
+  virtual bool DetermineDownloadTarget(
+      content::DownloadItem* download,
+      const content::DownloadTargetCallback& callback) OVERRIDE;
+  virtual bool ShouldOpenDownload(
+      content::DownloadItem* item,
+      const content::DownloadOpenDelayedCallback& callback) OVERRIDE;
+
+  // Inhibits prompting and sets the default download path.
+  void SetDownloadBehaviorForTesting(
+      const base::FilePath& default_download_path);
+
+ protected:
+  // To allow subclasses for testing.
+  virtual ~RuntimeDownloadManagerDelegate();
+
+ private:
+  friend class base::RefCountedThreadSafe<RuntimeDownloadManagerDelegate>;
+
+  void GenerateFilename(int32 download_id,
+                        const content::DownloadTargetCallback& callback,
+                        const base::FilePath& generated_name,
+                        const base::FilePath& suggested_directory);
+  void OnDownloadPathGenerated(int32 download_id,
+                               const content::DownloadTargetCallback& callback,
+                               const base::FilePath& suggested_path);
+  void ChooseDownloadPath(int32 download_id,
+                          const content::DownloadTargetCallback& callback,
+                          const base::FilePath& suggested_path);
+
+  content::DownloadManager* download_manager_;
+  base::FilePath default_download_path_;
+  bool suppress_prompting_;
+
+  DISALLOW_COPY_AND_ASSIGN(RuntimeDownloadManagerDelegate);
+};
+
+}  // namespace cameo
+
+#endif  // CAMEO_RUNTIME_BROWSER_RUNTIME_DOWNLOAD_MANAGER_DELEGATE_H_

--- a/test/data/download/test.lib
+++ b/test/data/download/test.lib
@@ -1,0 +1,3 @@
+Random byte that looks binary for sniffing: 
+The quick brow fox jumped over the lazy dog
+(In earlier tellings, the dog had a better reputation.)


### PR DESCRIPTION
Currently, download function can't work, it resulted ino crash directly,
since DownloadManagerDelegate class wasn't implemented.

This patch implemented DownloadManagerDelegate interface, like what
content shell is doing.

Issue: https://github.com/otcshare/cameo/issues/106
