### PR TITLE
[Android] Enable remote debugging

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkDevToolsServer.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkDevToolsServer.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import org.chromium.base.JNINamespace;
+
+/**
+ * Controller for Remote Web Debugging (Developer Tools).
+ */
+@JNINamespace("xwalk")
+public class XWalkDevToolsServer {
+
+    private int mNativeDevToolsServer = 0;
+
+    public XWalkDevToolsServer(String socketName) {
+        mNativeDevToolsServer = nativeInitRemoteDebugging(socketName);
+    }
+
+    public void destroy() {
+        nativeDestroyRemoteDebugging(mNativeDevToolsServer);
+        mNativeDevToolsServer = 0;
+    }
+
+    public boolean isRemoteDebuggingEnabled() {
+        return nativeIsRemoteDebuggingEnabled(mNativeDevToolsServer);
+    }
+
+    public void setRemoteDebuggingEnabled(boolean enabled) {
+        nativeSetRemoteDebuggingEnabled(mNativeDevToolsServer, enabled);
+    }
+
+    private native int nativeInitRemoteDebugging(String socketName);
+    private native void nativeDestroyRemoteDebugging(int devToolsServer);
+    private native boolean nativeIsRemoteDebuggingEnabled(int devToolsServer);
+    private native void nativeSetRemoteDebuggingEnabled(int devToolsServer, boolean enabled);
+}

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -11,9 +11,12 @@ import android.util.AttributeSet;
 import android.webkit.WebSettings;
 import android.widget.FrameLayout;
 
