### PR TITLE
Implement Dialog Extension

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Caio Marcelo de Oliveira Filho <caio.de.oliveira.filho@intel.com>
 Girish Ramakrishnan <girish.ramakrishnan@intel.com>
 Gao Chun <chun.gao@intel.com>
 Hongbo Min <hongbo.min@intel.com>
+Jesus Sanchez-Palencia <jesus.sanchez-palencia.fernandez.fil@intel.com>
 John Chen <zhang.z.chen@intel.com>
 Junmin Zhu <junmin.zhu@intel.com>
 Kenneth Rohde Christiansen <kenneth.r.christiansen@intel.com>

--- a/experimental/dialog/dialog.gypi
+++ b/experimental/dialog/dialog.gypi
@@ -1,0 +1,7 @@
+{
+  'sources': [
+    'dialog_extension.h',
+    'dialog_extension.cc',
+    'dialog_api.js',
+  ],
+}

--- a/experimental/dialog/dialog_api.js
+++ b/experimental/dialog/dialog_api.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+xwalk.experimental = xwalk.experimental || {};
+
+(function() {
+
+  var _callbacks = {};
+  var _next_reply_id = 0;
+
+  var postMessage = function(msg, callback) {
+    var reply_id = _next_reply_id;
+    _next_reply_id += 1;
+    _callbacks[reply_id] = callback;
+    msg._reply_id = reply_id.toString();
+    xwalk.postMessage('xwalk.experimental.dialog', JSON.stringify(msg));
+  };
+
+  xwalk.setMessageListener('xwalk.experimental.dialog', function(json) {
+    var msg = JSON.parse(json);
+    var reply_id = msg._reply_id;
+    var callback = _callbacks[reply_id];
+    if (callback) {
+      delete msg._reply_id;
+      delete _callbacks[reply_id];
+      callback(msg);
+    } else {
+      console.log('Invalid reply_id received from xwalk.experimental.dialog extension: ' + reply_id);
+    }
+  });
+
+  xwalk.experimental.dialog = xwalk.experimental.dialog || {};
+  xwalk.experimental.dialog.showOpenDialog = function (allowMultipleSelection, chooseDirectory, title, initialPath, fileTypes, callback) {
+    var msg = {
+      'cmd': 'ShowOpenDialog',
+      'allow_multiple_selection': allowMultipleSelection,
+      'choose_directory': chooseDirectory,
+      'title': title,
+      'initial_path': initialPath,
+      'file_types': fileTypes
+    };
+
+    postMessage(msg, function(r) {
+      callback(0, r.file);
+    });
+  }
+
+  xwalk.experimental.dialog.showSaveDialog = function (title, initialPath, proposedNewFilename, callback) {
+    var msg = {
+      'cmd': 'ShowSaveDialog',
+      'title': title,
+      'initial_path': initialPath,
+      'proposed_name': proposedNewFilename
+    };
+
+    postMessage(msg, function(r) {
+      callback(0, r.file);
+    });
+  }
+
+})();

