### PR TITLE
Create a new layout for NativeAppWindow in Views

### DIFF
--- a/runtime/browser/ui/native_app_window_views.h
+++ b/runtime/browser/ui/native_app_window_views.h
@@ -69,7 +69,7 @@ class NativeAppWindowViews : public NativeAppWindow,
       views::Widget* widget) OVERRIDE;
 
   // views::View implementation.
-  virtual void Layout() OVERRIDE;
+  virtual void ChildPreferredSizeChanged(views::View* child) OVERRIDE;
   virtual void ViewHierarchyChanged(
       bool is_add, views::View *parent, views::View *child) OVERRIDE;
   virtual void OnFocus() OVERRIDE;

--- a/runtime/browser/ui/top_view_layout_views.cc
+++ b/runtime/browser/ui/top_view_layout_views.cc
@@ -1,0 +1,48 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ui/top_view_layout_views.h"
+
+#include "ui/views/view.h"
+
+namespace xwalk {
+
+TopViewLayout::TopViewLayout()
+    : top_view_(NULL),
+      content_view_(NULL) {}
+
+TopViewLayout::~TopViewLayout() {}
+
+void TopViewLayout::Layout(views::View* host) {
+  if (!host->has_children())
+    return;
+
+  if (!top_view_) {
+    content_view_->SetBoundsRect(host->GetLocalBounds());
+    return;
+  }
+
+  CHECK_EQ(2, host->child_count());
+  CHECK(content_view_);
+  CHECK_EQ(host, top_view_->parent());
+  CHECK_EQ(host, content_view_->parent());
+
+  gfx::Rect top_view_bounds = host->GetLocalBounds();
+  top_view_bounds.set_height(top_view_->GetPreferredSize().height());
+  top_view_->SetBoundsRect(top_view_bounds);
+
+  gfx::Rect content_view_bounds = host->GetLocalBounds();
+  content_view_bounds.Inset(0, top_view_bounds.height(), 0, 0);
+  content_view_->SetBoundsRect(content_view_bounds);
+}
+
+gfx::Size TopViewLayout::GetPreferredSize(views::View* host) {
+  CHECK(content_view_);
+  gfx::Rect rect(content_view_->GetPreferredSize());
+  if (top_view_)
+    rect.Inset(0, -top_view_->GetPreferredSize().height(), 0, 0);
+  return rect.size();
+}
+
+}  // namespace xwalk

