### PR TITLE
Move the Sync messages to use base::Value instead of std::string

### DIFF
--- a/extensions/browser/xwalk_extension_web_contents_handler.h
+++ b/extensions/browser/xwalk_extension_web_contents_handler.h
@@ -40,7 +40,7 @@ class XWalkExtensionWebContentsHandler
   void OnPostMessage(const std::string& extension_name,
                      const base::ListValue& msg);
   void OnSendSyncMessage(const std::string& extension_name,
-                         const std::string& msg, std::string* result);
+                         const base::ListValue& msg, base::ListValue* result);
 
   friend class content::WebContentsUserData<XWalkExtensionWebContentsHandler>;
   explicit XWalkExtensionWebContentsHandler(content::WebContents* contents);

--- a/extensions/common/xwalk_extension.cc
+++ b/extensions/common/xwalk_extension.cc
@@ -19,9 +19,10 @@ XWalkExtension::Context::Context(const PostMessageCallback& post_message)
 
 XWalkExtension::Context::~Context() {}
 
-std::string XWalkExtension::Context::HandleSyncMessage(const std::string& msg) {
+scoped_ptr<base::Value> XWalkExtension::Context::HandleSyncMessage(
+    scoped_ptr<base::Value> msg) {
   LOG(FATAL) << "Sending sync message to extension which doesn't support it!";
-  return std::string();
+  return scoped_ptr<base::Value>(base::Value::CreateNullValue());
 }
 
 }  // namespace extensions

