### PR TITLE
Fix test with multiple navigations

### DIFF
--- a/extensions/test/external_extension.cc
+++ b/extensions/test/external_extension.cc
@@ -58,6 +58,7 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionTest, NavigateWithExternalExtension) {
 
   for (int i = 0; i < 5; i++) {
     xwalk_test_utils::NavigateToURL(runtime(), url);
+    WaitForLoadStop(runtime()->web_contents());
     EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
   }
 }


### PR DESCRIPTION
If we don't wait for navigation to happen, we'll get the previous title.
In this case, all the checks after the first were trivially
passing. Waiting for load to stop makes sure the test actually change
the title to Pass again.
