### PR TITLE
[Android] Enable the geolocation feature. 

### DIFF
--- a/app/android/app_template/AndroidManifest.xml
+++ b/app/android/app_template/AndroidManifest.xml
@@ -24,6 +24,8 @@
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/android/runtime_client_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_shell/AndroidManifest.xml
@@ -30,6 +30,8 @@
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -30,6 +30,8 @@
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/runtime/android/java/src/org/xwalk/core/InMemorySharedPreferences.java
+++ b/runtime/android/java/src/org/xwalk/core/InMemorySharedPreferences.java
@@ -1,0 +1,238 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.content.SharedPreferences;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An implementation of SharedPreferences that can be used to create XWalkBrowserContext.
+ * <p/>
+ * It keeps all state in memory, and there is no difference between apply() and commit().
+ */
+public class InMemorySharedPreferences implements SharedPreferences {
+
+    // Guarded on its own monitor.
+    private final Map<String, Object> mData;
+
+    public InMemorySharedPreferences() {
+        mData = new HashMap<String, Object>();
+    }
+
+    public InMemorySharedPreferences(Map<String, Object> data) {
+        mData = data;
+    }
+
+    @Override
+    public Map<String, ?> getAll() {
+        synchronized (mData) {
+            return Collections.unmodifiableMap(mData);
+        }
+    }
+
+    @Override
+    public String getString(String key, String defValue) {
+        synchronized (mData) {
+            if (mData.containsKey(key)) {
+                return (String) mData.get(key);
+            }
+        }
+        return defValue;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Set<String> getStringSet(String key, Set<String> defValues) {
+        synchronized (mData) {
+            if (mData.containsKey(key)) {
+                return Collections.unmodifiableSet((Set<String>) mData.get(key));
+            }
+        }
+        return defValues;
+    }
+
+    @Override
+    public int getInt(String key, int defValue) {
+        synchronized (mData) {
+            if (mData.containsKey(key)) {
+                return (Integer) mData.get(key);
+            }
+        }
+        return defValue;
+    }
+
+    @Override
+    public long getLong(String key, long defValue) {
+        synchronized (mData) {
+            if (mData.containsKey(key)) {
+                return (Long) mData.get(key);
+            }
+        }
+        return defValue;
+    }
+
+    @Override
+    public float getFloat(String key, float defValue) {
+        synchronized (mData) {
+            if (mData.containsKey(key)) {
+                return (Float) mData.get(key);
+            }
+        }
+        return defValue;
+    }
+
+    @Override
+    public boolean getBoolean(String key, boolean defValue) {
+        synchronized (mData) {
+            if (mData.containsKey(key)) {
+                return (Boolean) mData.get(key);
+            }
+        }
+        return defValue;
+    }
+
+    @Override
+    public boolean contains(String key) {
+        synchronized (mData) {
+            return mData.containsKey(key);
+        }
+    }
+
+    @Override
+    public SharedPreferences.Editor edit() {
+        return new InMemoryEditor();
+    }
+
+    @Override
+    public void registerOnSharedPreferenceChangeListener(
+            SharedPreferences.OnSharedPreferenceChangeListener
+                    listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unregisterOnSharedPreferenceChangeListener(
+            SharedPreferences.OnSharedPreferenceChangeListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    private class InMemoryEditor implements SharedPreferences.Editor {
+
+        // All guarded by |mChanges|
+        private boolean mClearCalled;
+        private volatile boolean mApplyCalled;
+        private final Map<String, Object> mChanges = new HashMap<String, Object>();
+
+        @Override
+        public SharedPreferences.Editor putString(String key, String value) {
+            synchronized (mChanges) {
+                if (mApplyCalled) throw new IllegalStateException();
+                mChanges.put(key, value);
+                return this;
+            }
+        }
+
+        @Override
+        public SharedPreferences.Editor putStringSet(String key, Set<String> values) {
+            synchronized (mChanges) {
+                if (mApplyCalled) throw new IllegalStateException();
+                mChanges.put(key, values);
+                return this;
+            }
+        }
+
+        @Override
+        public SharedPreferences.Editor putInt(String key, int value) {
+            synchronized (mChanges) {
+                if (mApplyCalled) throw new IllegalStateException();
+                mChanges.put(key, value);
+                return this;
+            }
+        }
+
+        @Override
+        public SharedPreferences.Editor putLong(String key, long value) {
+            synchronized (mChanges) {
+                if (mApplyCalled) throw new IllegalStateException();
+                mChanges.put(key, value);
+                return this;
+            }
+        }
+
+        @Override
+        public SharedPreferences.Editor putFloat(String key, float value) {
+            synchronized (mChanges) {
+                if (mApplyCalled) throw new IllegalStateException();
+                mChanges.put(key, value);
+                return this;
+            }
+        }
+
+        @Override
+        public SharedPreferences.Editor putBoolean(String key, boolean value) {
+            synchronized (mChanges) {
+                if (mApplyCalled) throw new IllegalStateException();
+                mChanges.put(key, value);
+                return this;
+            }
+        }
+
+        @Override
+        public SharedPreferences.Editor remove(String key) {
+            synchronized (mChanges) {
+                if (mApplyCalled) throw new IllegalStateException();
+                // Magic value for removes
+                mChanges.put(key, this);
+                return this;
+            }
+        }
+
+        @Override
+        public SharedPreferences.Editor clear() {
+            synchronized (mChanges) {
+                if (mApplyCalled) throw new IllegalStateException();
+                mClearCalled = true;
+                return this;
+            }
+        }
+
+        @Override
+        public boolean commit() {
+            apply();
+            return true;
+        }
+
+        @Override
+        public void apply() {
+            synchronized (mData) {
+                synchronized (mChanges) {
+                    if (mApplyCalled) throw new IllegalStateException();
+                    if (mClearCalled) {
+                        mData.clear();
+                    }
+                    for (Map.Entry<String, Object> entry : mChanges.entrySet()) {
+                        String key = entry.getKey();
+                        Object value = entry.getValue();
+                        if (value == this) {
+                            // Special value for removal
+                            mData.remove(key);
+                        } else {
+                            mData.put(key, value);
+                        }
+                    }
+                    // The real shared prefs clears out the temporaries allowing the caller to
+                    // reuse the Editor instance, however this is undocumented behavior and subtle
+                    // to read, so instead we just ban any future use of this instance.
+                    mApplyCalled = true;
+                }
+            }
+        }
+    }
+
+}

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClient.java
@@ -18,7 +18,6 @@ import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.ConsoleMessage;
-import android.webkit.GeolocationPermissions;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 
@@ -123,7 +122,7 @@ public abstract class XWalkContentsClient extends ContentViewClient {
             String mimeType, long contentLength);
 
     public abstract void onGeolocationPermissionsShowPrompt(String origin,
-            GeolocationPermissions.Callback callback);
+            XWalkGeolocationPermissions.Callback callback);
 
     public abstract void onGeolocationPermissionsHidePrompt();
 

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -14,7 +14,6 @@ import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.ConsoleMessage;
-import android.webkit.GeolocationPermissions;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 
@@ -150,11 +149,15 @@ public class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onGeolocationPermissionsShowPrompt(String origin,
-            GeolocationPermissions.Callback callback) {
+            XWalkGeolocationPermissions.Callback callback) {
+        if (mXWalkWebChromeClient != null)
+            mXWalkWebChromeClient.onGeolocationPermissionsShowPrompt(origin, callback);
     }
 
     @Override
     public void onGeolocationPermissionsHidePrompt() {
+        if (mXWalkWebChromeClient != null)
+            mXWalkWebChromeClient.onGeolocationPermissionsHidePrompt();
     }
 
     @Override

--- a/runtime/android/java/src/org/xwalk/core/XWalkGeolocationPermissions.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkGeolocationPermissions.java
@@ -1,0 +1,142 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.content.SharedPreferences;
+import android.webkit.ValueCallback;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.chromium.base.ThreadUtils;
+import org.chromium.net.GURLUtils;
+
+/**
+ * This class is used to manage permissions for the WebView's Geolocation JavaScript API.
+ *
+ * Callbacks are posted on the UI thread.
+ */
+public final class XWalkGeolocationPermissions {
+    /**
+     * Callback interface used by the browser to report a Geolocation permission
+     * state set by the user in response to a permissions prompt.
+     */
+    public interface Callback {
+        public void invoke(String origin, boolean allow, boolean remember);
+    };
+
+    private static final String PREF_PREFIX =
+            XWalkGeolocationPermissions.class.getCanonicalName() + "%";
+    private final SharedPreferences mSharedPreferences;
+
+    public XWalkGeolocationPermissions(SharedPreferences sharedPreferences) {
+        mSharedPreferences = sharedPreferences;
+    }
+
+    /**
+     * Set one origin to be allowed.
+     */
+    public void allow(String origin) {
+        String key = getOriginKey(origin);
+        if (key != null) {
+            mSharedPreferences.edit().putBoolean(key, true).apply();
+        }
+    }
+
+    /**
+     * Set one origin to be denied.
+     */
+    public void deny(String origin) {
+        String key = getOriginKey(origin);
+        if (key != null) {
+            mSharedPreferences.edit().putBoolean(key, false).apply();
+        }
+    }
+
+    /**
+     * Clear the stored permission for a particular origin.
+     */
+    public void clear(String origin) {
+        String key = getOriginKey(origin);
+        if (key != null) {
+            mSharedPreferences.edit().remove(key).apply();
+        }
+    }
+
+    /**
+     * Clear stored permissions for all origins.
+     */
+    public void clearAll() {
+        SharedPreferences.Editor editor = null;
+        for (String name : mSharedPreferences.getAll().keySet()) {
+            if (name.startsWith(PREF_PREFIX)) {
+                if (editor == null) {
+                    editor = mSharedPreferences.edit();
+                }
+                editor.remove(name);
+            }
+        }
+        if (editor != null) {
+            editor.apply();
+        }
+    }
+
+    /**
+     * Synchronous method to get if an origin is set to be allowed.
+     */
+    public boolean isOriginAllowed(String origin) {
+        return mSharedPreferences.getBoolean(getOriginKey(origin), false);
+    }
+
+    /**
+     * Returns true if the origin is either set to allowed or denied.
+     */
+    public boolean hasOrigin(String origin) {
+        return mSharedPreferences.contains(getOriginKey(origin));
+    }
+
+    /**
+     * Asynchronous method to get if an origin set to be allowed.
+     */
+    public void getAllowed(String origin, final ValueCallback<Boolean> callback) {
+        final boolean finalAllowed = isOriginAllowed(origin);
+        ThreadUtils.postOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                callback.onReceiveValue(finalAllowed);
+            }
+        });
+    }
+
+    /**
+     * Async method to get the domains currently allowed or denied.
+     */
+    public void getOrigins(final ValueCallback<Set<String>> callback) {
+        final Set<String> origins = new HashSet<String>();
+        for (String name : mSharedPreferences.getAll().keySet()) {
+            if (name.startsWith(PREF_PREFIX)) {
+                origins.add(name.substring(PREF_PREFIX.length()));
+            }
+        }
+        ThreadUtils.postOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                callback.onReceiveValue(origins);
+            }
+        });
+    }
+
+    /**
+     * Get the domain of an URL using the GURL library.
+     */
+    private String getOriginKey(String url) {
+        String origin = GURLUtils.getOrigin(url);
+        if (origin.isEmpty()) {
+            return null;
+        }
+
+        return PREF_PREFIX + origin;
+    }
+}

