### PR TITLE
[Android] Fix that resume application will cause reload

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -54,8 +54,10 @@ public class XWalkContent extends FrameLayout {
         // Initialize ContentViewRenderView
         mContentViewRenderView = new ContentViewRenderView(context) {
             protected void onReadyToRender() {
-                if (mPendingUrl != null)
+                if (mPendingUrl != null) {
                     doLoadUrl(mPendingUrl);
+                    mPendingUrl = null;
+                }
 
                 mReadyToLoad = true;
             }


### PR DESCRIPTION
The cause is that mPendingUrl hasn't got reset after loading request consumed.
mPendingUrl is for the case that loading request is sent before render is ready.
It should be reset after pending loading finished.

BUG=https://github.com/crosswalk-project/crosswalk/issues/524
