### PR TITLE
Invalidate the message filter when WCH is about to be destroyed

### DIFF
--- a/extensions/browser/xwalk_extension_message_filter.h
+++ b/extensions/browser/xwalk_extension_message_filter.h
@@ -9,6 +9,7 @@
 #include <string>
 #include "content/public/browser/browser_message_filter.h"
 #include "base/basictypes.h"
+#include "base/synchronization/lock.h"
 #include "base/values.h"
 
 using content::BrowserThread;
@@ -39,7 +40,7 @@ class XWalkExtensionMessageFilter : public content::BrowserMessageFilter {
                                  bool* message_was_ok) OVERRIDE;
 
  private:
-  friend class content::BrowserMessageFilter;
+  friend class XWalkExtensionWebContentsHandler;
   virtual ~XWalkExtensionMessageFilter();
 
   // IPC message handlers.
@@ -50,9 +51,17 @@ class XWalkExtensionMessageFilter : public content::BrowserMessageFilter {
   void DidCreateScriptContext(int64_t frame_id);
   void WillReleaseScriptContext(int64_t frame_id);
 
+  // MessageFilter is destroyed by the channel in the IO process, but we
+  // should stop using it once we destroy the WebContentsHandler (which
+  // happens in the UI process).
+  void Invalidate();
+
   XWalkExtensionWebContentsHandler* handler_;
   XWalkExtensionRunnerStore* runners_;
   int routing_id_;
+
+  base::Lock is_valid_lock_;
+  bool is_valid_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkExtensionMessageFilter);
 };

--- a/extensions/browser/xwalk_extension_web_contents_handler.cc
+++ b/extensions/browser/xwalk_extension_web_contents_handler.cc
@@ -54,6 +54,8 @@ void XWalkExtensionWebContentsHandler::set_render_process_host(
 void XWalkExtensionWebContentsHandler::ClearMessageFilter(void) {
   DCHECK(render_process_host_ && message_filter_);
 
+  message_filter_->Invalidate();
+
   // RemoveFilter() deletes the filter internally.
   if (render_process_host_->GetChannel())
     render_process_host_->GetChannel()->RemoveFilter(message_filter_);


### PR DESCRIPTION
RemoveFilter() will post a task to delete the filter in another thread,
so there's still room for the filter be used before deletion task come,
but the WCH could be already destroyed at this point.

This issue could be reproduced in my machine by opening "Xvfb :22" and
then using the command:

```
DISPLAY=:22 out/Release/xwalk_browsertest \
--gtest_filter="*OpenLink*" --gtest_repeat=2000
```
