### PR TITLE
Define ENABLE_XI21_MT for the multi-touch support.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -1,0 +1,20 @@
+{
+  'variables': {
+    # Enable multitouch support with XInput2.1. When it is enabled, unlike
+    # XInput2.2, there are no XI_TouchBegin, XI_TouchUpdate and XI_TouchEnd
+    # raw touch events emitted from touch device. Instead, the touch event is
+    # simulated by a normal mouse event, since X server maintains multiple
+    # virtual touch screen devices as floating device, each of them can
+    # simulate a touch event tracked by the device id of event source, as a
+    # result, multi-touch support works with these simulated touch events
+    # dispatched from floating device.
+    'enable_xi21_mt%': 0,
+  },
+  'target_defaults': {
+    'conditions': [
+      ['enable_xi21_mt==1', {
+        'defines': ['ENABLE_XI21_MT=1'],
+      }],
+    ],
+  },
+}

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -69,6 +69,9 @@ def additional_include_files(args=[]):
     if os.path.realpath(path) not in specified_includes:
       result.append(path)
 
+  # Include xwalk common.gypi to effect chromium source tree.
+  AddInclude(os.path.join(xwalk_dir, 'build', 'common.gypi'))
+
   # Always include common.gypi.
   AddInclude(os.path.join(chrome_src, 'build', 'common.gypi'))
 


### PR DESCRIPTION
This patch introduced common.gypi to define variables that effect chromium
compile.

chromium counter part: https://github.com/otcshare/chromium-crosswalk/pull/46