--- a/runtime/browser/ui/top_view_layout_views.h
+++ b/runtime/browser/ui/top_view_layout_views.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_TOP_VIEW_LAYOUT_VIEWS_H_
+#define XWALK_RUNTIME_BROWSER_UI_TOP_VIEW_LAYOUT_VIEWS_H_
+
+#include "base/basictypes.h"
+#include "base/compiler_specific.h"
+#include "ui/views/layout/layout_manager.h"
+
+namespace xwalk {
+
+// Layout manager that handle a main content view taking all the space and
+// optionally an top view. The top view will always get its preferred
+// height. Used for implementing Tizen Indicator when running fullscreen.
+//
+// This layout expects that the view it is managing have either one or two
+// children, and that the setter methods are called accordingly.
+class TopViewLayout : public views::LayoutManager {
+ public:
+  TopViewLayout();
+  virtual ~TopViewLayout();
+
+  // Must be set to the content view, that will fill all the remaining available
+  // space in the layout. The |content_view| must be child of the view that this
+  // layout manages.
+  void set_content_view(views::View* content_view) {
+    content_view_ = content_view;
+  }
+
+  // Optionally sets a top view, that will be positioned on the top and with its
+  // preferred height. The |top_view| must be children from the view that this
+  // layout manages.
+  void set_top_view(views::View* top_view) { top_view_ = top_view; }
+
+  views::View* top_view() const { return top_view_; }
+
+  // views::LayoutManager implementation.
+  virtual void Layout(views::View* host) OVERRIDE;
+  virtual gfx::Size GetPreferredSize(views::View* host) OVERRIDE;
+
+ private:
+  views::View* top_view_;
+  views::View* content_view_;
+
+  DISALLOW_COPY_AND_ASSIGN(TopViewLayout);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_TOP_VIEW_LAYOUT_VIEWS_H_

--- a/runtime/browser/ui/top_view_layout_views_unittest.cc
+++ b/runtime/browser/ui/top_view_layout_views_unittest.cc
@@ -1,0 +1,111 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ui/top_view_layout_views.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/views/view.h"
+
+using views::View;
+using xwalk::TopViewLayout;
+
+namespace {
+
+class TopViewLayoutTest : public testing::Test {
+ public:
+  virtual void SetUp() OVERRIDE {
+    host_.reset(new View);
+  }
+
+  scoped_ptr<View> host_;
+  scoped_ptr<TopViewLayout> layout_;
+};
+
+class ViewWithPreferredSize : public View {
+ public:
+  explicit ViewWithPreferredSize(const gfx::Size& preferred_size)
+      : preferred_size_(preferred_size) {}
+
+  void set_preferred_size(const gfx::Size& preferred_size) {
+    preferred_size_ = preferred_size;
+  }
+
+  // View implementation.
+  virtual gfx::Size GetPreferredSize() OVERRIDE { return preferred_size_; }
+
+ private:
+  gfx::Size preferred_size_;
+};
+
+}  // namespace
+
+TEST_F(TopViewLayoutTest, OnlyContentView) {
+  layout_.reset(new TopViewLayout);
+  View* content = new View();
+  host_->AddChildView(content);
+  layout_->set_content_view(content);
+
+  host_->SetSize(gfx::Size(200, 150));
+  layout_->Layout(host_.get());
+  EXPECT_EQ(gfx::Rect(0, 0, 200, 150), content->bounds());
+
+  host_->SetSize(gfx::Size(300, 400));
+  layout_->Layout(host_.get());
+  EXPECT_EQ(gfx::Rect(0, 0, 300, 400), content->bounds());
+}
+
+TEST_F(TopViewLayoutTest, BothViews) {
+  layout_.reset(new TopViewLayout);
+
+  View* content = new View();
+  host_->AddChildView(content);
+  layout_->set_content_view(content);
+
+  View* top_view = new ViewWithPreferredSize(gfx::Size(20, 20));
+  host_->AddChildView(top_view);
+  layout_->set_top_view(top_view);
+
+  host_->SetSize(gfx::Size(200, 150));
+  layout_->Layout(host_.get());
+  EXPECT_EQ(gfx::Rect(0, 20, 200, 130), content->bounds());
+  EXPECT_EQ(gfx::Rect(0, 0, 200, 20), top_view->bounds());
+
+  host_->SetSize(gfx::Size(300, 400));
+  layout_->Layout(host_.get());
+  EXPECT_EQ(gfx::Rect(0, 20, 300, 380), content->bounds());
+  EXPECT_EQ(gfx::Rect(0, 0, 300, 20), top_view->bounds());
+}
+
+TEST_F(TopViewLayoutTest, ChangingTopViewHeight) {
+  layout_.reset(new TopViewLayout);
+
+  View* content = new View();
+  host_->AddChildView(content);
+  layout_->set_content_view(content);
+
+  ViewWithPreferredSize* top_view =
+      new ViewWithPreferredSize(gfx::Size(20, 20));
+  host_->AddChildView(top_view);
+  layout_->set_top_view(top_view);
+
+  host_->SetSize(gfx::Size(200, 150));
+  layout_->Layout(host_.get());
+  EXPECT_EQ(gfx::Rect(0, 20, 200, 130), content->bounds());
+  EXPECT_EQ(gfx::Rect(0, 0, 200, 20), top_view->bounds());
+
+  top_view->set_preferred_size(gfx::Size(100, 100));
+  layout_->Layout(host_.get());
+  EXPECT_EQ(gfx::Rect(0, 100, 200, 50), content->bounds());
+  EXPECT_EQ(gfx::Rect(0, 0, 200, 100), top_view->bounds());
+
+  host_->SetSize(gfx::Size(300, 400));
+  layout_->Layout(host_.get());
+  EXPECT_EQ(gfx::Rect(0, 100, 300, 300), content->bounds());
+  EXPECT_EQ(gfx::Rect(0, 0, 300, 100), top_view->bounds());
+
+  top_view->set_preferred_size(gfx::Size(20, 20));
+  layout_->Layout(host_.get());
+  EXPECT_EQ(gfx::Rect(0, 20, 300, 380), content->bounds());
+  EXPECT_EQ(gfx::Rect(0, 0, 300, 20), top_view->bounds());
+}

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -130,6 +130,8 @@
         'runtime/browser/ui/native_app_window_mac.mm',
         'runtime/browser/ui/native_app_window_views.cc',
         'runtime/browser/ui/native_app_window_views.h',
+        'runtime/browser/ui/top_view_layout_views.cc',
+        'runtime/browser/ui/top_view_layout_views.h',
         'runtime/browser/ui/taskbar_util.h',
         'runtime/browser/ui/taskbar_util_win.cc',
         'runtime/common/paths_mac.h',

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -77,6 +77,14 @@
           '../base/allocator/allocator.gyp:allocator',
         ],
       }],
+      ['toolkit_views == 1', {
+        'sources': [
+          'runtime/browser/ui/top_view_layout_views_unittest.cc',
+        ],
+        'dependencies': [
+          '../skia/skia.gyp:skia',
+        ],
+      }],
     ],
   }, # xwalk_unit_tests target
 


### PR DESCRIPTION
The TopViewLayout manages up to two children: the content view and an
optional top view. If there's a top view, it will be layouted with its
preferred height and fill the width with the window width. The remaining
space will be given to the content view.

This is a preparation for landing support for Indicator (the bar on
top with date, battery info and other data) in Tizen Mobile. Also can
be useful for other platforms. Since the layout works correctly
without setting a top view, we use it for all cases.

TEST=Added a new unit test for layout behavior; tested old behavior of
     window manually resizing it and inspecting the content; tested creating
     a top view that changes its preferred size after a timeout and the
     window was correctly repainted.
