### PR TITLE
[Android] Enable WebGL by default in XWalk.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -82,6 +82,9 @@ void XWalkBrowserMainParts::PreMainMessageLoopStart() {
       switches::kEnableWebRTC);
   CommandLine::ForCurrentProcess()->AppendSwitch(
       switches::kAllowFileAccessFromFiles);
+  // WebGL is disabled by default on Android, explicitly enable it in switches.
+  CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kEnableExperimentalWebGL);
 #endif
 
 #if !defined(OS_ANDROID)


### PR DESCRIPTION
WebGL is disabled by default on Android, in XWalk, we have to explicitly enable
it in switches.
