### PR TITLE
Pass the window show state to initialize Widget

### DIFF
--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -82,6 +82,7 @@ NativeAppWindowViews::NativeAppWindowViews(
   params.use_system_default_icon = true;
   params.top_level = true;
   params.bounds = create_params.bounds;
+  params.show_state = create_params.state;
   window_->Init(params);
 
   window_->CenterWindow(create_params.bounds.size());


### PR DESCRIPTION
It can make sure the views widget know its show state and decide how to
show the app window, e.g. fullscreen.

BUG=https://github.com/otcshare/crosswalk/issues/188
