### PR TITLE
Make sure cameo_extension_init() function is marked as `extern "C"`.

### DIFF
--- a/extensions/public/cameo_extension_public.h
+++ b/extensions/public/cameo_extension_public.h
@@ -72,13 +72,19 @@ struct CCameoExtensionContext_ {
 //   an extension context (see comment below).
 
 #if defined(_WIN32)
-#define CAMEO_EXTENSION_PUBLIC_EXPORT __declspec(dllexport)
+#define PUBLIC_EXPORT __declspec(dllexport)
 #else
-#define CAMEO_EXTENSION_PUBLIC_EXPORT __attribute__((visibility("default")))
+#define PUBLIC_EXPORT __attribute__((visibility("default")))
 #endif
 
-CAMEO_EXTENSION_PUBLIC_EXPORT CCameoExtension* cameo_extension_init(
-    int32_t api_version);
+#if defined(__cplusplus)
+#define EXTERN_C extern "C"
+#else
+#define EXTERN_C
+#endif
+
+EXTERN_C PUBLIC_EXPORT CCameoExtension* cameo_extension_init(
+      int32_t api_version);
 
 // A CCameoExtension structure holds the global state for a extension.
 // Due to the multithreaded way Cameo is written, one should not
@@ -106,6 +112,10 @@ static void cameo_extension_context_post_message(
 
   context->api->post_message(context, message);
 }
+
+#undef PUBLIC_EXPORT
+#undef EXTERN_C
+
 #endif  // INTERNAL_IMPLEMENTATION
 
 #endif  // CAMEO_EXTENSIONS_PUBLIC_CAMEO_EXTENSION_PUBLIC_H_


### PR DESCRIPTION
This avoids name mangling when building external extensions with a C++ compiler.
