### PR TITLE
Remove unused base/hash_tables.h include.

### DIFF
--- a/application/common/application.h
+++ b/application/common/application.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "base/files/file_path.h"
-#include "base/hash_tables.h"
 #include "base/memory/linked_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_ptr.h"


### PR DESCRIPTION
The header's contents are not being used anywhere, and it does not exist in 
subsequent versions of Chromium.
