### PR TITLE
runtime: Add enable-remote-application switch

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -134,7 +134,9 @@ void XWalkBrowserMainParts::RegisterExternalExtensions() {
   if (!cmd_line->HasSwitch(switches::kXWalkExternalExtensionsPath))
     return;
 
-  if (!startup_url_.SchemeIsFile()) {
+  if (!cmd_line->HasSwitch(
+          switches::kXWalkAllowExternalExtensionsForRemoteSources) &&
+      !startup_url_.SchemeIsFile()) {
     VLOG(0) << "Unsupported scheme for external extensions: " <<
           startup_url_.scheme();
     return;

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -19,4 +19,7 @@ const char kFullscreen[] = "fullscreen";
 // Specifies where XWalk will look for external extensions.
 const char kXWalkExternalExtensionsPath[] = "external-extensions-path";
 
+const char kXWalkAllowExternalExtensionsForRemoteSources[] =
+    "allow-external-extensions-for-remote-sources";
+
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -16,6 +16,8 @@ extern const char kFullscreen[];
 
 extern const char kXWalkExternalExtensionsPath[];
 
+extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
+
 }  // namespace switches
 
 #endif  // XWALK_RUNTIME_COMMON_XWALK_SWITCHES_H_


### PR DESCRIPTION
This allows for remote applications (via http, for example) to be
loaded.

When this switch is not present only applications with scheme file://
will be loaded.
