### PR TITLE
Add a description stub to the IDL files

### DIFF
--- a/extensions/test/test.idl
+++ b/extensions/test/test.idl
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// Crosswalk Test API
 namespace test {
   dictionary Person {
     DOMString name;

--- a/jsapi/dialog.idl
+++ b/jsapi/dialog.idl
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// Crosswalk Dialog API
 namespace dialog {
   callback ShowOpenDialogSuccessCallback = void (DOMString[] selected_paths);
   callback ShowSaveDialogSuccessCallback = void (DOMString new_file_path);

--- a/jsapi/runtime.idl
+++ b/jsapi/runtime.idl
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// Crosswalk Runtime API
 namespace runtime {
   callback GetAPIVersionCallback = void (long version);
 


### PR DESCRIPTION
The IDL parser of the newer Chromium release requires a description
string on every IDL namespace otherwise it will assert.

The patch adds stubs, but eventually we should add a more complete
documentation, with links to specs, etc.