+import org.xwalk.core.XWalkDevToolsServer;
+
 public class XWalkView extends FrameLayout {
 
     XWalkContent mContent;
+    XWalkDevToolsServer mDevToolsServer;
 
     public XWalkView(Context context) {
         this(context, null);
@@ -95,6 +98,26 @@ public class XWalkView extends FrameLayout {
     }
 
     public void setXWalkClient(XWalkClient client) {
+    }
+
+    public void enableRemoteDebugging() {
+        if (mDevToolsServer != null) {
+            disableRemoteDebugging();
+        }
+        // Chrome looks for "devtools_remote" pattern in the name of a unix domain socket
+        // to identify a debugging page
+        final String socketName = getContext().getPackageName();
+        mDevToolsServer = new XWalkDevToolsServer(socketName + "_devtools_remote");
+        mDevToolsServer.setRemoteDebuggingEnabled(true);
+    }
+
+    public void disableRemoteDebugging() {
+        if (mDevToolsServer ==  null) {
+            return;
+        }
+        mDevToolsServer.setRemoteDebuggingEnabled(false);
+        mDevToolsServer.destroy();
+        mDevToolsServer = null;
     }
 
     public void onPause() {

--- a/runtime/android/shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -74,6 +74,8 @@ public class XWalkViewShellActivity extends Activity {
         initializeUrlField();
         initializeNavigationButtons();
         initializeXWalkViewClients();
+
+        mView.enableRemoteDebugging();
     }
 
     @Override

--- a/runtime/app/android/xwalk_jni_registrar.cc
+++ b/runtime/app/android/xwalk_jni_registrar.cc
@@ -11,6 +11,7 @@
 #include "xwalk/runtime/browser/android/xwalk_content.h"
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
 #include "xwalk/runtime/browser/android/xwalk_web_contents_delegate.h"
+#include "xwalk/runtime/browser/android/xwalk_dev_tools_server.h"
 
 namespace xwalk {
 
@@ -22,6 +23,7 @@ static base::android::RegistrationMethod kXWalkRegisteredMethods[] = {
   { "XWalkContentsClientBridge", RegisterXWalkContentsClientBridge },
   { "XWalkContent", RegisterXWalkContent },
   { "XWalkWebContentsDelegate", RegisterXWalkWebContentsDelegate },
+  { "XWalkDevToolsServer", RegisterXWalkDevToolsServer },
 };
 
 bool RegisterJni(JNIEnv* env) {

--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -1,0 +1,147 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/android/xwalk_dev_tools_server.h"
+
+#include "base/android/jni_string.h"
+#include "base/basictypes.h"
+#include "base/bind.h"
+#include "base/callback.h"
+#include "base/compiler_specific.h"
+#include "base/logging.h"
+#include "base/stringprintf.h"
+#include "content/public/browser/android/devtools_auth.h"
+#include "content/public/browser/devtools_http_handler.h"
+#include "content/public/browser/devtools_http_handler_delegate.h"
+#include "jni/XWalkDevToolsServer_jni.h"
+#include "net/socket/unix_domain_socket_posix.h"
+
+namespace {
+
+// FIXME(girish): The frontend URL needs to be served from the domain below
+// for remote debugging to work in chrome (see chrome's devtools_ui.cc).
+// Currently, the chrome version is hardcoded because of this dependancy.
+const char kFrontEndURL[] =
+    "http://chrome-devtools-frontend.appspot.com/static/%s/devtools.html";
+// TODO(girish): Get version from build system.
+const char kChromeVersion[] = "28.0.1500.36";
+
+// Delegate implementation for the devtools http handler on android. A new
+// instance of this gets created each time devtools is enabled.
+class XWalkDevToolsServerDelegate : public content::DevToolsHttpHandlerDelegate {
+ public:
+  explicit XWalkDevToolsServerDelegate() {
+  }
+
+  virtual std::string GetDiscoveryPageHTML() OVERRIDE {
+    return std::string();
+  }
+
+  virtual bool BundlesFrontendResources() OVERRIDE {
+    return false;
+  }
+
+  virtual base::FilePath GetDebugFrontendDir() OVERRIDE {
+    return base::FilePath();
+  }
+
+  virtual std::string GetPageThumbnailData(const GURL& url) OVERRIDE {
+    return std::string();
+  }
+
+  virtual content::RenderViewHost* CreateNewTarget() OVERRIDE {
+    return NULL;
+  }
+
+  virtual TargetType GetTargetType(content::RenderViewHost*) OVERRIDE {
+    return kTargetTypeTab;
+  }
+
+  virtual std::string GetViewDescription(content::RenderViewHost*) OVERRIDE {
+    return std::string();
+  }
+
+  virtual scoped_refptr<net::StreamListenSocket> CreateSocketForTethering(
+      net::StreamListenSocket::Delegate* delegate,
+      std::string* name) OVERRIDE {
+    return NULL;
+  }
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(XWalkDevToolsServerDelegate);
+};
+
+}  // namespace
+
+namespace xwalk {
+
+XWalkDevToolsServer::XWalkDevToolsServer(const std::string& socket_name)
+    : socket_name_(socket_name),
+      protocol_handler_(NULL) {
+}
+
+XWalkDevToolsServer::~XWalkDevToolsServer() {
+  Stop();
+}
+
+void XWalkDevToolsServer::Start() {
+  if (protocol_handler_)
+    return;
+
+  protocol_handler_ = content::DevToolsHttpHandler::Start(
+      new net::UnixDomainSocketWithAbstractNamespaceFactory(
+          socket_name_,
+          base::Bind(&content::CanUserConnectToDevTools)),
+      base::StringPrintf(kFrontEndURL, kChromeVersion),
+      new XWalkDevToolsServerDelegate());
+}
+
+void XWalkDevToolsServer::Stop() {
+  if (!protocol_handler_)
+    return;
+  // Note that the call to Stop() below takes care of |protocol_handler_|
+  // deletion.
+  protocol_handler_->Stop();
+  protocol_handler_ = NULL;
+}
+
+bool XWalkDevToolsServer::IsStarted() const {
+  return protocol_handler_;
+}
+
+bool RegisterXWalkDevToolsServer(JNIEnv* env) {
+  return RegisterNativesImpl(env);
+}
+
+static jint InitRemoteDebugging(JNIEnv* env,
+                                jobject obj,
+                                jstring socketName) {
+  XWalkDevToolsServer* server = new XWalkDevToolsServer(
+      base::android::ConvertJavaStringToUTF8(env, socketName));
+  return reinterpret_cast<jint>(server);
+}
+
+static void DestroyRemoteDebugging(JNIEnv* env, jobject obj, jint server) {
+  delete reinterpret_cast<XWalkDevToolsServer*>(server);
+}
+
+static jboolean IsRemoteDebuggingEnabled(JNIEnv* env,
+                                         jobject obj,
+                                         jint server) {
+  return reinterpret_cast<XWalkDevToolsServer*>(server)->IsStarted();
+}
+
+static void SetRemoteDebuggingEnabled(JNIEnv* env,
+                                      jobject obj,
+                                      jint server,
+                                      jboolean enabled) {
+  XWalkDevToolsServer* devtools_server = reinterpret_cast<XWalkDevToolsServer*>(server);
+  if (enabled) {
+    devtools_server->Start();
+  } else {
+    devtools_server->Stop();
+  }
+}
+
+}  // namespace xwalk

--- a/runtime/browser/android/xwalk_dev_tools_server.h
+++ b/runtime/browser/android/xwalk_dev_tools_server.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_ANDROID_XWALK_DEV_TOOLS_SERVER_H_
+#define XWALK_RUNTIME_BROWSER_ANDROID_XWALK_DEV_TOOLS_SERVER_H_
+
+#include <string>
+#include <jni.h>
+#include "base/basictypes.h"
+
+namespace content {
+class DevToolsHttpHandler;
+}
+
+namespace xwalk {
+
+// This class controls Developer Tools remote debugging server.
+class XWalkDevToolsServer {
+ public:
+  XWalkDevToolsServer(const std::string& socket_name);
+  ~XWalkDevToolsServer();
+
+  // Opens linux abstract socket to be ready for remote debugging.
+  void Start();
+
+  // Closes debugging socket, stops debugging.
+  void Stop();
+
+  bool IsStarted() const;
+
+ private:
+  std::string socket_name_;
+  content::DevToolsHttpHandler* protocol_handler_;
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkDevToolsServer);
+};
+
+bool RegisterXWalkDevToolsServer(JNIEnv* env);
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_ANDROID_XWALK_DEV_TOOLS_SERVER_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -68,6 +68,8 @@
         'runtime/browser/android/xwalk_contents_client_bridge.h',
         'runtime/browser/android/xwalk_contents_client_bridge_base.cc',
         'runtime/browser/android/xwalk_contents_client_bridge_base.h',
+        'runtime/browser/android/xwalk_dev_tools_server.cc',
+        'runtime/browser/android/xwalk_dev_tools_server.h',
         'runtime/browser/android/xwalk_web_contents_delegate.cc',
         'runtime/browser/android/xwalk_web_contents_delegate.h',
         'runtime/browser/xwalk_application_mac.h',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -50,6 +50,7 @@
       'sources': [
         'runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java',
         'runtime/android/java/src/org/xwalk/core/XWalkContent.java',
+        'runtime/android/java/src/org/xwalk/core/XWalkDevToolsServer.java',
         'runtime/android/java/src/org/xwalk/core/XWalkWebContentsDelegate.java',
       ],
       'includes': ['../build/jni_generator.gypi'],


### PR DESCRIPTION
For the moment, we reuse Chrome's CDN for delivery of the devtools page.
The CDN itself cannot be changed since it is hardcoded in chrome's code.
