### PR TITLE
mac: compile

### DIFF
--- a/application/browser/application_process_manager.cc
+++ b/application/browser/application_process_manager.cc
@@ -21,6 +21,9 @@ ApplicationProcessManager::ApplicationProcessManager(
     : weak_ptr_factory_(this) {
 }
 
+ApplicationProcessManager::~ApplicationProcessManager() {
+}
+
 bool ApplicationProcessManager::LaunchApplication(
         RuntimeContext* runtime_context,
         const Application* application) {

--- a/application/browser/application_process_manager.h
+++ b/application/browser/application_process_manager.h
@@ -34,6 +34,7 @@ class ApplicationHost;
 class ApplicationProcessManager {
  public:
   explicit ApplicationProcessManager(xwalk::RuntimeContext* runtime_context);
+  ~ApplicationProcessManager();
 
   bool LaunchApplication(xwalk::RuntimeContext* runtime_context,
                        const Application* application);


### PR DESCRIPTION
Fixes the following error:
[chromium-style] Complex class/struct needs an explicit out-of-line destructor.
