### PR TITLE
Make extension tests slightly more robust

### DIFF
--- a/extensions/test/data/echo.html
+++ b/extensions/test/data/echo.html
@@ -1,12 +1,17 @@
 <html>
 <head>
-<title>Fail</title>
+<title></title>
 </head>
 <body>
 <script>
-echo.echo("Pass", function(msg) {
-        document.title = msg;
-    });
+try {
+    echo.echo("Pass", function(msg) {
+            document.title = msg;
+        });
+} catch(e) {
+    console.log(e);
+    document.title = "Fail";
+}
 </script>
 </body>
 </html>

--- a/extensions/test/data/sync_echo.html
+++ b/extensions/test/data/sync_echo.html
@@ -1,10 +1,15 @@
 <html>
 <head>
-<title>Fail</title>
+<title></title>
 </head>
 <body>
 <script>
-document.title = echo.syncEcho("Pass");
+try {
+  document.title = echo.syncEcho("Pass");
+} catch (e) {
+  console.log(e);
+  document.title = "Fail";
+}
 </script>
 </body>
 </html>

--- a/extensions/test/data/test_extension.html
+++ b/extensions/test/data/test_extension.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>Fail</title>
+    <title></title>
   </head>
   <body>
     <script>
@@ -11,9 +11,13 @@
         test_list[current_test++]();
       }
 
+      window.onerror = function() {
+        error++;
+        endTest();
+      };
+
       function endTest() {
-        if (!error)
-          document.title = "Pass";
+        document.title = error ? "Fail" : "Pass";
       }
 
       function echoStuff(stuff) {

--- a/extensions/test/data/test_internal_extension.html
+++ b/extensions/test/data/test_internal_extension.html
@@ -1,15 +1,19 @@
 <html>
   <head>
-    <title>Fail</title>
+    <title></title>
   </head>
   <body>
     <script>
       var Person = test.Person;
       var error = 0;
 
+      window.onerror = function(e) {
+        error++;
+        endTest();
+      };
+
       function endTest() {
-        if (!error)
-          document.title = "Pass";
+        document.title = error ? "Fail" : "Pass";
       }
 
       test.clearDatabase();

--- a/extensions/test/external_extension.cc
+++ b/extensions/test/external_extension.cc
@@ -43,10 +43,10 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionTest, ExternalExtension) {
   content::RunAllPendingInMessageLoop();
   GURL url = GetExtensionsTestURL(base::FilePath(),
                                   base::FilePath().AppendASCII("echo.html"));
-  string16 title = ASCIIToUTF16("Pass");
-  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
   xwalk_test_utils::NavigateToURL(runtime(), url);
-  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }
 
 
@@ -60,8 +60,8 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionTest, ExternalExtensionSync) {
   GURL url = GetExtensionsTestURL(
       base::FilePath(),
       base::FilePath().AppendASCII("sync_echo.html"));
-  string16 title = ASCIIToUTF16("Pass");
-  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
   xwalk_test_utils::NavigateToURL(runtime(), url);
-  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }

--- a/extensions/test/external_extension_browsertest.cc
+++ b/extensions/test/external_extension_browsertest.cc
@@ -43,10 +43,10 @@ IN_PROC_BROWSER_TEST_F(OldExternalExtensionTest, ExternalExtension) {
   content::RunAllPendingInMessageLoop();
   GURL url = GetExtensionsTestURL(base::FilePath(),
                                   base::FilePath().AppendASCII("echo.html"));
-  string16 title = ASCIIToUTF16("Pass");
-  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
   xwalk_test_utils::NavigateToURL(runtime(), url);
-  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }
 
 
@@ -60,8 +60,8 @@ IN_PROC_BROWSER_TEST_F(OldExternalExtensionTest, ExternalExtensionSync) {
   GURL url = GetExtensionsTestURL(
       base::FilePath(),
       base::FilePath().AppendASCII("sync_echo.html"));
-  string16 title = ASCIIToUTF16("Pass");
-  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
   xwalk_test_utils::NavigateToURL(runtime(), url);
-  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }

--- a/extensions/test/internal_extension_browsertest.cc
+++ b/extensions/test/internal_extension_browsertest.cc
@@ -141,12 +141,12 @@ class InternalExtensionTest : public XWalkExtensionsTestBase {
 IN_PROC_BROWSER_TEST_F(InternalExtensionTest, InternalExtension) {
   content::RunAllPendingInMessageLoop();
 
-  string16 title = ASCIIToUTF16("Pass");
-  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
 
   GURL url = GetExtensionsTestURL(base::FilePath(),
       base::FilePath().AppendASCII("test_internal_extension.html"));
   xwalk_test_utils::NavigateToURL(runtime(), url);
 
-  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }

--- a/extensions/test/xwalk_extensions_browsertest.cc
+++ b/extensions/test/xwalk_extensions_browsertest.cc
@@ -83,10 +83,10 @@ IN_PROC_BROWSER_TEST_F(XWalkExtensionsTest, EchoExtension) {
   content::RunAllPendingInMessageLoop();
   GURL url = GetExtensionsTestURL(base::FilePath(),
       base::FilePath().AppendASCII("test_extension.html"));
-  string16 title = ASCIIToUTF16("Pass");
-  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
   xwalk_test_utils::NavigateToURL(runtime(), url);
-  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }
 
 // FIXME(cmarcelo): See https://github.com/otcshare/crosswalk/issues/268.
@@ -99,8 +99,8 @@ IN_PROC_BROWSER_TEST_F(XWalkExtensionsTest, EchoExtensionSync) {
   GURL url = GetExtensionsTestURL(base::FilePath(),
                                   base::FilePath().AppendASCII(
                                       "sync_echo.html"));
-  string16 title = ASCIIToUTF16("Pass");
-  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
   xwalk_test_utils::NavigateToURL(runtime(), url);
-  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }

--- a/extensions/test/xwalk_extensions_test_base.h
+++ b/extensions/test/xwalk_extensions_test_base.h
@@ -24,4 +24,7 @@ class XWalkExtensionsTestBase : public InProcessBrowserTest {
 GURL GetExtensionsTestURL(const base::FilePath& dir,
                           const base::FilePath& file);
 
+const string16 kPassString = ASCIIToUTF16("Pass");
+const string16 kFailString = ASCIIToUTF16("Fail");
+
 #endif  // XWALK_EXTENSIONS_TEST_XWALK_EXTENSIONS_TEST_BASE_H_


### PR DESCRIPTION
If something goes wrong, we were failing and simply timing out,
because title wouldn't change to "Pass". Now we watch for both "Pass"
and "Fail" titles, and check that it is "Pass". This allows the test
to indicate failure, and we rely less on the timeout.
