### PR TITLE
Make lint.py ignore a closing parentheses

### DIFF
--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -180,7 +180,7 @@ static std::string WrapAPICode(const std::string& api_code,
 #if !defined(OS_WIN)
       , name
 #endif
-      );
+      ); // NOLINT
 }
 
 void XWalkExtensionRendererController::InstallJavaScriptAPIs(


### PR DESCRIPTION
This parentheses are not exactly complying to the style because
of the macros at its surroundings. The error is creating a false
positive and the build is being reported as failed.
