### PR TITLE
[android] Create target xwalk_app_template which generate a tarball

### DIFF
--- a/build/android/ant/apk-codegen.xml
+++ b/build/android/ant/apk-codegen.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2005-2008 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project default="-code-gen">
+  <property name="verbose" value="false" />
+
+  <property name="out.dir" location="${OUT_DIR}" />
+  <property name="out.absolute.dir" location="${out.dir}" />
+  <property name="out.res.absolute.dir" location="${out.dir}/res" />
+  <property name="out.manifest.abs.file" location="${out.dir}/AndroidManifest.xml" />
+  <property name="gen.absolute.dir" value="${out.dir}/gen"/>
+
+  <!-- tools location -->
+  <property name="sdk.dir" location="${ANDROID_SDK_ROOT}"/>
+  <property name="target" value="android-${ANDROID_SDK_VERSION}"/>
+  <property name="android.tools.dir" location="${sdk.dir}/tools" />
+  <property name="android.platform.tools.dir" location="${sdk.dir}/platform-tools" />
+  <property name="aapt" location="${android.platform.tools.dir}/aapt" />
+  <property name="project.target.android.jar" location="${ANDROID_SDK_JAR}" />
+
+  <!-- jar file from where the tasks are loaded -->
+  <path id="android.antlibs">
+      <pathelement path="${ANT_TASKS_JAR}" />
+  </path>
+
+  <!-- Custom tasks -->
+  <taskdef resource="anttasks.properties" classpathref="android.antlibs" />
+
+  <!--
+    Include additional resource folders in the apk, e.g. content/.../res.  We
+    list the res folders in project.library.res.folder.path and the
+    corresponding java packages in project.library.packages, which must be
+    semicolon-delimited while ADDITIONAL_RES_PACKAGES is space-delimited, hence
+    the javascript task.
+  -->
+  <path id="project.library.res.folder.path">
+    <filelist files="${ADDITIONAL_RES_DIRS}"/>
+  </path>
+  <path id="project.library.bin.r.file.path">
+    <filelist files="${ADDITIONAL_R_TEXT_FILES}"/>
+  </path>
+  <script language="javascript">
+    var before = project.getProperty("ADDITIONAL_RES_PACKAGES");
+    project.setProperty("project.library.packages", before.replaceAll(" ", ";"));
+  </script>
+
+  <path id="project.library.manifest.file.path">
+    <filelist files="${LIBRARY_MANIFEST_PATHS}"/>
+  </path>
+
+  <!-- manifest merger default value -->
+  <condition property="manifestmerger.enabled"
+      value="false"
+      else="true">
+    <equals arg1="${LIBRARY_MANIFEST_PATHS}" arg2="" />
+  </condition>
+
+  <property name="resource.absolute.dir" value="${RESOURCE_DIR}"/>
+
+  <property name="manifest.file" value="${ANDROID_MANIFEST}" />
+  <property name="manifest.abs.file" location="${manifest.file}" />
+
+  <!-- Intermediate files -->
+  <property name="resource.package.file.name" value="${APK_NAME}.ap_" />
+
+  <property name="aapt.ignore.assets" value="" />
+
+  <target name="-mergemanifest">
+      <mergemanifest
+              appManifest="${manifest.abs.file}"
+              outManifest="${out.manifest.abs.file}"
+              enabled="${manifestmerger.enabled}">
+        <library refid="project.library.manifest.file.path" />
+      </mergemanifest>
+  </target>
+
+  <!-- Code Generation: compile resources (aapt -> R.java), aidl -->
+  <target name="-code-gen" depends="-mergemanifest">
+      <mkdir dir="${out.absolute.dir}" />
+      <mkdir dir="${out.res.absolute.dir}" />
+      <mkdir dir="${gen.absolute.dir}" />
+
+      <aapt executable="${aapt}"
+              command="package"
+              verbose="${verbose}"
+              manifest="${out.manifest.abs.file}"
+              androidjar="${project.target.android.jar}"
+              rfolder="${gen.absolute.dir}"
+              nonConstantId="false"
+              libraryResFolderPathRefid="project.library.res.folder.path"
+              libraryPackagesRefid="project.library.packages"
+              libraryRFileRefid="project.library.bin.r.file.path"
+              ignoreAssets="${aapt.ignore.assets}"
+              binFolder="${out.absolute.dir}"
+              proguardFile="${out.absolute.dir}/proguard.txt">
+          <res path="${out.res.absolute.dir}" />
+          <res path="${resource.absolute.dir}" />
+      </aapt>
+
+      <touch file="${STAMP}" />
+  </target>
+</project>

