### PR TITLE
[Tizen] Install install_into_pkginfo_db.py

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -11,6 +11,7 @@ Source1:        xwalk
 Source1001:     crosswalk.manifest
 Source1002:     %{name}.xml.in
 Source1003:     %{name}.png
+Source1004:     install_into_pkginfo_db.py
 Patch1:         %{name}-1.29-do-not-look-for-gtk2-when-using-aura.patch
 Patch2:         %{name}-1.29-look-for-pvr-libGLESv2.so.patch
 Patch3:         %{name}-1.29-revert-nss-commits.patch
@@ -76,6 +77,7 @@ This package contains additional support files that are needed for running Cross
 cp %{SOURCE1001} .
 cp %{SOURCE1002} .
 cp %{SOURCE1003} .
+cp %{SOURCE1004} .
 sed "s/@VERSION@/%{version}/g" %{name}.xml.in > %{name}.xml
 
 cp -a src/AUTHORS AUTHORS.chromium
@@ -115,6 +117,7 @@ make %{?_smp_mflags} -C src BUILDTYPE=Release xwalk
 # Binaries.
 install -p -D %{SOURCE1} %{buildroot}%{_bindir}/xwalk
 install -p -D src/out/Release/xwalk %{buildroot}%{_libdir}/xwalk/xwalk
+install -p -D %{SOURCE1004} %{buildroot}%{_bindir}/install_into_pkginfo_db.py
 
 # Supporting libraries and resources.
 install -p -D src/out/Release/libffmpegsumo.so %{buildroot}%{_libdir}/xwalk/libffmpegsumo.so
@@ -129,6 +132,7 @@ install -p -D %{name}.png %{buildroot}%{_desktop_icondir}/%{name}.png
 %manifest %{name}.manifest
 # %license AUTHORS.chromium AUTHORS.xwalk LICENSE.chromium LICENSE.xwalk
 %{_bindir}/xwalk
+%{_bindir}/install_into_pkginfo_db.py
 %{_libdir}/xwalk/libffmpegsumo.so
 %{_libdir}/xwalk/xwalk
 %{_libdir}/xwalk/xwalk.pak

--- a/packaging/install_into_pkginfo_db.py
+++ b/packaging/install_into_pkginfo_db.py
@@ -123,7 +123,7 @@ class InstallHelper(object):
         if os.path.exists(icon):
           shutil.copy2(icon, icon_path)
 
-      xwalk_path = "/usr/bin/xwalk"
+      xwalk_path = "/usr/lib/xwalk/xwalk"
       install_dir = "/opt/usr/apps/applications/" + self.package_id_ + "/bin/"
       install_path = install_dir + self.package_id_
       if not os.path.exists(install_dir):


### PR DESCRIPTION
This change will install install_into_pkginfo_db.py under /usr/bin/.
Besides, due to task manager can not communicate with shell script
process, the application execution path is linked to Crosswalk binary.
Command parameter handling will be implemented within Crosswalk C++
code.
