### PR TITLE
Fix typo when checking whether an XW_Instance is valid

### DIFF
--- a/extensions/common/xwalk_external_adapter.cc
+++ b/extensions/common/xwalk_external_adapter.cc
@@ -96,7 +96,7 @@ bool XWalkExternalAdapter::IsValidXWExtension(XW_Extension xw_extension) {
 }
 
 bool XWalkExternalAdapter::IsValidXWInstance(XW_Instance xw_instance) {
-  return xw_instance > 0 && xw_instance < next_xw_extension_;
+  return xw_instance > 0 && xw_instance < next_xw_instance_;
 }
 
 XWalkExternalExtension* XWalkExternalAdapter::GetExtension(

--- a/extensions/test/external_extension.cc
+++ b/extensions/test/external_extension.cc
@@ -49,6 +49,18 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionTest, ExternalExtension) {
   EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }
 
+IN_PROC_BROWSER_TEST_F(ExternalExtensionTest, NavigateWithExternalExtension) {
+  content::RunAllPendingInMessageLoop();
+  GURL url = GetExtensionsTestURL(base::FilePath(),
+                                  base::FilePath().AppendASCII("echo.html"));
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+
+  for (int i = 0; i < 5; i++) {
+    xwalk_test_utils::NavigateToURL(runtime(), url);
+    EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+  }
+}
 
 // FIXME(cmarcelo): See https://github.com/otcshare/crosswalk/issues/268.
 #if defined(OS_WIN)


### PR DESCRIPTION
We were checking the wrong range. For our existing tests was fine
because we didn't created multiple instances for external extensions.
This patch also adds a test case that navigates when loading an external
extension, that will force creation of new instances.
