### PR TITLE
[Tizen] Introduce AppcoreContext to make Tizen task switcher be able to control xwalk's web applications.

### DIFF
--- a/application/common/application.cc
+++ b/application/common/application.cc
@@ -29,6 +29,10 @@
 #include "url/url_util.h"
 #include "ui/base/l10n/l10n_util.h"
 
+#if defined(OS_TIZEN_MOBILE)
+#include "xwalk/tizen/appcore_context.h"
+#endif
+
 namespace keys = xwalk::application_manifest_keys;
 namespace errors = xwalk::application_manifest_errors;
 
@@ -196,6 +200,9 @@ bool Application::Init(string16* error) {
 
   application_url_ = Application::GetBaseURLFromApplicationId(ID());
   finished_parsing_manifest_ = true;
+#if defined(OS_TIZEN_MOBILE)
+  appcore_context_ = tizen::AppcoreContext::Create();
+#endif
   return true;
 }
 

--- a/application/common/application.h
+++ b/application/common/application.h
@@ -29,6 +29,12 @@ class ListValue;
 class Version;
 }
 
+#if defined(OS_TIZEN_MOBILE)
+namespace tizen {
+class AppcoreContext;
+}
+#endif
+
 namespace xwalk {
 namespace application {
 
@@ -175,6 +181,10 @@ class Application : public base::RefCountedThreadSafe<Application> {
   // initialization happens from the same thread (this can happen when certain
   // parts of the initialization process need information from previous parts).
   base::ThreadChecker thread_checker_;
+
+#if defined(OS_TIZEN_MOBILE)
+  scoped_ptr<tizen::AppcoreContext> appcore_context_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -53,6 +53,7 @@
           'dependencies': [
             '../third_party/libxml/libxml.gyp:libxml',
             'build/system.gyp:tizen',
+            'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
           ],
           'sources': [
             'browser/installer/tizen/packageinfo_constants.cc',

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -29,6 +29,30 @@
             ],
           },
         },
+        {
+          'target_name': 'tizen_appcore',
+          'type': 'none',
+          'variables': {
+            'packages': [
+              'appcore-efl',
+              'aul',
+              'capi-appfw-application',
+            ],
+          },
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags <@(packages))',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(pkg-config --libs-only-L --libs-only-other <@(packages))',
+            ],
+            'libraries': [
+              '<!@(pkg-config --libs-only-l <@(packages))',
+            ],
+          },
+        },
       ],  # targets
     }],
   ],  # conditions

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -28,7 +28,10 @@ BuildRequires:  python
 BuildRequires:  python-xml
 BuildRequires:  perl
 BuildRequires:  which
+BuildRequires:  pkgconfig(appcore-efl)
+BuildRequires:  pkgconfig(aul)
 BuildRequires:  pkgconfig(cairo)
+BuildRequires:  pkgconfig(capi-appfw-application)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(fontconfig)
 BuildRequires:  pkgconfig(freetype2)

