### PR TITLE
Add support for JS to send synchronous messages to extension

### DIFF
--- a/extensions/browser/xwalk_extension_web_contents_handler.cc
+++ b/extensions/browser/xwalk_extension_web_contents_handler.cc
@@ -42,6 +42,7 @@ bool XWalkExtensionWebContentsHandler::OnMessageReceived(
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(XWalkExtensionWebContentsHandler, message)
     IPC_MESSAGE_HANDLER(XWalkViewHostMsg_PostMessage, OnPostMessage)
+    IPC_MESSAGE_HANDLER(XWalkViewHostMsg_SendSyncMessage, OnSendSyncMessage)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
   return handled;
@@ -54,6 +55,17 @@ void XWalkExtensionWebContentsHandler::OnPostMessage(
     it->second->PostMessageToContext(msg);
   else
     LOG(WARNING) << "Couldn't handle message for unregistered extension '"
+                 << extension_name << "'";
+}
+
+void XWalkExtensionWebContentsHandler::OnSendSyncMessage(
+    const std::string& extension_name, const std::string& msg,
+    std::string* result) {
+  RunnerMap::iterator it = runners_.find(extension_name);
+  if (it != runners_.end())
+    *result = it->second->SendSyncMessageToContext(msg);
+  else
+    LOG(WARNING) << "Couldn't handle sync message for unregistered extension '"
                  << extension_name << "'";
 }
 

--- a/extensions/browser/xwalk_extension_web_contents_handler.h
+++ b/extensions/browser/xwalk_extension_web_contents_handler.h
@@ -37,6 +37,8 @@ class XWalkExtensionWebContentsHandler
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
 
   void OnPostMessage(const std::string& extension_name, const std::string& msg);
+  void OnSendSyncMessage(const std::string& extension_name,
+                         const std::string& msg, std::string* result);
 
   friend class content::WebContentsUserData<XWalkExtensionWebContentsHandler>;
   explicit XWalkExtensionWebContentsHandler(content::WebContents* contents);

--- a/extensions/common/xwalk_extension.cc
+++ b/extensions/common/xwalk_extension.cc
@@ -4,6 +4,8 @@
 
 #include "xwalk/extensions/common/xwalk_extension.h"
 
+#include "base/logging.h"
+
 namespace xwalk {
 namespace extensions {
 
@@ -16,6 +18,11 @@ XWalkExtension::Context::Context(const PostMessageCallback& post_message)
 }
 
 XWalkExtension::Context::~Context() {}
+
+std::string XWalkExtension::Context::HandleSyncMessage(const std::string& msg) {
+  LOG(FATAL) << "Sending sync message to extension which doesn't support it!";
+  return std::string();
+}
 
 }  // namespace extensions
 }  // namespace xwalk

