### PR TITLE
Move extensions system JS code to its own file

### DIFF
--- a/extensions/extensions.gypi
+++ b/extensions/extensions.gypi
@@ -15,5 +15,9 @@
     'renderer/xwalk_extension_renderer_controller.h',
     'renderer/xwalk_extension_render_view_handler.cc',
     'renderer/xwalk_extension_render_view_handler.h',
+    'renderer/xwalk_api.js',
+  ],
+  'includes': [
+    'xwalk_js2c.gypi',
   ],
 }

--- a/extensions/renderer/xwalk_api.js
+++ b/extensions/renderer/xwalk_api.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+var xwalk = xwalk || {};
+
+xwalk.postMessage = function(extension, msg) {
+  native function PostMessage();
+  PostMessage(extension, msg);
+};
+
+xwalk._message_listeners = {};
+
+xwalk.setMessageListener = function(extension, callback) {
+  if (callback === undefined)
+    delete xwalk._message_listeners[extension];
+  else
+    xwalk._message_listeners[extension] = callback;
+};
+
+xwalk.onpostmessage = function(extension, msg) {
+  var listener = xwalk._message_listeners[extension];
+  if (listener !== undefined)
+    listener(msg);
+};

--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -11,6 +11,9 @@
 #include "third_party/WebKit/Source/WebKit/chromium/public/WebScriptSource.h"
 #include "v8/include/v8.h"
 
+// This will be generated from xwalk_api.js.
+extern const char kSource_xwalk_api[];
+
 namespace xwalk {
 namespace extensions {
 
@@ -26,29 +29,8 @@ class XWalkExtensionV8Wrapper : public v8::Extension {
   static v8::Handle<v8::Value> PostMessage(const v8::Arguments& args);
 };
 
-// FIXME(cmarcelo): Implement this in C++ instead of JS. Tie it to the
-// window object lifetime.
-static const char* const kXWalkExtensionV8WrapperAPI =
-    "var xwalk = xwalk || {};"
-    "xwalk.postMessage = function(extension, msg) {"
-    "  native function PostMessage();"
-    "  PostMessage(extension, msg);"
-    "};"
-    "xwalk._message_listeners = {};"
-    "xwalk.setMessageListener = function(extension, callback) {"
-    "  if (callback === undefined)"
-    "    delete xwalk._message_listeners[extension];"
-    "  else"
-    "    xwalk._message_listeners[extension] = callback;"
-    "};"
-    "xwalk.onpostmessage = function(extension, msg) {"
-    "  var listener = xwalk._message_listeners[extension];"
-    "  if (listener !== undefined)"
-    "    listener(msg);"
-    "};";
-
 XWalkExtensionV8Wrapper::XWalkExtensionV8Wrapper()
-    : v8::Extension("xwalk", kXWalkExtensionV8WrapperAPI) {
+    : v8::Extension("xwalk", kSource_xwalk_api) {
 }
 
 v8::Handle<v8::FunctionTemplate>

--- a/extensions/tools/generate_api.py
+++ b/extensions/tools/generate_api.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import sys
+
+TEMPLATE = """\
+extern const char %s[];
+const char %s[] = { %s, 0 };
+"""
+
+js_code = sys.argv[1]
+lines = file(js_code).read()
+c_code = ', '.join(str(ord(c)) for c in lines)
+
+symbol_name = sys.argv[2]
+output = open(sys.argv[3], "w")
+output.write(TEMPLATE % (symbol_name, symbol_name, c_code))
+output.close()

--- a/extensions/xwalk_js2c.gypi
+++ b/extensions/xwalk_js2c.gypi
@@ -1,0 +1,24 @@
+{
+  'rules': [
+    {
+      'rule_name': 'xwalk_js2c',
+      'extension': 'js',
+      'msvs_external_rule': 1,
+      'inputs': [
+        'tools/generate_api.py',
+      ],
+      'outputs': [
+        '<(SHARED_INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).cc'
+      ],
+      'process_outputs_as_sources': 1,
+      'action': [
+        'python',
+        '<@(_inputs)',
+        '<(RULE_INPUT_PATH)',
+        'kSource_<(RULE_INPUT_ROOT)',
+        '<@(_outputs)',
+      ],
+      'message': 'Generating code from <(RULE_INPUT_PATH)',
+    },
+  ],
+}


### PR DESCRIPTION
Use a Python script to read a JS file and write out a "const char[]"
to make the data available for C++ code during compile time.

Rationale: it improves the readability of the code by avoiding to
quote the code line by line.

TEST=xwalk_browsertest cover whether basic xwalk.\* API is working
