### PR TITLE
mac: compile

### DIFF
--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -38,12 +38,13 @@ g_register_extensions_callback;
 class ExtensionServerMessageFilter : public IPC::ChannelProxy::MessageFilter {
  public:
   explicit ExtensionServerMessageFilter(XWalkExtensionServer* server);
-  virtual ~ExtensionServerMessageFilter() {}
 
   // IPC::ChannelProxy::MessageFilter Implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
 
  private:
+  friend class IPC::ChannelProxy::MessageFilter;
+  virtual ~ExtensionServerMessageFilter() {}
   XWalkExtensionServer* server_;
 };
 

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -38,7 +38,7 @@ class XWalkExtensionServer : public IPC::Listener,
   virtual ~XWalkExtensionServer();
 
   // IPC::Listener Implementation.
-  virtual bool OnMessageReceived(const IPC::Message& message);
+  virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
 
   void Initialize(IPC::Sender* sender) { sender_ = sender; }
   bool Send(IPC::Message* msg);

--- a/extensions/renderer/xwalk_extension_client.cc
+++ b/extensions/renderer/xwalk_extension_client.cc
@@ -18,6 +18,9 @@ XWalkExtensionClient::XWalkExtensionClient(IPC::Sender* sender)
       next_instance_id_(0) {
 }
 
+XWalkExtensionClient::~XWalkExtensionClient() {
+}
+
 bool XWalkExtensionClient::Send(IPC::Message* msg) {
   DCHECK(sender_);
 

--- a/extensions/renderer/xwalk_extension_client.h
+++ b/extensions/renderer/xwalk_extension_client.h
@@ -32,10 +32,10 @@ class XWalkModuleSystem;
 class XWalkExtensionClient : public IPC::Listener {
  public:
   explicit XWalkExtensionClient(IPC::Sender* sender);
-  virtual ~XWalkExtensionClient() {}
+  virtual ~XWalkExtensionClient();
 
   // IPC::Listener Implementation.
-  virtual bool OnMessageReceived(const IPC::Message& message);
+  virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
 
   void CreateRunnersForModuleSystem(XWalkModuleSystem* module_system);
 

--- a/extensions/renderer/xwalk_extension_module.h
+++ b/extensions/renderer/xwalk_extension_module.h
@@ -47,7 +47,7 @@ class XWalkExtensionModule : public XWalkRemoteExtensionRunner::Client {
 
  private:
   // XWalkRemoteExtensionRunner::Client implementation.
-  void HandleMessageFromNative(const base::Value& msg) OVERRIDE;
+  virtual void HandleMessageFromNative(const base::Value& msg) OVERRIDE;
 
   // Callbacks for JS functions available in 'extension' object.
   static void PostMessageCallback(


### PR DESCRIPTION
Keep the mac build working

[chromium-style] Overriding method must be marked with OVERRIDE.
[chromium-style] Classes that are ref-counted should have destructors that are declared protected or private.
[chromium-style] Complex destructor has an inline body.
[chromium-style] Overriding method must have "virtual" keyword.

http://www.chromium.org/developers/coding-style/chromium-style-checker-errors
