### PR TITLE
Add TizenPlug and TizenIndicator

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -96,7 +96,8 @@ export GYP_GENERATORS='make'
 -Duse_system_libexif=1 \
 -Duse_system_libxml=1 \
 -Duse_system_nspr=1 \
--Denable_xi21_mt=1
+-Denable_xi21_mt=1 \
+-Dtizen_mobile=1
 
 make %{?_smp_mflags} -C src BUILDTYPE=Release xwalk
 

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -31,6 +31,10 @@
 #include "ui/gfx/icon_util.h"
 #endif
 
+#if defined(OS_TIZEN_MOBILE)
+#include "xwalk/runtime/browser/ui/tizen_indicator.h"
+#endif
+
 #if defined(USE_AURA)
 namespace {
 
@@ -272,6 +276,16 @@ void NativeAppWindowViews::ViewHierarchyChanged(
     web_view_->SetWebContents(web_contents_);
     AddChildView(web_view_);
     layout->set_content_view(web_view_);
+
+#if defined(OS_TIZEN_MOBILE)
+    TizenIndicator* indicator = new TizenIndicator();
+    if (indicator->IsConnected()) {
+      AddChildView(indicator);
+      layout->set_top_view(indicator);
+    } else {
+      delete indicator;
+    }
+#endif
   }
 }
 

--- a/runtime/browser/ui/tizen_indicator.cc
+++ b/runtime/browser/ui/tizen_indicator.cc
@@ -1,0 +1,58 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ui/tizen_indicator.h"
+
+#include "ui/gfx/canvas.h"
+#include "content/public/browser/browser_thread.h"
+#include "xwalk/runtime/browser/ui/tizen_plug.h"
+
+namespace {
+
+SkColor kTizenIndicatorColor = SkColorSetARGB(255, 52, 52, 50);
+
+}  // namespace
+
+namespace xwalk {
+
+TizenIndicator::TizenIndicator()
+    : plug_(new TizenPlug(this)) {
+  if (!plug_->Connect()) {
+    plug_.reset();
+    return;
+  }
+
+  set_background(
+      views::Background::CreateSolidBackground(kTizenIndicatorColor));
+
+  content::BrowserThread::PostTask(
+      content::BrowserThread::IO, FROM_HERE,
+      base::Bind(&TizenPlug::StartWatching, base::Unretained(plug_.get())));
+}
+
+TizenIndicator::~TizenIndicator() {
+}
+
+bool TizenIndicator::IsConnected() const {
+  return plug_;
+}
+
+void TizenIndicator::OnPaint(gfx::Canvas* canvas) {
+  View::OnPaint(canvas);
+
+  if (image_.isNull())
+    return;
+  canvas->DrawImageInt(image_, 0, 0);
+}
+
+gfx::Size TizenIndicator::GetPreferredSize() {
+  return plug_->GetSize();
+}
+
+void TizenIndicator::SetImage(const gfx::ImageSkia& img) {
+  image_ = img;
+  SchedulePaint();
+}
+
+}  // namespace xwalk