--- a/runtime/android/java/src/org/xwalk/core/XWalkWebChromeClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkWebChromeClient.java
@@ -22,7 +22,6 @@ import android.net.Uri;
 import android.os.Message;
 import android.view.View;
 import android.webkit.WebStorage;
-import android.webkit.GeolocationPermissions;
 import android.webkit.ConsoleMessage;
 import android.webkit.ValueCallback;
 
@@ -282,7 +281,7 @@ public class XWalkWebChromeClient {
      *                 origin.
      */
     public void onGeolocationPermissionsShowPrompt(String origin,
-            GeolocationPermissions.Callback callback) {}
+            XWalkGeolocationPermissions.Callback callback) {}
 
     /**
      * Notify the host application that a request for Geolocation permissions,

--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultWebChromeClient.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultWebChromeClient.java
@@ -17,7 +17,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.webkit.WebStorage;
-import android.webkit.GeolocationPermissions;
 import android.webkit.ConsoleMessage;
 import android.webkit.ValueCallback;
 import android.widget.EditText;

--- a/runtime/android/runtime_shell/AndroidManifest.xml
+++ b/runtime/android/runtime_shell/AndroidManifest.xml
@@ -30,6 +30,8 @@
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -7,6 +7,10 @@
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/path_service.h"
+#include "content/public/browser/browser_main_runner.h"
+#include "content/public/common/content_switches.h"
+#include "ui/base/resource/resource_bundle.h"
+#include "ui/base/ui_base_paths.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/extensions/extension_process/xwalk_extension_process_main.h"
 #include "xwalk/runtime/browser/xwalk_content_browser_client.h"
@@ -14,10 +18,6 @@
 #include "xwalk/runtime/common/paths_mac.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 #include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
-#include "content/public/browser/browser_main_runner.h"
-#include "content/public/common/content_switches.h"
-#include "ui/base/resource/resource_bundle.h"
-#include "ui/base/ui_base_paths.h"
 
 namespace xwalk {
 
@@ -90,5 +90,4 @@ content::ContentRendererClient*
   renderer_client_.reset(new XWalkContentRendererClient);
   return renderer_client_.get();
 }
-
 }  // namespace xwalk

--- a/runtime/app/xwalk_main_delegate.h
+++ b/runtime/app/xwalk_main_delegate.h
@@ -9,8 +9,8 @@
 
 #include "base/compiler_specific.h"
 #include "base/memory/scoped_ptr.h"
-#include "xwalk/runtime/common/xwalk_content_client.h"
 #include "content/public/app/content_main_delegate.h"
+#include "xwalk/runtime/common/xwalk_content_client.h"
 
 namespace content {
 class ContentBrowserClient;

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -19,6 +19,7 @@
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/application/common/constants.h"
 #include "xwalk/runtime/browser/runtime_download_manager_delegate.h"
+#include "xwalk/runtime/browser/runtime_geolocation_permission_context.h"
 #include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
@@ -162,7 +163,13 @@ content::ResourceContext* RuntimeContext::GetResourceContext()  {
 
 content::GeolocationPermissionContext*
     RuntimeContext::GetGeolocationPermissionContext()  {
-  return NULL;
+#if defined(OS_ANDROID)
+  if (!geolocation_permission_context_) {
+    geolocation_permission_context_ =
+        RuntimeGeolocationPermissionContext::Create(this);
+  }
+#endif
+  return geolocation_permission_context_.get();
 }
 
 quota::SpecialStoragePolicy* RuntimeContext::GetSpecialStoragePolicy() {

--- a/runtime/browser/runtime_context.h
+++ b/runtime/browser/runtime_context.h
@@ -11,6 +11,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/content_browser_client.h"
+#include "content/public/browser/geolocation_permission_context.h"
 
 namespace net {
 class URLRequestContextGetter;
@@ -93,6 +94,8 @@ class RuntimeContext : public content::BrowserContext {
   scoped_ptr<xwalk::application::ApplicationSystem> application_system_;
   scoped_refptr<RuntimeDownloadManagerDelegate> download_manager_delegate_;
   scoped_refptr<RuntimeURLRequestContextGetter> url_request_getter_;
+  scoped_refptr<content::GeolocationPermissionContext>
+       geolocation_permission_context_;
 
   DISALLOW_COPY_AND_ASSIGN(RuntimeContext);
 };

--- a/runtime/browser/runtime_geolocation_permission_context.cc
+++ b/runtime/browser/runtime_geolocation_permission_context.cc
@@ -1,0 +1,104 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/runtime_geolocation_permission_context.h"
+
+#include "base/bind.h"
+#include "base/callback.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/web_contents.h"
+#if defined(OS_ANDROID)
+#include "xwalk/runtime/browser/android/xwalk_content.h"
+#endif
+
+namespace xwalk {
+
+RuntimeGeolocationPermissionContext::~RuntimeGeolocationPermissionContext() {
+}
+
+void
+RuntimeGeolocationPermissionContext::RequestGeolocationPermissionOnUIThread(
+    int render_process_id,
+    int render_view_id,
+    int bridge_id,
+    const GURL& requesting_frame,
+    const base::Callback<void(bool)> callback) {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+
+#if defined(OS_ANDROID)
+  XWalkContent* xwalk_content =
+      XWalkContent::FromID(render_process_id, render_view_id);
+  if (!xwalk_content) {
+    callback.Run(false);
+    return;
+  }
+
+  xwalk_content->ShowGeolocationPrompt(requesting_frame, callback);
+#endif
+}
+
+void
+RuntimeGeolocationPermissionContext::RequestGeolocationPermission(
+    int render_process_id,
+    int render_view_id,
+    int bridge_id,
+    const GURL& requesting_frame,
+    const base::Callback<void(bool)> callback) {
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI, FROM_HERE,
+      base::Bind(
+          &RuntimeGeolocationPermissionContext::
+              RequestGeolocationPermissionOnUIThread,
+          this,
+          render_process_id,
+          render_view_id,
+          bridge_id,
+          requesting_frame,
+          callback));
+}
+
+// static
+content::GeolocationPermissionContext*
+RuntimeGeolocationPermissionContext::Create(RuntimeContext* runtime_context) {
+  return new RuntimeGeolocationPermissionContext();
+}
+
+void
+RuntimeGeolocationPermissionContext
+    ::CancelGeolocationPermissionRequestOnUIThread(
+        int render_process_id,
+        int render_view_id,
+        int bridge_id,
+        const GURL& requesting_frame) {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+
+#if defined(OS_ANDROID)
+  XWalkContent* xwalk_content =
+      XWalkContent::FromID(render_process_id, render_view_id);
+  if (xwalk_content) {
+      xwalk_content->HideGeolocationPrompt(requesting_frame);
+  }
+#endif
+}
+
+void
+RuntimeGeolocationPermissionContext::CancelGeolocationPermissionRequest(
+    int render_process_id,
+    int render_view_id,
+    int bridge_id,
+    const GURL& requesting_frame) {
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI, FROM_HERE,
+      base::Bind(
+          &RuntimeGeolocationPermissionContext::
+              CancelGeolocationPermissionRequestOnUIThread,
+          this,
+          render_process_id,
+          render_view_id,
+          bridge_id,
+          requesting_frame));
+}
+
+}  // namespace xwalk

--- a/runtime/browser/runtime_geolocation_permission_context.h
+++ b/runtime/browser/runtime_geolocation_permission_context.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_RUNTIME_GEOLOCATION_PERMISSION_CONTEXT_H_
+#define XWALK_RUNTIME_BROWSER_RUNTIME_GEOLOCATION_PERMISSION_CONTEXT_H_
+
+#include "content/public/browser/geolocation_permission_context.h"
+
+class GURL;
+
+namespace xwalk {
+
+class RuntimeContext;
+
+class RuntimeGeolocationPermissionContext
+    : public content::GeolocationPermissionContext {
+ public:
+  static content::GeolocationPermissionContext* Create(
+      RuntimeContext* runtime_context);
+
+  // content::GeolocationPermissionContext implementation
+  virtual void RequestGeolocationPermission(
+      int render_process_id,
+      int render_view_id,
+      int bridge_id,
+      const GURL& requesting_frame,
+      const base::Callback<void(bool)> callback) OVERRIDE;
+  virtual void CancelGeolocationPermissionRequest(
+      int render_process_id,
+      int render_view_id,
+      int bridge_id,
+      const GURL& requesting_frame) OVERRIDE;
+
+ protected:
+  virtual ~RuntimeGeolocationPermissionContext();
+
+ private:
+  void RequestGeolocationPermissionOnUIThread(
+      int render_process_id,
+      int render_view_id,
+      int bridge_id,
+      const GURL& requesting_frame,
+      const base::Callback<void(bool)> callback);
+
+  void CancelGeolocationPermissionRequestOnUIThread(
+      int render_process_id,
+      int render_view_id,
+      int bridge_id,
+      const GURL& requesting_frame);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_RUNTIME_GEOLOCATION_PERMISSION_CONTEXT_H_

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GeolocationPermissionTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GeolocationPermissionTest.java
@@ -1,0 +1,92 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.graphics.Bitmap;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+
+import org.chromium.base.test.util.DisabledTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.core.XWalkClient;
+import org.xwalk.core.XWalkGeolocationPermissions;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkWebChromeClient;
+
+/**
+ * Test suite for onGeolocationPermissionsShowPrompt() and
+ *                onGeolocationPermissionsHidePrompt().
+ */
+public class GeolocationPermissionTest extends XWalkViewTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        class TestXWalkClient extends XWalkClient {
+            @Override
+            public void onPageStarted(XWalkView view, String url, Bitmap favicon) {
+                mTestContentsClient.onPageStarted(url);
+            }
+
+            @Override
+            public void onPageFinished(XWalkView view, String url) {
+                mTestContentsClient.didFinishLoad(url);
+            }
+        }
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkClient(new TestXWalkClient());
+                getXWalkView().getSettings().setJavaScriptEnabled(true);
+                getXWalkView().getSettings().setGeolocationEnabled(true);
+            }
+        });
+    }
+
+    // TODO(hengzhi): Since the device issue, it can not access the network,
+    // so disabled this test temporarily. It will be enabled later.
+    // @SmallTest
+    // @Feature({"GeolocationPermission"})
+    @DisabledTest
+    public void testGeolocationPermissionShowPrompt() throws Throwable {
+        class TestWebChromeClient extends XWalkWebChromeClient {
+            @Override
+            public void onGeolocationPermissionsShowPrompt(String origin,
+                    XWalkGeolocationPermissions.Callback callback) {
+                String expected_origin = "http://html5demos.com/";
+                assertEquals(expected_origin, origin);
+                // Do something.
+            }
+        }
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkWebChromeClient(new TestWebChromeClient());
+            }
+        });
+        loadUrlSync("http://html5demos.com/geo");
+    }
+
+    // @SmallTest
+    // @Feature({"GeolocationPermission"})
+    @DisabledTest
+    public void testGeolocationPermissionHidePrompt() throws Throwable {
+        class TestWebChromeClient extends XWalkWebChromeClient {
+            @Override
+            public void onGeolocationPermissionsHidePrompt() {
+                // Do something.
+            }
+        }
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkWebChromeClient(new TestWebChromeClient());
+            }
+        });
+        loadUrlSync("http://html5demos.com/geo");
+        // TODO: how to verify it automaticly.
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/NullContentsClient.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/NullContentsClient.java
@@ -11,7 +11,6 @@ import android.os.Message;
 import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.ConsoleMessage;
