### PR TITLE
Implement quota permission context

### DIFF
--- a/runtime/browser/runtime_quota_permission_context.cc
+++ b/runtime/browser/runtime_quota_permission_context.cc
@@ -1,0 +1,26 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/runtime_quota_permission_context.h"
+
+#include "webkit/quota/quota_types.h"
+
+namespace xwalk {
+
+RuntimeQuotaPermissionContext::RuntimeQuotaPermissionContext() {}
+
+void RuntimeQuotaPermissionContext::RequestQuotaPermission(
+    const GURL& origin_url,
+    quota::StorageType type,
+    int64 requested_quota,
+    int render_process_id,
+    int render_view_id,
+    const PermissionCallback& callback) {
+  // TODO(wang16): Handle request according to app's manifest declaration.
+  callback.Run(QUOTA_PERMISSION_RESPONSE_ALLOW);
+}
+
+RuntimeQuotaPermissionContext::~RuntimeQuotaPermissionContext() {}
+
+}  // namespace xwalk

--- a/runtime/browser/runtime_quota_permission_context.h
+++ b/runtime/browser/runtime_quota_permission_context.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_RUNTIME_QUOTA_PERMISSION_CONTEXT_H_
+#define XWALK_RUNTIME_BROWSER_RUNTIME_QUOTA_PERMISSION_CONTEXT_H_
+
+#include "base/compiler_specific.h"
+#include "content/public/browser/quota_permission_context.h"
+
+namespace xwalk {
+
+class RuntimeQuotaPermissionContext : public content::QuotaPermissionContext {
+ public:
+  RuntimeQuotaPermissionContext();
+
+  // The callback will be dispatched on the IO thread.
+  virtual void RequestQuotaPermission(
+      const GURL& origin_url,
+      quota::StorageType type,
+      int64 new_quota,
+      int render_process_id,
+      int render_view_id,
+      const PermissionCallback& callback) OVERRIDE;
+
+ private:
+  virtual ~RuntimeQuotaPermissionContext();
+
+  DISALLOW_COPY_AND_ASSIGN(RuntimeQuotaPermissionContext);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_RUNTIME_QUOTA_PERMISSION_CONTEXT_H_

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -14,6 +14,7 @@
 #include "xwalk/runtime/browser/geolocation/xwalk_access_token_store.h"
 #include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
 #include "xwalk/runtime/browser/runtime_context.h"
+#include "xwalk/runtime/browser/runtime_quota_permission_context.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents.h"
@@ -96,6 +97,11 @@ XWalkContentBrowserClient::CreateRequestContextForStoragePartition(
   return static_cast<RuntimeContext*>(browser_context)->
       CreateRequestContextForStoragePartition(
           partition_path, in_memory, protocol_handlers);
+}
+
+content::QuotaPermissionContext*
+XWalkContentBrowserClient::CreateQuotaPermissionContext() {
+  return new RuntimeQuotaPermissionContext();
 }
 
 content::AccessTokenStore* XWalkContentBrowserClient::CreateAccessTokenStore() {

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -13,6 +13,7 @@
 
 namespace content {
 class BrowserContext;
+class QuotaPermissionContext;
 class WebContents;
 class WebContentsViewDelegate;
 }
@@ -47,6 +48,8 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
       const base::FilePath& partition_path,
       bool in_memory,
       content::ProtocolHandlerMap* protocol_handlers) OVERRIDE;
+  virtual content::QuotaPermissionContext*
+      CreateQuotaPermissionContext() OVERRIDE;
   virtual content::AccessTokenStore* CreateAccessTokenStore() OVERRIDE;
   virtual content::WebContentsViewDelegate* GetWebContentsViewDelegate(
       content::WebContents* web_contents) OVERRIDE;

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -99,6 +99,8 @@
         'runtime/browser/runtime_platform_util_linux.cc',
         'runtime/browser/runtime_platform_util_mac.mm',
         'runtime/browser/runtime_platform_util_win.cc',
+        'runtime/browser/runtime_quota_permission_context.cc',
+        'runtime/browser/runtime_quota_permission_context.h',
         'runtime/browser/runtime_registry.cc',
         'runtime/browser/runtime_registry.h',
         'runtime/browser/runtime_select_file_policy.cc',


### PR DESCRIPTION
Fix that xwalk's browser client does not create quota
permission context. For some web apps, when they requiring
more local storage, xwalk will crash.

Current implemented quota permission context is more like
a mock one. It will allow all request.
In future, it should handle request according to app's declaration
in manifest.

BUG=https://github.com/otcshare/crosswalk/issues/429
