### PR TITLE
generate-flat-tree: Pass --verbose to tar(1).

### DIFF
--- a/packaging/generate-flat-tree.sh
+++ b/packaging/generate-flat-tree.sh
@@ -25,4 +25,5 @@ echo "Adding ${GCLIENT_DEP_PATH}..."
 
 tar --append --file ${XWALK_PREFIX}/flat-xwalk-tree.tar \
     --exclude-vcs --exclude=native_client --exclude=LayoutTests \
+    --verbose \
     ${GCLIENT_DEP_PATH}


### PR DESCRIPTION
List every file being added to the tarball. It should help with the build 
bots, as the build would sometimes fail because there would be no output for 
too long.
