### PR TITLE
Remove references to `selinux' from the build system.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -410,11 +410,11 @@
             },
           },
         }],  # OS=="win"
-        ['OS == "win" or (toolkit_uses_gtk == 1 and selinux == 0)', {
+        ['OS == "win" or toolkit_uses_gtk == 1', {
           'dependencies': [
             '../sandbox/sandbox.gyp:sandbox',
           ],
-        }],  # OS=="win" or (toolkit_uses_gtk == 1 and selinux == 0)
+        }],  # OS=="win" or toolkit_uses_gtk == 1
         ['OS == "linux"', {
           'dependencies': [
             # Build osmesa to workaround egl backend issue on Tizen 2.1 emulator


### PR DESCRIPTION
This is basically the same thing as Chromium r200838: the SELinux code is 
unmaintained, and support for it was removed from Chromium.

We weren't using SELinux ourselves, so removing the code does not make us lose
any features and makes us more future-proof against future rebases of our
Chromium tree.
