### PR TITLE
Do not use generated bundles

### DIFF
--- a/extensions/jsapi_test.gyp
+++ b/extensions/jsapi_test.gyp
@@ -7,7 +7,6 @@
         '<@(schema_files)',
       ],
       'includes': [
-        '../../build/json_schema_bundle_compile.gypi',
         '../../build/json_schema_compile.gypi',
       ],
       'variables': {

--- a/extensions/test/internal_extension_browsertest.cc
+++ b/extensions/test/internal_extension_browsertest.cc
@@ -9,7 +9,6 @@
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
-#include "xwalk/extensions/test/generated_api.h"
 #include "xwalk/extensions/test/test.h"
 #include "xwalk/extensions/test/xwalk_extensions_test_base.h"
 #include "xwalk/runtime/browser/runtime.h"

--- a/jsapi/jsapi.gyp
+++ b/jsapi/jsapi.gyp
@@ -7,7 +7,6 @@
         '<@(schema_files)',
       ],
       'includes': [
-        '../../build/json_schema_bundle_compile.gypi',
         '../../build/json_schema_compile.gypi',
       ],
       'variables': {


### PR DESCRIPTION
We will need generated bundles in the future when automating the
JavaScript shim creation for Internal Extensions, but for instance
when can skip it and remove the custom patch we have in Chromium
just for that.