--- a/build/android/ant/apk-package-resources.xml
+++ b/build/android/ant/apk-package-resources.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2005-2008 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project default="-package-resources">
+  <property name="out.dir" location="${OUT_DIR}" />
+  <property name="out.absolute.dir" location="${out.dir}" />
+  <property name="out.res.absolute.dir" location="${out.dir}/res" />
+  <property name="out.manifest.abs.file" location="${out.dir}/AndroidManifest.xml" />
+
+  <!-- tools location -->
+  <property name="sdk.dir" location="${ANDROID_SDK_ROOT}"/>
+  <property name="project.target.android.jar" location="${ANDROID_SDK_JAR}" />
+  <property name="android.tools.dir" location="${sdk.dir}/tools" />
+  <property name="android.platform.tools.dir" location="${sdk.dir}/platform-tools" />
+
+  <!-- jar file from where the tasks are loaded -->
+  <path id="android.antlibs">
+    <pathelement path="${ANT_TASKS_JAR}" />
+  </path>
+
+  <!-- Custom tasks -->
+  <taskdef resource="anttasks.properties" classpathref="android.antlibs" />
+
+  <condition property="build.target" value="release" else="debug">
+    <equals arg1="${CONFIGURATION_NAME}" arg2="Release" />
+  </condition>
+  <condition property="build.is.packaging.debug" value="true" else="false">
+    <equals arg1="${build.target}" arg2="debug" />
+  </condition>
+
+  <property name="resource.dir" value="${RESOURCE_DIR}"/>
+  <property name="resource.absolute.dir" location="${resource.dir}"/>
+
+  <property name="asset.dir" value="${ASSET_DIR}" />
+  <property name="asset.absolute.dir" location="${asset.dir}" />
+
+  <property name="aapt" location="${android.platform.tools.dir}/aapt" />
+
+  <property name="version.code" value="${APP_MANIFEST_VERSION_CODE}"/>
+  <property name="version.name" value="${APP_MANIFEST_VERSION_NAME}"/>
+
+  <property name="aapt.resource.filter" value="" />
+  <!-- 'aapt.ignore.assets' is the list of file patterns to ignore under /res and /assets.
+         Default is "!.svn:!.git:.*:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*.scc:*~"
+
+         Overall patterns syntax is:
+           [!][<dir>|<file>][*suffix-match|prefix-match*|full-match]:more:patterns...
+
+         - The first character flag ! avoids printing a warning.
+         - Pattern can have the flag "<dir>" to match only directories
+           or "<file>" to match only files. Default is to match both.
+         - Match is not case-sensitive.
+  -->
+  <property name="aapt.ignore.assets" value="" />
+
+  <!--
+      Include additional resource folders in the apk, e.g. content/.../res.  We
+      list the res folders in project.library.res.folder.path and the
+      corresponding java packages in project.library.packages, which must be
+      semicolon-delimited while ADDITIONAL_RES_PACKAGES is space-delimited, hence
+      the javascript task.
+  -->
+  <path id="project.library.res.folder.path">
+    <filelist files="${ADDITIONAL_RES_DIRS}"/>
+  </path>
+  <path id="project.library.bin.r.file.path">
+    <filelist files="${ADDITIONAL_R_TEXT_FILES}"/>
+  </path>
+  <script language="javascript">
+    var before = project.getProperty("ADDITIONAL_RES_PACKAGES");
+    project.setProperty("project.library.packages", before.replaceAll(" ", ";"));
+  </script>
+
+  <property name="build.packaging.nocrunch" value="true" />
+
+  <!-- Intermediate files -->
+  <property name="resource.package.file.name" value="${APK_NAME}.ap_" />
+
+  <target name="-crunch">
+    <!-- Updates the pre-processed PNG cache -->
+    <exec executable="${aapt}" taskName="crunch">
+      <arg value="crunch" />
+      <arg value="-v" />
+      <arg value="-S" />
+      <arg path="${resource.absolute.dir}" />
+      <arg value="-C" />
+      <arg path="${out.res.absolute.dir}" />
+    </exec>
+  </target>
+
+  <target name="-package-resources" depends="-crunch">
+    <aapt
+        executable="${aapt}"
+        command="package"
+        versioncode="${version.code}"
+        versionname="${version.name}"
+        debug="${build.is.packaging.debug}"
+        manifest="${out.manifest.abs.file}"
+        assets="${asset.absolute.dir}"
+        androidjar="${project.target.android.jar}"
+        apkfolder="${out.absolute.dir}"
+        nocrunch="${build.packaging.nocrunch}"
+        resourcefilename="${resource.package.file.name}"
+        resourcefilter="${aapt.resource.filter}"
+        libraryResFolderPathRefid="project.library.res.folder.path"
+        libraryPackagesRefid="project.library.packages"
+        libraryRFileRefid="project.library.bin.r.file.path"
+        previousBuildType=""
+        buildType="${build.target}"
+        ignoreAssets="${aapt.ignore.assets}">
+      <res path="${out.res.absolute.dir}" />
+      <res path="${resource.absolute.dir}" />
+      <!-- <nocompress /> forces no compression on any files in assets or res/raw -->
+      <!-- <nocompress extension="xml" /> forces no compression on specific file extensions in assets and res/raw -->
+    </aapt>
+
+    <touch file="${STAMP}" />
+  </target>
+</project>

