### PR TITLE
[Android] Add code stub for Android extension system

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreExtensionBridge.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreExtensionBridge.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime;
+
+import android.content.Context;
+import android.content.Intent;
+
+// TODO(yongsheng): Enable it once it's done.
+// import org.xwalk.core.extensions.XWalkExtensionBridge;
+import org.xwalk.runtime.extension.XWalkExtension;
+
+/**
+ * This class is to bridge the extension system provided from runtime core
+ * to our runtime extension system.
+ */
+class XWalkCoreExtensionBridge /* extends XWalkExtensionBridge */ {
+    private XWalkExtension mExtension;
+    private XWalkRuntimeViewProvider mProvider;
+
+    public XWalkCoreExtensionBridge(XWalkExtension extension, XWalkRuntimeViewProvider provider) {
+        // super(extension.getApiVersion(), extension.getExtensionName(), extension.getJsApi());
+        mExtension = extension;
+        mProvider = provider;
+    }
+
+    public void handleMessage(String message) {
+        mProvider.onMessage(mExtension, message);
+    }
+
+    public void handleSyncMessage(String message) {
+        mProvider.onSyncMessage(mExtension, message);
+    }
+
+    // TODO(yongsheng): Depends on runtime core impl.
+    public void postMessage(String message) {
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -11,16 +11,18 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import org.xwalk.core.XWalkView;
+import org.xwalk.runtime.extension.XWalkExtension;
 
 /**
- * The implementation class for XWalkCoreProvider. It calls the interfaces provided
- * by runtime core and customizes the behaviors here.
+ * The implementation class for runtime core. It calls the methods provided
+ * by runtime core and customizes the behaviors for runtime.
  */
-class XWalkCoreProvider implements XWalkRuntimeViewProvider {
+class XWalkCoreProviderImpl extends XWalkRuntimeViewProvider {
     private Context mContext;
     private XWalkView mXwalkView;
 
-    public XWalkCoreProvider(Context context, Activity activity) {
+    public XWalkCoreProviderImpl(Context context, Activity activity) {
+        super(context, activity);
         mContext = context;
 
         // TODO(yongsheng): do customizations for XWalkView. There will
@@ -40,37 +42,36 @@ class XWalkCoreProvider implements XWalkRuntimeViewProvider {
 
     @Override
     public void onCreate() {
-        // TODO(yongsheng): Pass it to extensions.
+        super.onCreate();
     }
 
     @Override
     public void onResume() {
-        // TODO(yongsheng): Pass it to extensions.
+        super.onResume();
         mXwalkView.onResume();
     }
 
     @Override
     public void onPause() {
-        // TODO(yongsheng): Pass it to extensions.
+        super.onPause();
         mXwalkView.onPause();
     }
 
     @Override
     public void onDestroy() {
-        // TODO(yongsheng): Pass it to extensions.
+        super.onDestroy();
     }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        // TODO(yongsheng): Pass it to extensions.
+        super.onActivityResult(requestCode, resultCode, data);
         mXwalkView.onActivityResult(requestCode, resultCode, data);
     }
 
     @Override
     public String enableRemoteDebugging(String frontEndUrl, String socketName) {
-        // TODO(yongsheng): Enable this once the remote debugging feature is supported.
-        // return mXwalkView.enableRemoteDebugging(socketName);
-        return "";
+        // TODO(yongsheng): Enable two parameters once they're supported in XWalkView.
+        return mXwalkView.enableRemoteDebugging();
     }
 
     @Override
@@ -81,5 +82,24 @@ class XWalkCoreProvider implements XWalkRuntimeViewProvider {
     @Override
     public View getView() {
         return mXwalkView;
+    }
+
+    @Override
+    public Object onExtensionRegistered(XWalkExtension extension) {
+        // TODO(yongsheng): This object is supposed to register itself into native extension system.
+        // If not, we'll need to register it.
+        XWalkCoreExtensionBridge bridge = new XWalkCoreExtensionBridge(extension, this);
+        return bridge;
+    }
+
+    @Override
+    public void onExtensionUnregistered(XWalkExtension extension) {
+        // TODO(yongsheng): Figure out how to do this.
+    }
+
+    @Override
+    public void postMessage(XWalkExtension extension, String message) {
+        XWalkCoreExtensionBridge bridge = (XWalkCoreExtensionBridge)extension.getRegisteredId();
+        bridge.postMessage(message);
     }
 }

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -4,23 +4,89 @@
 
 package org.xwalk.runtime;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.view.View;
 
+import org.xwalk.runtime.extension.XWalkExtension;
+import org.xwalk.runtime.extension.XWalkExtensionContext;
+import org.xwalk.runtime.extension.XWalkExtensionContextImpl;
+import org.xwalk.runtime.extension.XWalkExtensionManager;
+
 /**
- * The interface to provide the bridge between XWalkRuntimeView and the
- * real implementation.
+ * The abstract class to provide the bridge between XWalkRuntimeView and the
+ * real implementation like runtime core.
+ *
+ * This class is also used by XWalkExtensionManager to get the capability to
+ * build runtime extension system.
  */
-interface XWalkRuntimeViewProvider {
-    public View getView();
-    public void loadAppFromUrl(String url);
-    public void loadAppFromManifest(String manifestUrl);
-    public void onCreate();
-    public void onResume();
-    public void onPause();
-    public void onDestroy();
-    public void onActivityResult(int requestCode, int resultCode, Intent data);
-    public String enableRemoteDebugging(String frontEndUrl, String socketName);
-    public void disableRemoteDebugging();
+public abstract class XWalkRuntimeViewProvider {
+    private Context mContext;
+    private Activity mActivity;
+    private XWalkExtensionManager mExtensionManager;
+    private XWalkExtensionContextImpl mExtensionContext;
+
+    XWalkRuntimeViewProvider(Context context, Activity activity) {
+        mContext = context;
+        mActivity = activity;
+        mExtensionManager = new XWalkExtensionManager(context, activity, this);
+    }
+
+    public XWalkExtensionContext getExtensionContext() {
+        return mExtensionManager.getExtensionContext();
+    }
+
+    public void onCreate() {
+
+    }
+
+    public void onResume() {
+        mExtensionManager.onResume();
+    }
+
+    public void onPause() {
+        mExtensionManager.onPause();
+    }
+
+    public void onDestroy() {
+        mExtensionManager.onDestroy();
+    }
+
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        mExtensionManager.onActivityResult(requestCode, resultCode, data);
+    }
+
+    public abstract View getView();
+    public abstract void loadAppFromUrl(String url);
+    public abstract void loadAppFromManifest(String manifestUrl);
+    public abstract String enableRemoteDebugging(String frontEndUrl, String socketName);
+    public abstract void disableRemoteDebugging();
+
+    /*
+     * Once runtime extension is created, notify the internal mechanism so that
+     * it can create/do something it wants.
+     */
+    public abstract Object onExtensionRegistered(XWalkExtension extension);
+    public abstract void onExtensionUnregistered(XWalkExtension extension);
+
+    /**
+     * Pass messages from native extension system to runtime extension system.
+     * Might be overrided to do customizations here.
+     */
+    public void onMessage(XWalkExtension extension, String message) {
+        extension.onMessage(message);
+    }
+
+    /**
+     * Pass synchronized messages.
+     */
+    public void onSyncMessage(XWalkExtension extension, String message) {
+        extension.onSyncMessage(message);
+    }
+
+    /**
+     * Pass message from runtime extension system to native and then to JavaScript.
+     */
+    public abstract void postMessage(XWalkExtension extension, String message);
 }

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProviderFactory.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProviderFactory.java
@@ -15,6 +15,6 @@ final class XWalkRuntimeViewProviderFactory {
     static public XWalkRuntimeViewProvider getProvider(Context context, Activity activity) {
         // TODO(yongsheng): Do checkings here to decide which provider should
         // be used. The default is to use runtime core provider.
-        return new XWalkCoreProvider(context, activity);
+        return new XWalkCoreProviderImpl(context, activity);
     }
 }

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
@@ -1,0 +1,128 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension;
+
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * The public base class of xwalk extensions. Each extension should inherit
+ * this class and implement its interfaces. Note that it's for every extensions.
+ * For internal extensions, each one should base on it directly. For external
+ * extensions, there'll be a bridge class in the runtime client side.
+ */
+public abstract class XWalkExtension {
+    // The unique name for this extension.
+    protected String mName;
+
+    // The version of API.
+    protected String mApiVersion;
+
+    // The JavaScript code stub. Will be injected to JS engine.
+    protected String mJsApi;
+
+    // The context used by extensions.
+    protected XWalkExtensionContext mExtensionContext;
+
+    // The ID for registration.
+    private Object mRegisteredId;
+
+    /**
+     * Constructor with the information of an extension.
+     * @param name the extension name.
+     * @param apiVersion the version of API.
+     * @param jsApi the code stub of JavaScript for this extension.
+     * @param context the extension context.
+     */
+    public XWalkExtension(String name, String apiVersion, String jsApi, XWalkExtensionContext context) {
+        mName = name;
+        mApiVersion = apiVersion;
+        mJsApi = jsApi;
+        mExtensionContext = context;
+        mRegisteredId = mExtensionContext.registerExtension(this);
+    }
+
+    /**
+     * Get the unique name of extension.
+     * @return the name of extension set from constructor.
+     */
+    public String getExtensionName() {
+        return mName;
+    }
+
+    /**
+     * Get the api name of extension.
+     * @return the api version.
+     */
+    public String getApiVersion() {
+        return mApiVersion;
+    }
+
+    /**
+     * Get the JavaScript code stub.
+     * @return the JavaScript code stub.
+     */
+    public String getJsApi() {
+        return mJsApi;
+    }
+
+    /**
+     * JavaScript call into Java code. The message contains
+     * the JavaScript function name and parameters.
+     * The message format should be like below:
+     * @param message the message from JavaScript code.
+     */
+    public abstract void onMessage(String message);
+
+    /**
+     * Synchronized JavaScript call into Java code. Similar to
+     * onMessage. The only difference is it's a synchronized
+     * message.
+     * @param message the message from JavaScript code.
+     */
+    public void onSyncMessage(String message) {
+    }
+
+    /**
+     * Post messages to JavaScript via extension's context.
+     * @param message the message to be passed to Javascript.
+     */
+    public void postMessage(String message) {
+        mExtensionContext.postMessage(this, message);
+    }
+
+    /**
+     * Called when this app is onResume.
+     */
+    public void onResume() {
+    }
+
+    /**
+     * Called when this app is onPause.
+     */
+    public void onPause() {
+    }
+
+    /**
+     * Called when this app is onDestroy.
+     */
+    public void onDestroy() {
+    }
+
+    /**
+     * Tell extension that one activity exists so that it can know the result code
+     * of the exit code.
+     */
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    }
+
+    /**
+     * Get the registered ID.
+     * @return the registered ID object.
+     */
+    public Object getRegisteredId() {
+        return mRegisteredId;
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContext.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContext.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension;
+
+import android.app.Activity;
+import android.content.Context;
+
+/**
+ * This is a public class to provide context for extensions.
+ * It'll be shared by all extensions.
+ */
+public abstract class XWalkExtensionContext {
+    /**
+     * Register the current extension into system and return the unique ID
+     * from extension system.
+     * @return the registered extension ID.
+     */
+    public abstract Object registerExtension(XWalkExtension extension);
+
+    /**
+     * Post message to JavaScript via internal mechanism.
+     * @param extension the extension which needs to post message to JavaScript.
+     * @param message the message to be passed.
+     */
+    public abstract void postMessage(XWalkExtension extension, String message);
+
+    /**
+     * Get current Android Context.
+     * @return the current Android Context.
+     */
+    public abstract Context getContext();
+
+    /**
+     * Get the current Android Activity.
+     * @return the current Android Activity.
+     */
+    public abstract Activity getActivity();
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextImpl.java
@@ -1,0 +1,46 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension;
+
+import android.app.Activity;
+import android.content.Context;
+
+import org.xwalk.runtime.XWalkRuntimeViewProvider;
+
+/*
+ * Internal implementation class which bridges the capabilities to external
+ * users.
+ */
+public class XWalkExtensionContextImpl extends XWalkExtensionContext {
+    private Context mContext;
+    private Activity mActivity;
+    private XWalkExtensionManager mManager;
+
+    public XWalkExtensionContextImpl(Context context, Activity activity, XWalkExtensionManager manager) {
+        mContext = context;
+        mActivity = activity;
+        mManager = manager;
+    }
+
+    @Override
+    public Object registerExtension(XWalkExtension extension) {
+        return mManager.registerExtension(extension);
+    }
+
+    @Override
+    public void postMessage(XWalkExtension extension, String message) {
+        mManager.postMessage(extension, message);
+    }
+
+    @Override
+    public Context getContext() {
+        return mContext;
+    }
+
+    @Override
+    public Activity getActivity() {
+        return mActivity;
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import java.util.ArrayList;
+import org.xwalk.runtime.XWalkRuntimeViewProvider;
+
+/**
+ * This internal class acts a manager to manage extensions.
+ */
+public class XWalkExtensionManager {
+    // TODO(yongsheng): figure out how to support extension's configuration system.
+    private Context mContext;
+    private Activity mActivity;
+    private XWalkRuntimeViewProvider mXwalkProvider;
+    private XWalkExtensionContextImpl mExtensionContextImpl;
+
+    private ArrayList<XWalkExtension> mExtensions;
+
+    public XWalkExtensionManager(Context context, Activity activity, XWalkRuntimeViewProvider xwalkProvider) {
+        mContext = context;
+        mActivity = activity;
+        mXwalkProvider = xwalkProvider;
+        mExtensionContextImpl = new XWalkExtensionContextImpl(context, activity, this);
+        mExtensions = new ArrayList<XWalkExtension>();
+    }
+
+    public XWalkExtensionContext getExtensionContext() {
+        return mExtensionContextImpl;
+    }
+
+    public void postMessage(XWalkExtension extension, String message) {
+        mXwalkProvider.postMessage(extension, message);
+    }
+
+    public Object registerExtension(XWalkExtension extension) {
+        mExtensions.add(extension);
+        return mXwalkProvider.onExtensionRegistered(extension);
+    }
+
+    public void unregisterExtensions() {
+        for(XWalkExtension extension: mExtensions) {
+            mXwalkProvider.onExtensionUnregistered(extension);
+        }
+        mExtensions.clear();
+    }
+
+    public void onResume() {
+    }
+
+    public void onPause() {
+    }
+
+    public void onDestroy() {
+    }
+
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    }
+}


### PR DESCRIPTION
For Android, we'll build a Java extension system which is independent
on current native extension system. It sits on native one but with
an abstract layer.

Since extension will be used by developers, limited classes will be exposed.
Now XWalkExtension and XWalkExtensionContext will be public.
