### PR TITLE
Build and package libosmesa.so to support --use-gl=osmesa as GPU implementation.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -99,6 +99,7 @@ install -m 755 -D src/out/Release/xwalk %{buildroot}%{_libdir}/xwalk/xwalk
 
 # Supporting libraries and resources.
 install -m 644 -D src/out/Release/libffmpegsumo.so %{buildroot}%{_libdir}/xwalk/libffmpegsumo.so
+install -m 644 -D src/out/Release/libosmesa.so %{buildroot}%{_libdir}/xwalk/libosmesa.so
 install -m 644 -D src/out/Release/xwalk.pak %{buildroot}%{_libdir}/xwalk/xwalk.pak
 
 %files
@@ -106,5 +107,6 @@ install -m 644 -D src/out/Release/xwalk.pak %{buildroot}%{_libdir}/xwalk/xwalk.p
 # %license AUTHORS.chromium AUTHORS.xwalk LICENSE.chromium LICENSE.xwalk
 %{_bindir}/xwalk
 %{_libdir}/xwalk/libffmpegsumo.so
+%{_libdir}/xwalk/libosmesa.so
 %{_libdir}/xwalk/xwalk
 %{_libdir}/xwalk/xwalk.pak

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -376,6 +376,11 @@
           ],
         }],  # OS=="win" or (toolkit_uses_gtk == 1 and selinux == 0)
         ['OS == "linux"', {
+          'dependencies': [
+            # Build osmesa to workaround egl backend issue on Tizen 2.1 emulator
+            # TODO: remove this once hardware backend works.
+            '../third_party/mesa/mesa.gyp:osmesa',
+          ],
           'copies': [
             {
               'destination': '<(PRODUCT_DIR)',


### PR DESCRIPTION
It could be a backup solution for issue https://github.com/otcshare/crosswalk/issues/272. Osmesa backend is the software GL implementation. Users could use `--use-gl=osmesa`, if hardware backend solutions `--use-gl=egl` and `--use-gl=desktop` are not able to work on Tizen emulator.
