### PR TITLE
Switch to set the path to look for external extensions

### DIFF
--- a/runtime/common/cameo_switches.cc
+++ b/runtime/common/cameo_switches.cc
@@ -15,4 +15,8 @@ const char kAppIcon[] = "app-icon";
 
 // Specifies the window whether launched with fullscreen mode.
 const char kFullscreen[] = "fullscreen";
+
+// Specifies where XWalk will look for external extensions.
+const char kXWalkExternalExtensionsPath[] = "external-extensions-path";
+
 }  // namespace switches

--- a/runtime/common/cameo_switches.h
+++ b/runtime/common/cameo_switches.h
@@ -13,6 +13,9 @@ extern const char kCameoDataPath[];
 extern const char kAppIcon[];
 
 extern const char kFullscreen[];
+
+extern const char kXWalkExternalExtensionsPath[];
+
 }  // namespace switches
 
 #endif  // CAMEO_RUNTIME_COMMON_CAMEO_SWITCHES_H_


### PR DESCRIPTION
Pass --external-extensions-path=/path/to/extensions to make XWalk load
extensions from there. Removed the previous default to look at
"startup_dir/extensions". If not path is passed, no external
extensions will be loaded.
