### PR TITLE
[Android] Let App Template buildable in more general environment.

### DIFF
--- a/build/android/ant/apk-codegen.xml
+++ b/build/android/ant/apk-codegen.xml
@@ -29,7 +29,7 @@
   <property name="target" value="android-${ANDROID_SDK_VERSION}"/>
   <property name="android.tools.dir" location="${sdk.dir}/tools" />
   <property name="android.platform.tools.dir" location="${sdk.dir}/platform-tools" />
-  <property name="aapt" location="${android.platform.tools.dir}/aapt" />
+  <property name="aapt" location="${AAPT_PATH}" />
   <property name="project.target.android.jar" location="${ANDROID_SDK_JAR}" />
 
   <!-- jar file from where the tasks are loaded -->

--- a/build/android/ant/apk-package-resources.xml
+++ b/build/android/ant/apk-package-resources.xml
@@ -48,7 +48,7 @@
   <property name="asset.dir" value="${ASSET_DIR}" />
   <property name="asset.absolute.dir" location="${asset.dir}" />
 
-  <property name="aapt" location="${android.platform.tools.dir}/aapt" />
+  <property name="aapt" location="${AAPT_PATH}" />
 
   <property name="version.code" value="${APP_MANIFEST_VERSION_CODE}"/>
   <property name="version.name" value="${APP_MANIFEST_VERSION_NAME}"/>


### PR DESCRIPTION
1. Track aapt's location without hardcode.
2. Support xwalk app template build on API level (>= 14).
3. Raise exception when no path found.