--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -44,7 +44,8 @@ class XWalkExtension {
 
     // Allow to handle synchronous messages sent from JavaScript code. Renderer
     // will block until this function returns.
-    virtual std::string HandleSyncMessage(const std::string& msg);
+    virtual scoped_ptr<base::Value> HandleSyncMessage(
+        scoped_ptr<base::Value> msg);
 
    protected:
     explicit Context(const PostMessageCallback& post_message);

--- a/extensions/common/xwalk_extension_external.h
+++ b/extensions/common/xwalk_extension_external.h
@@ -49,7 +49,8 @@ class XWalkExternalExtension : public XWalkExtension {
 
    private:
     virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
-    virtual std::string HandleSyncMessage(const std::string& msg) OVERRIDE;
+    virtual scoped_ptr<base::Value> HandleSyncMessage(
+        scoped_ptr<base::Value> msg) OVERRIDE;
 
     static const CXWalkExtensionContextAPI* GetAPIWrappers();
     static void PostMessageWrapper(CXWalkExtensionContext* context,

--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -28,5 +28,5 @@ IPC_MESSAGE_CONTROL2(XWalkViewMsg_RegisterExtension,  // NOLINT(*)
 
 IPC_SYNC_MESSAGE_ROUTED2_1(XWalkViewHostMsg_SendSyncMessage,  // NOLINT(*)
                            std::string /* target extension */,
-                           std::string /* input contents */,
-                           std::string /* output contents */)
+                           base::ListValue /* input contents */,
+                           base::ListValue /* output contents */)

--- a/extensions/common/xwalk_extension_runner.cc
+++ b/extensions/common/xwalk_extension_runner.cc
@@ -18,9 +18,9 @@ void XWalkExtensionRunner::PostMessageToContext(scoped_ptr<base::Value> msg) {
   HandleMessageFromClient(msg.Pass());
 }
 
-std::string XWalkExtensionRunner::SendSyncMessageToContext(
-    const std::string& msg) {
-  return HandleSyncMessageFromClient(msg);
+scoped_ptr<base::Value> XWalkExtensionRunner::SendSyncMessageToContext(
+    scoped_ptr<base::Value> msg) {
+  return HandleSyncMessageFromClient(msg.Pass());
 }
 
 void XWalkExtensionRunner::PostMessageToClient(scoped_ptr<base::Value> msg) {

--- a/extensions/common/xwalk_extension_runner.h
+++ b/extensions/common/xwalk_extension_runner.h
@@ -38,14 +38,15 @@ class XWalkExtensionRunner {
   virtual ~XWalkExtensionRunner();
 
   void PostMessageToContext(scoped_ptr<base::Value> msg);
-  std::string SendSyncMessageToContext(const std::string& msg);
+  scoped_ptr<base::Value> SendSyncMessageToContext(scoped_ptr<base::Value> msg);
 
   std::string extension_name() const { return extension_name_; }
 
  protected:
   void PostMessageToClient(scoped_ptr<base::Value> msg);
   virtual void HandleMessageFromClient(scoped_ptr<base::Value> msg) = 0;
-  virtual std::string HandleSyncMessageFromClient(const std::string& msg) = 0;
+  virtual scoped_ptr<base::Value> HandleSyncMessageFromClient(
+      scoped_ptr<base::Value> msg) = 0;
 
   Client* client_;
 

--- a/extensions/common/xwalk_extension_threaded_runner.h
+++ b/extensions/common/xwalk_extension_threaded_runner.h
@@ -34,8 +34,8 @@ class XWalkExtensionThreadedRunner : public XWalkExtensionRunner {
  private:
   // XWalkExtensionRunner implementation.
   virtual void HandleMessageFromClient(scoped_ptr<base::Value> msg) OVERRIDE;
-  virtual std::string HandleSyncMessageFromClient(
-      const std::string& msg) OVERRIDE;
+  virtual scoped_ptr<base::Value> HandleSyncMessageFromClient(
+      scoped_ptr<base::Value> msg) OVERRIDE;
 
   bool CalledOnExtensionThread() const;
   bool PostTaskToExtensionThread(const tracked_objects::Location& from_here,
@@ -43,7 +43,7 @@ class XWalkExtensionThreadedRunner : public XWalkExtensionRunner {
   void CreateContext();
   void DestroyContext();
 
-  void CallHandleSyncMessage(const std::string& msg, std::string* reply);
+  void CallHandleSyncMessage(scoped_ptr<base::Value> msg, base::Value** reply);
 
   scoped_ptr<XWalkExtension::Context> context_;
   scoped_ptr<base::Thread> thread_;

--- a/extensions/renderer/xwalk_extension_render_view_handler.cc
+++ b/extensions/renderer/xwalk_extension_render_view_handler.cc
@@ -46,12 +46,13 @@ bool XWalkExtensionRenderViewHandler::PostMessageToExtension(
   return Send(new XWalkViewHostMsg_PostMessage(routing_id(), extension, msg));
 }
 
-std::string XWalkExtensionRenderViewHandler::SendSyncMessageToExtension(
-    const std::string& extension, const std::string& msg) {
-  std::string reply;
+scoped_ptr<base::ListValue>
+XWalkExtensionRenderViewHandler::SendSyncMessageToExtension(
+    const std::string& extension, const base::ListValue& msg) {
+  base::ListValue* reply = new base::ListValue;
   Send(new XWalkViewHostMsg_SendSyncMessage(
-      routing_id(), extension, msg, &reply));
-  return reply;
+      routing_id(), extension, msg, reply));
+  return scoped_ptr<base::ListValue>(reply);
 }
 
 bool XWalkExtensionRenderViewHandler::OnMessageReceived(

--- a/extensions/renderer/xwalk_extension_render_view_handler.h
+++ b/extensions/renderer/xwalk_extension_render_view_handler.h
@@ -34,8 +34,8 @@ class XWalkExtensionRenderViewHandler
 
   bool PostMessageToExtension(const std::string& extension,
                               const base::ListValue& msg);
-  std::string SendSyncMessageToExtension(const std::string& extension,
-                                         const std::string& msg);
+  scoped_ptr<base::ListValue> SendSyncMessageToExtension(
+      const std::string& extension, const base::ListValue& msg);
 
   // RenderViewObserver implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;

--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -23,18 +23,35 @@ namespace extensions {
 class XWalkExtensionV8Wrapper : public v8::Extension {
  public:
   XWalkExtensionV8Wrapper();
+  virtual ~XWalkExtensionV8Wrapper();
 
   // v8::Extension implementation.
   virtual v8::Handle<v8::FunctionTemplate> GetNativeFunction(
       v8::Handle<v8::String> name);
 
  private:
+  static scoped_ptr<base::ListValue> V8ValueToListValue(
+      const v8::Handle<v8::Value> value);
+
   static v8::Handle<v8::Value> PostMessage(const v8::Arguments& args);
   static v8::Handle<v8::Value> SendSyncMessage(const v8::Arguments& args);
+
+  static content::V8ValueConverter* converter_;
 };
+
+// Also static because is gonna be used inside the static methods. The
+// lifetime is bound to XWalkExtensionV8Wrapper which will initialize this
+// object. We should have only one instance of this class per process.
+content::V8ValueConverter* XWalkExtensionV8Wrapper::converter_ = NULL;
 
 XWalkExtensionV8Wrapper::XWalkExtensionV8Wrapper()
     : v8::Extension("xwalk", kSource_xwalk_api) {
+  DCHECK(!converter_);
+  converter_ = content::V8ValueConverter::create();
+}
+
+XWalkExtensionV8Wrapper::~XWalkExtensionV8Wrapper() {
+  delete converter_;
 }
 
 v8::Handle<v8::FunctionTemplate>
@@ -46,29 +63,42 @@ XWalkExtensionV8Wrapper::GetNativeFunction(v8::Handle<v8::String> name) {
   return v8::Handle<v8::FunctionTemplate>();
 }
 
+scoped_ptr<base::ListValue> XWalkExtensionV8Wrapper::V8ValueToListValue(
+    const v8::Handle<v8::Value> v8_value) {
+  // We first convert a V8 Value to a base::Value and later we wrap it
+  // into a base::ListValue for dispatching to the browser process. We need
+  // this wrapping because base::Value doesn't have param traits and
+  // implementing one is not a viable option (would require fork base::Value
+  // and create a new empty type).
+  XWalkExtensionRenderViewHandler* handler =
+      XWalkExtensionRenderViewHandler::GetForCurrentContext();
+
+  scoped_ptr<base::Value> value(
+      converter_->FromV8Value(v8_value, handler->GetV8Context()));
+
+  if (!value)
+    return scoped_ptr<base::ListValue>(NULL);
+
+  scoped_ptr<base::ListValue> list_value(new base::ListValue);
+  list_value->Append(value.release());
+
+  return list_value.Pass();
+}
+
 v8::Handle<v8::Value> XWalkExtensionV8Wrapper::PostMessage(
     const v8::Arguments& args) {
   if (args.Length() != 2)
     return v8::False();
 
+  scoped_ptr<base::ListValue> list_value_args(V8ValueToListValue(args[1]));
+  if (!list_value_args)
+    return v8::False();
+
   XWalkExtensionRenderViewHandler* handler =
       XWalkExtensionRenderViewHandler::GetForCurrentContext();
 
-  scoped_ptr<content::V8ValueConverter> converter(
-      content::V8ValueConverter::create());
-  scoped_ptr<base::Value> value_args(
-      converter->FromV8Value(args[1], handler->GetV8Context()));
-
-  if (!value_args.get())
-    return v8::False();
-
-  // FIXME(tmpsantos): We could serialize base::Value if it had
-  // param traits for it. Instead, we always add it to a list.
-  base::ListValue list_value_args;
-  list_value_args.Append(value_args.release());
-
   std::string extension(*v8::String::Utf8Value(args[0]));
-  if (!handler->PostMessageToExtension(extension, list_value_args))
+  if (!handler->PostMessageToExtension(extension, *list_value_args))
     return v8::False();
   return v8::True();
 }
@@ -78,13 +108,21 @@ v8::Handle<v8::Value> XWalkExtensionV8Wrapper::SendSyncMessage(
   if (args.Length() != 2)
     return v8::False();
 
-  std::string extension(*v8::String::Utf8Value(args[0]));
-  std::string msg(*v8::String::Utf8Value(args[1]));
+  scoped_ptr<base::ListValue> list_value_args(V8ValueToListValue(args[1]));
+  if (!list_value_args)
+    return v8::False();
 
   XWalkExtensionRenderViewHandler* handler =
       XWalkExtensionRenderViewHandler::GetForCurrentContext();
-  std::string reply = handler->SendSyncMessageToExtension(extension, msg);
-  return v8::String::New(reply.c_str(), reply.size());
+
+  std::string extension(*v8::String::Utf8Value(args[0]));
+  scoped_ptr<base::ListValue> reply(handler->SendSyncMessageToExtension(
+          extension, *list_value_args));
+
+  const base::Value* value;
+  reply->Get(0, &value);
+
+  return converter_->ToV8Value(value, handler->GetV8Context());
 }
 
 XWalkExtensionRendererController::XWalkExtensionRendererController() {

--- a/extensions/test/xwalk_extensions_browsertest.cc
+++ b/extensions/test/xwalk_extensions_browsertest.cc
@@ -47,8 +47,9 @@ class EchoExtension : public XWalkExtension {
     virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE {
       PostMessage(msg.Pass());
     }
-    virtual std::string HandleSyncMessage(const std::string& msg) OVERRIDE {
-      return msg;
+    virtual scoped_ptr<base::Value> HandleSyncMessage(
+        scoped_ptr<base::Value> msg) OVERRIDE {
+      return msg.Pass();
     }
   };
 


### PR DESCRIPTION
This is basically the same change we did for the async messages. It will
save a few copies (currently we copy the string is some places, specially
when posting it to another thread). But the main benefit is it will be
easier to work with the serializers created from IDL files.
