### PR TITLE
[Android] Implement the evaluateJavaScript interface in XWalkCore

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -177,6 +177,10 @@ public class XWalkContent extends FrameLayout {
         return null;
     }
 
+    public void evaluateJavaScript(String script) throws IllegalStateException {
+        mContentView.evaluateJavaScript(script);
+    }
+
     // For instrumentation test.
     public ContentViewCore getContentViewCoreForTest() {
         return mContentViewCore;

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -137,6 +137,10 @@ public class XWalkView extends FrameLayout {
         mContent.stopLoading();
     }
 
+    public void evaluateJavaScript(String script) throws IllegalStateException {
+        mContent.evaluateJavaScript(script);
+    }
+
     // Enables remote debugging and returns the URL at which the dev tools server is listening
     // for commands.
     public String enableRemoteDebugging() {


### PR DESCRIPTION
This API allows native to inject JavaScript code into the page and evaluate it
in XWalk.

This API is needed to enable NativeToJs bridge for cordova container.
