### PR TITLE
[Android] Enable WebRTC on Crosswalk for Android platform

### DIFF
--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -31,6 +31,8 @@
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+  <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
 </manifest>

--- a/runtime/android/runtime_shell/AndroidManifest.xml
+++ b/runtime/android/runtime_shell/AndroidManifest.xml
@@ -24,6 +24,8 @@
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+  <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
 </manifest>

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -9,6 +9,7 @@
 #include "base/message_loop.h"
 #include "content/public/browser/web_contents.h"
 #include "jni/XWalkWebContentsDelegate_jni.h"
+#include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
 #include "xwalk/runtime/browser/runtime_file_select_helper.h"
 #include "xwalk/runtime/browser/runtime_javascript_dialog_manager.h"
 
@@ -86,6 +87,14 @@ XWalkWebContentsDelegate::GetJavaScriptDialogManager() {
     javascript_dialog_manager_.reset(new RuntimeJavaScriptDialogManager);
   }
   return javascript_dialog_manager_.get();
+}
+
+void XWalkWebContentsDelegate::RequestMediaAccessPermission(
+    content::WebContents* web_contents,
+    const content::MediaStreamRequest& request,
+    const content::MediaResponseCallback& callback) {
+  XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission(
+      web_contents, request, callback);
 }
 
 bool RegisterXWalkWebContentsDelegate(JNIEnv* env) {

--- a/runtime/browser/android/xwalk_web_contents_delegate.h
+++ b/runtime/browser/android/xwalk_web_contents_delegate.h
@@ -33,6 +33,10 @@ class XWalkWebContentsDelegate
   virtual content::JavaScriptDialogManager*
       GetJavaScriptDialogManager() OVERRIDE;
 
+  virtual void RequestMediaAccessPermission(
+      content::WebContents* web_contents,
+      const content::MediaStreamRequest& request,
+      const content::MediaResponseCallback& callback) OVERRIDE;
  private:
   scoped_ptr<content::JavaScriptDialogManager> javascript_dialog_manager_;
   DISALLOW_COPY_AND_ASSIGN(XWalkWebContentsDelegate);

--- a/runtime/browser/media/media_capture_devices_dispatcher.cc
+++ b/runtime/browser/media/media_capture_devices_dispatcher.cc
@@ -38,6 +38,43 @@ XWalkMediaCaptureDevicesDispatcher*
   return Singleton<XWalkMediaCaptureDevicesDispatcher>::get();
 }
 
+void XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission(
+    content::WebContents* web_contents,
+    const content::MediaStreamRequest& request,
+    const content::MediaResponseCallback& callback) {
+
+  content::MediaStreamDevices devices;
+  // Based on chrome/browser/media/media_stream_devices_controller.cc.
+  bool microphone_requested =
+      (request.audio_type == content::MEDIA_DEVICE_AUDIO_CAPTURE);
+  bool webcam_requested =
+      (request.video_type == content::MEDIA_DEVICE_VIDEO_CAPTURE);
+  if (microphone_requested || webcam_requested) {
+    switch (request.request_type) {
+      case content::MEDIA_OPEN_DEVICE:
+        // For open device request pick the desired device or fall back to the
+        // first available of the given type.
+        XWalkMediaCaptureDevicesDispatcher::GetInstance()->GetRequestedDevice(
+            request.requested_device_id,
+            microphone_requested,
+            webcam_requested,
+            &devices);
+        break;
+      case content::MEDIA_DEVICE_ACCESS:
+      case content::MEDIA_GENERATE_STREAM:
+      case content::MEDIA_ENUMERATE_DEVICES:
+        // Get the default devices for the request.
+        XWalkMediaCaptureDevicesDispatcher::GetInstance()->GetRequestedDevice(
+            "",
+            microphone_requested,
+            webcam_requested,
+            &devices);
+        break;
+    }
+  }
+  callback.Run(devices, scoped_ptr<content::MediaStreamUI>());
+}
+
 XWalkMediaCaptureDevicesDispatcher::XWalkMediaCaptureDevicesDispatcher()
     : devices_enumerated_(false) {}
 

--- a/runtime/browser/media/media_capture_devices_dispatcher.h
+++ b/runtime/browser/media/media_capture_devices_dispatcher.h
@@ -13,6 +13,7 @@
 #include "base/memory/singleton.h"
 #include "base/observer_list.h"
 #include "content/public/browser/media_observer.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/common/media_stream_request.h"
 
 // This singleton is used to receive updates about media events from the content
@@ -42,6 +43,11 @@ class XWalkMediaCaptureDevicesDispatcher : public content::MediaObserver {
   };
 
   static XWalkMediaCaptureDevicesDispatcher* GetInstance();
+
+  static void RunRequestMediaAccessPermission(
+      content::WebContents* web_contents,
+      const content::MediaStreamRequest& request,
+      const content::MediaResponseCallback& callback);
 
   // Methods for observers. Called on UI thread.
   // Observers should add themselves on construction and remove themselves

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -328,37 +328,8 @@ void Runtime::RequestMediaAccessPermission(
     content::WebContents* web_contents,
     const content::MediaStreamRequest& request,
     const content::MediaResponseCallback& callback) {
-
-  content::MediaStreamDevices devices;
-  // Based on chrome/browser/media/media_stream_devices_controller.cc
-  bool microphone_requested =
-      (request.audio_type == content::MEDIA_DEVICE_AUDIO_CAPTURE);
-  bool webcam_requested =
-      (request.video_type == content::MEDIA_DEVICE_VIDEO_CAPTURE);
-  if (microphone_requested || webcam_requested) {
-    switch (request.request_type) {
-      case content::MEDIA_OPEN_DEVICE:
-        // For open device request pick the desired device or fall back to the
-        // first available of the given type.
-        XWalkMediaCaptureDevicesDispatcher::GetInstance()->GetRequestedDevice(
-            request.requested_device_id,
-            microphone_requested,
-            webcam_requested,
-            &devices);
-        break;
-      case content::MEDIA_DEVICE_ACCESS:
-      case content::MEDIA_GENERATE_STREAM:
-      case content::MEDIA_ENUMERATE_DEVICES:
-        // Get the default devices for the request.
-        XWalkMediaCaptureDevicesDispatcher::GetInstance()->GetRequestedDevice(
-            "",
-            microphone_requested,
-            webcam_requested,
-            &devices);
-        break;
-    }
-  }
-  callback.Run(devices, scoped_ptr<content::MediaStreamUI>());
+  XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission(
+      web_contents, request, callback);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -77,6 +77,11 @@ void XWalkBrowserMainParts::SetRuntimeContext(RuntimeContext* context) {
 #endif
 
 void XWalkBrowserMainParts::PreMainMessageLoopStart() {
+#if defined(OS_ANDROID)
+  CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kEnableWebRTC);
+#endif
+
 #if !defined(OS_ANDROID)
   CommandLine* command_line = CommandLine::ForCurrentProcess();
   const CommandLine::StringVector& args = command_line->GetArgs();


### PR DESCRIPTION
1. xwalk_core_shell application needs camera and record audio permission.
2. “—enable-webrtc” is needed to add to command line, since WebRTC is
   disabled by default on Android platform. We can through the followed
   command to enable it.
   adb shell "echo 'XWalkCoreShell --enable-webrtc' > /data/local/tmp/xwview-shell-command-line"
3. Android implemented different WebContentsDelegate class with GTK and
   Windows platform.
