### PR TITLE
[Android] Remove hidden assets('.*', '_*') from ANDROID_AAPT_IGNORE.

### DIFF
--- a/app/tools/android/ant/apk-package-resources.xml
+++ b/app/tools/android/ant/apk-package-resources.xml
@@ -65,7 +65,7 @@
            or "<file>" to match only files. Default is to match both.
          - Match is not case-sensitive.
   -->
-  <property name="aapt.ignore.assets" value="" />
+  <property name="aapt.ignore.assets" value="!.svn:!.git:!CVS:!thumbs.db:!picasa.ini:!*.scc:*~" />
 
   <!--
       Include additional resource folders in the apk, e.g. content/.../res.  We


### PR DESCRIPTION
This patch will remove the "._" and "__" from the default exclude list,
and thus "hidden" assets will now be included in your assets
directory inside your .APK.

BUG=https://github.com/crosswalk-project/crosswalk/issues/631
