### PR TITLE
Change target name from api to xwalk_jsapi.

### DIFF
--- a/jsapi/jsapi.gyp
+++ b/jsapi/jsapi.gyp
@@ -1,7 +1,7 @@
 {
   'targets': [
     {
-      'target_name': 'api',
+      'target_name': 'xwalk_jsapi',
       'type': 'static_library',
       'sources': [
         '<@(schema_files)',

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -49,7 +49,7 @@
         '../v8/tools/gyp/v8.gyp:v8',
         '../webkit/support/webkit_support.gyp:webkit_resources',
         '../webkit/support/webkit_support.gyp:webkit_support',
-        'jsapi/jsapi.gyp:api',
+        'jsapi/jsapi.gyp:xwalk_jsapi',
         'xwalk_application_lib',
         'xwalk_resources',
       ],


### PR DESCRIPTION
The api target is taken common/extensions/api/api.gyp. This results in the following
warning in the android build.

ninja: warning: multiple rules generate libapi.a. builds involving this target will not be correct; continuing anyway

The build itself later errors with
gen/chrome/common/extensions/api/generated_schemas.cc:11:6: error: 'GeneratedSchemas' has not been declared
(because it built the target in api.gyp).