--- a/runtime/browser/ui/tizen_indicator.h
+++ b/runtime/browser/ui/tizen_indicator.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_TIZEN_INDICATOR_H_
+#define XWALK_RUNTIME_BROWSER_UI_TIZEN_INDICATOR_H_
+
+#include <string>
+#include "ui/gfx/image/image_skia.h"
+#include "ui/views/view.h"
+
+namespace xwalk {
+
+class TizenPlug;
+
+// This view paints the Tizen Mobile indicator provided by the system. We get
+// to it by using the elementary "plug" system from EFL, reading the image from
+// a shared memory area.
+class TizenIndicator : public views::View {
+ public:
+  TizenIndicator();
+  virtual ~TizenIndicator();
+
+  bool IsConnected() const;
+
+  // views::View implementation.
+  virtual void OnPaint(gfx::Canvas* canvas) OVERRIDE;
+  gfx::Size GetPreferredSize() OVERRIDE;
+
+ private:
+  // Will be called by plug when the image is updated.
+  void SetImage(const gfx::ImageSkia& img);
+
+  gfx::ImageSkia image_;
+  scoped_ptr<TizenPlug> plug_;
+  friend class TizenPlug;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_TIZEN_INDICATOR_H_

--- a/runtime/browser/ui/tizen_plug.cc
+++ b/runtime/browser/ui/tizen_plug.cc
@@ -1,0 +1,502 @@
+// Copyright (C) 2000-2011 Carsten Haitzler and various contributors.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ui/tizen_plug.h"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+
+#include "base/file_util.h"
+#include "base/files/file_path.h"
+#include "content/public/browser/browser_thread.h"
+#include "ipc/unix_domain_socket_util.h"
+#include "xwalk/runtime/browser/ui/tizen_indicator.h"
+#include "base/strings/string_tokenizer.h"
+#include "base/environment.h"
+
+using content::BrowserThread;
+
+namespace {
+
+const char kServiceName[] = "elm_indicator_portrait";
+const char kServiceNumber[] = "0";
+
+// Environment variable format is x, y, width, height.
+const char kEnvironmentVar[] = "ILLUME_IND";
+
+// Should match the MAJOR version in ecore_evas_extn.c. We are using
+// the same version used by EFL 1.7 available in Tizen Mobile 2.1.
+const int kPlugProtocolVersion = 0x1011;
+
+// Copied from EFL 1.7, in src/lib/ecore_evas/ecore_evas_extn.c.
+enum TizenPlugOperation {
+  OP_RESIZE,
+  OP_SHOW,
+  OP_HIDE,
+  OP_FOCUS,
+  OP_UNFOCUS,
+  OP_UPDATE,
+  OP_UPDATE_DONE,
+  OP_LOCK_FILE,
+  OP_SHM_REF,
+  OP_EV_MOUSE_IN,
+  OP_EV_MOUSE_OUT,
+  OP_EV_MOUSE_UP,
+  OP_EV_MOUSE_DOWN,
+  OP_EV_MOUSE_MOVE,
+  OP_EV_MOUSE_WHEEL,
+  OP_EV_MULTI_UP,
+  OP_EV_MULTI_DOWN,
+  OP_EV_MULTI_MOVE,
+  OP_EV_KEY_UP,
+  OP_EV_KEY_DOWN,
+  OP_EV_HOLD
+};
+
+}  // namespace
+
+namespace xwalk {
+
+TizenPlug::TizenPlug(TizenIndicator* indicator)
+  : indicator_(indicator),
+    width_(-1),
+    height_(-1),
+    alpha_(-1),
+    updated_(false),
+    shm_size_(-1),
+    shm_fd_(-1),
+    fd_(-1),
+    shm_mem_(MAP_FAILED) {
+  memset(&current_msg_header_, 0, sizeof(current_msg_header_));
+  SetSizeFromEnvironment();
+}
+
+TizenPlug::~TizenPlug() {
+  ShmUnload();
+}
+
+void TizenPlug::OnFileCanReadWithoutBlocking(int fd) {
+  if (!GetHeader()) {
+    PLOG(ERROR) << "Error while getting header";
+    StopWatching();
+    return;
+  }
+
+  if (!ProcessPayload()) {
+    PLOG(ERROR) << "Error while processing payload";
+    StopWatching();
+  }
+}
+
+void TizenPlug::OnFileCanWriteWithoutBlocking(int fd) {
+}
+
+void TizenPlug::StartWatching() {
+  base::MessageLoopForIO::current()->WatchFileDescriptor(
+     fd_, true, base::MessageLoopForIO::WATCH_READ, &fd_watcher_, this);
+}
+
+void TizenPlug::StopWatching() {
+  BrowserThread::PostTask(
+      BrowserThread::IO,
+      FROM_HERE,
+      base::Bind(base::IgnoreResult(&base::MessagePumpLibevent::
+                                    FileDescriptorWatcher::
+                                    StopWatchingFileDescriptor),
+                 base::Unretained(&fd_watcher_)));
+}
+
+bool TizenPlug::Connect() {
+  base::FilePath path(file_util::GetHomeDir()
+                      .Append(".ecore")
+                      .Append(kServiceName)
+                      .Append(kServiceNumber));
+  return IPC::CreateClientUnixDomainSocket(path, &fd_);
+}
+
+gfx::Size TizenPlug::GetSize() const {
+  return gfx::Size(width_, height_);
+}
+
+namespace {
+
+// Headers contain a set of "instructions" and a payload. The instructions are
+// used to build the new header based on a previous header. This allows the
+// system to save bytes when a certain header field wasn't updated.
+//
+// This utility class is used to construct the next header based on the previous
+// one and the new instructions.
+//
+// This parser is compatible with the protocol implemented in EFL 1.7 on the
+// Tizen Mobile 2.1 platform. See src/lib/ecore_ipc/ecore_ipc.c in ecore source.
+class HeaderParser {
+ public:
+  HeaderParser(unsigned int instructions,
+               uint8_t* payload,
+               struct ecore_ipc_msg_header* prev_header,
+               struct ecore_ipc_msg_header* next_header)
+      : instructions_(instructions),
+        payload_(payload),
+        prev_(prev_header),
+        next_(next_header) {}
+
+  enum Instruction {
+    DLT_ZERO,
+    DLT_ONE,
+    DLT_SAME,
+    DLT_SHL,
+    DLT_SHR,
+    DLT_ADD8,      // 1 bytes.
+    DLT_DEL8,
+    DLT_ADDU8,
+    DLT_DELU8,
+    DLT_ADD16,     // 2 bytes.
+    DLT_DEL16,
+    DLT_ADDU16,
+    DLT_DELU16,
+    DLT_SET,       // 4 bytes.
+    DLT_R1,
+    DLT_R2
+  };
+
+  void Parse() {
+    next_->major = ProcessNextInstruction(prev_->major);
+    next_->minor = ProcessNextInstruction(prev_->minor);
+    next_->ref = ProcessNextInstruction(prev_->ref);
+    next_->ref_to = ProcessNextInstruction(prev_->ref_to);
+    next_->response = ProcessNextInstruction(prev_->response);
+    next_->size = ProcessNextInstruction(prev_->size);
+    if (next_->size < 0)
+      next_->size = 0;
+  }
+
+ private:
+  // The instruction determine how much data we are going to read from the
+  // payload.
+  int ExtractInstructionData(Instruction instruction) {
+    if (instruction >= DLT_SET) {
+      uint32_t v;
+      uint8_t* dv = reinterpret_cast<uint8_t*>(&v);
+      dv[0] = *(payload_++);
+      dv[1] = *(payload_++);
+      dv[2] = *(payload_++);
+      dv[3] = *(payload_++);
+      return static_cast<int>(ntohl(v));
+    }
+    if (instruction >= DLT_ADD16) {
+      uint16_t v;
+      uint8_t* dv = reinterpret_cast<uint8_t*>(&v);
+      dv[0] = *(payload_++);
+      dv[1] = *(payload_++);
+      return static_cast<int>(ntohs(v));
+    }
+    if (instruction >= DLT_ADD8) {
+      uint8_t v;
+      v = *(payload_++);
+      return static_cast<int>(v);
+    }
+    return 0;
+  }
+
+  // Takes the previous value for the field, reads the next instruction and
+  // calculates the value based on the instruction data and the previous value.
+  int ProcessNextInstruction(int prev) {
+    Instruction instruction = Instruction(instructions_ & 0xf);
+    instructions_ >>= 4;
+    int data = ExtractInstructionData(instruction);
+
+    switch (instruction) {
+      case DLT_ZERO:   return 0;
+      case DLT_ONE:    return 0xffffffff;
+      case DLT_SAME:   return prev;
+      case DLT_SHL:    return prev << 1;
+      case DLT_SHR:    return prev >> 1;
+      case DLT_ADD8:   return prev + data;
+      case DLT_DEL8:   return prev - data;
+      case DLT_ADDU8:  return prev + (data << 24);
+      case DLT_DELU8:  return prev - (data << 24);
+      case DLT_ADD16:  return prev + data;
+      case DLT_DEL16:  return prev - data;
+      case DLT_ADDU16: return prev + (data << 16);
+      case DLT_DELU16: return prev - (data << 16);
+      case DLT_SET:    return data;
+      case DLT_R1:     return 0;
+      case DLT_R2:     return 0;
+    }
+    return 0;
+  }
+
+  unsigned int instructions_;
+  uint8_t* payload_;
+  struct ecore_ipc_msg_header* prev_;
+  struct ecore_ipc_msg_header* next_;
+};
+
+bool ReadSafe(int fd, uint8_t* buffer, size_t len) {
+  size_t todo = len;
+  while (todo) {
+     ssize_t r = read(fd, buffer, todo);
+     if (r == 0)
+       return false;
+     if (r < 0) {
+       if (errno == EAGAIN || errno == EINTR)
+         continue;
+       return false;
+     }
+     todo -= r;
+     buffer += r;
+  }
+  return true;
+}
+
+}  // namespace
+
+
+size_t TizenPlug::GetHeaderSize(unsigned int header_instructions) {
+  // Header size will depend on the instructions we read from the header. Each
+  // instruction is stored in a nibble.
+  int header_size = 0;
+  for (int i = 0; i < 6; i++) {
+    int instruction = (header_instructions >> (4 * i)) & 0xf;
+    if (instruction >= HeaderParser::DLT_SET)
+      header_size += 4;
+    else if (instruction >= HeaderParser::DLT_ADD16)
+      header_size += 2;
+    else if (instruction >= HeaderParser::DLT_ADD8)
+      header_size += 1;
+  }
+  return header_size;
+}
+
+bool TizenPlug::GetHeader() {
+  unsigned int header_instructions;
+  if (!ReadSafe(fd_, reinterpret_cast<uint8_t*>(&header_instructions),
+                sizeof(header_instructions))) {
+    if (errno != EAGAIN)
+      PLOG(ERROR) << "Failed to read header_instructions";
+    return false;
+  }
+
+  header_instructions = ntohl(header_instructions);
+  size_t header_size = GetHeaderSize(header_instructions);
+
+  if (header_size == 0)
+    return true;
+
+  scoped_ptr<unsigned char[]> header_payload(new unsigned char[header_size]);
+
+  if (!header_payload) {
+    PLOG(ERROR) << "Failed to allocate memory for header_payload";
+    return false;
+  }
+
+  if (!ReadSafe(fd_, header_payload.get(), header_size)) {
+    PLOG(ERROR) << "Failed to read header_payload";
+    return false;
+  }
+
+  struct ecore_ipc_msg_header next_msg_header;
+  HeaderParser parser(header_instructions, header_payload.get(),
+                      &current_msg_header_, &next_msg_header);
+  parser.Parse();
+
+  if (next_msg_header.major != kPlugProtocolVersion) {
+    LOG(WARNING) << "Incorrect protocol version " << next_msg_header.major
+                 << " expected " << kPlugProtocolVersion;
+    return false;
+  }
+
+  current_msg_header_ = next_msg_header;
+  return true;
+}
+
+bool TizenPlug::ShmLoad() {
+  shm_fd_ = shm_open(shm_name_.c_str(), O_RDONLY, S_IRUSR | S_IWUSR);
+  if (shm_fd_ < 0) {
+    PLOG(ERROR) << "Failed to open shm";
+    return false;
+  }
+
+  shm_size_ = width_ * height_ * 4;
+
+  shm_mem_ = mmap(NULL, shm_size_, PROT_READ, MAP_SHARED, shm_fd_, 0);
+  if (shm_mem_ == MAP_FAILED) {
+    PLOG(ERROR) << "Failed to mmap shm";
+    close(shm_fd_);
+    shm_fd_ = -1;
+    return false;
+  }
+
+  return true;
+}
+
+void TizenPlug::ShmUnload() {
+  if (shm_mem_ != MAP_FAILED) {
+    munmap(shm_mem_, shm_size_);
+    shm_mem_ = MAP_FAILED;
+  }
+
+  if (shm_fd_ >= 0) {
+    close(shm_fd_);
+    shm_fd_ = -1;
+    shm_size_ = 0;
+  }
+}
+
+bool TizenPlug::OpResize(const uint8_t* payload, size_t size) {
+  memcpy(&width_, payload, sizeof(width_));
+  memcpy(&height_, payload + sizeof(width_), sizeof(height_));
+
+  if (shm_fd_ < 0) {
+    if (!ShmLoad())
+      return false;
+  }
+
+  BrowserThread::PostTask(
+      BrowserThread::UI, FROM_HERE,
+      base::Bind(&TizenPlug::ResizeTizenIndicator, base::Unretained(this)));
+
+  return true;
+}
+
+bool TizenPlug::OpUpdate() {
+  updated_ = true;
+  return true;
+}
+
+bool TizenPlug::OpUpdateDone() {
+  if (!updated_) {
+    LOG(WARNING) << "OpUpdateDone received without previous OpUpdate!";
+    return true;
+  }
+
+  if (shm_fd_ < 0) {
+    if (!ShmLoad())
+      LOG(WARNING) << "Failed to load shm";
+      return false;
+  }
+
+  BrowserThread::PostTask(
+      BrowserThread::UI, FROM_HERE,
+      base::Bind(&TizenPlug::SetImageInTizenIndicator, base::Unretained(this)));
+
+  updated_ = false;
+  return true;
+}
+
+bool TizenPlug::OpShmRef(const uint8_t* payload, size_t size) {
+  if (size <= 1)
+    return false;
+
+  ShmUnload();
+
+  shm_name_ = std::string(reinterpret_cast<const char*>(payload), size);
+  // Extra information about the shared memory is passed in the header.
+  width_ = current_msg_header_.ref;
+  height_ = current_msg_header_.ref_to;
+  alpha_ = current_msg_header_.response;
+
+  return true;
+}
+
+bool TizenPlug::ProcessPayload() {
+  TizenPlugOperation op_code = TizenPlugOperation(current_msg_header_.minor);
+  size_t payload_size = current_msg_header_.size;
+
+  scoped_ptr<unsigned char[]> payload(new unsigned char[1024]);
+  if (!payload) {
+    PLOG(ERROR) << "Could not allocate memory to payload";
+    return false;
+  }
+
+  if (!ReadSafe(fd_, payload.get(), payload_size)) {
+    PLOG(ERROR) << "Failed to read op payload";
+    return false;
+  }
+
+  bool ret = false;
+  switch (op_code) {
+    case OP_RESIZE:
+      ret = OpResize(payload.get(), payload_size);
+      break;
+
+    case OP_UPDATE:
+      // We are always updating the entire area, so we ignore the
+      // x, y, w, h passed on the payload.
+      ret = OpUpdate();
+      break;
+
+    case OP_UPDATE_DONE:
+      ret = OpUpdateDone();
+      break;
+
+    case OP_SHM_REF:
+      ret = OpShmRef(payload.get(), payload_size);
+      break;
+
+    case OP_SHOW:
+    case OP_HIDE:
+    case OP_FOCUS:
+    case OP_UNFOCUS:
+    case OP_LOCK_FILE:
+    case OP_EV_MOUSE_IN:
+    case OP_EV_MOUSE_OUT:
+    case OP_EV_MOUSE_UP:
+    case OP_EV_MOUSE_DOWN:
+    case OP_EV_MOUSE_MOVE:
+    case OP_EV_MOUSE_WHEEL:
+    case OP_EV_MULTI_UP:
+    case OP_EV_MULTI_DOWN:
+    case OP_EV_MULTI_MOVE:
+    case OP_EV_KEY_UP:
+    case OP_EV_KEY_DOWN:
+    case OP_EV_HOLD:
+      // Not implemented yet.
+      ret = true;
+      break;
+  }
+
+  return ret;
+}
+
+void TizenPlug::SetImageInTizenIndicator() {
+  SkBitmap bitmap;
+
+  bitmap.setConfig(SkBitmap::kARGB_8888_Config, width_, height_);
+  bitmap.setPixels(shm_mem_);
+
+  const gfx::ImageSkia img_skia = gfx::ImageSkia::CreateFrom1xBitmap(bitmap);
+  indicator_->SetImage(img_skia);
+}
+
+void TizenPlug::SetSizeFromEnvironment() {
+  std::string preferred_size;
+  scoped_ptr<base::Environment> env(base::Environment::Create());
+
+  env->GetVar(kEnvironmentVar, &preferred_size);
+
+  if (preferred_size.empty())
+    return;
+
+  base::StringTokenizer t(preferred_size, ", ");
+
+  // Environment variable format is: x, y, width, height.
+  t.GetNext();
+  t.GetNext();
+
+  if (t.GetNext())
+    width_ = std::atoi(t.token().c_str());
+
+  if (t.GetNext())
+    height_ = std::atoi(t.token().c_str());
+}
+
+void TizenPlug::ResizeTizenIndicator() {
+  indicator_->PreferredSizeChanged();
+  SetImageInTizenIndicator();
+}
+
+}  // namespace xwalk

--- a/runtime/browser/ui/tizen_plug.h
+++ b/runtime/browser/ui/tizen_plug.h
@@ -1,0 +1,78 @@
+// Copyright (C) 2000-2011 Carsten Haitzler and various contributors.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_H_
+#define XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_H_
+
+#include <string>
+#include "base/memory/scoped_ptr.h"
+#include "base/message_pump_libevent.h"
+#include "ui/gfx/size.h"
+
+namespace xwalk {
+
+class TizenIndicator;
+
+// Copied from EFL 1.7, in src/lib/ecore_ipc/ecore_ipc.c.
+struct ecore_ipc_msg_header {
+  int major;
+  int minor;
+  int ref;
+  int ref_to;
+  int response;
+  int size;
+};
+
+// Implementation of the socket protocol for sharing memory used by Elementary
+// "plugs" in EFL. This class implements the low level protocol and is used by
+// TizenIndicator to update its image.
+class TizenPlug : public base::MessagePumpLibevent::Watcher {
+ public:
+  explicit TizenPlug(TizenIndicator* indicator);
+  virtual ~TizenPlug();
+
+  // base::MessagePumpLibevent::Watcher implementation.
+  void OnFileCanReadWithoutBlocking(int fd) OVERRIDE;
+  void OnFileCanWriteWithoutBlocking(int fd) OVERRIDE;
+
+  void StartWatching();
+  void StopWatching();
+  bool Connect();
+
+  gfx::Size GetSize() const;
+
+ private:
+  size_t GetHeaderSize(unsigned int header_instructions);
+  bool UpdateMessageHeader(unsigned int header_instructions,
+                           uint8_t* header_payload);
+  bool GetHeader();
+  bool ShmLoad();
+  void ShmUnload();
+  bool OpResize(const uint8_t* payload, size_t size);
+  bool OpUpdate();
+  bool OpUpdateDone();
+  bool OpShmRef(const uint8_t* payload, size_t size);
+  bool ProcessPayload();
+  void SetImageInTizenIndicator();
+  void SetSizeFromEnvironment();
+  void ResizeTizenIndicator();
+
+  TizenIndicator* indicator_;
+  base::MessagePumpLibevent::FileDescriptorWatcher fd_watcher_;
+  int width_;
+  int height_;
+  int alpha_;
+  bool updated_;
+  int shm_size_;
+  int shm_fd_;
+  int fd_;
+  std::string shm_name_;
+  struct ecore_ipc_msg_header current_msg_header_;
+  void* shm_mem_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -2,6 +2,7 @@
   'variables': {
     'xwalk_product_name': 'XWalk',
     'xwalk_version': '1.28.2.0',
+    'tizen_mobile%': 0,
     'conditions': [
       ['OS=="linux"', {
        'use_custom_freetype%': 1,
@@ -145,6 +146,15 @@
         },
       },
       'conditions': [
+        [ 'tizen_mobile == 1', {
+          'defines': [ 'OS_TIZEN_MOBILE=1' ],
+          'sources': [
+            'runtime/browser/ui/tizen_indicator.cc',
+            'runtime/browser/ui/tizen_indicator.h',
+            'runtime/browser/ui/tizen_plug.cc',
+            'runtime/browser/ui/tizen_plug.h',
+          ],
+        }],
         ['OS=="android"',{
           'sources': [
             'runtime/app/android/xwalk_main_delegate_android.cc',


### PR DESCRIPTION
Indicator is used on tizen mobile as a status bar, showing mobile's clock,
wi-fi, bluetooth infos and so. It's also used as a shortcut to homescreen
and settings (when scrolled down).

In this initial implementation the TizenPlug gets an image from which other
process created, in this case tizen mobile. This image is provided by a
socket and we watch a file descriptor to get this image updated.
The TizenIndicator shows this image.

The platform expects that we send touch events when the user interacts
with the indicator we painted. This is not supported yet

To enable it you should use -Dtizen_mobile=1 (only for tizen mobile builds).
