### PR TITLE
DEPS.xwalk: Stop using SSH for the crosswalk repositories URLs.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -10,8 +10,8 @@ chromium_version = '29.0.1547.57'
 chromium_crosswalk_point = 'd845fd7564ae03a3763589a2a7aa0a7ce9939b94'
 blink_crosswalk_point = 'bcc7da6145656ada9a0840b3f3b73878ed99b389'
 deps_xwalk = {
-  'src': 'ssh://git@github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,
-  'src/third_party/WebKit': 'ssh://git@github.com/crosswalk-project/blink-crosswalk.git@%s' % blink_crosswalk_point,
+  'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,
+  'src/third_party/WebKit': 'https://github.com/crosswalk-project/blink-crosswalk.git@%s' % blink_crosswalk_point,
   # Please delete this dependency when based chromium was rebased to more than M30.
   'src/third_party/webrtc': 'http://webrtc.googlecode.com/svn/stable/webrtc@4297',
 }


### PR DESCRIPTION
Now that the crosswalk repositories are public, we can use direct https URLs
to clone them instead of the previous ones that used SSH.

The overhead of using SSH may be negligible in terms of speed, but doing so
allows truly anonymous checkouts: people may not have a GitHub account (or
have their SSH keys in the machine they're using at the moment).

Note that git:// would also work, but can cause problems for people behind
firewalls.
