### PR TITLE
[Android] Fix unnormalized asset URI accessing issue in AndroidProtocolHandler

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/AndroidProtocolHandler.java
+++ b/runtime/android/java/src/org/xwalk/core/AndroidProtocolHandler.java
@@ -125,7 +125,10 @@ public class AndroidProtocolHandler {
         assert(uri.getScheme().equals(FILE_SCHEME));
         assert(uri.getPath() != null);
         assert(uri.getPath().startsWith(nativeGetAndroidAssetPath()));
-        String path = uri.getPath().replaceFirst(nativeGetAndroidAssetPath(), "");
+        String path = uri.getPath();
+        // Remove duplicate slashes and normalize the URL.
+        path = (new java.io.File(path)).getAbsolutePath();
+        path = path.replaceFirst(nativeGetAndroidAssetPath(), "");
         try {
             AssetManager assets = context.getAssets();
             return assets.open(path, AssetManager.ACCESS_STREAMING);


### PR DESCRIPTION
In some case, html file may contain unnormalized URIs with duplicate slashes,
for example: "file:///android_asset/path//asset_file.html",
It causes AndroidProtocolHandler can't read the asset data, so remove the
duplicate slashes before reading asset.

BUG=
