### PR TITLE
[Android] Fix gyp failure for target runtimelib

### DIFF
--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -78,7 +78,6 @@
       'variables': {
         'apk_name': 'XWalkRuntimeLib',
         'java_in_dir': 'runtime/android/runtimelib',
-        'resource_dir': 'runtime/android/runtimelib/res',
         'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
           '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/xwalk.pak',


### PR DESCRIPTION
Runtimelib doesn't have res right now. The empty res
folder won't be mananged by git. So remove the res line
in gyp.
