### PR TITLE
Add TizenPlugMessageWriter and TizenSystemIndicator event support.

### DIFF
--- a/runtime/browser/ui/tizen_plug_message_writer.cc
+++ b/runtime/browser/ui/tizen_plug_message_writer.cc
@@ -1,0 +1,164 @@
+// Copyright (C) 2000-2011 Carsten Haitzler and various contributors.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ui/tizen_plug_message_writer.h"
+
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cerrno>
+
+namespace xwalk {
+
+// This MessageWriter is used to build and write messages using the protocol
+// implemented in EFL 1.7 on the Tizen Mobile 2.1 platform.
+//
+// Messages contain a header and a payload. The instructions are used to build
+// the new header based on the previous header. This allows the system to save
+// bytes when a certain header field wasn't updated.
+//
+// This class is used to construct the next message based on the previous one
+// and the new instructions.
+//
+// See src/lib/ecore_ipc/ecore_ipc.c in ecore source
+// (http://git.enlightenment.org/legacy/ecore.git).
+
+TizenPlugMessageWriter::TizenPlugMessageWriter(int* fd)
+  : fd_(fd) {
+  memset(&prev_, 0, sizeof(struct EcoreIPCMsgHeader));
+}
+
+TizenPlugMessageWriter::~TizenPlugMessageWriter() {
+}
+
+void TizenPlugMessageWriter::SendEvent(int minor, const void* data, int size) {
+  Send(*fd_, kPlugProtocolVersion, minor, 0, 0, 0, data, size);
+}
+
+void TizenPlugMessageWriter::Send(int fd, int major, int minor, int ref,
+                                  int ref_to, int response, const void* data,
+                                  int size) {
+  struct EcoreIPCMsgHeader msg;
+  Instruction instruction = DLT_ZERO;
+  int s = 4;
+  unsigned char dat[sizeof(struct EcoreIPCMsgHeader)];
+  int* head = reinterpret_cast<int*>(dat);
+
+  memset(&msg, 0, sizeof(msg));
+
+  if (size < 0)
+    size = 0;
+
+  msg.major    = major;
+  msg.minor    = minor;
+  msg.ref      = ref;
+  msg.ref_to   = ref_to;
+  msg.response = response;
+  msg.size     = size;
+
+  *head  = AttachInstructionData(msg.major, prev_.major, instruction,
+                                 &s, dat);
+  *head |= AttachInstructionData(msg.minor, prev_.minor, instruction,
+                                 &s, dat) << (4 * 1);
+  *head |= AttachInstructionData(msg.ref, prev_.ref, instruction,
+                                 &s, dat) << (4 * 2);
+  *head |= AttachInstructionData(msg.ref_to, prev_.ref_to, instruction,
+                                 &s, dat) << (4 * 3);
+  *head |= AttachInstructionData(msg.response, prev_.response, instruction,
+                                 &s, dat) << (4 * 4);
+  *head |= AttachInstructionData(msg.size, prev_.size, instruction,
+                                 &s, dat) << (4 * 5);
+  *head = htonl(*head);
+
+  prev_ = msg;  // Store previous message.
+
+  if (!WriteSafe(reinterpret_cast<const uint8_t*>(&dat), s)) {
+    perror("Failed to write msg_header");
+    return;
+  }
+
+  if (size <= 0)
+    return;
+
+  if (!WriteSafe(reinterpret_cast<const uint8_t*>(data), size))
+    perror("Failed to write msg");
+}
+
+int TizenPlugMessageWriter::ProcessNextInstruction(int out, int prev,
+                                                   Instruction* inst) {
+  int int_max = static_cast<int>(0xffffffff);
+  // 0 byte.
+  if (out == 0) {            *inst = DLT_ZERO;   return 0; }
+  if (out == int_max) {      *inst = DLT_ONE;    return 0; }
+  if (out == prev) {         *inst = DLT_SAME;   return 0; }
+  if (out == prev << 1) {    *inst = DLT_SHL;    return 0; }
+  if (out == prev >> 1) {    *inst = DLT_SHR;    return 0; }
+  // 1 byte.
+  int dlt = out - prev;
+  if (!(dlt & 0xffffff00)) { *inst = DLT_ADD8;   return dlt & 0xff; }
+  dlt = prev - out;
+  if (!(dlt & 0xffffff00)) { *inst = DLT_DEL8;   return dlt & 0xff; }
+  dlt = out - prev;
+  if (!(dlt & 0x00ffffff)) { *inst = DLT_ADDU8;  return (dlt >> 24) & 0xff; }
+  dlt = prev - out;
+  if (!(dlt & 0x00ffffff)) { *inst = DLT_DELU8;  return (dlt >> 24) & 0xff; }
+  // 2 bytes.
+  dlt = out - prev;
+  if (!(dlt & 0xffff0000)) { *inst = DLT_ADD16;  return dlt & 0xffff; }
+  dlt = prev - out;
+  if (!(dlt & 0xffff0000)) { *inst = DLT_DEL16;  return dlt & 0xffff; }
+  dlt = out - prev;
+  if (!(dlt & 0x0000ffff)) { *inst = DLT_ADDU16; return (dlt >> 16) & 0xffff; }
+  dlt = prev - out;
+  if (!(dlt & 0x0000ffff)) { *inst = DLT_DELU16; return (dlt >> 16) & 0xffff; }
+  // 4 bytes.
+  *inst = DLT_SET;
+  return out;
+}
+
+Instruction TizenPlugMessageWriter::AttachInstructionData(int msg, int prev,
+                                                          Instruction inst,
+                                                          int* s,
+                                                          unsigned char* dat) {
+  int d = ProcessNextInstruction(msg, prev, &inst);
+  if (inst >= DLT_SET) {
+    uint32_t v = htonl(d);
+    uint8_t* dd = reinterpret_cast<uint8_t*>(&v);
+    *(dat + *s + 0) = dd[0];
+    *(dat + *s + 1) = dd[1];
+    *(dat + *s + 2) = dd[2];
+    *(dat + *s + 3) = dd[3];
+    *s += 4;
+  } else if (inst >= DLT_ADD16) {
+      uint16_t v = htons(d);
+      uint8_t* dd = reinterpret_cast<uint8_t*>(&v);
+      *(dat + *s + 0) = dd[0];
+      *(dat + *s + 1) = dd[1];
+      *s += 2;
+  } else if (inst >= DLT_ADD8) {
+      *(dat + *s + 0) = static_cast<uint8_t>(d);
+      *s += 1;
+  }
+  return inst;
+}
+
+bool TizenPlugMessageWriter::WriteSafe(const uint8_t* buffer, size_t len) {
+  size_t todo = len;
+  while (todo) {
+     ssize_t r = write(*fd_, buffer, todo);
+     if (r == 0)
+       return false;
+     if (r < 0) {
+       if (errno == EAGAIN || errno == EINTR)
+         continue;
+       return false;
+     }
+     todo -= r;
+     buffer += r;
+  }
+  return true;
+}
+
+}  // namespace xwalk

