### PR TITLE
Revert "Revert "Initialize Chromium's logging infrastructure.""

### DIFF
--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -30,6 +30,7 @@ XWalkMainDelegate::~XWalkMainDelegate() {
 }
 
 bool XWalkMainDelegate::BasicStartupComplete(int* exit_code) {
+  logging::InitLogging(logging::LoggingSettings());
   SetContentClient(content_client_.get());
 #if defined(OS_WIN)
   CommandLine* command_line = CommandLine::ForCurrentProcess();


### PR DESCRIPTION
Now that we're using Chromium 29 we can finally reintroduce this patch, which
should work fine now.

Originally this was:

commit e5d8f14ab83ff19b4e853859fc91b773646f89cc Author: Raphael Kubo da Costa
raphael.kubo.da.costa@intel.com Date:   Wed Aug 28 19:00:40 2013 +0300

```
Initialize Chromium's logging infrastructure.

Without calling InitializeLogging(), VLOG() and possibly other logging
```

   calls
   simply have no effect even if ones passes --v=1 when running xwalk.

This reverts commit 43c82ec801437c8a71d2b4432541e1b1d81269da.
