### PR TITLE
Fix windows build failure after rebase to chromium 29

### DIFF
--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -234,8 +234,8 @@ void NativeAppWindowViews::ChildPreferredSizeChanged(views::View* child) {
 }
 
 void NativeAppWindowViews::ViewHierarchyChanged(
-    bool is_add, views::View *parent, views::View *child) {
-  if (is_add && child == this) {
+    const ViewHierarchyChangedDetails& details) {
+  if (details.is_add && details.child == this) {
     TopViewLayout* layout = new TopViewLayout();
     SetLayoutManager(layout);
 

--- a/runtime/browser/ui/native_app_window_views.h
+++ b/runtime/browser/ui/native_app_window_views.h
@@ -71,7 +71,7 @@ class NativeAppWindowViews : public NativeAppWindow,
   // views::View implementation.
   virtual void ChildPreferredSizeChanged(views::View* child) OVERRIDE;
   virtual void ViewHierarchyChanged(
-      bool is_add, views::View *parent, views::View *child) OVERRIDE;
+      const ViewHierarchyChangedDetails& details) OVERRIDE;
   virtual void OnFocus() OVERRIDE;
   virtual gfx::Size GetMaximumSize() OVERRIDE { return maximum_size_; }
   virtual gfx::Size GetMinimumSize() OVERRIDE { return minimum_size_; }

--- a/test/base/xwalk_test_launcher.cc
+++ b/test/base/xwalk_test_launcher.cc
@@ -28,16 +28,10 @@
 #include "ui/views/focus/accelerator_handler.h"
 #endif
 
-const char kEmptyTestName[] = "InProcessBrowserTest.Empty";
-
 class XWalkTestLauncherDelegate : public content::TestLauncherDelegate {
  public:
   XWalkTestLauncherDelegate() {}
   virtual ~XWalkTestLauncherDelegate() {}
-
-  virtual std::string GetEmptyTestName() OVERRIDE {
-    return kEmptyTestName;
-  }
 
   virtual int RunTestSuite(int argc, char** argv) OVERRIDE {
     return XWalkTestSuite(argc, argv).Run();


### PR DESCRIPTION
1. Upstream changes views::ViewHierachyChanged method's param.
2. Upstream removes TestLauncherDelegate::GetEmptyTestName method

Update xwalk code accordingly.
