### PR TITLE
[Android] Add the code stub and test shell for runtime APIs

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeView.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeView.java
@@ -1,0 +1,140 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.AttributeSet;
+import android.widget.FrameLayout;
+
+/**
+ * This class is to provide public APIs which are called by web application
+ * APKs. Since the runtime is shared as a library APK, web application APKs
+ * have to call them via class loader but not direct API calling.
+ *
+ * A web application APK should create its Activity and set this view as
+ * its content view.
+ */
+// Implementation notes.
+// Please be careful to change any public APIs for the backward compatibility
+// is very important to us. Don't change any of them without permisson.
+public class XWalkRuntimeView extends FrameLayout {
+    // The actual implementation to hide the internals to API users.
+    private XWalkRuntimeViewProvider mProvider;
+
+    /**
+     * Contructs a XWalkRuntimeView with a Context object.
+     *
+     * @param context a Context used by runtime from web app APK.
+     */
+    public XWalkRuntimeView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mProvider = new XWalkRuntimeViewProvider(context, this);
+    }
+
+    /**
+     * Get the version information of current runtime library.
+     *
+     * @return the string containing the version information.
+     */
+    public static String getVersion() {
+        // TODO(yongsheng): Implement the real version information.
+        // May include our customized information by containing chromium
+        // version info.
+        return "0.1";
+    }
+
+    /**
+     * Load a web application through the entry url. It may be
+     * a file from assets or a url from network.
+     *
+     * @param url the url of loaded html resource.
+     */
+    public void loadAppFromUrl(String url) {
+        mProvider.loadAppFromUrl(url);
+    }
+
+    /**
+     * Load a web application through the url of the manifest file.
+     * The manifest file typically is placed in android assets. Now it is
+     * compliant to W3C SysApps spec.
+     *
+     * @param manifestUrl the url of the manifest file
+     */
+    public void loadAppFromManifest(String manifestUrl) {
+        mProvider.loadAppFromManifest(manifestUrl);
+    }
+
+    /**
+     * Tell runtime that the application is on creating. This can make runtime
+     * be aware of application life cycle.
+     */
+    public void onCreate() {
+        mProvider.onCreate();
+    }
+
+    /**
+     * Tell runtime that the application is on resuming. This can make runtime
+     * be aware of application life cycle.
+     */
+    public void onResume() {
+        mProvider.onResume();
+    }
+
+    /**
+     * Tell runtime that the application is on pausing. This can make runtime
+     * be aware of application life cycle.
+     */
+    public void onPause() {
+        mProvider.onPause();
+    }
+
+    /**
+     * Tell runtime that the application is on destroying. This can make runtime
+     * be aware of application life cycle.
+     */
+    public void onDestroy() {
+        mProvider.onDestroy();
+    }
+
+    /**
+     * Tell runtime that one activity exists so that it can know the result code
+     * of the exit code.
+     *
+     * @param requestCode the request code to identify where the result is from
+     * @param resultCode the result code of the activity
+     * @param data the data to contain the result data
+     */
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        mProvider.onActivityResult(requestCode, resultCode, data);
+    }
+
+    /**
+     * Enable remote debugging for the loaded web application. The caller
+     * can set the url of debugging url. Besides, the socket name for remote
+     * debugging has to be unique so typically the string can be appended
+     * with the package name of the application.
+     *
+     * @param frontEndUrl the url of debugging url. If it's empty, then a
+     *                    default url will be used.
+     * @param socketName the unique socket name for setting up socket for
+     *                   remote debugging. If it's empty, then a default
+     *                   name will be used.
+     * @return the url of web socket for remote debugging
+     */
+    public String enableRemoteDebugging(String frontEndUrl, String socketName) {
+        // TODO(yongsheng): Figure out which parameters are needed once we
+        // have a conclusion.
+        return mProvider.enableRemoteDebugging(frontEndUrl,socketName);
+    }
+
+    /**
+     * Disable remote debugging so runtime can close related stuff for
+     * this feature.
+     */
+    public void disableRemoteDebugging() {
+        mProvider.disableRemoteDebugging();
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -1,0 +1,69 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime;
+
+import android.content.Context;
+import android.content.Intent;
+import android.widget.FrameLayout;
+
+import org.xwalk.core.XWalkView;
+
+/**
+ * The implementation class for XWalkRuntimeView. It calls the interfaces provided
+ * by runtime core and customizes the behaviors here.
+ * Note that it's a provisional solution. Will need a new refactoring.
+ */
+class XWalkRuntimeViewProvider {
+    private Context mContext;
+    private XWalkView mXwalkView;
+
+    public XWalkRuntimeViewProvider(Context context, XWalkRuntimeView runtime) {
+        mContext = context;
+
+        // TODO(yongsheng): do customizations for XWalkView. There will
+        // be many callback classes which are needed to be implemented.
+        mXwalkView = new XWalkView(context);
+        runtime.addView(mXwalkView,
+                new FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT));
+    }
+
+    public void loadAppFromUrl(String url) {
+        mXwalkView.loadUrl(url);
+    }
+
+    // TODO(yongsheng): Enable SysApps manifest support.
+    public void loadAppFromManifest(String manifestUrl) {
+    }
+
+    // TODO(yongsheng): Implement these 4 methods once they are
+    // supported by class XWalkView.
+    public void onCreate() {
+    }
+
+    public void onResume() {
+    }
+
+    public void onPause() {
+    }
+
+    public void onDestroy() {
+    }
+
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        // TODO(yongsheng): Implement it.
+    }
+
+    // TODO(yongsheng): Enable this once the remote debugging feature is supported.
+    public String enableRemoteDebugging(String frontEndUrl, String socketName) {
+        // return mXwalkView.enableRemoteDebugging(socketName);
+        return "";
+    }
+
+    public void disableRemoteDebugging() {
+        // mXwalkView.disableRemoteDebugging();
+    }
+}

