### PR TITLE
Fix the issue WebRTC can't work on chrome 29 for android on X86 platform

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -12,6 +12,8 @@ blink_crosswalk_point = 'bcc7da6145656ada9a0840b3f3b73878ed99b389'
 deps_xwalk = {
   'src': 'ssh://git@github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,
   'src/third_party/WebKit': 'ssh://git@github.com/crosswalk-project/blink-crosswalk.git@%s' % blink_crosswalk_point,
+  # Please delete this dependency when based chromium was rebased to more than M30.
+  'src/third_party/webrtc': 'http://webrtc.googlecode.com/svn/stable/webrtc@4297',
 }
 vars_xwalk = {
   'jsoncpp': 'http://svn.code.sf.net/p/jsoncpp/code',


### PR DESCRIPTION
1. The root cause is that remote peer discarded the video frame from peer
   because of frame timeout, but actaully it was caused from wrong tick
   calculating on X86 Android platform.
2. Currently, there is a patch can fix this issue on WebRTC upstream.
   See: https://code.google.com/p/webrtc/source/detail?spec=svn4274&r=4274
   We needed to change the based third_party webrtc version to 4297.
   And it is required to remove this dependency when based chromium was
   rebased to more than M30.
