### PR TITLE
packaging: Change the order we use to look for GL implementations.

### DIFF
--- a/packaging/crosswalk-1.28.1.0-reorder-gl-implementation-lookup.patch
+++ b/packaging/crosswalk-1.28.1.0-reorder-gl-implementation-lookup.patch
@@ -1,0 +1,30 @@
+Author: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+
+See issue #272 for more information. In short, we need to use EGL on Tizen
+Mobile devices and OSMesa in the emulator (the EGL implementation in 2.1 does
+not work as expected in the emulator and crashes Crosswalk).
+
+The easiest way for this to work is to look for the GL implementations
+available in a different order: if we ship libosmesa.so in the emulator RPM
+package, we can look for OSMesa first and, if it is not available, we fall back
+to EGL (which means a real device without libosmesa.so in the system) and only
+then look for the Desktop GL implementation (Tizen PC, maybe).
+
+Once we move to a Tizen version whose emulator image works correctly with EGL,
+we can drop this patch.
+
+Not upstreamable.
+--- src/ui/gl/gl_implementation_x11.cc
++++ src/ui/gl/gl_implementation_x11.cc
+@@ -52,9 +52,9 @@ base::NativeLibrary LoadLibrary(const char* filename) {
+ }  // namespace
+ 
+ void GetAllowedGLImplementations(std::vector<GLImplementation>* impls) {
+-  impls->push_back(kGLImplementationDesktopGL);
+-  impls->push_back(kGLImplementationEGLGLES2);
+   impls->push_back(kGLImplementationOSMesaGL);
++  impls->push_back(kGLImplementationEGLGLES2);
++  impls->push_back(kGLImplementationDesktopGL);
+ }
+ 
+ bool InitializeGLBindings(GLImplementation implementation) {

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -12,6 +12,7 @@ Source1001:     crosswalk.manifest
 Patch1:         %{name}-%{version}-do-not-look-for-gtk2-when-using-aura.patch
 Patch2:         %{name}-%{version}-pull-request-40.patch
 Patch3:         %{name}-%{version}-look-for-pvr-libGLESv2.so.patch
+Patch4:         %{name}-%{version}-reorder-gl-implementation-lookup.patch
 
 BuildRequires:  bison
 BuildRequires:  bzip2-devel
@@ -55,6 +56,16 @@ BuildRequires:  pkgconfig(xtst)
 %description
 Crosswalk is an app runtime based on Chromium. It is an open source project started by the Intel Open Source Technology Center (http://www.01.org).
 
+%package emulator-support
+Summary:        Support files necessary for running Crosswalk on the Tizen emulator
+# License:        (BSD-3-Clause and LGPL-2.1+)
+License:        BSD-3-Clause
+Group:          Web Framework/Web Run Time
+Url:            https://github.com/otcshare/crosswalk
+
+%description emulator-support
+This package contains additional support files that are needed for running Crosswalk on the Tizen emulator.
+
 %prep
 %setup -q
 
@@ -68,6 +79,7 @@ cp -a src/xwalk/LICENSE LICENSE.xwalk
 %patch1
 %patch2
 %patch3
+%patch4
 
 %build
 
@@ -107,6 +119,8 @@ install -m 644 -D src/out/Release/xwalk.pak %{buildroot}%{_libdir}/xwalk/xwalk.p
 # %license AUTHORS.chromium AUTHORS.xwalk LICENSE.chromium LICENSE.xwalk
 %{_bindir}/xwalk
 %{_libdir}/xwalk/libffmpegsumo.so
-%{_libdir}/xwalk/libosmesa.so
 %{_libdir}/xwalk/xwalk
 %{_libdir}/xwalk/xwalk.pak
+
+%files emulator-support
+%{_libdir}/xwalk/libosmesa.so

--- a/packaging/xwalk
+++ b/packaging/xwalk
@@ -1,6 +1,3 @@
-
 #!/bin/sh
 
-# TODO(rakuco): Passing --use-gl=egl by default makes sense on Tizen
-# mobile, but may not be the best option for all platforms.
-exec /usr/lib/xwalk/xwalk --use-gl=egl --fullscreen --ignore-gpu-blacklist --allow-file-access-from-files "$@"
+exec /usr/lib/xwalk/xwalk --fullscreen --ignore-gpu-blacklist --allow-file-access-from-files "$@"


### PR DESCRIPTION
We need to use EGL on Tizen Mobile devices and OSMesa in the emulator (the EGL
implementation in 2.1 does not work as expected in the emulator and crashes
Crosswalk).

The easiest way for this to work is to look for the GL implementations 
available in a different order: if we ship libosmesa.so in the emulator RPM 
package, we can look for OSMesa first and, if it is not available, we fall ack
to EGL (which means a real device without libosmesa.so in the system) and nly
then look for the Desktop GL implementation (Tizen PC, maybe).

Once we move to a Tizen version whose emulator image works correctly with GL,
we can drop this patch.

Related to issue #272.
