### PR TITLE
Packaging: enable Tizen 2.1 multi-touch support build flag.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -100,7 +100,7 @@ export GYP_GENERATORS='make'
 -Duse_system_libexif=1 \
 -Duse_system_libxml=1 \
 -Duse_system_nspr=1 \
--Duse_xi2_mt=2 \
+-Denable_xi21_mt=1 \
 
 make %{?_smp_mflags} -C src BUILDTYPE=Release xwalk
 


### PR DESCRIPTION
Fix bug https://github.com/otcshare/crosswalk/issues/314
