### PR TITLE
[Tizen] Set correct icon destination path when copying application icon.

### DIFF
--- a/packaging/install_into_pkginfo_db.py
+++ b/packaging/install_into_pkginfo_db.py
@@ -114,12 +114,12 @@ class InstallHelper(object):
     XML path     : /opt/share/packages/|package_id_|.xml
     """
     try:
-      icon_path = "/opt/share/icons/default/small/" + self.package_id_ + ".png"
-      if ('name' in self.data_ and
-          'icons' in self.data_ and
+      if 'name' in self.data_:
+        icon_path = "/opt/share/icons/default/small/" + self.package_id_ +\
+                    "." + self.data_['name'] + ".png"
+      if ('icons' in self.data_ and
           '128' in self.data_['icons']):
-        icon = self.data_path_ + "." + self.data_['name'] +\
-               self.data_['icons']['128']
+        icon = self.data_path_ + "/" + self.data_['icons']['128']
         if os.path.exists(icon):
           shutil.copy2(icon, icon_path)
 


### PR DESCRIPTION
After install xwalk application, only application label shows on home screen, while application icon doesn't show on home screen. The reason is path is source/destination path are not set correct when copy the icon.

The correct paths should be,
Icon source: /opt/usr/apps/applications/|package_id|/|icon|
Icon destination: /opt/share/icons/default/small/|package_id|.|name|.png