--- a/experimental/dialog/dialog_extension.cc
+++ b/experimental/dialog/dialog_extension.cc
@@ -1,0 +1,176 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/experimental/dialog/dialog_extension.h"
+
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
+#include "base/strings/utf_string_conversions.h"
+#include "content/public/browser/browser_thread.h"
+
+using content::BrowserThread;
+
+// This will be generated from dialog_api.js.
+extern const char kSource_dialog_api[];
+
+namespace xwalk {
+
+DialogExtension::DialogExtension(RuntimeRegistry* runtime_registry)
+  : XWalkExtension(),
+    runtime_registry_(runtime_registry),
+    owning_window_(NULL) {
+  set_name("xwalk.experimental.dialog");
+  runtime_registry_->AddObserver(this);
+}
+
+DialogExtension::~DialogExtension() {
+  runtime_registry_->RemoveObserver(this);
+}
+
+const char* DialogExtension::GetJavaScriptAPI() {
+  return kSource_dialog_api;
+}
+
+XWalkExtension::Context* DialogExtension::CreateContext(
+  const XWalkExtension::PostMessageCallback& post_message) {
+  return new DialogContext(this, post_message);
+}
+
+void DialogExtension::OnRuntimeAdded(Runtime* runtime) {
+  // FIXME(cmarcelo): We only support one runtime! (like MenuExtension)
+  if (owning_window_)
+    return;
+  owning_window_ = runtime->window()->GetNativeWindow();
+}
+
+DialogContext::DialogContext(DialogExtension* extension,
+  const XWalkExtension::PostMessageCallback& post_message)
+  : XWalkExtension::Context(post_message),
+    extension_(extension),
+    dialog_(NULL) {
+}
+
+void DialogContext::HandleShowOpenDialog(const base::DictionaryValue* input) {
+  CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+
+  std::string reply_id;
+  input->GetString("_reply_id", &reply_id);
+  std::string* reply_id_ptr = new std::string(reply_id);
+
+  bool is_multiple_selection = false;
+  input->GetBoolean("allow_multiple_selection", &is_multiple_selection);
+
+  bool is_choose_directory = false;
+  input->GetBoolean("choose_directory", &is_choose_directory);
+
+  std::string title;
+  input->GetString("title", &title);
+  string16 title16;
+  UTF8ToUTF16(title.c_str(), title.length(), &title16);
+
+  base::FilePath::StringType initial_path;
+  input->GetString("title", &initial_path);
+
+  base::FilePath::StringType file_extension;
+
+  SelectFileDialog::Type dialog_type = SelectFileDialog::SELECT_OPEN_FILE;
+  if (is_choose_directory)
+    dialog_type = SelectFileDialog::SELECT_FOLDER;
+  else if (is_multiple_selection)
+    dialog_type = SelectFileDialog::SELECT_OPEN_MULTI_FILE;
+
+  if (!dialog_)
+    dialog_ = ui::SelectFileDialog::Create(this, 0 /* policy */);
+
+  // FIXME(jeez): implement file_type and file_extension support.
+  dialog_->SelectFile(dialog_type, title16, base::FilePath(initial_path),
+    NULL /* file_type */, 0 /* type_index */, file_extension,
+    extension_->owning_window_, reply_id_ptr);
+}
+
+void DialogContext::HandleShowSaveDialog(const base::DictionaryValue* input) {
+  CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+
+  std::string reply_id;
+  input->GetString("_reply_id", &reply_id);
+  std::string* reply_id_ptr = new std::string(reply_id);
+
+  std::string title;
+  input->GetString("title", &title);
+  string16 title16;
+  UTF8ToUTF16(title.c_str(), title.length(), &title16);
+
+  base::FilePath::StringType initial_path;
+  input->GetString("initial_path", &initial_path);
+
+  base::FilePath::StringType proposed_filename;
+  input->GetString("proposed_name", &proposed_filename);
+
+  base::FilePath::StringType file_extension;
+
+  if (!dialog_)
+    dialog_ = ui::SelectFileDialog::Create(this, 0 /* policy */);
+
+  dialog_->SelectFile(SelectFileDialog::SELECT_SAVEAS_FILE, title16,
+    base::FilePath(initial_path).Append(proposed_filename),
+    NULL /* file_type */, 0 /* type_index */, file_extension,
+    extension_->owning_window_, reply_id_ptr);
+}
+
+void DialogContext::HandleMessage(const std::string& msg) {
+  if (!BrowserThread::CurrentlyOn(BrowserThread::UI)) {
+    BrowserThread::PostTask(
+      BrowserThread::UI, FROM_HERE,
+      base::Bind(&DialogContext::HandleMessage, base::Unretained(this), msg));
+    return;
+  }
+
+  scoped_ptr<base::Value> v(base::JSONReader().ReadToValue(msg));
+  const base::DictionaryValue* input = static_cast<base::DictionaryValue*>(
+    v.get());
+
+  std::string cmd;
+  input->GetString("cmd", &cmd);
+
+  if (cmd == "ShowOpenDialog")
+    HandleShowOpenDialog(input);
+  else if (cmd == "ShowSaveDialog")
+    HandleShowSaveDialog(input);
+}
+
+void DialogContext::FileSelected(const base::FilePath& path,
+  int index, void* params) {
+  std::string* reply_id = static_cast<std::string*>(params);
+  scoped_ptr<base::DictionaryValue> output(new base::DictionaryValue);
+  output->SetString("_reply_id", *reply_id);
+  output->SetString("file", path.value());
+
+  std::string result;
+  base::JSONWriter::Write(output.get(), &result);
+  PostMessage(result);
+
+  delete reply_id;
+}
+
+void DialogContext::MultiFilesSelected(
+  const std::vector<base::FilePath>& files, void* params) {
+  std::string* reply_id = static_cast<std::string*>(params);
+  scoped_ptr<base::DictionaryValue> output(new base::DictionaryValue);
+  output->SetString("_reply_id", *reply_id);
+
+  base::ListValue* filesList = new base::ListValue;
+  std::vector<base::FilePath>::const_iterator it;
+  for (it = files.begin(); it != files.end(); ++it)
+    filesList->AppendString(it->value());
+
+  output->Set("file", filesList);
+
+  std::string result;
+  base::JSONWriter::Write(output.get(), &result);
+  PostMessage(result);
+
+  delete reply_id;
+}
+
+}  // namespace xwalk

