### PR TITLE
[Android] Add the test case about setDatabaseEnabled

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetDatabaseEnabledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetDatabaseEnabledTest.java
@@ -1,0 +1,148 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.graphics.Bitmap;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+import android.webkit.WebResourceResponse;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.base.test.util.UrlUtils;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkClient;
+
+/**
+ * Test suite for setDatabaseEnabled().
+ */
+public class SetDatabaseEnabledTest extends XWalkViewTestBase {
+    private static final boolean ENABLED = true;
+    private static final boolean DISABLED = false;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        class TestXWalkClient extends XWalkClient {
+            @Override
+            public void onPageStarted(XWalkView view, String url, Bitmap favicon) {
+                mTestContentsClient.onPageStarted(url);
+            }
+
+            @Override
+            public void onPageFinished(XWalkView view, String url) {
+                mTestContentsClient.didFinishLoad(url);
+            }
+
+            @Override
+            public WebResourceResponse shouldInterceptRequest(XWalkView view,
+                    String url) {
+                return mTestContentsClient.shouldInterceptRequest(url);
+            }
+
+            @Override
+            public void onLoadResource(XWalkView view, String url) {
+                mTestContentsClient.onLoadResource(url);
+            }
+        }
+        getXWalkView().setXWalkClient(new TestXWalkClient());
+    }
+
+    abstract class XWalkViewSettingsTestHelper<T> {
+        XWalkViewSettingsTestHelper(boolean requiresJsEnabled) throws Throwable {
+            if (requiresJsEnabled) {
+                getXWalkView().getSettings().setJavaScriptEnabled(true);
+            }
+        }
+
+        void ensureSettingHasAlteredValue() throws Throwable {
+            ensureSettingHasValue(getAlteredValue());
+        }
+
+        void ensureSettingHasInitialValue() throws Throwable {
+            ensureSettingHasValue(getInitialValue());
+        }
+
+        void setAlteredSettingValue() throws Throwable {
+            setCurrentValue(getAlteredValue());
+        }
+
+        void setInitialSettingValue() throws Throwable {
+            setCurrentValue(getInitialValue());
+        }
+
+        protected abstract T getAlteredValue();
+
+        protected abstract T getInitialValue();
+
+        protected abstract T getCurrentValue();
+
+        protected abstract void setCurrentValue(T value) throws Throwable;
+
+        protected abstract void doEnsureSettingHasValue(T value) throws Throwable;
+
+        private void ensureSettingHasValue(T value) throws Throwable {
+            assertEquals(value, getCurrentValue());
+            doEnsureSettingHasValue(value);
+        }
+    }
+
+    class XWalkViewSettingsDatabaseTestHelper extends XWalkViewSettingsTestHelper<Boolean> {
+        private static final String NO_DATABASE = "No database";
+        private static final String HAS_DATABASE = "Has database";
+
+        XWalkViewSettingsDatabaseTestHelper() throws Throwable {
+            super(true);
+        }
+
+        @Override
+        protected Boolean getAlteredValue() {
+            return ENABLED;
+        }
+
+        @Override
+        protected Boolean getInitialValue() {
+            return DISABLED;
+        }
+
+        @Override
+        protected Boolean getCurrentValue() {
+            Boolean enabled = getXWalkView().getSettings().getDatabaseEnabled();
+            return enabled;
+        }
+
+        @Override
+        protected void setCurrentValue(Boolean value) {
+            getXWalkView().getSettings().setDatabaseEnabled(value);
+        }
+
+        @Override
+        protected void doEnsureSettingHasValue(Boolean value) throws Throwable {
+            // It seems accessing the database through a data scheme is not
+            // supported, and fails with a DOM exception (likely a cross-domain
+            // violation).
+            loadUrlSync(UrlUtils.getTestFileUrl("xwalkview/database_access.html"));
+            assertEquals(
+                value == ENABLED ? HAS_DATABASE : NO_DATABASE,
+                getTitleOnUiThread());
+        }
+    }
+
+    @SmallTest
+    @Feature({"XWalkView", "Preferences"})
+    public void testDatabaseEnabled() throws Throwable {
+        XWalkViewSettingsDatabaseTestHelper helper = new XWalkViewSettingsDatabaseTestHelper();
+        helper.setAlteredSettingValue();
+        helper.ensureSettingHasAlteredValue();
+    }
+
+    @SmallTest
+    @Feature({"XWalkView", "Preferences"})
+    public void testDatabaseDisabled() throws Throwable {
+        XWalkViewSettingsDatabaseTestHelper helper = new XWalkViewSettingsDatabaseTestHelper();
+        helper.setInitialSettingValue();
+        helper.ensureSettingHasInitialValue();
+    }
+}

--- a/test/data/device_files/database_access.html
+++ b/test/data/device_files/database_access.html
@@ -1,0 +1,13 @@
+<html>
+    <head><title>None</title><script>
+        function checkDatabase() {
+            var db = null;
+            if ('openDatabase' in window) {
+                db = window.openDatabase('test', '1.0', 'results', 1*1024*1024);
+            }
+            document.title = db ? "Has database" : "No database";
+        }
+    </script></head>
+    <body onload='checkDatabase()'>
+    </body>
+</html>


### PR DESCRIPTION
Test database by set the function setDatabaseEnabled true or false. \
Then get the result by load the html which check the database \
enabled or not.

This test case should add the parameter "--test_data", as follows:
build/android/run_instrumentation_tests.py --test-apk XWalkCoreTest \
--test_data xwalkview:xwalk/test/data/device_files/ \
--verbose -I --num_retries=1 -f testDatabaseEnabled
