### PR TITLE
Screen rotation support

### DIFF
--- a/runtime/browser/sensor_provider.cc
+++ b/runtime/browser/sensor_provider.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/sensor_provider.h"
+
+#include "base/logging.h"
+
+#if defined(OS_TIZEN_MOBILE)
+#include "xwalk/runtime/browser/tizen_system_sensor.h"
+#endif
+
+namespace xwalk {
+
+SensorProvider* SensorProvider::GetInstance() {
+  if (!instance_) {
+#if defined(OS_TIZEN_MOBILE)
+    instance_ = new TizenSystemSensor();
+#endif
+    if (instance_ && !instance_->Initialize()) {
+      delete instance_;
+      instance_ = NULL;
+    }
+  }
+  return instance_;
+}
+
+SensorProvider::SensorProvider() {
+}
+
+SensorProvider::~SensorProvider() {
+  DCHECK(instance_ == this);
+  Finish();
+  instance_ = NULL;
+}
+
+SensorProvider* SensorProvider::instance_ = NULL;
+
+}  // namespace xwalk

--- a/runtime/browser/sensor_provider.h
+++ b/runtime/browser/sensor_provider.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_SENSOR_PROVIDER_H_
+#define XWALK_RUNTIME_BROWSER_SENSOR_PROVIDER_H_
+
+#include <set>
+
+#include "ui/gfx/display.h"
+
+namespace xwalk {
+
+class SensorProvider {
+ public:
+  class Observer {
+   public:
+    virtual void OnRotationChanged(gfx::Display::Rotation r) {}
+    virtual void OnOrientationChanged(float alpha, float beta, float gamma) {}
+    virtual void OnAccelerationChanged(float x, float y, float z) {}
+
+   protected:
+    virtual ~Observer() {}
+  };
+
+  static SensorProvider* GetInstance();
+
+  virtual void AddObserver(Observer* observer) {
+    observers_.insert(observer);
+  }
+  virtual void RemoveObserver(Observer* observer) {
+    observers_.erase(observer);
+  }
+
+ protected:
+  SensorProvider();
+  virtual ~SensorProvider();
+
+  virtual bool Initialize() = 0;
+  virtual void Finish() {}
+
+  virtual void OnRotationChanged(gfx::Display::Rotation rotation) {
+    std::set<Observer*>::iterator it;
+    for (it = observers_.begin(); it != observers_.end(); ++it)
+      (*it)->OnRotationChanged(rotation);
+  }
+  virtual void OnOrientationChanged(float alpha, float beta, float gamma) {
+    std::set<Observer*>::iterator it;
+    for (it = observers_.begin(); it != observers_.end(); ++it)
+      (*it)->OnOrientationChanged(alpha, beta, gamma);
+  }
+  virtual void OnAccelerationChanged(float x, float y, float z) {
+    std::set<Observer*>::iterator it;
+    for (it = observers_.begin(); it != observers_.end(); ++it)
+      (*it)->OnOrientationChanged(x, y, z);
+  }
+
+  std::set<Observer*> observers_;
+
+ private:
+  static SensorProvider* instance_;
+
+  DISALLOW_COPY_AND_ASSIGN(SensorProvider);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_SENSOR_PROVIDER_H_

--- a/runtime/browser/tizen_system_sensor.cc
+++ b/runtime/browser/tizen_system_sensor.cc
@@ -1,0 +1,176 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/tizen_system_sensor.h"
+
+#include <string>
+
+#include "base/files/file_path.h"
+#include "base/logging.h"
+
+namespace xwalk {
+
+TizenSystemSensor::TizenSystemSensor()
+    : handle_(-1),
+      dso_(NULL),
+      connect_(NULL),
+      disconnect_(NULL),
+      start_(NULL),
+      stop_(NULL),
+      register_event_(NULL),
+      unregister_event_(NULL),
+      get_data_(NULL),
+      check_rotation_(NULL) {
+}
+
+TizenSystemSensor::~TizenSystemSensor() {
+}
+
+bool TizenSystemSensor::Initialize() {
+  if (!LoadLibrary())
+    return false;
+
+  handle_ = connect_(ACCELEROMETER_SENSOR);
+  if (handle_ < 0) {
+    LOG(ERROR) << "Connection to accelerometer sensor failed";
+    return false;
+  }
+
+  if (register_event_(handle_, ACCELEROMETER_EVENT_ROTATION_CHECK,
+                      NULL, OnEventReceived, this) >= 0 &&
+      register_event_(handle_, ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME,
+                      NULL, OnEventReceived, this) >= 0) {
+    if (start_(handle_, 0) >= 0)
+      return true;
+    unregister_event_(handle_, ACCELEROMETER_EVENT_ROTATION_CHECK);
+    unregister_event_(handle_, ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME);
+  }
+  LOG(ERROR) << "Register sensor handler failed";
+  disconnect_(handle_);
+  handle_ = -1;
+  return false;
+}
+
+void TizenSystemSensor::Finish() {
+  if (handle_ < 0)
+    return;
+
+  stop_(handle_);
+  unregister_event_(handle_, ACCELEROMETER_EVENT_ROTATION_CHECK);
+  unregister_event_(handle_, ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME);
+  disconnect_(handle_);
+  handle_ = -1;
+
+  UnloadLibrary();
+}
+
+bool TizenSystemSensor::LoadLibrary() {
+  if (dso_)
+    return true;
+
+  base::FilePath name("libsensor.so.1");
+  std::string errmsg;
+  dso_ = base::LoadNativeLibrary(name, &errmsg);
+  if (!dso_) {
+    LOG(ERROR) << "Load " << name.value() << " failed (" << errmsg << ")";
+    return false;
+  }
+
+  connect_ = (sf_connect)
+      base::GetFunctionPointerFromNativeLibrary(dso_, "sf_connect");
+  disconnect_ = (sf_disconnect)
+      base::GetFunctionPointerFromNativeLibrary(dso_, "sf_disconnect");
+  start_ = (sf_start)
+      base::GetFunctionPointerFromNativeLibrary(dso_, "sf_start");
+  stop_ = (sf_stop)
+      base::GetFunctionPointerFromNativeLibrary(dso_, "sf_stop");
+  register_event_ = (sf_register_event)
+      base::GetFunctionPointerFromNativeLibrary(dso_, "sf_register_event");
+  unregister_event_ = (sf_unregister_event)
+      base::GetFunctionPointerFromNativeLibrary(dso_, "sf_unregister_event");
+  get_data_ = (sf_get_data)
+      base::GetFunctionPointerFromNativeLibrary(dso_, "sf_get_data");
+  check_rotation_ = (sf_check_rotation)
+      base::GetFunctionPointerFromNativeLibrary(dso_, "sf_check_rotation");
+  bool rt = connect_ && disconnect_ && start_ && stop_ &&
+            register_event_ && unregister_event_ &&
+            get_data_ &&check_rotation_;
+  if (!rt) {
+    LOG(ERROR) << "Incompatible version of " << name.value();
+    UnloadLibrary();
+  }
+  return rt;
+}
+
+void TizenSystemSensor::UnloadLibrary() {
+  connect_ = NULL;
+  disconnect_ = NULL;
+  start_ = NULL;
+  stop_ = NULL;
+  register_event_ = NULL;
+  unregister_event_ = NULL;
+  get_data_ = NULL;
+  check_rotation_ = NULL;
+
+  if (dso_)
+    base::UnloadNativeLibrary(dso_);
+  dso_ = NULL;
+}
+
+gfx::Display::Rotation TizenSystemSensor::ToDisplayRotation(
+    int rotation) const {
+  gfx::Display::Rotation r = gfx::Display::ROTATE_0;
+  switch (rotation) {
+    case ROTATION_EVENT_0:
+      r = gfx::Display::ROTATE_0;
+      break;
+    case ROTATION_EVENT_90:
+      r = gfx::Display::ROTATE_90;
+      break;
+    case ROTATION_EVENT_180:
+      r = gfx::Display::ROTATE_180;
+      break;
+    case ROTATION_EVENT_270:
+      r = gfx::Display::ROTATE_270;
+      break;
+  }
+  return r;
+}
+
+void TizenSystemSensor::OnEventReceived(unsigned int event_type,
+                                        sensor_event_data_t* event_data,
+                                        void* udata) {
+  TizenSystemSensor* sensor = reinterpret_cast<TizenSystemSensor*>(udata);
+
+  switch (event_type) {
+    case ACCELEROMETER_EVENT_ROTATION_CHECK: {
+      int* data = reinterpret_cast<int*>(event_data->event_data);
+      gfx::Display::Rotation r = sensor->ToDisplayRotation(*data);
+      sensor->OnRotationChanged(r);
+      break;
+    }
+    case ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME: {
+      sensor_data_t* accel =
+          reinterpret_cast<sensor_data_t*>(event_data->event_data);
+      size_t cnt = event_data->event_data_size / sizeof(sensor_data_t);
+      for (size_t i = 0; i < cnt; i++) {
+        sensor->OnAccelerationChanged(accel[i].values[0],
+                                      accel[i].values[1],
+                                      accel[i].values[2]);
+      }
+
+      sensor_data_t data;
+      if (sensor->get_data_(sensor->handle_,
+                            ACCELEROMETER_ORIENTATION_DATA_SET,
+                            &data) >= 0) {
+        sensor->OnOrientationChanged(data.values[0],
+                                     data.values[1],
+                                     data.values[2]);
+      }
+      break;
+    }
+  }
+}
+
+}  // namespace xwalk

--- a/runtime/browser/tizen_system_sensor.h
+++ b/runtime/browser/tizen_system_sensor.h
@@ -1,0 +1,139 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_TIZEN_SYSTEM_SENSOR_H_
+#define XWALK_RUNTIME_BROWSER_TIZEN_SYSTEM_SENSOR_H_
+
+#include "base/native_library.h"
+#include "xwalk/runtime/browser/sensor_provider.h"
+
+namespace xwalk {
+
+class TizenSystemSensor : public SensorProvider {
+ public:
+  TizenSystemSensor();
+  virtual ~TizenSystemSensor();
+
+  virtual bool Initialize() OVERRIDE;
+  virtual void Finish() OVERRIDE;
+
+ private:
+  bool LoadLibrary();
+  void UnloadLibrary();
+  gfx::Display::Rotation ToDisplayRotation(int rotation) const;
+
+  int handle_;
+  base::NativeLibrary dso_;
+
+  // Type definitions which are copied from libslp-sensor
+  typedef enum {
+    UNKNOWN_SENSOR       = 0x0000,
+    ACCELEROMETER_SENSOR = 0x0001,
+    GEOMAGNETIC_SENSOR   = 0x0002,
+    LIGHT_SENSOR         = 0x0004,
+    PROXIMITY_SENSOR     = 0x0008,
+    THERMOMETER_SENSOR   = 0x0010,
+    GYROSCOPE_SENSOR     = 0x0020,
+    PRESSURE_SENSOR      = 0x0040,
+    MOTION_SENSOR        = 0x0080,
+  } sensor_type_t;
+
+  enum accelerometer_data_id {
+    ACCELEROMETER_BASE_DATA_SET =
+        (ACCELEROMETER_SENSOR << 16) | 0x0001,
+    ACCELEROMETER_ORIENTATION_DATA_SET =
+        (ACCELEROMETER_SENSOR << 16) | 0x0002,
+  };
+
+  enum accelerometer_event_type {
+    ACCELEROMETER_EVENT_ROTATION_CHECK =
+        (ACCELEROMETER_SENSOR << 16) | 0x0001,
+    ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME =
+        (ACCELEROMETER_SENSOR << 16) | 0x0002,
+    ACCELEROMETER_EVENT_CALIBRATION_NEEDED =
+        (ACCELEROMETER_SENSOR << 16) | 0x0004,
+    ACCELEROMETER_EVENT_SET_HORIZON =
+        (ACCELEROMETER_SENSOR << 16) | 0x0008,
+    ACCELEROMETER_EVENT_SET_WAKEUP =
+        (ACCELEROMETER_SENSOR << 16) | 0x0010,
+    ACCELEROMETER_EVENT_ORIENTATION_DATA_REPORT_ON_TIME =
+        (ACCELEROMETER_SENSOR << 16) | 0x0011,
+  };
+
+  enum accelerometer_rotate_state {
+    ROTATION_UNKNOWN         = 0,
+    ROTATION_LANDSCAPE_LEFT  = 1,
+    ROTATION_PORTRAIT_TOP    = 2,
+    ROTATION_PORTRAIT_BTM    = 3,
+    ROTATION_LANDSCAPE_RIGHT = 4,
+    ROTATION_EVENT_0         = 2,
+    ROTATION_EVENT_90        = 1,
+    ROTATION_EVENT_180       = 3,
+    ROTATION_EVENT_270       = 4,
+  };
+
+  typedef enum {
+    CONDITION_NO_OP,
+    CONDITION_EQUAL,
+    CONDITION_GREAT_THAN,
+    CONDITION_LESS_THAN,
+  } condition_op_t;
+
+  typedef struct {
+    condition_op_t cond_op;
+    float cond_value1;
+  } event_condition_t;
+
+  typedef struct {
+    size_t event_data_size;
+    void* event_data;
+  } sensor_event_data_t;
+
+  typedef struct {
+    int data_accuracy;
+    int data_unit_idx;
+    unsigned long long time_stamp;  // NOLINT
+    int values_num;
+    float values[12];
+  } sensor_data_t;
+
+  typedef void (*sensor_callback_func_t)(unsigned int event_type,
+                                         sensor_event_data_t* event_data,
+                                         void* udata);
+
+  typedef int (*sf_connect)(int sensor_type);
+  typedef int (*sf_disconnect)(int handle);
+  typedef int (*sf_start)(int handle, int option);
+  typedef int (*sf_stop)(int handle);
+  typedef int (*sf_register_event)(int handle,
+                                   unsigned int event_type,
+                                   event_condition_t* event_condition,
+                                   sensor_callback_func_t cb,
+                                   void* cb_data);
+  typedef int (*sf_unregister_event)(int handle, int event_type);
+  typedef int (*sf_get_data)(int handle,
+                             unsigned int data_id,
+                             sensor_data_t* values);
+  typedef int (*sf_check_rotation)(unsigned long* curr_state);  // NOLINT
+  // end of libslp-sensor
+
+  sf_connect connect_;
+  sf_disconnect disconnect_;
+  sf_start start_;
+  sf_stop stop_;
+  sf_register_event register_event_;
+  sf_unregister_event unregister_event_;
+  sf_get_data get_data_;
+  sf_check_rotation check_rotation_;
+
+  static void OnEventReceived(unsigned int event_type,
+                              sensor_event_data_t* event_data,
+                              void* udata);
+
+  DISALLOW_COPY_AND_ASSIGN(TizenSystemSensor);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_TIZEN_SYSTEM_SENSOR_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -106,6 +106,8 @@
         'runtime/browser/runtime_select_file_policy.h',
         'runtime/browser/runtime_url_request_context_getter.cc',
         'runtime/browser/runtime_url_request_context_getter.h',
+        'runtime/browser/sensor_provider.cc',
+        'runtime/browser/sensor_provider.h',
         'runtime/browser/ui/color_chooser.cc',
         'runtime/browser/ui/color_chooser.h',
         'runtime/browser/ui/color_chooser_aura.cc',
@@ -158,6 +160,8 @@
             'runtime/browser/ui/tizen_system_indicator_watcher.h',
             'runtime/browser/ui/tizen/desktop_root_window_host_tizen_x11.cc',
             'runtime/browser/ui/tizen/desktop_root_window_host_tizen_x11.h',
+            'runtime/browser/tizen_system_sensor.cc',
+            'runtime/browser/tizen_system_sensor.h',
           ],
         }],
         ['OS=="android"',{


### PR DESCRIPTION
This PR is to implement the screen rotation (rotate the graphic layer, not the W3C screen orientation API) and device orientation API. The screen orientation API is planed in M3, and will base on this patch.

SensorProvider class is designed to abstract sensor framework and provide all sensor related notification for xwalk (currently support rotation, orientation, may support motion, compass, geolocation and gyroscope in future). TizenSystemSensor is the Tizen mobile platform specific implementation of SensorProvider interface. It is designed to not depend Tizen in build time (follow the philosophy of TizenSystemIndicator).

ScreenRotation class is an observer of SensorProvider to rotate the graphic layer. It doesn't support web API in current stage.

DeviceOrientation is another observer for device orientation event. Chromium has device orientation API support, but not on Tizen. To leverage the chromium code, DeviceOrientation object is also a provider for chromium, so it acts as a bridge to connect the SensorProvider and chromium.

I'm trying to make this PR as simple as possible, make it easy to understand and review.
