### PR TITLE
Disable manifest_version check; print loadManifest error message.

### DIFF
--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -40,11 +40,15 @@ Manifest::~Manifest() {
 bool Manifest::ValidateManifest(
     std::string* error,
     std::vector<InstallWarning>* warnings) const {
+  // TODO(changbin): field 'manifest_version' of manifest.json is not clearly
+  // defined at present. Temporarily disable check of this field.
+  /*
   *error = "";
   if (type_ == Manifest::TYPE_PACKAGED_APP && GetManifestVersion() < 2) {
     *error = errors::kPlatformAppNeedsManifestVersion2;
     return false;
   }
+  */
 
   // TODO(xiang): support features validation
   return true;

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -212,6 +212,8 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
               path,
               xwalk::application::Manifest::COMMAND_LINE,
               &error);
+      if (!error.empty())
+        LOG(ERROR) << "Failed to load application: " << error;
       if (application != NULL) {
         xwalk::application::ApplicationSystem* system =
             runtime_context_->GetApplicationSystem();


### PR DESCRIPTION
QA reports that if manifest.json doesn't contain 'manifest_version' field, then launch fails, moreover, even no error message print on the terminal.