--- a/runtime/android/runtimeshell/AndroidManifest.xml
+++ b/runtime/android/runtimeshell/AndroidManifest.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--  Copyright (c) 2013 Intel Corporation. All rights reserved.
+
+  Use of this source code is governed by a BSD-style license that can be
+  found in the LICENSE file.
+-->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.xwalk.runtime.shell">
+
+    <permission android:name="org.xwalk.runtime.shell.permission.SANDBOX"
+            android:protectionLevel="signature" />
+
+    <application android:name="org.xwalk.runtime.shell.XWalkRuntimeShellApplication"
+        android:label="XWalkRuntimeShell" android:hardwareAccelerated="true">
+        <activity android:name="org.xwalk.runtime.shell.XWalkRuntimeShellActivity"
+            android:theme="@android:style/Theme.Holo.Light.NoActionBar"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize"
+            android:label="XWalkRuntimeShell">
+          <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+          </intent-filter>
+        </activity>
+        <service android:name="org.chromium.content.app.SandboxedProcessService0"
+                 android:process=":sandboxed_process0"
+                 android:permission="org.xwalk.runtime.shell.permission.SANDBOX"
+                 android:isolatedProcess="true"
+                 android:exported="false" />
+        <service android:name="org.chromium.content.app.SandboxedProcessService1"
+                 android:process=":sandboxed_process1"
+                 android:permission="org.xwalk.runtime.shell.permission.SANDBOX"
+                 android:isolatedProcess="true"
+                 android:exported="false" />
+        <service android:name="org.chromium.content.app.SandboxedProcessService2"
+                 android:process=":sandboxed_process2"
+                 android:permission="org.xwalk.runtime.shell.permission.SANDBOX"
+                 android:isolatedProcess="true"
+                 android:exported="false" />
+        <service android:name="org.chromium.content.app.SandboxedProcessService3"
+                 android:process=":sandboxed_process3"
+                 android:permission="org.xwalk.runtime.shell.permission.SANDBOX"
+                 android:isolatedProcess="true"
+                 android:exported="false" />
+        <service android:name="org.chromium.content.app.SandboxedProcessService4"
+                 android:process=":sandboxed_process4"
+                 android:permission="org.xwalk.runtime.shell.permission.SANDBOX"
+                 android:isolatedProcess="true"
+                 android:exported="false" />
+        <service android:name="org.chromium.content.app.SandboxedProcessService5"
+                 android:process=":sandboxed_process5"
+                 android:permission="org.xwalk.runtime.shell.permission.SANDBOX"
+                 android:isolatedProcess="true"
+                 android:exported="false" />
+    </application>
+
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.WAKE_LOCK"/>
+</manifest>