--- a/experimental/dialog/dialog_extension.h
+++ b/experimental/dialog/dialog_extension.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXPERIMENTAL_DIALOG_DIALOG_EXTENSION_H_
+#define XWALK_EXPERIMENTAL_DIALOG_DIALOG_EXTENSION_H_
+
+#include <string>
+#include <vector>
+#include "base/files/file_path.h"
+#include "base/values.h"
+#include "ui/shell_dialogs/select_file_dialog.h"
+#include "xwalk/extensions/browser/xwalk_extension.h"
+#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/runtime/browser/runtime_registry.h"
+
+using ui::SelectFileDialog;
+
+namespace xwalk {
+
+using extensions::XWalkExtension;
+
+class DialogExtension : public XWalkExtension,
+                        public RuntimeRegistryObserver {
+ public:
+  explicit DialogExtension(RuntimeRegistry* runtime_registry);
+  virtual ~DialogExtension();
+
+  // XWalkExtension implementation.
+  virtual const char* GetJavaScriptAPI() OVERRIDE;
+  virtual Context* CreateContext(
+    const PostMessageCallback& post_message) OVERRIDE;
+
+    // RuntimeRegistryObserver implementation.
+  virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE;
+  virtual void OnRuntimeRemoved(Runtime* runtime) OVERRIDE {}
+  virtual void OnRuntimeAppIconChanged(Runtime* runtime) OVERRIDE {}
+
+ private:
+  friend class DialogContext;
+
+  RuntimeRegistry* runtime_registry_;
+  gfx::NativeWindow owning_window_;
+};
+
+
+class DialogContext : public XWalkExtension::Context,
+                      public SelectFileDialog::Listener {
+ public:
+  DialogContext(DialogExtension* extension,
+    const XWalkExtension::PostMessageCallback& post_message);
+
+  virtual void HandleMessage(const std::string& msg);
+
+  // ui::SelectFileDialog::Listener implementation.
+  virtual void FileSelected(const base::FilePath& path,
+    int index, void* params);
+  virtual void MultiFilesSelected(
+    const std::vector<base::FilePath>& files, void* params);
+
+ private:
+  void HandleShowOpenDialog(const base::DictionaryValue* input);
+  void HandleShowSaveDialog(const base::DictionaryValue* input);
+
+  DialogExtension* extension_;
+  scoped_refptr<SelectFileDialog> dialog_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_EXPERIMENTAL_DIALOG_DIALOG_EXTENSION_H_

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -11,6 +11,7 @@
 #include "base/file_util.h"
 #include "base/files/file_path.h"
 #include "base/strings/string_number_conversions.h"
+#include "xwalk/experimental/dialog/dialog_extension.h"
 #include "xwalk/extensions/browser/xwalk_extension_external.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/runtime/browser/devtools/remote_debugging_server.h"
@@ -106,6 +107,7 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
   extension_service_.reset(
       new extensions::XWalkExtensionService(runtime_registry_.get()));
 
+  RegisterInternalExtensions();
   RegisterExternalExtensions();
 
   CommandLine* command_line = CommandLine::ForCurrentProcess();
@@ -141,6 +143,11 @@ bool XWalkBrowserMainParts::MainMessageLoopRun(int* result_code) {
 
 void XWalkBrowserMainParts::PostMainMessageLoopRun() {
   runtime_context_.reset();
+}
+
+void XWalkBrowserMainParts::RegisterInternalExtensions() {
+  extension_service_->RegisterExtension(
+      new DialogExtension(runtime_registry_.get()));  // experimental
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -42,6 +42,7 @@ class XWalkBrowserMainParts : public content::BrowserMainParts {
 
  private:
   void RegisterExternalExtensions();
+  void RegisterInternalExtensions();
 #if defined(OS_MACOSX)
   void PreMainMessageLoopStartMac();
 #endif

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -55,6 +55,7 @@
       ],
       'includes': [
         'extensions/extensions.gypi',
+        'experimental/dialog/dialog.gypi',
       ],
       'sources': [
         'runtime/app/xwalk_main_delegate.cc',


### PR DESCRIPTION
This patch provides an experimental JS API that enables
apps to use native dialogs through xwalk.experimental.dialog.

Two methods are provided: xwalk.experimental.dialog.showOpenDialog
and xwalk.experimental.dialog.showSaveDialog. Their prototypes are:
- showOpenDialog = function (allowMultipleSelection, chooseDirectory, title, initialPath, fileTypes, callback)

*allowMultipleSelection - If true then multiple files/directories can be selected.
*chooseDirectory - If true then only directories can be selected.
*title - Title of the open dialog.
*initialPath - Initial path to display in the dialog. NULL or "" for current path.
*fileTypes - Array of strings specifying the selectable file extensions.
*callback = function(error, selection) - Async callback. Selection is an array of the names of the selected files.
- showSaveDialog = function (title, initialPath, proposedNewFilename, callback)

*title - Title of the Save As dialog.
*initialPath - Initial path to display in the dialog. NULL or "" for current path.
*proposedNewFilename - Filename proposal to be used for saving the file.
*callback = function(error, absoluteFilePath) - Async callback. Absolutefilepath is the absolute path to the saved file.
