### PR TITLE
TizenSystemIndicator: fix service name

### DIFF
--- a/runtime/browser/ui/tizen_system_indicator_watcher.cc
+++ b/runtime/browser/ui/tizen_system_indicator_watcher.cc
@@ -21,7 +21,7 @@ using content::BrowserThread;
 
 namespace {
 
-const char kServiceName[] = "ello";
+const char kServiceName[] = "elm_indicator_portrait";
 const char kServiceNumber[] = "0";
 
 // Environment variable format is x, y, width, height.


### PR DESCRIPTION
Last patch changed by mistake.
