### PR TITLE
[Tizen] Appid format must be XXX.XXX[.XXX]*

### DIFF
--- a/packaging/install_into_pkginfo_db.py
+++ b/packaging/install_into_pkginfo_db.py
@@ -73,7 +73,7 @@ class InstallHelper(object):
         self.__createTextNode(document, description, self.data_['description'])
 
       ui_application = self.__createNode(document, manifest, "ui-application")
-      self.__setAttribute(ui_application, "appid", self.package_id_)
+      self.__setAttribute(ui_application, "appid", self.package_id_ + "." + self.data_['name'])
       self.__setAttribute(ui_application, "exec", "/opt/usr/apps/applications/"
                           + self.package_id_ + "/bin/" + self.package_id_)
       # Set application type to "c++app" for now,


### PR DESCRIPTION
Tizen framework requires that Appid format of native app must be XXX.XXX[.XXX]*,
not just XXX. We make our web app pretend native app to Tizen, so we must follow
the format. Otherwise, app_get_id() in app.h in Tizen application framework
failes and XWalk can not initialize appcore.

BUG=https://github.com/crosswalk-project/crosswalk/issues/609