--- a/tizen/appcore_context.cc
+++ b/tizen/appcore_context.cc
@@ -1,0 +1,147 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/tizen/appcore_context.h"
+
+#include <appcore-common.h>
+#include <aul.h>
+#include <malloc.h>
+#include <tizen.h>
+#include "base/logging.h"
+#include "base/message_loop/message_loop.h"
+
+// AppcoreContextImpl uses private Tizen appcore API to reuse Tizen 2.0
+// implementation.
+// This private implementation of appcore is a bit huge. We will decide later
+// whether to maintain the code similar to appcore private implementation
+// in Crosswalk or not after investigating appcore in Tizen 3.0.
+extern "C" {
+// define in app.h
+int app_get_id(char** id);
+
+// define in app_private.h
+int app_get_package_app_name(const char* package, char** name);
+void app_finalizer_execute(void);
+
+// define in status.c
+int aul_status_update(int status);
+
+// define in appcore-internal.h
+enum app_event {
+  AE_UNKNOWN,
+  AE_CREATE,
+  AE_TERMINATE,
+  AE_PAUSE,
+  AE_RESUME,
+  AE_RESET,
+  AE_LOWMEM_POST,
+  AE_MEM_FLUSH,
+  AE_MAX
+};
+
+struct ui_ops {
+  void* data;
+  void (*cb_app)(enum app_event evnt, void* data, bundle*);
+};
+}
+
+namespace tizen {
+
+// FIXME: this implementation is not compatible with shared process mode,
+// because Tizen task switcher cannot recognize multiple tasks per process.
+// Shared process mode requires one Crosswalk process to include multiple tasks
+// (= web applications). It is not supported by current task switcher.
+class AppcoreContextImpl
+    : public AppcoreContext {
+ public:
+  AppcoreContextImpl();
+  virtual ~AppcoreContextImpl();
+
+  bool Initialize();
+
+ private:
+  static void HandleAppcoreEvents(enum app_event, void*, bundle*);
+  void HandleAppcoreEventsInternal(enum app_event, bundle*);
+
+  char* package_;
+  char* application_name_;
+  struct ui_ops appcore_operations_;
+
+  DISALLOW_COPY_AND_ASSIGN(AppcoreContextImpl);
+};
+
+scoped_ptr<AppcoreContext> AppcoreContext::Create() {
+  scoped_ptr<AppcoreContextImpl> context(new AppcoreContextImpl());
+  if (context->Initialize())
+    return context.PassAs<AppcoreContext>();
+  return scoped_ptr<AppcoreContext>();
+}
+
+AppcoreContextImpl::AppcoreContextImpl()
+    : package_(NULL),
+      application_name_(NULL) {
+  appcore_operations_.data = this;
+  appcore_operations_.cb_app = HandleAppcoreEvents;
+}
+
+AppcoreContextImpl::~AppcoreContextImpl() {
+  app_finalizer_execute();
+  aul_status_update(STATUS_DYING);
+  appcore_exit();
+
+  // app_get_id() and app_get_package_app_name() allocated them using malloc.
+  free(package_);
+  free(application_name_);
+}
+
+bool AppcoreContextImpl::Initialize() {
+  if (app_get_id(&package_) != TIZEN_ERROR_NONE) {
+    LOG(ERROR) << "Failed to get the package: " << package_;
+    return false;
+  }
+
+  if (app_get_package_app_name(package_, &application_name_) !=
+      TIZEN_ERROR_NONE) {
+    LOG(ERROR) << "Failed to get the package's application name: "
+               << application_name_;
+    return false;
+  }
+
+  DCHECK(application_name_ && application_name_[0] != '\0');
+  char* argv[2] = {'\0', };
+  int r = appcore_init(application_name_, &appcore_operations_, 1, argv);
+  if (r == -1) {
+    LOG(ERROR) << "Failed to initialize appcore. application name: "
+               << application_name_;
+    return false;
+  }
+
+  return true;
+}
+
+
+void AppcoreContextImpl::HandleAppcoreEvents(enum app_event event,
+                                                  void* data,
+                                                  bundle* b) {
+  static_cast<AppcoreContextImpl*>(data)->
+      HandleAppcoreEventsInternal(event, b);
+}
+
+void AppcoreContextImpl::HandleAppcoreEventsInternal(enum app_event event,
+                                                          bundle* b) {
+  if (event >= AE_MAX)
+    return;
+
+  switch (event) {
+    case AE_TERMINATE:
+      LOG(INFO) << "[XWalk " << getpid() <<"] TERMINATE";
+      base::MessageLoop::current()->QuitNow();
+      break;
+    default:
+      break;
+  }
+}
+
+}  // namespace tizen
+

--- a/tizen/appcore_context.h
+++ b/tizen/appcore_context.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_TIZEN_APPCORE_CONTEXT_H_
+#define XWALK_TIZEN_APPCORE_CONTEXT_H_
+
+#include "base/basictypes.h"
+#include "base/memory/scoped_ptr.h"
+
+namespace tizen {
+
+// AppcoreContext makes Tizen task switcher be able to control xwalk.
+class AppcoreContext {
+ public:
+  static scoped_ptr<AppcoreContext> Create();
+  virtual ~AppcoreContext() {}
+};
+
+}  // namespace tizen
+
+#endif  // XWALK_TIZEN_APPCORE_CONTEXT_H_

--- a/tizen/xwalk_tizen.gypi
+++ b/tizen/xwalk_tizen.gypi
@@ -1,0 +1,17 @@
+{
+  'targets': [
+  {
+    'target_name': 'xwalk_tizen_lib',
+    'type': 'static_library',
+    'dependencies': [
+      '../build/system.gyp:tizen_appcore',
+    ],
+    'include_dirs': [
+      '../..',
+    ],
+    'sources': [
+      'appcore_context.cc',
+      'appcore_context.h',
+    ],
+  }],
+}


### PR DESCRIPTION
[Tizen] Introduce AppcoreContext to make Tizen task switcher be able to control xwalk's web applications.

Xwalk's web application must communicate with Tizen application framework.

The most important task we need to do is to call appcore_init() in Tizen.
appcore_init() connects Tizen task manager via IPC. After calling
appcore_init(), the given process that called appcore_init() can communicate with
Tizen task switcher.

AppcoreContext calls appcore_init() with a callback function, and handles
messages in the callback function. Currently, AppcoreContext handles only
AE_TERMINATE message. When AppcoreContext receives AE_TERMINATE message,
AppcoreContext quits the xwalk. The task switcher sends AE_TERMINATE message
when an user kills the app on the task switcher.

AppcoreContextImpl uses private Tizen appcore API to reuse Tizen 2.0 implementation.
This private implementation of appcore is a bit huge. We will decide later
whether to maintain the code similar to appcore private implementation in xwalk
or not after investigating appcore in Tizen 3.0.

To concentrate Tizen implementation detail on cc file, we declare
AppcoreContextImpl that extends AppcoreContext in cc file.

NOTE: this implementation is not compatible with shared process mode, because
tizen task switcher cannot recognize multiple tasks per process. Shared process
mode requires one xwalk process to include multiple tasks (= web applications).
It is not supported by current task switcher.

appcore_context.cc is similar to a part of appcore-efl.c in appcore.

BUG=https://github.com/otcshare/crosswalk/issues/609
