### PR TITLE
Port Chromium r204115 to gyp_xwalk.

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -28,6 +28,9 @@ sys.path.insert(1, os.path.join(chrome_src, 'tools', 'grit'))
 sys.path.insert(1, os.path.join(chrome_src, 'chrome', 'tools', 'build'))
 sys.path.insert(1, os.path.join(chrome_src, 'native_client', 'build'))
 sys.path.insert(1, os.path.join(chrome_src, 'third_party', 'WebKit',
+    'Source', 'core', 'scripts'))
+# TODO(adamk): Remove this line once core.gyp is no longer a directory
+sys.path.insert(1, os.path.join(chrome_src, 'third_party', 'WebKit',
     'Source', 'core', 'core.gyp', 'scripts'))
 
 


### PR DESCRIPTION
Prepare gyp_chromium for moving Source/core/core.gyp/core.gyp up a
 directory

  This adds a new import path for pymod_do_main (and removes an old one).
 After core.gyp moves up a directory, the old path can be removed.

  R=abarth@chromium.org

  Review URL: https://codereview.chromium.org/15968014

This is needed to make sure xwalk keeps building when we bump our Chromium and
Blink versions.
