### PR TITLE
Make our v8 usage friendlier to upcoming changes

### DIFF
--- a/extensions/renderer/xwalk_extension_module.h
+++ b/extensions/renderer/xwalk_extension_module.h
@@ -47,8 +47,6 @@ class XWalkExtensionModule {
   std::string extension_name() const { return extension_name_; }
 
  private:
-  void SetFunction(const char* name, v8::InvocationCallback callback);
-
   // Callbacks for JS functions available in 'extension' object.
   static v8::Handle<v8::Value> PostMessageCallback(const v8::Arguments& args);
   static v8::Handle<v8::Value> SendSyncMessageCallback(

--- a/extensions/renderer/xwalk_v8tools_module.cc
+++ b/extensions/renderer/xwalk_v8tools_module.cc
@@ -22,10 +22,12 @@ v8::Handle<v8::Value> ForceSetPropertyCallback(const v8::Arguments& args) {
 XWalkV8ToolsModule::XWalkV8ToolsModule() {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope handle_scope(isolate);
-  object_template_ = v8::Persistent<v8::ObjectTemplate>::New(
-      isolate, v8::ObjectTemplate::New());
-  object_template_->Set("forceSetProperty",
+  v8::Handle<v8::ObjectTemplate> object_template = v8::ObjectTemplate::New();
+  object_template->Set("forceSetProperty",
                         v8::FunctionTemplate::New(ForceSetPropertyCallback));
+
+  object_template_ = v8::Persistent<v8::ObjectTemplate>::New(isolate,
+                                                             object_template);
 }
 
 XWalkV8ToolsModule::~XWalkV8ToolsModule() {
@@ -35,7 +37,10 @@ XWalkV8ToolsModule::~XWalkV8ToolsModule() {
 }
 
 v8::Handle<v8::Object> XWalkV8ToolsModule::NewInstance() {
-  return object_template_->NewInstance();
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+  v8::Handle<v8::ObjectTemplate> object_template = object_template_;
+  return handle_scope.Close(object_template->NewInstance());
 }
 
 }  // namespace extensions


### PR DESCRIPTION
In V8 API, there was a big change (already in trunk but still not in our
branches) on the way v8::Persistents can be created / used. Before the
change, v8::Persistent could act as a v8::Handle, so we could "use" a
value directly. With the new behaviour, we need to unwrap them for
using.

This patch adds the code to unwrap them, reducing the amount of change
needed to run Crosswalk in trunk.
