### PR TITLE
[Android] Handle BACK key event instead of default action.

### DIFF
--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -208,4 +208,12 @@ public class XWalkViewShellActivity extends Activity {
             imm.hideSoftInputFromWindow(mUrlTextView.getWindowToken(), 0);
         }
     }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            if (mView.onKeyUp(keyCode, event)) return true;
+        }
+        return super.onKeyUp(keyCode, event);
+    }
 }

--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -168,8 +168,13 @@ public class XWalkContent extends FrameLayout {
         contentClient.installWebContentsObserver(mContentViewCore);
     }
 
+    public boolean onBackPressed() {
+        return nativeHandleBackPressed(mXWalkContent);
+    }
+
     private native int nativeInit(XWalkWebContentsDelegate webViewContentsDelegate,
             XWalkContentsClientBridge bridge);
     private native int nativeGetWebContents(int nativeXWalkContent);
     private native void nativeClearCache(int nativeXWalkContent, boolean includeDiskFiles);
+    private native boolean nativeHandleBackPressed(int nativeXWalkContent);
 }

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -7,6 +7,7 @@ package org.xwalk.core;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Rect;
+import android.view.KeyEvent;
 import android.view.ViewGroup;
 import android.util.AttributeSet;
 import android.webkit.WebSettings;
@@ -137,6 +138,14 @@ public class XWalkView extends FrameLayout {
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         mContent.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            return mContent.onBackPressed();
+        }
+        return super.onKeyUp(keyCode, event);
     }
 
     // TODO(shouqun): requestFocusFromTouch, setVerticalScrollBarEnabled are

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -72,6 +72,16 @@ void XWalkContent::Destroy(JNIEnv* env, jobject obj) {
   delete this;
 }
 
+jboolean XWalkContent::HandleBackPressed(JNIEnv* env, jobject obj) {
+  // When BACK key is pressed, default action is to check whether can navigate
+  // back, if not, then return false means the event is not processed.
+  if (!web_contents_->GetController().CanGoBack())
+    return static_cast<jboolean>(false);
+
+  web_contents_->GetController().GoBack();
+  return static_cast<jboolean>(true);
+}
+
 static jint Init(JNIEnv* env, jobject obj, jobject web_contents_delegate,
     jobject contents_client_bridge) {
   XWalkContent* xwalk_core_content =

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -29,6 +29,7 @@ class XWalkContent {
   jint GetWebContents(JNIEnv* env, jobject obj);
   void ClearCache(JNIEnv* env, jobject obj, jboolean include_disk_files);
   void Destroy(JNIEnv* env, jobject obj);
+  jboolean HandleBackPressed(JNIEnv* env, jobject obj);
 
  private:
   content::WebContents* CreateWebContents();


### PR DESCRIPTION
On Android, the default BACK key action is stop the activity, which is not the
desired action for XWalk, in XWalk, the action is first check whether it can
navigate back.

Add onKeyUp in XWalkView to handle it.