--- a/runtime/android/runtimeshell/res/layout/testshell_activity.xml
+++ b/runtime/android/runtimeshell/res/layout/testshell_activity.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright (c) 2013 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+ -->
+
+<LinearLayout android:id="@+id/testshell_activity"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <EditText android:id="@+id/url"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="bottom"
+            android:textSize="18sp"
+            android:autoText="true"
+            android:capitalize="sentences"
+            android:singleLine="true"
+            android:selectAllOnFocus="true"
+            android:inputType="textUri"
+            android:imeOptions="actionGo" />
+    </LinearLayout>
+
+    <org.xwalk.runtime.XWalkRuntimeView android:id="@+id/content_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </org.xwalk.runtime.XWalkRuntimeView>
+
+</LinearLayout>
+

--- a/runtime/android/runtimeshell/res/values/strings.xml
+++ b/runtime/android/runtimeshell/res/values/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright (c) 2013 Intel Corporation. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<resources>
+    <string name="test_string">Hello, Crosswalk!</string>
+</resources>

--- a/runtime/android/runtimeshell/src/org/xwalk/runtime/shell/XWalkRuntimeShellActivity.java
+++ b/runtime/android/runtimeshell/src/org/xwalk/runtime/shell/XWalkRuntimeShellActivity.java
@@ -1,0 +1,135 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.shell;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.Context;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.View.OnFocusChangeListener;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.TextView.OnEditorActionListener;
+
+import org.chromium.content.common.CommandLine;
+import org.xwalk.runtime.XWalkRuntimeView;
+
+public class XWalkRuntimeShellActivity extends Activity {
+    // TODO(yongsheng): Add one flag to hide the url bar.
+    public static final String COMMAND_LINE_FILE = "/data/local/tmp/runtime-shell-command-line";
+    private static final String TAG = XWalkRuntimeShellActivity.class.getName();
+    public static final String COMMAND_LINE_ARGS_KEY = "commandLineArgs";
+
+    private EditText mUrlTextView;
+    private XWalkRuntimeView mRuntimeView;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (!CommandLine.isInitialized()) {
+            CommandLine.initFromFile(COMMAND_LINE_FILE);
+            String[] commandLineParams = getCommandLineParamsFromIntent(getIntent());
+            if (commandLineParams != null) {
+                CommandLine.getInstance().appendSwitchesAndArguments(commandLineParams);
+            }
+        }
+
+        waitForDebuggerIfNeeded();
+
+        setContentView(R.layout.testshell_activity);
+        mRuntimeView = (XWalkRuntimeView) findViewById(R.id.content_container);
+
+        initializeUrlField();
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        mRuntimeView.onPause();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        mRuntimeView.onResume();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mRuntimeView.onDestroy();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        mRuntimeView.onActivityResult(requestCode, resultCode, data);
+    }
+
+
+    private void waitForDebuggerIfNeeded() {
+        if (CommandLine.getInstance().hasSwitch(CommandLine.WAIT_FOR_JAVA_DEBUGGER)) {
+            Log.e(TAG, "Waiting for Java debugger to connect...");
+            android.os.Debug.waitForDebugger();
+            Log.e(TAG, "Java debugger connected. Resuming execution.");
+        }
+    }
+
+    private static String[] getCommandLineParamsFromIntent(Intent intent) {
+        return intent != null ? intent.getStringArrayExtra(COMMAND_LINE_ARGS_KEY) : null;
+    }
+
+    private static String sanitizeUrl(String url) {
+        if (url == null) return url;
+        if (url.startsWith("www.") || url.indexOf(":") == -1) url = "http://" + url;
+        return url;
+    }
+
+    private void initializeUrlField() {
+        mUrlTextView = (EditText) findViewById(R.id.url);
+        mUrlTextView.setOnEditorActionListener(new OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if ((actionId != EditorInfo.IME_ACTION_GO) && (event == null ||
+                        event.getKeyCode() != KeyEvent.KEYCODE_ENTER ||
+                        event.getKeyCode() != KeyEvent.ACTION_DOWN)) {
+                    return false;
+                }
+
+                mRuntimeView.loadAppFromUrl(sanitizeUrl(mUrlTextView.getText().toString()));
+                mUrlTextView.clearFocus();
+                setKeyboardVisibilityForUrl(false);
+                return true;
+            }
+        });
+        mUrlTextView.setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                setKeyboardVisibilityForUrl(hasFocus);
+                if (!hasFocus) {
+                    // TODO(yongsheng): Fix this.
+                    // mUrlTextView.setText(mRuntimeView.getUrl());
+                }
+            }
+        });
+    }
+
+    private void setKeyboardVisibilityForUrl(boolean visible) {
+        InputMethodManager imm = (InputMethodManager) getSystemService(
+                Context.INPUT_METHOD_SERVICE);
+        if (visible) {
+            imm.showSoftInput(mUrlTextView, InputMethodManager.SHOW_IMPLICIT);
+        } else {
+            imm.hideSoftInputFromWindow(mUrlTextView.getWindowToken(), 0);
+        }
+    }
+}

