### PR TITLE
[Android] Cancel library-not-found dialog when library installed

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -31,6 +31,8 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
 
     private boolean mRemoteDebugging = false;
 
+    private AlertDialog mLibraryNotFoundDialog = null;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         IntentFilter intentFilter = new IntentFilter("org.xwalk.intent");
@@ -106,6 +108,7 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
             mRuntimeView = new XWalkRuntimeClient(this, null, this);
             if (mRuntimeView.get() != null) {
                 mShownNotFoundDialog = false;
+                if (mLibraryNotFoundDialog != null) mLibraryNotFoundDialog.cancel();
             }
             if (mRemoteDebugging) {
                 String mPackageName = getApplicationContext().getPackageName();
@@ -163,9 +166,20 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
                     });
             builder.setTitle(getString("download_dialog_title")).setMessage(getString("download_dialog_msg"));
 
-            // Create the AlertDialog
-            AlertDialog dialog = builder.create();
-            dialog.show();
+            mLibraryNotFoundDialog = builder.create();
+            mLibraryNotFoundDialog.setOnCancelListener(new DialogInterface.OnCancelListener() {                
+                @Override
+                public void onCancel(DialogInterface dialog) {
+                    mLibraryNotFoundDialog = null;
+                }
+            });
+            mLibraryNotFoundDialog.setOnDismissListener(new DialogInterface.OnDismissListener() {                
+                @Override
+                public void onDismiss(DialogInterface dialog) {
+                    mLibraryNotFoundDialog = null;
+                }
+            });
+            mLibraryNotFoundDialog.show();
             mShownNotFoundDialog = true;
         }
     }


### PR DESCRIPTION
For xwalk apps on Android, they will try to find runtime lib at
startup time. If runtime lib not found, an alert dialog will be
prompted for navigating user to download it from play store.

When the app is brought back to the front, it will check
runtime lib's existense. If runtime lib found, the alert dialog
should be automatically canceled.

BUG=https://github.com/crosswalk-project/crosswalk/issues/638
