### PR TITLE
[Android] Add the test case about DomStorageEnabled and AppCacheEnabled.

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetAppCacheEnabledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetAppCacheEnabledTest.java
@@ -1,0 +1,252 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.graphics.Bitmap;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Pair;
+import android.webkit.ValueCallback;
+import android.webkit.WebResourceResponse;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.Callable;
+
+import org.chromium.base.test.util.DisabledTest;
+import org.chromium.base.test.util.Feature;
+import org.chromium.content.browser.test.util.CallbackHelper;
+import org.chromium.content.browser.test.util.Criteria;
+import org.chromium.content.browser.test.util.CriteriaHelper;
+import org.chromium.net.test.util.TestWebServer;
+import org.xwalk.core.XWalkClient;
+import org.xwalk.core.XWalkContent;
+import org.xwalk.core.XWalkSettings;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkWebChromeClient;
+import org.xwalk.core.xwview.test.util.CommonResources;
+
+/**
+ * Test suite for setAppCacheEnabled().
+ */
+public class SetAppCacheEnabledTest extends XWalkViewTestBase {
+    private static final long TEST_TIMEOUT = 20000L;
+    private static final int CHECK_INTERVAL = 100;
+    private TestXWalkViewContentsClient mContentClient;
+    private XWalkSettings mSettings;
+
+    class TestXWalkViewClient extends XWalkClient {
+        @Override
+        public void onPageStarted(XWalkView view, String url, Bitmap favicon) {
+            mContentClient.onPageStarted(url);
+        }
+
+        @Override
+        public void onPageFinished(XWalkView view, String url) {
+            mContentClient.didFinishLoad(url);
+        }
+
+        @Override
+        public WebResourceResponse shouldInterceptRequest(XWalkView view,
+                String url) {
+            return mContentClient.shouldInterceptRequest(url);
+        }
+
+        @Override
+        public void onLoadResource(XWalkView view, String url) {
+            mContentClient.onLoadResource(url);
+        }
+    }
+
+    class TestXWalkChromeClient extends XWalkWebChromeClient {
+        @Override
+        public void onReceivedTitle(XWalkView view, String title) {
+            mTestContentsClient.onTitleChanged(title);
+        }
+    }
+
+    static class ManifestTestHelper {
+        private final TestWebServer mWebServer;
+        private final String mHtmlPath;
+        private final String mHtmlUrl;
+        private final String mManifestPath;
+
+        ManifestTestHelper(TestWebServer webServer, String htmlPageName, String manifestName) {
+            mWebServer = webServer;
+            mHtmlPath = "/" + htmlPageName;
+            mHtmlUrl = webServer.setResponse(
+                    mHtmlPath, "<html manifest=\"" + manifestName + "\"></html>", null);
+            mManifestPath = "/" + manifestName;
+            webServer.setResponse(
+                    mManifestPath,
+                    "CACHE MANIFEST",
+                    CommonResources.getContentTypeAndCacheHeaders("text/cache-manifest", false));
+        }
+
+        String getHtmlPath() {
+            return mHtmlPath;
+        }
+
+        String getHtmlUrl() {
+            return mHtmlUrl;
+        }
+
+        String getManifestPath() {
+            return mManifestPath;
+        }
+
+        int waitUntilHtmlIsRequested(final int initialRequestCount) throws InterruptedException {
+            return waitUntilResourceIsRequested(mHtmlPath, initialRequestCount);
+        }
+
+        int waitUntilManifestIsRequested(final int initialRequestCount)
+                throws InterruptedException {
+            return waitUntilResourceIsRequested(mManifestPath, initialRequestCount);
+        }
+
+        private int waitUntilResourceIsRequested(
+                final String path, final int initialRequestCount) throws InterruptedException {
+            boolean result = CriteriaHelper.pollForCriteria(new Criteria() {
+                @Override
+                public boolean isSatisfied() {
+                    return mWebServer.getRequestCount(path) > initialRequestCount;
+                }
+            }, TEST_TIMEOUT, CHECK_INTERVAL);
+            assertTrue(result);
+            return mWebServer.getRequestCount(path);
+        }
+    }
+
+    private ViewPair createViews() throws Throwable {
+        TestXWalkViewContentsClient contentClient0 = new TestXWalkViewContentsClient();
+        TestXWalkViewContentsClient contentClient1 = new TestXWalkViewContentsClient();
+        TestXWalkViewClient viewClient0 = new TestXWalkViewClient();
+        TestXWalkViewClient viewClient1 = new TestXWalkViewClient();
+        TestXWalkChromeClient chromeClient0 = new TestXWalkChromeClient();
+        TestXWalkChromeClient chromeClient1 = new TestXWalkChromeClient();
+        ViewPair viewPair =
+                createViewsOnMainSync(contentClient0, contentClient1, viewClient0,
+                        viewClient1, chromeClient0, chromeClient1, getActivity());
+
+        return viewPair;
+    }
+
+    private XWalkSettings getXWalkSettings(final XWalkView view) {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mSettings = view.getSettings();
+            }
+        });
+        return mSettings;
+    }
+
+    @SmallTest
+    @Feature({"XWalkView", "Preferences", "AppCache"})
+    public void testAppCache() throws Throwable {
+        final TestXWalkViewContentsClient contentClient =
+                new TestXWalkViewContentsClient();
+        mContentClient = contentClient;
+        final XWalkView xWalkView =
+                createXWalkViewContainerOnMainSync(getActivity(), contentClient,
+                        new TestXWalkViewClient(), new TestXWalkChromeClient());
+        final XWalkContent xWalkContent = getXWalkContentOnMainSync(xWalkView);
+        final XWalkSettings settings = getXWalkSettings(xWalkView);
+        settings.setJavaScriptEnabled(true);
+        // Note that the cache isn't actually enabled until the call to setAppCachePath.
+        settings.setAppCacheEnabled(true);
+
+        TestWebServer webServer = null;
+        try {
+            webServer = new TestWebServer(false);
+            ManifestTestHelper helper = new ManifestTestHelper(
+                    webServer, "testAppCache.html", "appcache.manifest");
+            loadUrlSyncByContent(
+                    xWalkContent,
+                    mContentClient,
+                    helper.getHtmlUrl());
+            helper.waitUntilHtmlIsRequested(0);
+            // Unfortunately, there is no other good way of verifying that AppCache is
+            // disabled, other than checking that it didn't try to fetch the manifest.
+            Thread.sleep(1000);
+            assertEquals(0, webServer.getRequestCount(helper.getManifestPath()));
+            settings.setAppCachePath("111");  // Enables AppCache.
+            loadUrlSyncByContent(
+                    xWalkContent,
+                    mContentClient,
+                    helper.getHtmlUrl());
+            helper.waitUntilManifestIsRequested(0);
+        } finally {
+            if (webServer != null) webServer.shutdown();
+        }
+    }
+
+    /*
+     * @SmallTest
+     * @Feature({"XWalkView", "Preferences", "AppCache"})
+     * This test is flaky but the root cause is not found yet. See crbug.com/171765.
+     */
+    @DisabledTest
+    public void testAppCacheWithTwoViews() throws Throwable {
+        // We don't use the test helper here, because making sure that AppCache
+        // is disabled takes a lot of time, so running through the usual drill
+        // will take about 20 seconds.
+        ViewPair views = createViews();
+
+        XWalkSettings settings0 = getXWalkSettingsOnUiThreadByContent(
+                views.getContent0());
+        settings0.setJavaScriptEnabled(true);
+        settings0.setAppCachePath("whatever");
+        settings0.setAppCacheEnabled(true);
+        XWalkSettings settings1 = getXWalkSettingsOnUiThreadByContent(
+                views.getContent1());
+        settings1.setJavaScriptEnabled(true);
+        // AppCachePath setting is global, no need to set it for the second view.
+        settings1.setAppCacheEnabled(true);
+
+        TestWebServer webServer = null;
+        try {
+            webServer = new TestWebServer(false);
+            ManifestTestHelper helper0 = new ManifestTestHelper(
+                    webServer, "testAppCache_0.html", "appcache.manifest_0");
+            mContentClient = views.getClient0();
+            loadUrlSyncByContent(
+                    views.getContent0(),
+                    mContentClient,
+                    helper0.getHtmlUrl());
+            int manifestRequests0 = helper0.waitUntilManifestIsRequested(0);
+            ManifestTestHelper helper1 = new ManifestTestHelper(
+                    webServer, "testAppCache_1.html", "appcache.manifest_1");
+            mContentClient = views.getClient1();
+            loadUrlSyncByContent(
+                    views.getContent1(),
+                    mContentClient,
+                    helper1.getHtmlUrl());
+            helper1.waitUntilManifestIsRequested(0);
+            settings1.setAppCacheEnabled(false);
+            mContentClient = views.getClient0();
+            loadUrlSyncByContent(
+                    views.getContent0(),
+                    mContentClient,
+                    helper0.getHtmlUrl());
+            helper0.waitUntilManifestIsRequested(manifestRequests0);
+            final int prevManifestRequestCount =
+                    webServer.getRequestCount(helper1.getManifestPath());
+            int htmlRequests1 = webServer.getRequestCount(helper1.getHtmlPath());
+            mContentClient = views.getClient1();
+            loadUrlSyncByContent(
+                    views.getContent1(),
+                    mContentClient,
+                    helper1.getHtmlUrl());
+            helper1.waitUntilHtmlIsRequested(htmlRequests1);
+            // Unfortunately, there is no other good way of verifying that AppCache is
+            // disabled, other than checking that it didn't try to fetch the manifest.
+            Thread.sleep(1000);
+            assertEquals(
+                    prevManifestRequestCount, webServer.getRequestCount(helper1.getManifestPath()));
+        } finally {
+            if (webServer != null) webServer.shutdown();
+        }
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetDomStorageEnabledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetDomStorageEnabledTest.java
@@ -1,0 +1,234 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.graphics.Bitmap;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.webkit.WebResourceResponse;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.base.test.util.UrlUtils;
+import org.xwalk.core.XWalkClient;
+import org.xwalk.core.XWalkContent;
+import org.xwalk.core.XWalkSettings;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkWebChromeClient;
+
+/**
+ * Test suite for setDomStorageEnabled().
+ */
+public class SetDomStorageEnabledTest extends XWalkViewTestBase {
+    private static final boolean ENABLED = true;
+    private static final boolean DISABLED = false;
+
+    class TestXWalkViewClient extends XWalkClient {
+        TestXWalkViewContentsClient walkViewContentClient;
+
+        TestXWalkViewClient(TestXWalkViewContentsClient contentClient) {
+            walkViewContentClient = contentClient;
+        }
+
+        @Override
+        public void onPageStarted(XWalkView view, String url, Bitmap favicon) {
+            walkViewContentClient.onPageStarted(url);
+        }
+
+        @Override
+        public void onPageFinished(XWalkView view, String url) {
+            walkViewContentClient.didFinishLoad(url);
+        }
+
+        @Override
+        public WebResourceResponse shouldInterceptRequest(XWalkView view,
+                String url) {
+            return walkViewContentClient.shouldInterceptRequest(url);
+        }
+
+        @Override
+        public void onLoadResource(XWalkView view, String url) {
+            walkViewContentClient.onLoadResource(url);
+        }
+    }
+
+    class TestXWalkChromeClient extends XWalkWebChromeClient {
+        TestXWalkViewContentsClient walkViewContentClient;
+
+        TestXWalkChromeClient(TestXWalkViewContentsClient contentClient) {
+            walkViewContentClient = contentClient;
+        }
+
+        @Override
+        public void onReceivedTitle(XWalkView view, String title) {
+            walkViewContentClient.onTitleChanged(title);
+        }
+    }
+
+    protected ViewPair createViews() throws Throwable {
+        TestXWalkViewContentsClient contentClient0 = new TestXWalkViewContentsClient();
+        TestXWalkViewContentsClient contentClient1 = new TestXWalkViewContentsClient();
+        TestXWalkViewClient viewClient0 = new TestXWalkViewClient(contentClient0);
+        TestXWalkViewClient viewClient1 = new TestXWalkViewClient(contentClient1);
+        TestXWalkChromeClient chromeClient0 = new TestXWalkChromeClient(contentClient0);
+        TestXWalkChromeClient chromeClient1 = new TestXWalkChromeClient(contentClient1);
+        ViewPair viewPair =
+                createViewsOnMainSync(contentClient0, contentClient1, viewClient0,
+                        viewClient1, chromeClient0, chromeClient1, getActivity());
+
+        return viewPair;
+    }
+
+    abstract class XWalkViewSettingsTestHelper<T> {
+        protected final XWalkContent mXWalkContent;
+        protected final XWalkSettings mXWalkSettings;
+
+        XWalkViewSettingsTestHelper(XWalkContent xWalkContent,
+                boolean requiresJsEnabled) throws Throwable {
+            mXWalkContent = xWalkContent;
+            mXWalkSettings = getXWalkSettingsOnUiThreadByContent(xWalkContent);
+            mXWalkSettings.setDomStorageEnabled(false);
+            if (requiresJsEnabled) {
+                mXWalkSettings.setJavaScriptEnabled(true);
+            }
+        }
+
+        void ensureSettingHasAlteredValue() throws Throwable {
+            ensureSettingHasValue(getAlteredValue());
+        }
+
+        void ensureSettingHasInitialValue() throws Throwable {
+            ensureSettingHasValue(getInitialValue());
+        }
+
+        void setAlteredSettingValue() throws Throwable {
+            setCurrentValue(getAlteredValue());
+        }
+
+        void setInitialSettingValue() throws Throwable {
+            setCurrentValue(getInitialValue());
+        }
+
+        protected abstract T getAlteredValue();
+
+        protected abstract T getInitialValue();
+
+        protected abstract T getCurrentValue();
+
+        protected abstract void setCurrentValue(T value) throws Throwable;
+
+        protected abstract void doEnsureSettingHasValue(T value) throws Throwable;
+
+        private void ensureSettingHasValue(T value) throws Throwable {
+            assertEquals(value, getCurrentValue());
+            doEnsureSettingHasValue(value);
+        }
+    }
+
+    class XWalkViewSettingsDomStorageEnabledTestHelper extends XWalkViewSettingsTestHelper<Boolean> {
+        private static final String NO_LOCAL_STORAGE = "No localStorage";
+        private static final String HAS_LOCAL_STORAGE = "Has localStorage";
+        TestXWalkViewContentsClient client;
+
+        XWalkViewSettingsDomStorageEnabledTestHelper(
+                XWalkContent xWalkContent,
+                final TestXWalkViewContentsClient contentClient) throws Throwable {
+            super(xWalkContent, true);
+            client = contentClient;
+        }
+
+        @Override
+        protected Boolean getAlteredValue() {
+            return ENABLED;
+        }
+
+        @Override
+        protected Boolean getInitialValue() {
+            return DISABLED;
+        }
+
+        @Override
+        protected Boolean getCurrentValue() {
+            return mXWalkSettings.getDomStorageEnabled();
+        }
+
+        @Override
+        protected void setCurrentValue(Boolean value) {
+            mXWalkSettings.setDomStorageEnabled(value);
+        }
+
+        @Override
+        protected void doEnsureSettingHasValue(Boolean value) throws Throwable {
+            // It is not permitted to access localStorage from data URLs in WebKit,
+            // that is why a standalone page must be used.
+            loadUrlSyncByContent(mXWalkContent, client,
+                    UrlUtils.getTestFileUrl("xwalkview/localStorage.html"));
+            assertEquals(
+                value == ENABLED ? HAS_LOCAL_STORAGE : NO_LOCAL_STORAGE,
+                        client.getChangedTitle());
+        }
+    }
+
+    /**
+     * Verifies the following statements about a setting:
+     *  - initially, the setting has a default value;
+     *  - the setting can be switched to an alternate value and back;
+     *  - switching a setting in the first XWalkView doesn't affect the setting
+     *    state in the second XWalkView and vice versa.
+     *
+     * @param helper0 Test helper for the first ContentView
+     * @param helper1 Test helper for the second ContentView
+     * @throws Throwable
+     */
+    private void runPerViewSettingsTest(XWalkViewSettingsTestHelper helper0,
+            XWalkViewSettingsTestHelper helper1) throws Throwable {
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper1.setAlteredSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasAlteredValue();
+
+        helper1.setInitialSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper0.setAlteredSettingValue();
+        helper0.ensureSettingHasAlteredValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper0.setInitialSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper0.setAlteredSettingValue();
+        helper0.ensureSettingHasAlteredValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper1.setAlteredSettingValue();
+        helper0.ensureSettingHasAlteredValue();
+        helper1.ensureSettingHasAlteredValue();
+
+        helper0.setInitialSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasAlteredValue();
+
+        helper1.setInitialSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasInitialValue();
+    }
+
+    @SmallTest
+    @Feature({"XWalkView", "Preferences"})
+    public void testDomStorageEnabledWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+            new XWalkViewSettingsDomStorageEnabledTestHelper(
+                    views.getContent0(), views.getClient0()),
+            new XWalkViewSettingsDomStorageEnabledTestHelper(
+                    views.getContent1(), views.getClient1()));
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/util/CommonResources.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/util/CommonResources.java
@@ -1,0 +1,105 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test.util;
+
+import android.util.Pair;
+import java.util.ArrayList;
+import java.util.List;
+
+// Auxiliary class providing common HTML and base64 resources using for testing.
+public class CommonResources {
+
+    // Content-type headers used for HTML code.
+    public static List<Pair<String, String>> getTextHtmlHeaders(boolean disableCache) {
+        return getContentTypeAndCacheHeaders("text/html", disableCache);
+    }
+
+    // Content-type headers used for javascript code.
+    public static List<Pair<String, String>> getTextJavascriptHeaders(boolean disableCache) {
+        return getContentTypeAndCacheHeaders("text/javascript", disableCache);
+    }
+
+    // Content-type headers used for png images.
+    public static List<Pair<String, String>> getImagePngHeaders(boolean disableCache) {
+        return getContentTypeAndCacheHeaders("image/png", disableCache);
+    }
+
+    public static List<Pair<String, String>> getContentTypeAndCacheHeaders(
+            String contentType, boolean disableCache) {
+        List<Pair<String, String>> headers = new ArrayList<Pair<String, String>>();
+        headers.add(Pair.create("Content-Type", contentType));
+        if (disableCache) headers.add(Pair.create("Cache-Control", "no-store"));
+        return headers;
+    }
+
+    // Returns the HTML code used to verify if an image has been successfully loaded.
+    public static String getOnImageLoadedHtml(String imageSrc) {
+        return "<html>\n" +
+               "  <head>\n" +
+               "    <script>\n" +
+               "      function updateTitle() {\n" +
+               "        document.title=document.getElementById('img').naturalHeight\n" +
+               "      }\n" +
+               "    </script>\n" +
+               "  </head>\n" +
+               "  <body onload='updateTitle();'>\n" +
+               "    <img id='img' onload='updateTitle();' src='" + imageSrc + "'>\n" +
+               "  </body>\n" +
+               "</html>\n";
+    }
+
+    // Default name for the favicon image.
+    public static final String FAVICON_FILENAME = "favicon.png";
+
+    // HTML code of a static simple page with a favicon.
+    public static final String FAVICON_STATIC_HTML =
+        "<html><head><link rel=\"icon\" type=\"image/png\" href=\"" + FAVICON_FILENAME + "\">" +
+        "</head><body>Favicon example</body></html>";
+
+    // Base64 data of a favicon image resource.
+    public static final String FAVICON_DATA_BASE64 =
+        "iVBORw0KGgoAAAANSUhEUgAAABAAAAAFCAYAAABM6GxJAAAABHNCSVQICAgIfAhkiAAAASJJREFU" +
+        "GJU9yDtLQnEYwOHfOZ40L3gZDJKgJCKaamvpGzS09wUaormh7xA0S5C0ZDTkZJsNUltkkpAUZkIX" +
+        "L3g9FzzH/9vm9vAgoqRUGUu20JHTXFfafUdERJSIKJnOPFUTERHpqIYclY5nb2QKFumky95OlO+W" +
+        "TSgATqOO5k3xr6ZxelXmDFDhdaqfLkPRWQglULaN/V5DPzl3iIb9xCI+Eskog/wdyhowLlb4vThE" +
+        "giF8zRsurx55beg8lMfMezZW9hqz20M/Owhwe2/yUrPI5Ds8//mRehN7JYWxvIX6eWJkbLK9laL8" +
+        "ZrKxFETzxTBNB5SOJjKV/mhCq+uSjGvE4hHc4QA9YGAEwnhWF1ePkCtOWFv0+PiasL8bR3QDr93h" +
+        "HyFup9LWUksHAAAAAElFTkSuQmCC";
+
+    // Default name for an example 'about' HTML page.
+    public static final String ABOUT_FILENAME = "about.html";
+
+    // Title used in the 'about' example.
+    public static final String ABOUT_TITLE = "About the Google";
+
+    // HTML code of an 'about' example.
+    public static final String ABOUT_HTML =
+        "<html>" +
+        "  <head>" +
+        "    <title>" + ABOUT_TITLE + "</title>" +
+        "  </head>" +
+        "  <body>" +
+        "    This is the Google!" +
+        "  </body>" +
+        "</html>";
+
+    public static String makeHtmlPageFrom(String headers, String body) {
+        return "<html>" +
+                 "<head>" +
+                     "<style type=\"text/css\">" +
+                         // Make the image take up all of the page so that we don't have to do
+                         // any fancy hit target calculations when synthesizing the touch event
+                         // to click it.
+                         "img.big { width:100%; height:100%; background-color:blue; }" +
+                         ".full_view { height:100%; width:100%; position:absolute; }" +
+                     "</style>" +
+                     headers +
+                 "</head>" +
+                 "<body>" +
+                     body +
+                 "</body>" +
+             "</html>";
+    }
+}

--- a/test/data/device_files/localStorage.html
+++ b/test/data/device_files/localStorage.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <script>document.title = localStorage ? "Has localStorage" : "No localStorage"</script>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Implement the test cases about DomStorageEnabled and AppCacheEnabled.

Test AppCache by setting the data in TestWebServer instance.
Test DomStorage by loading the html, in this html file, it checks
the domstorage enabled or not by javascript.

For test case "DomStorageEnabled" should add the parameter "--test_data", as follows:
build/android/run_instrumentation_tests.py --test-apk XWalkCoreTest \
--test_data xwalkview:xwalk/test/data/device_files/ \
--verbose -I --num_retries=1 -f testDomStorageEnabledWithTwoViews
