### PR TITLE
Add default JavaScript dialogs (alert/confirm/prompt) support.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -64,7 +64,7 @@ class XWalkContent extends FrameLayout {
                         FrameLayout.LayoutParams.MATCH_PARENT,
                         FrameLayout.LayoutParams.MATCH_PARENT));
 
-        mXWalkContent = nativeInit(mXWalkContentsDelegateAdapter);
+        mXWalkContent = nativeInit(mXWalkContentsDelegateAdapter, mContentsClientBridge);
         mWebContents = nativeGetWebContents(mXWalkContent);
 
         // Initialize mWindow which is needed by content
@@ -154,7 +154,8 @@ class XWalkContent extends FrameLayout {
         nativeClearCache(mXWalkContent, includeDiskFiles);
     }
 
-    private native int nativeInit(XWalkWebContentsDelegate webViewContentsDelegate);
+    private native int nativeInit(XWalkWebContentsDelegate webViewContentsDelegate,
+            XWalkContentsClientBridge bridge);
     private native int nativeGetWebContents(int nativeXWalkContent);
     private native void nativeClearCache(int nativeXWalkContent, boolean includeDiskFiles);
 }

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -12,6 +12,7 @@ import android.util.AttributeSet;
 import android.webkit.WebSettings;
 import android.widget.FrameLayout;
 
+import org.xwalk.core.client.XWalkDefaultWebChromeClient;
 import org.xwalk.core.XWalkDevToolsServer;
 
 public class XWalkView extends FrameLayout {
@@ -41,6 +42,9 @@ public class XWalkView extends FrameLayout {
                 new FrameLayout.LayoutParams(
                         FrameLayout.LayoutParams.MATCH_PARENT,
                         FrameLayout.LayoutParams.MATCH_PARENT));
+
+        // Set default XWalkWebChromeClient.
+        setXWalkWebChromeClient(new XWalkDefaultWebChromeClient(context));
     }
 
     public void loadUrl(String url) {

--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultWebChromeClient.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultWebChromeClient.java
@@ -1,0 +1,112 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.client;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.pm.ActivityInfo;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Message;
+import android.view.View;
+import android.webkit.WebStorage;
+import android.webkit.GeolocationPermissions;
+import android.webkit.ConsoleMessage;
+import android.webkit.ValueCallback;
+import android.widget.EditText;
+
+import org.xwalk.core.JsPromptResult;
+import org.xwalk.core.JsResult;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkWebChromeClient;
+
+public class XWalkDefaultWebChromeClient extends XWalkWebChromeClient {
+    private Context mContext;
+    private AlertDialog mDialog;
+    private EditText mPromptText;
+
+    public XWalkDefaultWebChromeClient(Context context) {
+        mContext = context;
+    }
+
+    @Override
+    public boolean onJsAlert(XWalkView view, String url, String message,
+            final JsResult result) {
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mContext);
+        // TODO(shouqun): the strings need to be localized.
+        dialogBuilder.setTitle("JavaScript Alert")
+                .setMessage(message)
+                .setCancelable(false)
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        result.confirm();
+                        dialog.dismiss();
+                    }
+                });
+        mDialog = dialogBuilder.create();
+        mDialog.show();
+        return false;
+    }
+
+    @Override
+    public boolean onJsConfirm(XWalkView view, String url, String message,
+            final JsResult result) {
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mContext);
+        // TODO(shouqun): the strings need to be localized.
+        dialogBuilder.setTitle("JavaScript Confirm")
+                .setMessage(message)
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        result.confirm();
+                        dialog.dismiss();
+                    }
+                })
+                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        result.cancel();
+                        dialog.dismiss();
+                    }
+                });
+        mDialog = dialogBuilder.create();
+        mDialog.show();
+        return false;
+    }
+
+    @Override
+    public boolean onJsPrompt(XWalkView view, String url, String message,
+            String defaultValue, final JsPromptResult result) {
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mContext);
+        // TODO(shouqun): the strings need to be localized.
+        dialogBuilder.setTitle("JavaScript Prompt")
+                .setMessage(message)
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        result.confirm(mPromptText.getText().toString());
+                        dialog.dismiss();
+                    }
+                })
+                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        result.cancel();
+                        dialog.dismiss();
+                    }
+                });
+        mPromptText = new EditText(mContext);
+        mPromptText.setVisibility(View.VISIBLE);
+        mPromptText.setText(defaultValue);
+        mPromptText.selectAll();
+
+        dialogBuilder.setView(mPromptText);
+        mDialog = dialogBuilder.create();
+        mDialog.show();
+        return false;
+    }
+}