--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -41,6 +41,10 @@ class XWalkExtension {
     // process.
     virtual void HandleMessage(const std::string& msg) = 0;
 
+    // Allow to handle synchronous messages sent from JavaScript code. Renderer
+    // will block until this function returns.
+    virtual std::string HandleSyncMessage(const std::string& msg);
+
    protected:
     explicit Context(const PostMessageCallback& post_message);
 

--- a/extensions/common/xwalk_extension_external.h
+++ b/extensions/common/xwalk_extension_external.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef XWALK_EXTENSIONS_BROWSER_XWALK_EXTENSION_EXTERNAL_H_
-#define XWALK_EXTENSIONS_BROWSER_XWALK_EXTENSION_EXTERNAL_H_
+#ifndef XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_EXTERNAL_H_
+#define XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_EXTERNAL_H_
 
 #include <string>
 #include "base/scoped_native_library.h"
@@ -40,20 +40,27 @@ class XWalkExternalExtension : public XWalkExtension {
 
  private:
   class ExternalContext : public XWalkExtension::Context {
-   private:
-     CXWalkExtensionContext* context_;
-
-     static const CXWalkExtensionContextAPI* GetAPIWrappers();
-     static void PostMessageWrapper(CXWalkExtensionContext* context,
-                                    const char* message);
    public:
-     ExternalContext(
+    ExternalContext(
         XWalkExternalExtension* external,
         const XWalkExtension::PostMessageCallback& post_message,
         CXWalkExtensionContext* context);
     virtual ~ExternalContext();
 
+   private:
     virtual void HandleMessage(const std::string& msg) OVERRIDE;
+    virtual std::string HandleSyncMessage(const std::string& msg) OVERRIDE;
+
+    static const CXWalkExtensionContextAPI* GetAPIWrappers();
+    static void PostMessageWrapper(CXWalkExtensionContext* context,
+                                   const char* message);
+    static void SetSyncReplyWrapper(CXWalkExtensionContext* context,
+                                    const char* reply);
+
+    void SetSyncReply(const char* reply);
+
+    CXWalkExtensionContext* context_;
+    std::string sync_reply_;
   };
 
   base::ScopedNativeLibrary library_;
@@ -65,4 +72,4 @@ class XWalkExternalExtension : public XWalkExtension {
 }  // namespace extensions
 }  // namespace xwalk
 
-#endif  // XWALK_EXTENSIONS_BROWSER_XWALK_EXTENSION_EXTERNAL_H_
+#endif  // XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_EXTERNAL_H_

--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -24,3 +24,8 @@ IPC_MESSAGE_ROUTED2(XWalkViewMsg_PostMessage,  // NOLINT(*)
 IPC_MESSAGE_CONTROL2(XWalkViewMsg_RegisterExtension,  // NOLINT(*)
                     std::string /* extension */,
                     std::string /* JS API code for extension */)
+
+IPC_SYNC_MESSAGE_ROUTED2_1(XWalkViewHostMsg_SendSyncMessage,  // NOLINT(*)
+                           std::string /* target extension */,
+                           std::string /* input contents */,
+                           std::string /* output contents */)

--- a/extensions/common/xwalk_extension_runner.cc
+++ b/extensions/common/xwalk_extension_runner.cc
@@ -18,6 +18,11 @@ void XWalkExtensionRunner::PostMessageToContext(const std::string& msg) {
   HandleMessageFromClient(msg);
 }
 
+std::string XWalkExtensionRunner::SendSyncMessageToContext(
+    const std::string& msg) {
+  return HandleSyncMessageFromClient(msg);
+}
+
 void XWalkExtensionRunner::PostMessageToClient(const std::string& msg) {
   client_->HandleMessageFromContext(this, msg);
 }

--- a/extensions/common/xwalk_extension_runner.h
+++ b/extensions/common/xwalk_extension_runner.h
@@ -36,12 +36,14 @@ class XWalkExtensionRunner {
   virtual ~XWalkExtensionRunner();
 
   void PostMessageToContext(const std::string& msg);
+  std::string SendSyncMessageToContext(const std::string& msg);
 
   std::string extension_name() const { return extension_name_; }
 
  protected:
   void PostMessageToClient(const std::string& msg);
   virtual void HandleMessageFromClient(const std::string& msg) = 0;
+  virtual std::string HandleSyncMessageFromClient(const std::string& msg) = 0;
 
   Client* client_;
 

--- a/extensions/common/xwalk_extension_threaded_runner.h
+++ b/extensions/common/xwalk_extension_threaded_runner.h
@@ -9,6 +9,7 @@
 #include "base/callback_forward.h"
 #include "base/compiler_specific.h"
 #include "base/memory/scoped_ptr.h"
+#include "base/synchronization/waitable_event.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
 #include "xwalk/extensions/common/xwalk_extension_runner.h"
 
@@ -33,6 +34,8 @@ class XWalkExtensionThreadedRunner : public XWalkExtensionRunner {
  private:
   // XWalkExtensionRunner implementation.
   virtual void HandleMessageFromClient(const std::string& msg) OVERRIDE;
+  virtual std::string HandleSyncMessageFromClient(
+      const std::string& msg) OVERRIDE;
 
   bool CalledOnExtensionThread() const;
   bool PostTaskToExtensionThread(const tracked_objects::Location& from_here,
@@ -40,9 +43,13 @@ class XWalkExtensionThreadedRunner : public XWalkExtensionRunner {
   void CreateContext();
   void DestroyContext();
 
+  void CallHandleSyncMessage(const std::string& msg, std::string* reply);
+
   scoped_ptr<XWalkExtension::Context> context_;
   scoped_ptr<base::Thread> thread_;
   XWalkExtension* extension_;
+
+  base::WaitableEvent sync_message_event_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkExtensionThreadedRunner);
 };

--- a/extensions/renderer/xwalk_api.js
+++ b/extensions/renderer/xwalk_api.js
@@ -23,3 +23,8 @@ xwalk.onpostmessage = function(extension, msg) {
   if (listener !== undefined)
     listener(msg);
 };
+
+xwalk.sendSyncMessage = function(extension, msg) {
+  native function SendSyncMessage();
+  return SendSyncMessage(extension, msg);
+}

--- a/extensions/renderer/xwalk_extension_render_view_handler.cc
+++ b/extensions/renderer/xwalk_extension_render_view_handler.cc
@@ -41,6 +41,14 @@ bool XWalkExtensionRenderViewHandler::PostMessageToExtension(
   return Send(new XWalkViewHostMsg_PostMessage(routing_id(), extension, msg));
 }
 
+std::string XWalkExtensionRenderViewHandler::SendSyncMessageToExtension(
+    const std::string& extension, const std::string& msg) {
+  std::string reply;
+  Send(new XWalkViewHostMsg_SendSyncMessage(
+      routing_id(), extension, msg, &reply));
+  return reply;
+}
+
 bool XWalkExtensionRenderViewHandler::OnMessageReceived(
     const IPC::Message& message) {
   bool handled = true;

--- a/extensions/renderer/xwalk_extension_render_view_handler.h
+++ b/extensions/renderer/xwalk_extension_render_view_handler.h
@@ -30,6 +30,8 @@ class XWalkExtensionRenderViewHandler
 
   bool PostMessageToExtension(const std::string& extension,
                               const std::string& msg);
+  std::string SendSyncMessageToExtension(const std::string& extension,
+                                         const std::string& msg);
 
   // RenderViewObserver implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;

--- a/extensions/test/data/sync_echo.html
+++ b/extensions/test/data/sync_echo.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>Fail</title>
+</head>
+<body>
+<script>
+document.title = echo.syncEcho("Pass");
+</script>
+</body>
+</html>

--- a/extensions/test/external_extension_browsertest.cc
+++ b/extensions/test/external_extension_browsertest.cc
@@ -48,3 +48,20 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionTest, ExternalExtension) {
   xwalk_test_utils::NavigateToURL(runtime(), url);
   EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
 }
+
+
+// FIXME(cmarcelo): See https://github.com/otcshare/crosswalk/issues/268.
+#if defined(OS_WIN)
+#define ExternalExtensionSync DISABLED_ExternalExtensionSync
+#endif
+
+IN_PROC_BROWSER_TEST_F(ExternalExtensionTest, ExternalExtensionSync) {
+  content::RunAllPendingInMessageLoop();
+  GURL url = GetExtensionsTestURL(
+      base::FilePath(),
+      base::FilePath().AppendASCII("sync_echo.html"));
+  string16 title = ASCIIToUTF16("Pass");
+  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  xwalk_test_utils::NavigateToURL(runtime(), url);
+  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+}

--- a/extensions/test/external_extension_sample.c
+++ b/extensions/test/external_extension_sample.c
@@ -15,6 +15,11 @@ static void context_handle_message(CXWalkExtensionContext* context,
   xwalk_extension_context_post_message(context, message);
 }
 
+static void context_handle_sync_message(CXWalkExtensionContext* context,
+					const char *message) {
+  xwalk_extension_context_set_sync_reply(context, message);
+}
+
 static void context_destroy(CXWalkExtensionContext* context) {
   free(context);
 }
@@ -26,6 +31,7 @@ static CXWalkExtensionContext* context_create(CXWalkExtension* extension) {
 
   context->destroy = context_destroy;
   context->handle_message = context_handle_message;
+  context->handle_sync_message = context_handle_sync_message;
 
   return context;
 }
@@ -41,6 +47,9 @@ static const char* get_javascript(CXWalkExtension* extension) {
       "exports.echo = function(msg, callback) {"
       "  echoListener = callback;"
       "  extension.postMessage(msg);"
+      "};"
+      "exports.syncEcho = function(msg) {"
+      "  return extension.internal.sendSyncMessage(msg);"
       "};";
   return kAPI;
 }


### PR DESCRIPTION
Support a new operation for JS API for extensions to send synchronous
messages to the extension, and get a reply back. It can be used on the
JS by calling

```
var reply = extension.internal.sendSyncMessage("message");
```

and handled at extension level by the new HandleSyncMessage(). The
choice of the term Send is to differentiate from the term Post which
is associated with asynchronous call.

In our current public API (in C) we expose a new callback in the
context struct for handling sync messages. The handler implemented
should call a new exposed function to set the reply. This approach
avoids having to deal with memory ownership of the reply.

I didn't used the versioning on C API for two reasons: we don't care
about versions of the external extension API until we do a proper
release, and this C interface will suffer a non-compatible change soon
-- after the feedback we got developing until now.

This commit adds tests for the sync messages.

NOTE: We'll make this clearer in the APIs and documentation but use of
synchronous calls to extensions is discouraged.