-import android.webkit.GeolocationPermissions;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 
@@ -20,6 +19,7 @@ import org.xwalk.core.JsPromptResult;
 import org.xwalk.core.JsResult;
 import org.xwalk.core.SslErrorHandler;
 import org.xwalk.core.XWalkContentsClient;
+import org.xwalk.core.XWalkGeolocationPermissions;
 import org.xwalk.core.XWalkWebChromeClient;
 
 /**
@@ -67,7 +67,7 @@ public class NullContentsClient extends XWalkContentsClient {
 
     @Override
     public void onGeolocationPermissionsShowPrompt(String origin,
-            GeolocationPermissions.Callback callback) {
+            XWalkGeolocationPermissions.Callback callback) {
     }
 
     @Override

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -87,6 +87,8 @@
         'runtime/browser/runtime_download_manager_delegate.h',
         'runtime/browser/runtime_file_select_helper.cc',
         'runtime/browser/runtime_file_select_helper.h',
+        'runtime/browser/runtime_geolocation_permission_context.cc',
+        'runtime/browser/runtime_geolocation_permission_context.h',
         'runtime/browser/runtime_javascript_dialog_manager.cc',
         'runtime/browser/runtime_javascript_dialog_manager.h',
         'runtime/browser/runtime_network_delegate.cc',


### PR DESCRIPTION
Enable the geolocation feature by responding the request permission from the content,
implementing the geolocation prompt by the callback functions.

Some files were copied from the android_webview, like as InMemorySharedPreferences.java,
runtime_geolocation_permission_context.cc. They were modified according to the current
project requirements, remove the jni dependency, since this feature is required on
other platforms.

BUG=
TEST=build/android/run_instrumentation_tests.py --test-apk XWalkCoreTest \
--verbose -I --num_retries=1 -f testGeolocationPermissionShowPrompt
