### PR TITLE
Fix windows functionality after rebase to 29

### DIFF
--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -30,7 +30,9 @@ XWalkMainDelegate::~XWalkMainDelegate() {
 }
 
 bool XWalkMainDelegate::BasicStartupComplete(int* exit_code) {
-  logging::InitLogging(logging::LoggingSettings());
+  logging::LoggingSettings loggingSettings;
+  loggingSettings.logging_dest = logging::LOG_TO_SYSTEM_DEBUG_LOG;
+  logging::InitLogging(loggingSettings);
   SetContentClient(content_client_.get());
 #if defined(OS_WIN)
   CommandLine* command_line = CommandLine::ForCurrentProcess();


### PR DESCRIPTION
On windows, default setting for logging is not working.
Set to output to system debug log.