--- a/runtime/android/shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -24,6 +24,7 @@ import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 
 import org.chromium.content.common.CommandLine;
+import org.xwalk.core.client.XWalkDefaultWebChromeClient;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkWebChromeClient;
 
@@ -163,7 +164,7 @@ public class XWalkViewShellActivity extends Activity {
     }
 
     private void initializeXWalkViewClients() {
-        mView.setXWalkWebChromeClient(new XWalkWebChromeClient() {
+        mView.setXWalkWebChromeClient(new XWalkDefaultWebChromeClient(this) {
             public void onProgressChanged(XWalkView view, int newProgress) {
                 mToolbar.removeCallbacks(mClearProgressRunnable);
 

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -18,10 +18,12 @@ class WebContents;
 namespace xwalk {
 
 class XWalkWebContentsDelegate;
+class XWalkContentsClientBridge;
 
 class XWalkContent {
  public:
-  XWalkContent(JNIEnv* env, jobject obj, jobject web_contents_delegate);
+  XWalkContent(JNIEnv* env, jobject obj, jobject web_contents_delegate,
+      jobject contents_client_bridge);
   ~XWalkContent();
 
   jint GetWebContents(JNIEnv* env, jobject obj);
@@ -35,6 +37,7 @@ class XWalkContent {
   scoped_ptr<content::WebContents> web_contents_;
   scoped_ptr<XWalkWebContentsDelegate> web_contents_delegate_;
   scoped_ptr<XWalkRenderViewHostExt> render_view_host_ext_;
+  scoped_ptr<XWalkContentsClientBridge> contents_client_bridge_;
 };
 
 bool RegisterXWalkContent(JNIEnv* env);

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -10,6 +10,7 @@
 #include "content/public/browser/web_contents.h"
 #include "jni/XWalkWebContentsDelegate_jni.h"
 #include "xwalk/runtime/browser/runtime_file_select_helper.h"
+#include "xwalk/runtime/browser/runtime_javascript_dialog_manager.h"
 
 using base::android::AttachCurrentThread;
 using base::android::ScopedJavaLocalRef;
@@ -77,6 +78,14 @@ void XWalkWebContentsDelegate::RunFileChooser(
     content::WebContents* web_contents,
     const content::FileChooserParams& params) {
   RuntimeFileSelectHelper::RunFileChooser(web_contents, params);
+}
+
+content::JavaScriptDialogManager*
+XWalkWebContentsDelegate::GetJavaScriptDialogManager() {
+  if (!javascript_dialog_manager_.get()) {
+    javascript_dialog_manager_.reset(new RuntimeJavaScriptDialogManager);
+  }
+  return javascript_dialog_manager_.get();
 }
 
 bool RegisterXWalkWebContentsDelegate(JNIEnv* env) {

--- a/runtime/browser/android/xwalk_web_contents_delegate.h
+++ b/runtime/browser/android/xwalk_web_contents_delegate.h
@@ -30,8 +30,11 @@ class XWalkWebContentsDelegate
   virtual void RunFileChooser(
       content::WebContents* web_contents,
       const content::FileChooserParams& params) OVERRIDE;
+  virtual content::JavaScriptDialogManager*
+      GetJavaScriptDialogManager() OVERRIDE;
 
  private:
+  scoped_ptr<content::JavaScriptDialogManager> javascript_dialog_manager_;
   DISALLOW_COPY_AND_ASSIGN(XWalkWebContentsDelegate);
 };
 

--- a/runtime/browser/runtime_javascript_dialog_manager.cc
+++ b/runtime/browser/runtime_javascript_dialog_manager.cc
@@ -1,0 +1,66 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/runtime_javascript_dialog_manager.h"
+
+#include <string>
+
+#include "content/public/browser/javascript_dialog_manager.h"
+#include "content/public/browser/web_contents.h"
+
+#if defined(OS_ANDROID)
+#include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
+#endif  // defined(OS_ANDROID)
+
+namespace xwalk {
+
+RuntimeJavaScriptDialogManager::RuntimeJavaScriptDialogManager() {
+}
+
+RuntimeJavaScriptDialogManager::~RuntimeJavaScriptDialogManager() {
+}
+
+void RuntimeJavaScriptDialogManager::RunJavaScriptDialog(
+    content::WebContents* web_contents,
+    const GURL& origin_url,
+    const std::string& accept_lang,
+    content::JavaScriptMessageType javascript_message_type,
+    const string16& message_text,
+    const string16& default_prompt_text,
+    const DialogClosedCallback& callback,
+    bool* did_suppress_message) {
+#if defined(OS_ANDROID)
+  XWalkContentsClientBridgeBase* bridge =
+      XWalkContentsClientBridgeBase::FromWebContents(web_contents);
+  bridge->RunJavaScriptDialog(javascript_message_type,
+                              origin_url,
+                              message_text,
+                              default_prompt_text,
+                              callback);
+#else
+  NOTIMPLEMENTED();
+#endif
+}
+
+void RuntimeJavaScriptDialogManager::RunBeforeUnloadDialog(
+    content::WebContents* web_contents,
+    const string16& message_text,
+    bool is_reload,
+    const DialogClosedCallback& callback) {
+#if defined(OS_ANDROID)
+  XWalkContentsClientBridgeBase* bridge =
+      XWalkContentsClientBridgeBase::FromWebContents(web_contents);
+  bridge->RunBeforeUnloadDialog(web_contents->GetURL(),
+                                message_text,
+                                callback);
+#else
+  NOTIMPLEMENTED();
+#endif
+}
+
+void RuntimeJavaScriptDialogManager::ResetJavaScriptState(
+    content::WebContents* web_contents) {
+}
+
+}  // namespace xwalk

--- a/runtime/browser/runtime_javascript_dialog_manager.h
+++ b/runtime/browser/runtime_javascript_dialog_manager.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_RUNTIME_JAVASCRIPT_DIALOG_MANAGER_H_
+#define XWALK_RUNTIME_BROWSER_RUNTIME_JAVASCRIPT_DIALOG_MANAGER_H_
+
+#include <string>
+
+#include "content/public/browser/javascript_dialog_manager.h"
+
+namespace xwalk {
+
+class RuntimeJavaScriptDialogManager : public content::JavaScriptDialogManager {
+ public:
+  explicit RuntimeJavaScriptDialogManager();
+  virtual ~RuntimeJavaScriptDialogManager();
+
+  virtual void RunJavaScriptDialog(
+      content::WebContents* web_contents,
+      const GURL& origin_url,
+      const std::string& accept_lang,
+      content::JavaScriptMessageType javascript_message_type,
+      const string16& message_text,
+      const string16& default_prompt_text,
+      const DialogClosedCallback& callback,
+      bool* did_suppress_message);
+
+  virtual void RunBeforeUnloadDialog(content::WebContents* web_contents,
+                                     const string16& message_text,
+                                     bool is_reload,
+                                     const DialogClosedCallback& callback);
+
+  virtual void ResetJavaScriptState(content::WebContents* web_contents);
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(RuntimeJavaScriptDialogManager);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_RUNTIME_JAVASCRIPT_DIALOG_MANAGER_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -87,6 +87,8 @@
         'runtime/browser/runtime_download_manager_delegate.h',
         'runtime/browser/runtime_file_select_helper.cc',
         'runtime/browser/runtime_file_select_helper.h',
+        'runtime/browser/runtime_javascript_dialog_manager.cc',
+        'runtime/browser/runtime_javascript_dialog_manager.h',
         'runtime/browser/runtime_network_delegate.cc',
         'runtime/browser/runtime_network_delegate.h',
         'runtime/browser/runtime_platform_util.h',


### PR DESCRIPTION
- Bridge up the XWalkContent with ContentsClientBridge.
- Add a default implementation of XWalkWebChromeClient, which provides the
  JavaScript dialogs support.