--- a/build/android/ant/apk-package.xml
+++ b/build/android/ant/apk-package.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2005-2008 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project default="-package">
+  <property name="verbose" value="false" />
+  <property name="out.dir" location="${OUT_DIR}" />
+  <property name="out.absolute.dir" location="${out.dir}" />
+
+  <property name="sdk.dir" location="${ANDROID_SDK_ROOT}"/>
+
+  <!-- jar file from where the tasks are loaded -->
+  <path id="android.antlibs">
+    <pathelement path="${ANT_TASKS_JAR}" />
+  </path>
+
+  <!-- Custom tasks -->
+  <taskdef resource="anttasks.properties" classpathref="android.antlibs" />
+
+  <condition property="build.target" value="release" else="debug">
+    <equals arg1="${CONFIGURATION_NAME}" arg2="Release" />
+  </condition>
+  <condition property="build.is.packaging.debug" value="true" else="false">
+    <equals arg1="${build.target}" arg2="debug" />
+  </condition>
+
+  <!-- Disables automatic signing. -->
+  <property name="build.is.signing.debug" value="false"/>
+
+  <!-- SDK tools assume that out.packaged.file is signed and name it "...-unaligned" -->
+  <property name="out.packaged.file" value="${UNSIGNED_APK_PATH}" />
+
+  <property name="native.libs.absolute.dir" location="${NATIVE_LIBS_DIR}" />
+
+  <!-- Intermediate files -->
+  <property name="resource.package.file.name" value="${APK_NAME}.ap_" />
+
+  <property name="dex.file.name" value="classes.dex" />
+  <property name="intermediate.dex.file" location="${out.absolute.dir}/${dex.file.name}" />
+
+  <property name="source.dir" value="${SOURCE_DIR}" />
+  <property name="source.absolute.dir" location="${source.dir}" />
+
+  <!-- Packages the application. -->
+  <target name="-package">
+    <apkbuilder
+        outfolder="${out.absolute.dir}"
+        resourcefile="${resource.package.file.name}"
+        apkfilepath="${out.packaged.file}"
+        debugpackaging="${build.is.packaging.debug}"
+        debugsigning="${build.is.signing.debug}"
+        verbose="${verbose}"
+        hascode="true"
+        previousBuildType="/"
+        buildType="${build.is.packaging.debug}/${build.is.signing.debug}">
+      <dex path="${intermediate.dex.file}"/>
+      <sourcefolder path="${source.absolute.dir}"/>
+      <nativefolder path="${native.libs.absolute.dir}" />
+    </apkbuilder>
+  </target>
+</project>

