### PR TITLE
[Android] Fix the dependency to jni headers while build xwalk_runtime co...

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -185,6 +185,10 @@
             'runtime/renderer/android/xwalk_render_view_ext.cc',
             'runtime/renderer/android/xwalk_render_view_ext.h',
           ],
+          'dependencies':[
+            'xwalk_core_jar_jni',
+            'xwalk_core_native_jni',
+          ],
         }],
         ['OS=="win" and win_use_allocator_shim==1', {
           'dependencies': [


### PR DESCRIPTION
...de.

The Jni headers need to be generated before building xwalk_runtime.
