### PR TITLE
Comment out some v8 calls.

### DIFF
--- a/extensions/renderer/xwalk_extension_module.cc
+++ b/extensions/renderer/xwalk_extension_module.cc
@@ -62,8 +62,10 @@ XWalkExtensionModule::~XWalkExtensionModule() {
   // this because it might be the case that the JS objects we created outlive
   // this object, even if we destroy the references we have.
   // TODO(cmarcelo): Add a test for this case.
-  v8::Handle<v8::Object> function_data = function_data_;
-  function_data->Delete(v8::String::New(kXWalkExtensionModule));
+  // FIXME(cmarcelo): These calls are causing crashes on shutdown with Chromium
+  //                  29.0.1547.57 and had to be commented out.
+  // v8::Handle<v8::Object> function_data = function_data_;
+  // function_data->Delete(v8::String::New(kXWalkExtensionModule));
 
   object_template_.Dispose(isolate);
   object_template_.Clear();

--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -31,7 +31,9 @@ XWalkExtensionRendererController::XWalkExtensionRendererController() {
 }
 
 XWalkExtensionRendererController::~XWalkExtensionRendererController() {
-  content::RenderThread::Get()->RemoveObserver(this);
+  // FIXME(cmarcelo): These call is causing crashes on shutdown with Chromium
+  //                  29.0.1547.57 and had to be commented out.
+  // content::RenderThread::Get()->RemoveObserver(this);
 }
 
 void XWalkExtensionRendererController::RenderViewCreated(

--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -88,8 +88,10 @@ XWalkModuleSystem::~XWalkModuleSystem() {
   // this because it might be the case that the JS objects we created outlive
   // this object, even if we destroy the references we have.
   // TODO(cmarcelo): Add a test for this case.
-  v8::Handle<v8::Object> function_data = function_data_;
-  function_data->Delete(v8::String::New(kXWalkModuleSystem));
+  // FIXME(cmarcelo): These calls are causing crashes on shutdown with Chromium
+  //                  29.0.1547.57 and had to be commented out.
+  // v8::Handle<v8::Object> function_data = function_data_;
+  // function_data->Delete(v8::String::New(kXWalkModuleSystem));
 
   require_native_template_.Dispose(isolate);
   require_native_template_.Clear();


### PR DESCRIPTION
Some calls in destructors were causing crashes on shutdown with Chromium 
29.0.1547.57. Per cmarcelo's suggestion, comment them out while someone works
on a fix. As a side-effect, some leaks have been introduced, hopefully not for
long.
