### PR TITLE
[Android] Stop devtools server if necessary when View get destroyed.

### DIFF
--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -86,6 +86,12 @@ public class XWalkViewShellActivity extends Activity {
     }
 
     @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mView.onDestroy();
+    }
+
+    @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         mView.onActivityResult(requestCode, resultCode, data);
     }

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -145,10 +145,11 @@ public class XWalkView extends FrameLayout {
     }
 
     public void disableRemoteDebugging() {
-        if (mDevToolsServer ==  null) {
-            return;
+        if (mDevToolsServer ==  null) return;
+
+        if (mDevToolsServer.isRemoteDebuggingEnabled()) {
+            mDevToolsServer.setRemoteDebuggingEnabled(false);
         }
-        mDevToolsServer.setRemoteDebuggingEnabled(false);
         mDevToolsServer.destroy();
         mDevToolsServer = null;
     }
@@ -159,6 +160,10 @@ public class XWalkView extends FrameLayout {
 
     public void onResume() {
         mContent.onResume();
+    }
+
+    public void onDestroy() {
+        disableRemoteDebugging();
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -60,6 +60,7 @@ class XWalkCoreProviderImpl extends XWalkRuntimeViewProvider {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        mXwalkView.onDestroy();
     }
 
     @Override


### PR DESCRIPTION
When the Activity & XWalkView get destroyed, the devtools server will also need
to be stopped. Otherwise, recreation of Activity&View will cause port binding error.

The most common case is use back key to stop Activity and then navigate back.

BUG=https://github.com/crosswalk-project/crosswalk/issues/565
