### PR TITLE
[Android] Enable fullscreen video support for xwalk

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -32,7 +32,6 @@ public class XWalkContent extends FrameLayout {
     private ContentViewRenderView mContentViewRenderView;
     private WindowAndroid mWindow;
     private XWalkView mXWalkView;
-    private XWalkContentsClient mContentsClient;
     private XWalkContentsClientBridge mContentsClientBridge;
     private XWalkWebContentsDelegateAdapter mXWalkContentsDelegateAdapter;
     private XWalkSettings mSettings;
@@ -71,23 +70,18 @@ public class XWalkContent extends FrameLayout {
         // Initialize mWindow which is needed by content
         mWindow = new WindowAndroid(xwView.getActivity());
 
-        // Initialize the ContentVideoView for fullscreen video playback.
-        // FIXME: 56f04e70d9b changed things
-        // ContentVideoView.registerContentVideoViewContextDelegate(
-        //         new XWalkContentVideoViewDelegate(mContentsClientBridge, getContext()));
-
         // Initialize ContentView.
         mContentView = ContentView.newInstance(getContext(), mWebContents, mWindow);
         addView(mContentView,
                 new FrameLayout.LayoutParams(
                         FrameLayout.LayoutParams.MATCH_PARENT,
                         FrameLayout.LayoutParams.MATCH_PARENT));
+        mContentView.setContentViewClient(mContentsClientBridge);
 
         mContentViewRenderView.setCurrentContentView(mContentView);
 
         // For addJavascriptInterface
         mContentViewCore = mContentView.getContentViewCore();
-        mContentViewCore.setContentViewClient(mContentsClientBridge);
         mContentsClientBridge.installWebContentsObserver(mContentViewCore);
 
         mSettings = new XWalkSettings(getContext(), mWebContents, true);

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentVideoViewClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentVideoViewClient.java
@@ -4,19 +4,21 @@
 
 package org.xwalk.core;
 
+import android.app.Activity;
 import android.content.Context;
 import android.view.View;
+import android.view.WindowManager;
 
 import org.chromium.content.browser.ContentVideoViewClient;
 import org.xwalk.core.XWalkWebChromeClient.CustomViewCallback;
 
-public class XWalkContentVideoViewDelegate implements ContentVideoViewClient {
-    private Context mContext;
+public class XWalkContentVideoViewClient implements ContentVideoViewClient {
     private XWalkContentsClient mContentsClient;
+    private Activity mActivity;
 
-    public XWalkContentVideoViewDelegate(XWalkContentsClient client, Context context) {
-        mContext = context;
+    public XWalkContentVideoViewClient(XWalkContentsClient client, Activity activity) {
         mContentsClient = client;
+        mActivity = activity;
     }
 
     @Override
@@ -36,6 +38,11 @@ public class XWalkContentVideoViewDelegate implements ContentVideoViewClient {
 
     @Override
     public void keepScreenOn(boolean screenOn) {
+        if (screenOn) {
+            mActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        } else {
+            mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
     }
 
     @Override

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -20,6 +20,7 @@ import android.webkit.WebResourceResponse;
 import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
 import org.chromium.base.ThreadUtils;
+import org.chromium.content.browser.ContentVideoViewClient;
 
 // Help bridge callback in XWalkContentsClient to XWalkViewClient and
 // WebChromeClient; Also handle the JNI conmmunication logic.
@@ -235,6 +236,11 @@ public class XWalkContentsClientBridge extends XWalkContentsClient {
 
     @Override
     public void didFinishLoad(String url) {
+    }
+
+    @Override
+    public ContentVideoViewClient getContentVideoViewClient() {
+        return new XWalkContentVideoViewClient(this, mXWalkView.getActivity());
     }
 
     // Used by the native peer to set/reset a weak ref to the native peer.


### PR DESCRIPTION
Upstream changes its interfaces so that we have to make corresponding
changes here as well. The main change is to use ContentViewClient to
get the ContentVideoViewClient object.
