### PR TITLE
[Android] Fix the issue of mixed context and activity

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/CrossPackageWrapper.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/CrossPackageWrapper.java
@@ -18,7 +18,7 @@ public abstract class CrossPackageWrapper {
     private Constructor<?> mCreator;
     private CrossPackageWrapperExceptionHandler mExceptionHandler;
 
-    public CrossPackageWrapper(Context ctx, String className, 
+    public CrossPackageWrapper(Context ctx, String className,
             CrossPackageWrapperExceptionHandler handler, Class<?>... parameters) {
         mExceptionHandler = handler;
         try {
@@ -36,7 +36,7 @@ public abstract class CrossPackageWrapper {
             handleException(e);
         }
     }
-    
+
     public Object createInstance(Object... parameters) {
         Object ret = null;
         if (mCreator != null) {

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.app.runtime;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.util.AttributeSet;
@@ -34,8 +35,8 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
     private Method mEnableRemoteDebugging;
     private Method mDisableRemoteDebugging;
 
-    public XWalkRuntimeClient(Context context, AttributeSet attrs, CrossPackageWrapperExceptionHandler exceptionHandler) {
-        super(context, RUNTIME_VIEW_CLASS_NAME, exceptionHandler, Context.class, AttributeSet.class);
+    public XWalkRuntimeClient(Activity activity, AttributeSet attrs, CrossPackageWrapperExceptionHandler exceptionHandler) {
+        super(activity, RUNTIME_VIEW_CLASS_NAME, exceptionHandler, Activity.class, Context.class, AttributeSet.class);
         Context libCtx = getLibraryContext();
         Method getVersion = lookupMethod("getVersion");
         String libVersion = (String) invokeMethod(getVersion, null);
@@ -43,7 +44,7 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
             handleException("Library apk is not up to date");
             return;
         }
-        mInstance = this.createInstance(new MixContext(libCtx, context), attrs);
+        mInstance = this.createInstance(activity, libCtx, attrs);
         mLoadAppFromUrl = lookupMethod("loadAppFromUrl", String.class);
         mLoadAppFromManifest = lookupMethod("loadAppFromManifest", String.class);
         mOnCreate = lookupMethod("onCreate");

--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -68,10 +68,7 @@ public class XWalkContent extends FrameLayout {
         mWebContents = nativeGetWebContents(mXWalkContent);
 
         // Initialize mWindow which is needed by content
-        if (getContext() instanceof Activity) {
-            Activity activity = (Activity) getContext();
-            mWindow = new WindowAndroid(activity);
-        }
+        mWindow = new WindowAndroid(xwView.getActivity());
 
         // Initialize the ContentVideoView for fullscreen video playback.
         ContentVideoView.registerContentVideoViewContextDelegate(

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.core;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Rect;
@@ -17,11 +18,29 @@ import org.xwalk.core.XWalkDevToolsServer;
 
 public class XWalkView extends FrameLayout {
 
-    XWalkContent mContent;
-    XWalkDevToolsServer mDevToolsServer;
+    private XWalkContent mContent;
+    private XWalkDevToolsServer mDevToolsServer;
+    private Activity mActivity;
 
-    public XWalkView(Context context) {
-        this(context, null);
+
+    public XWalkView(Context context, Activity activity) {
+        super(context, null);
+
+        // Make sure mActivity is initialized before calling 'init' method.
+        mActivity = activity;
+        init(context, null);
+    }
+
+    public Activity getActivity() {
+        if (mActivity != null) {
+            return mActivity;
+        } else if (getContext() instanceof Activity) {
+            return (Activity)getContext();
+        }
+
+        // Never achieve here.
+        assert(false);
+        return null;
     }
 
     /**
@@ -30,6 +49,10 @@ public class XWalkView extends FrameLayout {
     public XWalkView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
+        init(context, attrs);
+    }
+
+    private void init(Context context, AttributeSet attrs) {
         // Intialize library, paks and others.
         XWalkViewDelegate.init(context);
 

--- a/runtime/android/java/src/org/xwalk/runtime/MixContext.java
+++ b/runtime/android/java/src/org/xwalk/runtime/MixContext.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package org.xwalk.app.runtime;
+package org.xwalk.runtime;
 
 import android.content.Context;
 import android.content.ContextWrapper;
@@ -12,29 +12,28 @@ import android.content.ServiceConnection;
 /**
  * MixContext provides ApplicationContext for the contextImpl object
  * created by Context.CreatePackageContext().
- * 
+ *
  * For cross package usage, the library part need the possibility to
  * get both the application's context and the library itself's context.
- * 
+ *
  */
 public class MixContext extends ContextWrapper {
-
     private Context mAppCtx;
 
     public MixContext(Context base, Context app) {
         super(base);
         mAppCtx = app.getApplicationContext();
     }
-    
+
     @Override
     public Context getApplicationContext() {
         return mAppCtx;
     }
-    
+
     @Override
     public boolean bindService(Intent in, ServiceConnection conn, int flags) {
         return mAppCtx.bindService(in, conn, flags);
-    }   
+    }
 
     @Override
     public void unbindService(ServiceConnection conn) {

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProvider.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProvider.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.runtime;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.view.View;
@@ -19,12 +20,12 @@ class XWalkCoreProvider implements XWalkRuntimeViewProvider {
     private Context mContext;
     private XWalkView mXwalkView;
 
-    public XWalkCoreProvider(Context context) {
+    public XWalkCoreProvider(Context context, Activity activity) {
         mContext = context;
 
         // TODO(yongsheng): do customizations for XWalkView. There will
         // be many callback classes which are needed to be implemented.
-        mXwalkView = new XWalkView(context);
+        mXwalkView = new XWalkView(context, activity);
     }
 
     @Override

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeView.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeView.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.runtime;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.util.AttributeSet;
@@ -25,14 +26,34 @@ public class XWalkRuntimeView extends FrameLayout {
     private XWalkRuntimeViewProvider mProvider;
 
     /**
-     * Contructs a XWalkRuntimeView with a Context object.
+     * Contructs a XWalkRuntimeView with Activity and library Context. Called
+     * from runtime client.
      *
-     * @param context a Context used by runtime from web app APK.
+     * @param activity the activity from runtime client
+     * @param context a context when creating this package
+     * @param attrs the attributes of the XML tag that is inflating the view
+     */
+    public XWalkRuntimeView(Activity activity, Context libContext, AttributeSet attrs) {
+        super(libContext, attrs);
+
+        // MixContext is needed for cross package because the application
+        // context is different.
+        init(new MixContext(libContext, activity), activity);
+    }
+
+    /**
+     * This is for inflating this view from XML. Called from test shell.
+     * @param context a context to construct View
+     * @param attrs the attributes of the XML tag that is inflating the view
      */
     public XWalkRuntimeView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        mProvider = XWalkRuntimeViewProviderFactory.getProvider(context);
+        init(context, (Activity)context);
+    }
+
+    private void init(Context context, Activity activity) {
+        mProvider = XWalkRuntimeViewProviderFactory.getProvider(context, activity);
         this.addView(mProvider.getView(),
                 new FrameLayout.LayoutParams(
                         FrameLayout.LayoutParams.MATCH_PARENT,

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProviderFactory.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProviderFactory.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.runtime;
 
+import android.app.Activity;
 import android.content.Context;
 
 /**
@@ -11,9 +12,9 @@ import android.content.Context;
  * current setting.
  */
 final class XWalkRuntimeViewProviderFactory {
-    static public XWalkRuntimeViewProvider getProvider(Context context) {
+    static public XWalkRuntimeViewProvider getProvider(Context context, Activity activity) {
         // TODO(yongsheng): Do checkings here to decide which provider should
         // be used. The default is to use runtime core provider.
-        return new XWalkCoreProvider(context);
+        return new XWalkCoreProvider(context, activity);
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -35,7 +35,7 @@ public class XWalkViewTestBase
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                mXWalkView = new XWalkView(getActivity());
+                mXWalkView = new XWalkView(getActivity(), getActivity());
                 getActivity().addView(mXWalkView);
                 mXWalkView.getXWalkViewContentForTest().installWebContentsObserverForTest(mTestContentsClient);
             }


### PR DESCRIPTION
This is to resolve the two contexts needed by runtime side and activity
is used by runtime core.
1. Keep the mixed context inside of runtime. One context is for application and one is for package. they're different because runtime library is shared so the context for runtime library is different from the context for web app APK.
2. Pass activity from runtime client to runtime. This is needed for fullscreen support like video playback.
