### PR TITLE
Fix gclient sync failed to fetch chromium deps

### DIFF
--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -67,9 +67,8 @@ class FolderExistGitWrapper(gclient_scm.GitWrapper):
       try:
         # git fetch for chromium will take a looooong time for the
         # first time, so set timeout for 30 minutes
-        self._Run(fetch_cmd, options=options, cwd=self.checkout_path,
-                  filter_fn=_GitFilter, print_stdout=False,
-                  nag_timer=30, nag_max=60)
+        self._Run(fetch_cmd, options, cwd=self.checkout_path,
+                  git_filter=True, nag_timer=30, nag_max=60)
         break
       except subprocess2.CalledProcessError, e:
         if e.returncode == 128:
@@ -100,8 +99,8 @@ class FolderExistGitWrapper(gclient_scm.GitWrapper):
           co_args = ['-b', branch, revision]
     else:
       co_args = ['-b', 'master', 'origin/master']
-    self._Run(['checkout'] + co_args, options=options, cwd=self.checkout_path,
-              filter_fn=_GitFilter, print_stdout=False)
+    self._Run(['checkout'] + co_args, options, cwd=self.checkout_path,
+              git_filter=True)
 
   def DoInitAndCheckout(self, options):
     # Do git init if necessary


### PR DESCRIPTION
It's because that upstream depot tools update the
arg "options" in gclient_scm.GitWrapper._Run to
"_options", which makes the call in fetch_deps.py failed.
