### PR TITLE
Add support of fetch deps libraries for Android build.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Leandro Pereira <leandro.pereira@intel.com>
 Li Yin <li.yin@intel.com>
 Ningxin Hu <ningxin.hu@intel.com>
 Shiliu Wang <shiliu.wang@intel.com>
+Shouqun Liu <shouqun.liu@intel.com>

--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -220,6 +220,11 @@ class DepsFetcher(gclient_utils.WorkItem):
     gclient_file = open(self._new_gclient_file, 'w')
     print "Place %s with solutions:\n%s" % (self._new_gclient_file, solutions)
     gclient_file.write('solutions = %s' % pprint.pformat(solutions))
+    # Check whether the target OS is Android.
+    if os.environ.get('XWALK_OS_ANDROID'):
+      target_os = ['android']
+      gclient_file.write('\n')
+      gclient_file.write('target_os = %s' % target_os)
 
   def DoGclientSyncForChromium(self):
     gclient_cmd = ['gclient', 'sync', '--verbose', '--reset',


### PR DESCRIPTION
Android build needs a special set of third party libraries(android_tools, guava,
jsr...), this requires the "target_os=['android']" to be added in gclient file.

Environment variable "XWALK_OS_ANDROID" should be defined before sync.

Also add me to the AUTHORS file.