--- a/build/android/gyp/dex.py
+++ b/build/android/gyp/dex.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# pylint: disable=F0401
+
+import optparse
+import os
+import sys
+
+from util import build_utils
+from util import md5_check
+
+def Find(name, path):
+  for root, _, files in os.walk(path):
+    if name in files:
+      return os.path.join(root, name)
+
+
+def DoDex(options, paths):
+  dx_binary = os.path.join(Find('dx', options.android_sdk_root))
+  dex_cmd = [dx_binary, '--dex', '--output', options.dex_path] + paths
+
+  record_path = '%s.md5.stamp' % options.dex_path
+  md5_check.CallAndRecordIfStale(
+      lambda: build_utils.CheckCallDie(dex_cmd, suppress_output=True),
+      record_path=record_path,
+      input_paths=paths,
+      input_strings=dex_cmd)
+
+  build_utils.Touch(options.dex_path)
+
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option('--android-sdk-root', help='Android sdk root directory.')
+  parser.add_option('--dex-path', help='Dex output path.')
+  parser.add_option('--stamp', help='Path to touch on success.')
+
+  # TODO(newt): remove this once http://crbug.com/177552 is fixed in ninja.
+  parser.add_option('--ignore', help='Ignored.')
+
+  options, paths = parser.parse_args()
+
+  DoDex(options, paths)
+
+  if options.stamp:
+    build_utils.Touch(options.stamp)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/android/make_apk.py
+++ b/build/android/make_apk.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+import shutil
+import subprocess
+import sys
+
+def Which(name):
+  """Search PATH for executable files with the given name."""
+  result = []
+  exts = filter(None, os.environ.get('PATHEXT', '').split(os.pathsep))
+  path = os.environ.get('PATH', None)
+  if path is None:
+    return []
+  for p in os.environ.get('PATH', '').split(os.pathsep):
+    p = os.path.join(p, name)
+    if os.access(p, os.X_OK):
+      result.append(p)
+    for e in exts:
+      pext = p + e
+      if os.access(pext, os.X_OK):
+        result.append(pext)
+  return result
+
+
+def Execution():
+  android_path_array = Which("android")
+  if not android_path_array:
+    print "Please install Android SDK first."
+    return
+
+  sdk_root_path = os.path.dirname(os.path.dirname(android_path_array[0]))
+  sdk_jar_path = '%s/platforms/android-17/android.jar' % sdk_root_path
+  apk_name = 'XWalkAppTemplate'
+  key_store = 'scripts/ant/chromium-debug.keystore'
+
+  if not os.path.exists("out/"):
+    os.mkdir("out")
+
+  # Make sure to use ant-tasks.jar correctly.
+  # Default Android SDK names it as ant-tasks.jar
+  # Chrome third party Android SDk names it as anttasks.jar
+  ant_tasks_jar_path = '%s/tools/lib/ant-tasks.jar' % sdk_root_path
+  if not os.path.exists(ant_tasks_jar_path):
+    ant_tasks_jar_path = '%s/tools/lib/anttasks.jar' % sdk_root_path
+
+  # Check whether ant is installed.
+  try:
+    proc = subprocess.Popen(['ant', '-version'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  except EnvironmentError:
+    print "Please install ant first."
+    sys.exit()
+
+  proc = subprocess.Popen(['python', 'scripts/gyp/ant.py',
+                           '-DADDITIONAL_RES_DIRS=',
+                           '-DADDITIONAL_RES_PACKAGES=',
+                           '-DADDITIONAL_R_TEXT_FILES=',
+                           '-DANDROID_MANIFEST=app_src/AndroidManifest.xml',
+                           '-DANDROID_SDK_JAR=%s' % sdk_jar_path,
+                           '-DANDROID_SDK_ROOT=%s' % sdk_root_path,
+                           '-DANDROID_SDK_VERSION=17',
+                           '-DANT_TASKS_JAR=%s' % ant_tasks_jar_path,
+                           '-DLIBRARY_MANIFEST_PATHS=',
+                           '-DOUT_DIR=out',
+                           '-DRESOURCE_DIR=app_src/res',
+                           '-DSTAMP=codegen.stamp',
+                           '-Dbasedir=.',
+                           '-buildfile',
+                           'scripts/ant/apk-codegen.xml'],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  out, _ = proc.communicate()
+  print out
+
+  # Check whether java is installed.
+  try:
+    proc = subprocess.Popen(['java', '-version'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  except EnvironmentError:
+    print "Please install Oracle JDK first."
+    sys.exit()
+
+  classpath = ('--classpath=\"libs/xwalk_app_runtime_activity_java.jar\"'
+               ' \"libs/xwalk_app_runtime_client_java.jar\" %s' % sdk_jar_path)
+  proc = subprocess.Popen(['python', 'scripts/gyp/javac.py',
+                           '--output-dir=out/classes',
+                           classpath,
+                           '--src-dirs=app_src/src \"out/gen\"',
+                           '--javac-includes=',
+                           '--chromium-code=0',
+                           '--stamp=compile.stam'],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  out, _ = proc.communicate()
+  print out
+
+  proc = subprocess.Popen(['python', 'scripts/gyp/ant.py',
+                           '-DADDITIONAL_RES_DIRS=',
+                           '-DADDITIONAL_RES_PACKAGES=',
+                           '-DADDITIONAL_R_TEXT_FILES=',
+                           '-DANDROID_SDK_JAR=%s' % sdk_jar_path,
+                           '-DANDROID_SDK_ROOT=%s' % sdk_root_path,
+                           '-DANT_TASKS_JAR=%s' % ant_tasks_jar_path,
+                           '-DAPK_NAME=%s' % apk_name,
+                           '-DAPP_MANIFEST_VERSION_CODE=0',
+                           '-DAPP_MANIFEST_VERSION_NAME=Developer Build',
+                           '-DASSET_DIR=app_src/assets',
+                           '-DCONFIGURATION_NAME=Release',
+                           '-DOUT_DIR=out',
+                           '-DRESOURCE_DIR=app_src/res',
+                           '-DSTAMP=package_resources.stamp',
+                           '-Dbasedir=.',
+                           '-buildfile',
+                           'scripts/ant/apk-package-resources.xml'],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  out, _ = proc.communicate()
+  print out
+
+  proc = subprocess.Popen(['python', 'scripts/gyp/jar.py',
+                           '--classes-dir=out/classes',
+                           '--jar-path=libs/app_apk.jar',
+                           '--excluded-classes=',
+                           '--stamp=jar.stamp'],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  out, _ = proc.communicate()
+  print out
+
+  proc = subprocess.Popen(['python', 'scripts/gyp/dex.py',
+                           '--dex-path=out/classes.dex',
+                           '--android-sdk-root=%s' % sdk_root_path,
+                           'libs/xwalk_app_runtime_activity_java.dex.jar',
+                           'libs/xwalk_app_runtime_client_java.dex.jar',
+                           'out/classes'],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  out, _ = proc.communicate()
+  print out
+
+  proc = subprocess.Popen(['python', 'scripts/gyp/ant.py',
+                           '-DANDROID_SDK_ROOT=%s' % sdk_root_path,
+                           '-DANT_TASKS_JAR=%s' % ant_tasks_jar_path,
+                           '-DAPK_NAME=%s' % apk_name,
+                           '-DCONFIGURATION_NAME=Release',
+                           '-DOUT_DIR=out',
+                           '-DSOURCE_DIR=app_src/src',
+                           '-DUNSIGNED_APK_PATH=out/app-unsigned.apk',
+                           '-Dbasedir=.',
+                           '-buildfile',
+                           'scripts/ant/apk-package.xml'],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  out, _ = proc.communicate()
+  print out
+
+  proc = subprocess.Popen(['python', 'scripts/gyp/finalize_apk.py',
+                           '--android-sdk-root=%s' % sdk_root_path,
+                           '--unsigned-apk-path=out/app-unsigned.apk',
+                           '--final-apk-path=out/%s.apk' % apk_name,
+                           '--keystore-path=%s' % key_store],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  out, _ = proc.communicate()
+  print out
+
+  src_file = 'out/%s.apk' % apk_name
+  dst_file = '%s.apk' % apk_name
+  shutil.copyfile(src_file, dst_file)
+
+
+def main():
+  Execution()
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/build/android/FILES.cfg
+++ b/tools/build/android/FILES.cfg
@@ -43,4 +43,8 @@ FILES = [
     'filename': 'apks/XWalkAppTemplate.apk',
     'buildtype': ['dev', 'official'],
   },
+  {
+    'filename': 'xwalk_app_template.tar.gz',
+    'buildtype': ['dev', 'official'],
+  },
 ]

--- a/tools/tar.py
+++ b/tools/tar.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+import sys
+import tarfile
+
+def main(args):
+  if len(args) != 1:
+    print 'You must provide only one argument: folder to pack'
+    return 1
+  dir_to_tar = args[0]
+  if dir_to_tar.endswith(os.path.sep):
+    dir_to_tar = dir_to_tar[:-1]
+  if not os.path.isdir(dir_to_tar):
+    print '%s does not exist or not a directory' % dir_to_tar
+    return 1
+  work_dir, dir_name = os.path.split(dir_to_tar)
+  tar_filename = dir_name + ".tar.gz"
+  cur_cwd = os.getcwd()
+  try:
+    os.chdir(work_dir)
+    tar = tarfile.open(tar_filename, "w:gz")
+    for root, _, files in os.walk(dir_name):
+      for f in files:
+        tar.add(os.path.join(root, f))
+    tar.close()
+  finally:
+    os.chdir(cur_cwd)
+
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv[1:]))

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -522,6 +522,7 @@
             # For external testing.
             'xwalk_runtime_lib_apk',
             'xwalk_app_template_apk',
+            'xwalk_app_template',
           ],
         }],
       ],

--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -33,5 +33,83 @@
       },
       'includes': [ '../build/java_apk.gypi' ],
     },
+    {
+      'target_name': 'prepare_xwalk_app_template',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_app_template_apk',
+      ],
+      'copies': [
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_app_template/libs/',
+          'files': [
+            '<(PRODUCT_DIR)/lib.java/xwalk_app_runtime_activity_java.dex.jar',
+            '<(PRODUCT_DIR)/lib.java/xwalk_app_runtime_activity_java.jar',
+            '<(PRODUCT_DIR)/lib.java/xwalk_app_runtime_client_java.dex.jar',
+            '<(PRODUCT_DIR)/lib.java/xwalk_app_runtime_client_java.jar',
+          ],
+        },
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_app_template/scripts/ant',
+          'files': [
+            './build/android/ant/apk-codegen.xml',
+            './build/android/ant/apk-package.xml',
+            './build/android/ant/apk-package-resources.xml',
+            '../build/android/ant/chromium-debug.keystore',
+          ],
+        },
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_app_template/scripts/gyp/',
+          'files': [
+            './build/android/gyp/dex.py',
+            '../build/android/gyp/ant.py',
+            '../build/android/gyp/jar.py',
+            '../build/android/gyp/javac.py',
+            '../build/android/gyp/finalize_apk.py',
+            '../build/android/gyp/util/',
+          ],
+        },
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_app_template/app_src/',
+          'files': [
+            'app/android/app_template/AndroidManifest.xml',
+            'app/android/app_template/assets',
+            'app/android/app_template/res',
+            'app/android/app_template/src',
+          ],
+        },
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_app_template/',
+          'files': [
+            'build/android/make_apk.py',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'xwalk_app_template',
+      'type': 'none',
+      'dependencies': [
+        'prepare_xwalk_app_template',
+      ],
+      'actions': [
+        {
+          'action_name': 'tar_app_template',
+          'inputs': [
+            'app/android/app_template/AndroidManifest.xml',
+            'tools/tar.py',
+          ],
+          'outputs': [
+            '<(PRODUCT_DIR)/xwalk_app_template.tar.gz',
+            # put an inexist file here to do this step every time.
+            '<(PRODUCT_DIR)/xwalk_app_template.tar.gz1',
+          ],
+          'action': [
+            'python', 'tools/tar.py',
+            '<(PRODUCT_DIR)/xwalk_app_template'
+          ],
+        },
+      ],
+    },
   ],
 }


### PR DESCRIPTION
 for developer

Extract the built tarball, and run make_apk.py can build an apk which
is the same as xwalk_app_template_apk.

Fork the build/android xml setting and gyp tools, and adjust them to work with
default Android SDK, not the SDK under third_party.

Developer can put html resources into assets and modify the code after
untar to customize their apps.

This patch is based on Shiliu's previous work.