--- a/runtime/browser/ui/tizen_plug_message_writer.h
+++ b/runtime/browser/ui/tizen_plug_message_writer.h
@@ -1,0 +1,127 @@
+// Copyright (C) 2000-2011 Carsten Haitzler and various contributors.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_MESSAGE_WRITER_H_
+#define XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_MESSAGE_WRITER_H_
+
+#include "base/basictypes.h"
+
+// Should match the MAJOR version in ecore_evas_extn.c. We are using
+// the same version used by EFL 1.7 available in Tizen Mobile 2.1.
+const int kPlugProtocolVersion = 0x1011;
+
+namespace xwalk {
+
+// Copied from EFL 1.7, in src/lib/ecore_ipc/ecore_ipc.c.
+struct EcoreIPCMsgHeader {
+  int major;
+  int minor;
+  int ref;
+  int ref_to;
+  int response;
+  int size;
+};
+
+// Copied from EFL 1.7, in src/lib/ecore_evas/ecore_evas_extn.c.
+enum EvasButtonFlags {
+  EVAS_BUTTON_NONE = 0,
+  EVAS_BUTTON_DOUBLE_CLICK = (1 << 0),
+  EVAS_BUTTON_TRIPLE_CLICK = (1 << 1)
+};
+
+enum EvasEventFlags {
+  EVAS_EVENT_FLAG_NONE = 0,
+  EVAS_EVENT_FLAG_ON_HOLD = (1 << 0),
+  EVAS_EVENT_FLAG_ON_SCROLL = (1 << 1)
+};
+
+struct IPCDataEvMouseUp {
+  int button;
+  EvasButtonFlags flags;
+  int mask;
+  unsigned int timestamp;
+  EvasEventFlags event_flags;
+
+  IPCDataEvMouseUp() :
+    button(1),
+    flags(EVAS_BUTTON_NONE),
+    mask(0),
+    timestamp(0),
+    event_flags(EVAS_EVENT_FLAG_NONE) {}
+};
+
+struct IPCDataEvMouseDown {
+  int button;
+  EvasButtonFlags flags;
+  int mask;
+  unsigned int timestamp;
+  EvasEventFlags event_flags;
+
+  IPCDataEvMouseDown() :
+    button(1),
+    flags(EVAS_BUTTON_NONE),
+    mask(0),
+    timestamp(0),
+    event_flags(EVAS_EVENT_FLAG_NONE) {}
+};
+
+struct IPCDataEvMouseMove {
+  int x, y;
+  EvasButtonFlags flags;
+  int mask;
+  unsigned int timestamp;
+  EvasEventFlags event_flags;
+
+  IPCDataEvMouseMove() :
+    x(0),
+    y(0),
+    flags(EVAS_BUTTON_NONE),
+    mask(0),
+    timestamp(0),
+    event_flags(EVAS_EVENT_FLAG_NONE) {}
+};
+
+enum Instruction {
+  DLT_ZERO,
+  DLT_ONE,
+  DLT_SAME,
+  DLT_SHL,
+  DLT_SHR,
+  DLT_ADD8,      // 1 bytes.
+  DLT_DEL8,
+  DLT_ADDU8,
+  DLT_DELU8,
+  DLT_ADD16,     // 2 bytes.
+  DLT_DEL16,
+  DLT_ADDU16,
+  DLT_DELU16,
+  DLT_SET,       // 4 bytes.
+  DLT_R1,
+  DLT_R2
+};
+
+class TizenPlugMessageWriter {
+ public:
+  explicit TizenPlugMessageWriter(int* fd);
+  virtual ~TizenPlugMessageWriter();
+
+  void SendEvent(int minor, const void* data, int size);
+ private:
+  void Send(int fd, int major, int minor, int ref, int ref_to, int resp,
+            const void* data, int size);
+
+  int ProcessNextInstruction(int out, int prev, Instruction* inst);
+  Instruction AttachInstructionData(int msg, int prev, Instruction inst,
+                                    int* s, unsigned char* dat);
+
+  bool WriteSafe(const uint8_t* buffer, size_t len);
+
+  EcoreIPCMsgHeader prev_;
+  int* fd_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_MESSAGE_WRITER_H_

--- a/runtime/browser/ui/tizen_system_indicator.cc
+++ b/runtime/browser/ui/tizen_system_indicator.cc
@@ -8,6 +8,10 @@
 #include "content/public/browser/browser_thread.h"
 #include "xwalk/runtime/browser/ui/tizen_system_indicator_watcher.h"
 
+#include "ui/views/widget/native_widget.h"
+#include "ui/views/widget/root_view.h"
+#include "ui/aura/root_window.h"
+
 namespace {
 
 SkColor kBGColor = SkColorSetARGB(255, 52, 52, 50);
@@ -53,6 +57,74 @@ gfx::Size TizenSystemIndicator::GetPreferredSize() {
 void TizenSystemIndicator::SetImage(const gfx::ImageSkia& img) {
   image_ = img;
   SchedulePaint();
+}
+
+bool TizenSystemIndicator::OnMousePressed(const ui::MouseEvent& event) {
+  watcher_->OnMouseDown();
+  return true;
+}
+
+void TizenSystemIndicator::OnMouseReleased(const ui::MouseEvent& event) {
+  watcher_->OnMouseUp();
+}
+
+void TizenSystemIndicator::OnTouchEvent(ui::TouchEvent* event) {
+  const gfx::Point position = event->location();
+
+  switch (event->type()) {
+    case ui::ET_UNKNOWN:
+    case ui::ET_MOUSE_PRESSED:
+    case ui::ET_MOUSE_DRAGGED:
+    case ui::ET_MOUSE_RELEASED:
+    case ui::ET_MOUSE_MOVED:
+    case ui::ET_MOUSE_ENTERED:
+    case ui::ET_MOUSE_EXITED:
+    case ui::ET_KEY_PRESSED:
+    case ui::ET_KEY_RELEASED:
+    case ui::ET_MOUSEWHEEL:
+    case ui::ET_MOUSE_CAPTURE_CHANGED:
+    case ui::ET_TOUCH_RELEASED:
+      watcher_->OnMouseUp();
+      break;
+    case ui::ET_TOUCH_PRESSED:
+      watcher_->OnMouseDown();
+      break;
+    case ui::ET_TOUCH_MOVED:
+      watcher_->OnMouseMove(position.x(), position.y());
+      break;
+    case ui::ET_TOUCH_STATIONARY:
+    case ui::ET_TOUCH_CANCELLED:
+    case ui::ET_DROP_TARGET_EVENT:
+    case ui::ET_TRANSLATED_KEY_PRESS:
+    case ui::ET_TRANSLATED_KEY_RELEASE:
+    case ui::ET_GESTURE_SCROLL_BEGIN:
+    case ui::ET_GESTURE_SCROLL_END:
+    case ui::ET_GESTURE_SCROLL_UPDATE:
+    case ui::ET_GESTURE_TAP:
+    case ui::ET_GESTURE_TAP_DOWN:
+    case ui::ET_GESTURE_TAP_CANCEL:
+    case ui::ET_GESTURE_BEGIN:
+    case ui::ET_GESTURE_END:
+    case ui::ET_GESTURE_TWO_FINGER_TAP:
+    case ui::ET_GESTURE_PINCH_BEGIN:
+    case ui::ET_GESTURE_PINCH_END:
+    case ui::ET_GESTURE_PINCH_UPDATE:
+    case ui::ET_GESTURE_LONG_PRESS:
+    case ui::ET_GESTURE_LONG_TAP:
+    case ui::ET_GESTURE_MULTIFINGER_SWIPE:
+    case ui::ET_SCROLL:
+    case ui::ET_SCROLL_FLING_START:
+    case ui::ET_SCROLL_FLING_CANCEL:
+    case ui::ET_CANCEL_MODE:
+    case ui::ET_LAST:
+      break;
+  }
+  event->SetHandled();
+}
+
+void TizenSystemIndicator::OnMouseMoved(const ui::MouseEvent& event) {
+  const gfx::Point position = event.location();
+  watcher_->OnMouseMove(position.x(), position.y());
 }
 
 }  // namespace xwalk

--- a/runtime/browser/ui/tizen_system_indicator.h
+++ b/runtime/browser/ui/tizen_system_indicator.h
@@ -30,6 +30,10 @@ class TizenSystemIndicator : public views::View {
  private:
   // Will be called immediately after the image was updated
   void SetImage(const gfx::ImageSkia& img);
+  virtual bool OnMousePressed(const ui::MouseEvent& event) OVERRIDE;
+  virtual void OnMouseReleased(const ui::MouseEvent& event) OVERRIDE;
+  virtual void OnMouseMoved(const ui::MouseEvent& event) OVERRIDE;
+  virtual void OnTouchEvent(ui::TouchEvent* event) OVERRIDE;
 
   gfx::ImageSkia image_;
   scoped_ptr<TizenSystemIndicatorWatcher> watcher_;

--- a/runtime/browser/ui/tizen_system_indicator_watcher.h
+++ b/runtime/browser/ui/tizen_system_indicator_watcher.h
@@ -6,6 +6,8 @@
 #ifndef XWALK_RUNTIME_BROWSER_UI_TIZEN_SYSTEM_INDICATOR_WATCHER_H_
 #define XWALK_RUNTIME_BROWSER_UI_TIZEN_SYSTEM_INDICATOR_WATCHER_H_
 
+#include "xwalk/runtime/browser/ui/tizen_plug_message_writer.h"
+
 #include <string>
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/shared_memory.h"
@@ -15,16 +17,6 @@
 namespace xwalk {
 
 class TizenSystemIndicator;
-
-// Copied from EFL 1.7, in src/lib/ecore_ipc/ecore_ipc.c.
-struct ecore_ipc_msg_header {
-  int major;
-  int minor;
-  int ref;
-  int ref_to;
-  int response;
-  int size;
-};
 
 // Implementation of the socket protocol for sharing memory used by Elementary
 // "Plugs" in EFL. This class implements the low level protocol and is used by
@@ -41,6 +33,10 @@ class TizenSystemIndicatorWatcher : public base::MessagePumpLibevent::Watcher {
   void StartWatching();
   void StopWatching();
   bool Connect();
+
+  void OnMouseDown();
+  void OnMouseUp();
+  void OnMouseMove(int x, int y);
 
   gfx::Size GetSize() const;
 
@@ -60,6 +56,7 @@ class TizenSystemIndicatorWatcher : public base::MessagePumpLibevent::Watcher {
   void ResizeIndicator();
 
   TizenSystemIndicator* indicator_;
+  TizenPlugMessageWriter* writer_;
   base::MessagePumpLibevent::FileDescriptorWatcher fd_watcher_;
   scoped_ptr<base::SharedMemory> shared_memory_;
 

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -153,6 +153,8 @@
         [ 'tizen_mobile == 1', {
           'defines': [ 'OS_TIZEN_MOBILE=1' ],
           'sources': [
+            'runtime/browser/ui/tizen_plug_message_writer.cc',
+            'runtime/browser/ui/tizen_plug_message_writer.h',
             'runtime/browser/ui/tizen_system_indicator.cc',
             'runtime/browser/ui/tizen_system_indicator.h',
             'runtime/browser/ui/tizen_system_indicator_watcher.cc',


### PR DESCRIPTION
This class is used to build and write messages using the protocol
implemented in EFL 1.7 on the Tizen Mobile 2.1 platform.

Messages contain a header and a payload. The instructions are used
to build the new header based on a previous header. This allows the
system to save bytes when a certain header field wasn't updated.

This utility class is used to construct the next message based on the
previous one and the new instructions.

Now TizenSystemIndicator and TizenSystemIndicatorWatcher support
click and touch events.
