### PR TITLE
Use an unique ID for Crosswalk Extension IPC messages

### DIFF
--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -5,7 +5,13 @@
 #include <string>
 #include "ipc/ipc_message_macros.h"
 
-#define IPC_MESSAGE_START ExtensionMsgStart
+// Note: it is safe to use numbers after LastIPCMsgStart since that limit
+// is not relevant for embedders. It is used only by a tool inside chrome/
+// that we currently don't use.
+// See also https://code.google.com/p/chromium/issues/detail?id=110911.
+const int XWalkExtensionMsgStart = LastIPCMsgStart + 1;
+
+#define IPC_MESSAGE_START XWalkExtensionMsgStart
 
 IPC_MESSAGE_ROUTED2(XWalkViewHostMsg_PostMessage,  // NOLINT(*)
                     std::string /* target extension */,


### PR DESCRIPTION
We were reusing ExtensionMsgStart, but it is not needed, we can simply
take a number after the existing ones. The LastIPCMsgStart is
currently used only by certain Chrome tools, so we won't miss anything
for being a number larger than the last.
