### PR TITLE
Explicitly disable sandboxing on Linux.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -127,6 +127,13 @@ void XWalkBrowserMainParts::PreEarlyInitialization() {
   // Initialize the Compositor.
   content::Compositor::Initialize();
 #endif
+
+#if defined(OS_LINUX)
+  // FIXME: Issue 496. We need to explicitly disable sandboxing on Linux while
+  // we do not support it (ie. ship the appropriate binary), otherwise we will
+  // crash on startup.
+  CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoSandbox);
+#endif
 }
 
 int XWalkBrowserMainParts::PreCreateThreads() {


### PR DESCRIPTION
We do not have the proper infrastructure in place and do not build or ship a
sandbox binary like Chromium's "chromium_sandbox".

Once we move chromium-crosswalk to upstream version 29.0.1547.57, we need to 
explicitly disable sandboxing to avoid crashes on startup.

Related to issue #496.
