### PR TITLE
Tizen: Guess the GL implementation to use by poking the file system.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -55,6 +55,16 @@ BuildRequires:  pkgconfig(xtst)
 %description
 Crosswalk is an app runtime based on Chromium. It is an open source project started by the Intel Open Source Technology Center (http://www.01.org).
 
+%package emulator-support
+Summary:        Support files necessary for running Crosswalk on the Tizen emulator
+# License:        (BSD-3-Clause and LGPL-2.1+)
+License:        BSD-3-Clause
+Group:          Web Framework/Web Run Time
+Url:            https://github.com/otcshare/crosswalk
+
+%description emulator-support
+This package contains additional support files that are needed for running Crosswalk on the Tizen emulator.
+
 %prep
 %setup -q
 
@@ -107,6 +117,8 @@ install -m 644 -D src/out/Release/xwalk.pak %{buildroot}%{_libdir}/xwalk/xwalk.p
 # %license AUTHORS.chromium AUTHORS.xwalk LICENSE.chromium LICENSE.xwalk
 %{_bindir}/xwalk
 %{_libdir}/xwalk/libffmpegsumo.so
-%{_libdir}/xwalk/libosmesa.so
 %{_libdir}/xwalk/xwalk
 %{_libdir}/xwalk/xwalk.pak
+
+%files emulator-support
+%{_libdir}/xwalk/libosmesa.so

--- a/packaging/xwalk
+++ b/packaging/xwalk
@@ -1,6 +1,29 @@
-
 #!/bin/sh
 
-# TODO(rakuco): Passing --use-gl=egl by default makes sense on Tizen
-# mobile, but may not be the best option for all platforms.
-exec /usr/lib/xwalk/xwalk --use-gl=egl --fullscreen --ignore-gpu-blacklist --allow-file-access-from-files "$@"
+# Determine the most suitable GL implementation by guessing the Tizen profile
+# being used.
+#
+# We could leave it up to Chromium to pick the best GL implementation, but
+# right now it (ie. gl_implementation_x11.cc) will, by default, only try using
+# Desktop GL and optionally fall back to OSMesa, and hardcoding a single one
+# ("egl", for example), causes crashes in some configurations, such as the
+# emulator.
+if [ -f /usr/lib/xwalk/libosmesa.so ]; then
+    # If libosmesa.so is present, the crosswalk-emulator-support package has
+    # been installed and we can assume we're running in the emulator.
+    GL_IMPLEMENTATION="osmesa"
+elif [ -f /usr/lib/libGL.so ]; then
+    # libGL.so is not installed by the EGL packages used by the mobile profile,
+    # so we can assume full-blown Mesa (or something analogous) is present.
+    GL_IMPLEMENTATION="desktop"
+else
+    # Otherwise, assume libGLESv2.so is available and we have an EGL
+    # implementation.
+    GL_IMPLEMENTATION="egl"
+fi
+
+exec /usr/lib/xwalk/xwalk --use-gl="${GL_IMPLEMENTATION}" \
+                          --fullscreen \
+                          --ignore-gpu-blacklist \
+                          --allow-file-access-from-files \
+                          "$@"


### PR DESCRIPTION
We need to use EGL on Tizen Mobile devices and OSMesa in the emulator (the EGL
implementation in 2.1 does not work as expected in the emulator and crashes
Crosswalk).

The solution is two-fold:
1. Ship libosmesa.so separately in another package, called
   crosswalk-emulator-support.
2. Based on the presence of certain shared libraries on the system,
   determine whether to use OSMesa (emulator), Desktop GL (PC and maybe
   IVI) or EGL (mobile).

Related to issue #272.