--- a/runtime/android/runtimeshell/src/org/xwalk/runtime/shell/XWalkRuntimeShellApplication.java
+++ b/runtime/android/runtimeshell/src/org/xwalk/runtime/shell/XWalkRuntimeShellApplication.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.shell;
+
+import android.app.Application;
+import android.content.Context;
+
+public class XWalkRuntimeShellApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+}
+

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -476,6 +476,7 @@
         {
           'dependencies': [
             'xwalk_core_shell_apk',
+            'xwalk_runtime_shell_apk',
           ],
         }],
       ],

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -111,5 +111,41 @@
       },
       'includes': [ '../build/apk_test.gypi' ],
     },
+    {
+      'target_name': 'xwalk_runtime_shell_apk',
+      'type': 'none',
+      'dependencies': [
+        'libxwalkcore',
+        # Runtime code is also built by this target.
+        'xwalk_core_java',
+        'xwalk_runtime_shell_apk_pak',
+      ],
+      'variables': {
+        'apk_name': 'XWalkRuntimeShell',
+        'java_in_dir': 'runtime/android/runtimeshell',
+        'resource_dir': 'runtime/android/runtimeshell/res',
+        'native_lib_target': 'libxwalkcore',
+        'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_runtime/assets/xwalk.pak',
+        ],
+        'asset_location': '<(ant_build_out)/xwalk_runtime/assets',
+      },
+      'includes': [ '../build/java_apk.gypi' ],
+    },
+    {
+      'target_name': 'xwalk_runtime_shell_apk_pak',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_pak',
+      ],
+      'copies': [
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_runtime/assets',
+          'files': [
+            '<(PRODUCT_DIR)/xwalk.pak',
+          ],
+        },
+      ],
+    },
   ],
 }


### PR DESCRIPTION
Runtime will provide some simple APIs and be included in a library APK.
According to the design document, all APIs are added here.

A test shell is also included for testing runtime layer. There will be
instrumentation tests based on it. To build it, run the below command:
ninja -C out/Debug xwalk_runtime_shell_apk
