### PR TITLE
Roll Chromium DEPS

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '28.0.1500.36'
-chromium_crosswalk_point = '481ac27fa53671c4aa8198edd065f31ce6559cb9'
+chromium_crosswalk_point = '5748e71236a8e07aa8eabd3b76e3e3a8f21c030d'
 blink_crosswalk_point = 'abfee977cd60a915a094f247ff81f9d17dc85efe'
 deps_xwalk = {
   'src': 'ssh://git@github.com/otcshare/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
Include the change in the extensions generators to make
them work with Crosswalk. The changes are basically few
path adjustments.
