### PR TITLE
[Android] Fix exception issue in customize tool.

### DIFF
--- a/build/android/make_apk.py
+++ b/build/android/make_apk.py
@@ -31,12 +31,17 @@ def Which(name):
 
 
 def Find(name, path):
+  """Find executable file with the given name
+  and maximum API level under specific path."""
   result = {}
   for root, _, files in os.walk(path):
     if name in files:
       key = os.path.join(root, name)
-      value = int(re.search(r'\d+', key.split('/')[-2]).group())
-      result[key] = value
+      str_num = re.search(r'\d+', key.split('/')[-2])
+      if str_num:
+        result[key] = int(str_num.group())
+      else:
+        result[key] = 0
   if not result:
     raise Exception()
   return max(result.iteritems(), key=operator.itemgetter(1))[0]


### PR DESCRIPTION
```
Customize tool will raise exception when finding aapt
in the Chromium Android SDK. Because the Chromium Android SDK locates
aapi under "platform-tools" folder, not "build-tools/|APL version|"
as default Android SDK. Then "Find" function in customize tool can't
get API level in this situation, but the aapt does exist.

So if tool can't get API level of existing aapt,
tool would set it to zero by default.
```
