### PR TITLE
Refactor startup flags and enable viewport and touch feedback

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -21,6 +21,8 @@ class RuntimeContext;
 class RuntimeRegistry;
 class RemoteDebuggingServer;
 
+void SetXWalkCommandLineFlags();
+
 class XWalkBrowserMainParts : public content::BrowserMainParts {
  public:
   explicit XWalkBrowserMainParts(


### PR DESCRIPTION
The refactor makes the code similar to how it is done for Chrome for
Android and enables viewport (incl required fixed layout) and feedback
on touch.

It has been tested on desktop and works fine with the following:

xwalk "data:text/html,<meta name='viewport' content='width=320'>" \
  "<body><div style='width:300px; background-color:red;'> .</div></body>"
