### PR TITLE
Fix: #103 Unable to play MP4 format video on video website. v4

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -82,6 +82,25 @@ def additional_include_files(args=[]):
 if __name__ == '__main__':
   args = sys.argv[1:]
 
+  # Support external media types capability such as MP4/MP3.
+  args = list(set(args)) 
+  delist = []
+  ip_media_codecs = False # Default: no third-party codecs be build in.
+  for arg in args:
+    if arg.startswith('-Dproprietary_codecs') or arg.startswith('-Dffmpeg_branding'):
+      continue
+    elif arg == '-Dmediacodecs_EULA=1':
+      ip_media_codecs = True  # Exception: mediacodecs_EULA be enabled.
+    else:
+      delist.append(arg)
+
+  args = delist 
+  args.append('-Dproprietary_codecs=1')
+
+  # Triggering media playback dynamically with third-party codecs by owner. 
+  if ip_media_codecs == True:
+      args.append('-Dffmpeg_branding=Chrome')
+
   # Use the Psyco JIT if available.
   if psyco:
     psyco.profile()

--- a/tools/build/linux/FILES.cfg
+++ b/tools/build/linux/FILES.cfg
@@ -35,10 +35,6 @@ FILES = [
     'filename': 'xwalk.pak',
     'buildtype': ['dev', 'official'],
   },
-  {
-    'filename': 'libffmpegsumo.so',
-    'buildtype': ['dev'],
-  },
 # installer creation scripts
   {
     'filename': 'create_linux_installer.sh',

--- a/tools/build/win/FILES.cfg
+++ b/tools/build/win/FILES.cfg
@@ -34,10 +34,6 @@ FILES = [
     'buildtype': ['dev', 'official'],
   },
   {
-    'filename': 'ffmpegsumo.dll',
-    'buildtype': ['dev'],
-  },
-  {
     'filename': 'xwalk.pak',
     'buildtype': ['dev', 'official'],
   },
@@ -74,11 +70,6 @@ FILES = [
   {
     'filename': 'xwalk.exe.pdb',
     'buildtype': ['dev', 'official'],
-    'archive': 'xwalk-win32-syms.zip',
-  },
-  {
-    'filename': 'ffmpegsumo.dll.pdb',
-    'buildtype': ['dev'],
     'archive': 'xwalk-win32-syms.zip',
   },
   {


### PR DESCRIPTION
Default: No third-party media codec build in.
The private and proprietary owned codecs need be packaged by codecs
    owner such as 'ffmpegsumo.dll' or 'libffmpegsumo.so'.

The default be overridable at the command line by "-Dmediacodecs_EULA=1".
