### PR TITLE
Make new C API code more robust, and test it

### DIFF
--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -1,0 +1,13 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/common/xwalk_extension_server.h"
+
+namespace xwalk {
+namespace extensions {
+
+XWalkExtensionServer::XWalkExtensionServer() {}
+
+}  // namespace extensions
+}  // namespace xwalk

--- a/extensions/common/xwalk_external_adapter.cc
+++ b/extensions/common/xwalk_external_adapter.cc
@@ -103,7 +103,8 @@ XWalkExternalExtension* XWalkExternalAdapter::GetExtension(
     XW_Extension xw_extension) {
   XWalkExternalAdapter* adapter = XWalkExternalAdapter::GetInstance();
   ExtensionMap::iterator it = adapter->extension_map_.find(xw_extension);
-  CHECK(it != adapter->extension_map_.end());
+  if (it == adapter->extension_map_.end())
+    return NULL;
   return it->second;
 }
 
@@ -111,8 +112,17 @@ XWalkExternalContext* XWalkExternalAdapter::GetInstance(
     XW_Instance xw_instance) {
   XWalkExternalAdapter* adapter = XWalkExternalAdapter::GetInstance();
   InstanceMap::iterator it = adapter->instance_map_.find(xw_instance);
-  CHECK(it != adapter->instance_map_.end());
+  if (it == adapter->instance_map_.end())
+    return NULL;
   return it->second;
+}
+
+// static
+void XWalkExternalAdapter::LogInvalidCall(
+    int32_t value, const char* type,
+    const char* interface, const char* function) {
+  LOG(WARNING) << "Ignoring call to " << interface << " function " << function
+               << " as it received wrong XW_" << type << "=" << value << ".";
 }
 
 }  // namespace extensions

--- a/extensions/extensions_browsertests.gypi
+++ b/extensions/extensions_browsertests.gypi
@@ -1,5 +1,6 @@
 {
   'sources': [
+    'test/bad_extension_test.cc',
     'test/context_destruction.cc',
     'test/extension_in_iframe.cc',
     'test/external_extension.cc',

--- a/extensions/external_extension_sample.gyp
+++ b/extensions/external_extension_sample.gyp
@@ -20,6 +20,15 @@
       'test/echo_extension.c',
     ]
   },
-
+  {
+    'target_name': 'bad_extension',
+    'type': 'loadable_module',
+    'include_dirs': [
+      '../..',
+    ],
+    'sources': [
+      'test/bad_extension.c',
+    ]
+  },
   ],
 }

--- a/extensions/test/bad_extension.c
+++ b/extensions/test/bad_extension.c
@@ -1,0 +1,102 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This extension will post messages for incorrect instances. External
+// extensions should be treated as "user input" and not trusted. When possible,
+// Crosswalk should not crash in case of bad behavior from external extensions.
+
+#if defined(__cplusplus)
+#error "This file is written in C to make sure the C API works as intended."
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include "xwalk/extensions/public/XW_Extension.h"
+
+XW_Extension g_extension = 0;
+const XW_CoreInterface* g_core = NULL;
+const XW_MessagingInterface* g_messaging = NULL;
+
+XW_Instance g_last_instance_destroyed = 0;
+
+char* kDoneMessage = "DONE";
+
+void OnInstanceCreated(XW_Instance instance) {
+  void* data = kDoneMessage;
+
+  // BAD: Sending messages to invalid instances.
+  g_messaging->PostMessage(0, "Zero is never a valid instance");
+  g_messaging->PostMessage(instance + 1, "Wrong instance");
+  g_messaging->PostMessage(instance + 1000, "Another wrong instance");
+  g_messaging->PostMessage(g_last_instance_destroyed, "Destroyed instance");
+
+  // BAD: Setting extra data for invalid instances.
+  g_core->SetInstanceData(0, NULL);
+  g_core->SetInstanceData(instance + 1, NULL);
+  g_core->SetInstanceData(instance + 1000, NULL);
+  g_core->SetInstanceData(g_last_instance_destroyed, NULL);
+
+  g_core->SetInstanceData(instance, data);
+}
+
+void OnInstanceDestroyed(XW_Instance instance) {
+  g_last_instance_destroyed = instance;
+}
+
+void OnMessageReceived(XW_Instance instance, const char* message) {
+  char* done_message = NULL;
+  void* data = NULL;
+
+  // BAD: Sending messages to invalid instances.
+  g_messaging->PostMessage(0, "Zero is never a valid instance");
+  g_messaging->PostMessage(instance + 1, "Wrong instance");
+  g_messaging->PostMessage(instance + 1000, "Another wrong instance");
+  g_messaging->PostMessage(g_last_instance_destroyed, "Destroyed instance");
+
+  // BAD: Getting extra data for invalid instances.
+  data = g_core->GetInstanceData(0);
+  data = g_core->GetInstanceData(instance + 1);
+  data = g_core->GetInstanceData(instance + 1000);
+  data = g_core->GetInstanceData(g_last_instance_destroyed);
+
+  // Send a correct message to finish the test.
+  done_message = g_core->GetInstanceData(instance);
+  g_messaging->PostMessage(instance, done_message);
+}
+
+int32_t XW_Initialize(XW_Extension extension, XW_GetInterface get_interface) {
+  static const char* kAPI =
+      "exports.test = function() {"
+      "  extension.postMessage('TEST');"
+      "};"
+      "extension.setMessageListener(function(msg) {"
+      "  if (msg == 'DONE') {"
+      "    document.title = 'Pass';"
+      "  } else {"
+      "    document.title = 'Fail';"
+      "  }"
+      "});";
+  g_extension = extension;
+  g_core = get_interface(XW_CORE_INTERFACE);
+
+  g_core->SetExtensionName(extension, "bad");
+  g_core->SetJavaScriptAPI(extension, kAPI);
+  g_core->RegisterInstanceCallbacks(
+      extension, OnInstanceCreated, NULL);
+
+  // BAD: Use wrong extension value when setting extension name.
+  g_core->SetExtensionName(0, "bad");
+  g_core->SetExtensionName(extension + 1, "bad");
+  g_core->SetExtensionName(extension + 1000, "bad");
+
+  /* // BAD: Use wrong extension value to register instance callbacks. */
+  g_core->RegisterInstanceCallbacks(0, OnInstanceCreated, NULL);
+  g_core->RegisterInstanceCallbacks(extension + 1, OnInstanceCreated, NULL);
+  g_core->RegisterInstanceCallbacks(extension + 1000, OnInstanceCreated, NULL);
+
+  g_messaging = get_interface(XW_MESSAGING_INTERFACE);
+  g_messaging->Register(extension, OnMessageReceived);
+
+  return XW_OK;
+}

