### PR TITLE
[Tizen] Don't use fullscreen.

### DIFF
--- a/packaging/xwalk
+++ b/packaging/xwalk
@@ -23,7 +23,6 @@ else
 fi
 
 exec /usr/lib/xwalk/xwalk --use-gl="${GL_IMPLEMENTATION}" \
-                          --fullscreen \
                           --ignore-gpu-blacklist \
                           --allow-file-access-from-files \
                           "$@"

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -56,7 +56,14 @@ NativeAppWindowViews::NativeAppWindowViews(
   params.show_state = create_params.state;
   window_->Init(params);
 
+#if defined(OS_TIZEN_MOBILE)
+  // Widget::SetBoundsConstrained() in Widget::Init() shrinks 10 pixel
+  // on all edges, so we need to set the bounds again here.
+  window_->SetBounds(
+      gfx::Screen::GetNativeScreen()->GetPrimaryDisplay().work_area());
+#else
   window_->CenterWindow(create_params.bounds.size());
+#endif
   if (create_params.state == ui::SHOW_STATE_FULLSCREEN)
     SetFullscreen(true);
 


### PR DESCRIPTION
XWalk makes the same size window to the screen. If we use fullscreen, Tizen can
not hook the home button keyevent.

TODO: Widget::SetBoundsConstrained() shrinks 10 pixel on all edges. We need to
avoid it.
