### PR TITLE
Add envsetup.sh for Android env setup and build.

### DIFF
--- a/build/android/envsetup.sh
+++ b/build/android/envsetup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE:-$0}")"
+
+. ${SCRIPT_DIR}/../../../build/android/envsetup.sh "$@"
+
+xwalk_android_gyp() {
+  echo "GYP_GENERATORS set to '$GYP_GENERATORS'"
+  (
+    "${CHROME_SRC}/xwalk/gyp_xwalk" --check "$@"
+  )
+}


### PR DESCRIPTION
The directory structure follows the upstream Chromium, Android related build
scripts are put into 'build/android'.

For basic Android content shell build steps:
 $cd $CHROME_SRC
 $. xwalk/build/android/envsetup.sh --target-arch=x86
 $ninja -C out/Debug content_shell_apk
