### PR TITLE
[Tizen] Disable application database lazy writing on Tizen

### DIFF
--- a/application/common/db_store_json_impl.cc
+++ b/application/common/db_store_json_impl.cc
@@ -180,6 +180,11 @@ void DBStoreJsonImpl::ReportValueChanged(const std::string& key,
   FOR_EACH_OBSERVER(
       DBStore::Observer, observers_, OnDBValueChanged(key, value));
   writer_->ScheduleWrite(this);
+#if defined(OS_TIZEN_MOBILE)
+  // FIXME: Workaround for Tizen changing database file ownership during app
+  // installation: Write pending commits immediately.
+  CommitPendingWrite();
+#endif  // OS_TIZEN_MOBILE
 }
 
 void DBStoreJsonImpl::CommitPendingWrite() {


### PR DESCRIPTION
On Tizen, the database file owner will be changed when installing to
Tizen platform, so the database writing operation should be finished
before starting installation on Tizen, otherwise, the file owner should
roll back to super root, and applications can not launch from Tizen home
screen.
