### PR TITLE
Initialize Chromium's logging infrastructure.

### DIFF
--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -34,6 +34,7 @@ XWalkMainDelegate::~XWalkMainDelegate() {
 }
 
 bool XWalkMainDelegate::BasicStartupComplete(int* exit_code) {
+  logging::InitLogging(logging::LoggingSettings());
   SetContentClient(content_client_.get());
 #if defined(OS_WIN)
   CommandLine* command_line = CommandLine::ForCurrentProcess();


### PR DESCRIPTION
Without calling InitializeLogging(), VLOG() and possibly other logging calls 
simply have no effect even if ones passes --v=1 when running xwalk.
