### PR TITLE
[Android] Add navigation handler for handling platform-specific schemes.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -14,6 +14,7 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import org.chromium.base.JNINamespace;
+import org.chromium.components.navigation_interception.InterceptNavigationDelegate;
 import org.chromium.content.browser.ContentVideoView;
 import org.chromium.content.browser.ContentView;
 import org.chromium.content.browser.ContentViewCore;
@@ -69,7 +70,8 @@ public class XWalkContent extends FrameLayout {
                         FrameLayout.LayoutParams.MATCH_PARENT));
 
         mXWalkContent = nativeInit(mXWalkContentsDelegateAdapter, mContentsClientBridge);
-        mWebContents = nativeGetWebContents(mXWalkContent);
+        mWebContents = nativeGetWebContents(mXWalkContent,
+                mContentsClientBridge.getInterceptNavigationDelegate());
 
         // Initialize mWindow which is needed by content
         mWindow = new WindowAndroid(xwView.getActivity());
@@ -136,6 +138,10 @@ public class XWalkContent extends FrameLayout {
 
     public void setDownloadListener(DownloadListener listener) {
         mContentsClientBridge.setDownloadListener(listener);
+    }
+
+    public void setNavigationHandler(XWalkNavigationHandler handler) {
+        mContentsClientBridge.setNavigationHandler(handler);
     }
 
     public void onPause() {
@@ -220,7 +226,8 @@ public class XWalkContent extends FrameLayout {
     private native int nativeInit(XWalkWebContentsDelegate webViewContentsDelegate,
             XWalkContentsClientBridge bridge);
 
-    private native int nativeGetWebContents(int nativeXWalkContent);
+    private native int nativeGetWebContents(int nativeXWalkContent,
+            InterceptNavigationDelegate delegate);
     private native void nativeClearCache(int nativeXWalkContent, boolean includeDiskFiles);
     private native String nativeDevToolsAgentId(int nativeXWalkContent);
     private native String nativeGetVersion(int nativeXWalkContent);

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -20,6 +20,8 @@ import android.webkit.WebResourceResponse;
 import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
 import org.chromium.base.ThreadUtils;
+import org.chromium.components.navigation_interception.InterceptNavigationDelegate;
+import org.chromium.components.navigation_interception.NavigationParams;
 import org.chromium.content.browser.ContentVideoViewClient;
 import org.chromium.content.browser.ContentViewDownloadDelegate;
 
@@ -34,12 +36,25 @@ public class XWalkContentsClientBridge extends XWalkContentsClient
     private XWalkWebChromeClient mXWalkWebChromeClient;
     private Bitmap mFavicon;
     private DownloadListener mDownloadListener;
+    private InterceptNavigationDelegate mInterceptNavigationDelegate;
+    private XWalkNavigationHandler mNavigationHandler;
 
     // The native peer of the object
     private int mNativeContentsClientBridge;
 
+    private class InterceptNavigationDelegateImpl implements InterceptNavigationDelegate {
+        public boolean shouldIgnoreNavigation(NavigationParams navigationParams) {
+            if (mNavigationHandler != null) {
+                return mNavigationHandler.handleNavigation(navigationParams);
+            }
+            return false;
+        }
+    }
+
     public XWalkContentsClientBridge(XWalkView xwView) {
         mXWalkView = xwView;
+
+        mInterceptNavigationDelegate = new InterceptNavigationDelegateImpl();
     }
 
     public void setXWalkWebChromeClient(XWalkWebChromeClient client) {
@@ -48,6 +63,14 @@ public class XWalkContentsClientBridge extends XWalkContentsClient
 
     public void setXWalkClient(XWalkClient client) {
         mXWalkClient = client;
+    }
+
+    public void setNavigationHandler(XWalkNavigationHandler handler) {
+        mNavigationHandler = handler;
+    }
+
+    public InterceptNavigationDelegate getInterceptNavigationDelegate() {
+        return mInterceptNavigationDelegate;
     }
 
     // TODO(Xingnan): All the empty functions need to be implemented.

--- a/runtime/android/java/src/org/xwalk/core/XWalkNavigationHandler.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkNavigationHandler.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import org.chromium.components.navigation_interception.NavigationParams;
+
+public interface XWalkNavigationHandler {
+
+    /**
+     * Handles the navigation request.
+     * @param params The navigation parameters.
+     * @return true if the navigation request is handled.
+     */
+    boolean handleNavigation(NavigationParams params);
+}

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -14,6 +14,7 @@ import android.webkit.WebSettings;
 import android.widget.FrameLayout;
 
 import org.xwalk.core.client.XWalkDefaultDownloadListener;
+import org.xwalk.core.client.XWalkDefaultNavigationHandler;
 import org.xwalk.core.client.XWalkDefaultWebChromeClient;
 
 public class XWalkView extends FrameLayout {
@@ -69,6 +70,7 @@ public class XWalkView extends FrameLayout {
         // are provided via the following clients if special actions are not needed.
         setXWalkWebChromeClient(new XWalkDefaultWebChromeClient(context, this));
         setDownloadListener(new XWalkDefaultDownloadListener(context));
+        setNavigationHandler(new XWalkDefaultNavigationHandler(context));
     }
 
     public void loadUrl(String url) {
@@ -150,6 +152,10 @@ public class XWalkView extends FrameLayout {
 
     public void setDownloadListener(DownloadListener listener) {
         mContent.setDownloadListener(listener);
+    }
+
+    public void setNavigationHandler(XWalkNavigationHandler handler) {
+        mContent.setNavigationHandler(handler);
     }
 
     // Enables remote debugging and returns the URL at which the dev tools server is listening

--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultNavigationHandler.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultNavigationHandler.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.client;
+
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.util.Log;
+
+import org.chromium.components.navigation_interception.NavigationParams;
+
+import org.xwalk.core.XWalkNavigationHandler;
+
+public class XWalkDefaultNavigationHandler implements XWalkNavigationHandler {
+    private static final String TAG = "XWalkDefaultNavigationHandler";
+    private static final String PROTOCOL_WTAI_MC_PREFIX = "wtai://wp/mc;";
+
+    private Context mContext;
+
+    public XWalkDefaultNavigationHandler(Context context) {
+        mContext = context;
+    }
+
+    @Override
+    public boolean handleNavigation(NavigationParams params) {
+        if (params.url.startsWith(PROTOCOL_WTAI_MC_PREFIX)) {
+            return handlePhoneCall(params.url);
+        }
+        return false;
+    }
+
+    private boolean handlePhoneCall(String url) {
+        String number = url.substring(PROTOCOL_WTAI_MC_PREFIX.length());
+        String mcUrl= "tel:" + number;
+        Intent intent = new Intent(Intent.ACTION_DIAL);
+        intent.setData(Uri.parse(mcUrl));
+        try {
+            mContext.startActivity(intent);
+        } catch (ActivityNotFoundException exception) {
+            Log.w(TAG, "ACTION_DIAL: Activity not found.");
+            return false;
+        }
+        return true;
+    }
+}

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -30,7 +30,7 @@ class XWalkContent {
 
   static XWalkContent* FromWebContents(content::WebContents* web_contents);
 
-  jint GetWebContents(JNIEnv* env, jobject obj);
+  jint GetWebContents(JNIEnv* env, jobject obj, jobject delegate);
   void ClearCache(JNIEnv* env, jobject obj, jboolean include_disk_files);
   ScopedJavaLocalRef<jstring> DevToolsAgentId(JNIEnv* env, jobject obj);
   void Destroy(JNIEnv* env, jobject obj);
@@ -41,7 +41,7 @@ class XWalkContent {
   };
 
  private:
-  content::WebContents* CreateWebContents();
+  content::WebContents* CreateWebContents(JNIEnv* env, jobject delegate);
 
   JavaObjectWeakGlobalRef java_ref_;
   scoped_ptr<content::WebContents> web_contents_;


### PR DESCRIPTION
Some platform-specific schemes are needed to be handled, eg, "wtai://", we
provide default navigation handler in XWalkView to support such schemes.

"wtai://" is a protocol scheme that can initiate a dialog with the mobile phone
user whether to place a call to that number, send an SMS message, or store the
number in the address list of the mobile phone.

See: http://www.w3.org/wiki/UriSchemes/wtai

In this patch we support placing a call. And other functions will be added later.

BUG=https://github.com/crosswalk-project/crosswalk/issues/380
