### PR TITLE
Define OS_TIZEN_MOBILE even in chromium source tree.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -9,11 +9,16 @@
     # result, multi-touch support works with these simulated touch events
     # dispatched from floating device.
     'enable_xi21_mt%': 0,
+
+    'tizen_mobile%': 0,
   },
   'target_defaults': {
     'conditions': [
       ['enable_xi21_mt==1', {
         'defines': ['ENABLE_XI21_MT=1'],
+      }],
+      ['tizen_mobile==1', {
+        'defines': ['OS_TIZEN_MOBILE=1'],
       }],
     ],
   },

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -2,7 +2,6 @@
   'variables': {
     'xwalk_product_name': 'XWalk',
     'xwalk_version': '1.28.2.0',
-    'tizen_mobile%': 0,
     'conditions': [
       ['OS=="linux"', {
        'use_custom_freetype%': 1,
@@ -151,7 +150,6 @@
       },
       'conditions': [
         [ 'tizen_mobile == 1', {
-          'defines': [ 'OS_TIZEN_MOBILE=1' ],
           'sources': [
             'runtime/browser/ui/tizen_system_indicator.cc',
             'runtime/browser/ui/tizen_system_indicator.h',


### PR DESCRIPTION
Few chromium files needs this definition to integrate XWalk on Tizen.