--- a/extensions/test/bad_extension_test.cc
+++ b/extensions/test/bad_extension_test.cc
@@ -1,0 +1,69 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/native_library.h"
+#include "base/path_service.h"
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/extensions/browser/xwalk_extension_service.h"
+#include "xwalk/extensions/common/xwalk_external_extension.h"
+#include "xwalk/extensions/test/xwalk_extensions_test_base.h"
+#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/test/base/xwalk_test_utils.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
+
+using xwalk::extensions::XWalkExtension;
+using xwalk::extensions::XWalkExtensionService;
+using xwalk::extensions::XWalkExternalExtension;
+
+static base::FilePath GetNativeLibraryFilePath(const char* name) {
+  base::string16 library_name = base::GetNativeLibraryName(UTF8ToUTF16(name));
+#if defined(OS_WIN)
+  return base::FilePath(library_name);
+#else
+  return base::FilePath(UTF16ToUTF8(library_name));
+#endif
+}
+
+class BadExtensionTest : public XWalkExtensionsTestBase {
+ public:
+  void RegisterExtensions(XWalkExtensionService* extension_service) OVERRIDE {
+    base::FilePath extension_file;
+    PathService::Get(base::DIR_EXE, &extension_file);
+    extension_file = extension_file.Append(
+        GetNativeLibraryFilePath("bad_extension"));
+    XWalkExternalExtension* extension =
+        new XWalkExternalExtension(extension_file);
+    ASSERT_TRUE(extension->is_valid());
+    extension_service->RegisterExtension(scoped_ptr<XWalkExtension>(extension));
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(BadExtensionTest, DoNotCrash) {
+  content::RunAllPendingInMessageLoop();
+  LOG(WARNING) << "This test will produce a lot warnings which are expected."
+               << " The goal is to not crash.";
+  GURL url = GetExtensionsTestURL(base::FilePath(),
+                                  base::FilePath().AppendASCII("bad.html"));
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+  xwalk_test_utils::NavigateToURL(runtime(), url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}
+
+IN_PROC_BROWSER_TEST_F(BadExtensionTest, NavigateDoNotCrash) {
+  content::RunAllPendingInMessageLoop();
+  LOG(WARNING) << "This test will produce a lot warnings which are expected."
+               << " The goal is to not crash.";
+  GURL url = GetExtensionsTestURL(base::FilePath(),
+                                  base::FilePath().AppendASCII("bad.html"));
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+
+  for (int i = 0; i < 5; i++) {
+    xwalk_test_utils::NavigateToURL(runtime(), url);
+    WaitForLoadStop(runtime()->web_contents());
+    EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+  }
+}

--- a/extensions/test/data/bad.html
+++ b/extensions/test/data/bad.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+try {
+    bad.test();
+} catch(e) {
+    console.log(e);
+    document.title = "Fail";
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Instead of CHECK() whether XW_Instances and XW_Extensions coming from
the external extensions are correct, we now ignore calls to invalid
instances and extensions and loudly emit a warning with detailed
information.

Note that if multiple extensions or instances are running in a process,
they still can "guess" a valid (but incorrect) id.

This problem was identified when testing the new API with t-e-c, where
some extensions send messages to older (already destroyed) instances.
