### PR TITLE
[Android] Enable app customize/build tools works on Window Host.

### DIFF
--- a/app/tools/android/ant/apk-codegen.xml
+++ b/app/tools/android/ant/apk-codegen.xml
@@ -55,7 +55,9 @@
   </path>
   <script language="javascript">
     var before = project.getProperty("ADDITIONAL_RES_PACKAGES");
-    project.setProperty("project.library.packages", before.replaceAll(" ", ";"));
+    if (before) {
+        project.setProperty("project.library.packages", before.replaceAll(" ", ";"));
+    }
   </script>
 
   <path id="project.library.manifest.file.path">

--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -22,25 +22,27 @@ def Prepare(options):
   if os.path.exists(options.name):
     shutil.rmtree(options.name)
   shutil.copytree('app_src', options.name)
-  shutil.rmtree(options.name + '/src')
-  src_root = 'app_src/src/org/xwalk/app/template'
-  src_activity = '%s/AppTemplateActivity.java' % src_root
-  src_application = '%s/AppTemplateApplication.java' % src_root
+  shutil.rmtree(os.path.join(options.name, 'src'))
+  src_root = os.path.join('app_src', 'src', 'org', 'xwalk', 'app', 'template')
+  src_activity = os.path.join(src_root, 'AppTemplateActivity.java')
+  src_application = os.path.join(src_root, 'AppTemplateApplication.java')
   if (not os.path.isfile(src_activity) or
       not os.path.isfile(src_application)):
-    print ('Please make sure that the template java files'
+    print ('Please make sure that the java files'
            ' of activity and application do exist.')
     sys.exit(7)
-  root_path =  options.name + '/src/%s/' % options.package.replace('.', '/')
+  root_path =  os.path.join(options.name, 'src',
+                            options.package.replace('.', os.path.sep))
   if not os.path.exists(root_path):
     os.makedirs(root_path)
-  dest_activity = root_path + options.name + 'Activity.java'
-  dest_application =  root_path + options.name + 'Application.java'
+  dest_activity = os.path.join(root_path, options.name + 'Activity.java')
+  dest_application =  os.path.join(root_path, options.name + 'Application.java')
   shutil.copyfile(src_activity, dest_activity)
   shutil.copyfile(src_application, dest_application)
   if options.app_root:
-    shutil.rmtree(options.name + '/assets')
-    shutil.copytree(options.app_root, options.name + '/assets')
+    assets_path = os.path.join(options.name, 'assets')
+    shutil.rmtree(assets_path)
+    shutil.copytree(options.app_root, assets_path)
 
 
 def ReplaceNodeValue(doc, node, name, value):
@@ -67,7 +69,7 @@ def RemoveThemeStyle(doc, node, name, value):
 
 
 def CustomizeXML(options):
-  manifest_path = options.name + '/AndroidManifest.xml'
+  manifest_path = os.path.join(options.name, 'AndroidManifest.xml')
   if not os.path.isfile(manifest_path):
     print ('Please make sure AndroidManifest.xml'
            ' exists under app_src folder.')
@@ -86,7 +88,7 @@ def CustomizeXML(options):
   else:
     RemoveThemeStyle(xmldoc, 'activity', 'android:theme', 'Fullscreen')
   if options.icon:
-    drawable_path = '%s/res/drawable/' % options.name
+    drawable_path = os.path.join(options.name, 'res', 'drawable')
     if not os.path.exists(drawable_path):
       os.makedirs(drawable_path)
     icon_file = os.path.basename(options.icon)
@@ -96,7 +98,7 @@ def CustomizeXML(options):
     AddAttribute(xmldoc, 'application',
                  'android:icon', '@drawable/%s' % icon_name)
 
-  file_handle = open('%s/AndroidManifest.xml' % options.name, 'wb')
+  file_handle = open(os.path.join(options.name, 'AndroidManifest.xml'), 'wb')
   xmldoc.writexml(file_handle)
   file_handle.close()
 
@@ -125,9 +127,10 @@ def SetVariable(file_path, variable, value):
 
 
 def CustomizeJava(options):
-  root_path =  options.name + '/src/%s/' % options.package.replace('.', '/')
-  dest_activity = root_path + options.name + 'Activity.java'
-  dest_application =  root_path + options.name + 'Application.java'
+  root_path =  os.path.join(options.name, 'src',
+                            options.package.replace('.', os.path.sep))
+  dest_activity = os.path.join(root_path, options.name + 'Activity.java')
+  dest_application =  os.path.join(root_path, options.name + 'Application.java')
   ReplaceString(dest_activity, 'org.xwalk.app.template', options.package)
   ReplaceString(dest_activity, 'AppTemplate', options.name)
   ReplaceString(dest_application, 'org.xwalk.app.template', options.package)
@@ -137,7 +140,8 @@ def CustomizeJava(options):
       ReplaceString(dest_activity, 'file:///android_asset/index.html',
                     options.app_url)
   elif options.app_local_path:
-    if os.path.isfile(options.name + '/assets/' + options.app_local_path):
+    if os.path.isfile(os.path.join(options.name, 'assets',
+                                   options.app_local_path)):
       ReplaceString(dest_activity, 'index.html', options.app_local_path)
     else:
       print ('Please make sure that the reletive path of entry file'

--- a/app/tools/android/gyp/dex.py
+++ b/app/tools/android/gyp/dex.py
@@ -18,8 +18,21 @@ def Find(name, path):
       return os.path.join(root, name)
 
 
+def AddExeExtensions(name):
+  exts = filter(None, os.environ.get('PATHEXT', '').lower().split(os.pathsep))
+  result = []
+  result.append(name)
+  for e in exts:
+    result.append(name + e)
+  return result
+
+
 def DoDex(options, paths):
-  dx_binary = os.path.join(Find('dx', options.android_sdk_root))
+  dx_binary = ''
+  for dx_str in AddExeExtensions('dx'):
+    dx_binary = Find(dx_str, options.android_sdk_root)
+    if dx_binary:
+      break
   dex_cmd = [dx_binary, '--dex', '--output', options.dex_path] + paths
 
   record_path = '%s.md5.stamp' % options.dex_path

--- a/app/tools/android/gyp/jar.py
+++ b/app/tools/android/gyp/jar.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# pylint: disable=F0401
+
+import fnmatch
+import optparse
+import os
+import sys
+
+from util import build_utils
+from util import md5_check
+
+
+def DoJar(options):
+  class_files = build_utils.FindInDirectory(options.classes_dir, '*.class')
+  for exclude in options.excluded_classes.split():
+    class_files = filter(
+        lambda f: not fnmatch.fnmatch(f, exclude), class_files)
+
+  jar_path = os.path.abspath(options.jar_path)
+
+  # The paths of the files in the jar will be the same as they are passed in to
+  # the command. Because of this, the command should be run in
+  # options.classes_dir so the .class file paths in the jar are correct.
+  jar_cwd = options.classes_dir
+  class_files_rel = [os.path.relpath(f, jar_cwd) for f in class_files]
+  jar_cmd = ['jar', 'cf0', jar_path] + class_files_rel
+
+  record_path = '%s.md5.stamp' % options.jar_path
+  md5_check.CallAndRecordIfStale(
+      lambda: build_utils.CheckCallDie(jar_cmd, cwd=jar_cwd),
+      record_path=record_path,
+      input_paths=class_files,
+      input_strings=jar_cmd)
+
+  build_utils.Touch(options.jar_path)
+
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option('--classes-dir', help='Directory containing .class files.')
+  parser.add_option('--jar-path', help='Jar output path.')
+  parser.add_option('--excluded-classes',
+      help='List of .class file patterns to exclude from the jar.')
+  parser.add_option('--stamp', help='Path to touch on success.')
+
+  options, _ = parser.parse_args()
+
+  DoJar(options)
+
+  if options.stamp:
+    build_utils.Touch(options.stamp)
+
+
+if __name__ == '__main__':
+  sys.exit(main())
+

--- a/app/tools/android/gyp/javac.py
+++ b/app/tools/android/gyp/javac.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# pylint: disable=F0401
+
+import fnmatch
+import optparse
+import os
+import sys
+
+from util import build_utils
+from util import md5_check
+
+
+def DoJavac(options):
+  output_dir = options.output_dir
+
+  src_dirs = options.src_dirs.split()
+  java_files = build_utils.FindInDirectories(src_dirs, '*.java')
+  if options.javac_includes:
+    javac_includes = options.javac_includes.split()
+    filtered_java_files = []
+    for f in java_files:
+      for include in javac_includes:
+        if fnmatch.fnmatch(f, include):
+          filtered_java_files.append(f)
+          break
+    java_files = filtered_java_files
+
+  # Compiling guava with certain orderings of input files causes a compiler
+  # crash... Sorted order works, so use that.
+  # See https://code.google.com/p/guava-libraries/issues/detail?id=950
+  java_files.sort()
+  classpath = options.classpath.split()
+
+  jar_inputs = []
+  for path in classpath:
+    if os.path.exists(path + '.TOC'):
+      jar_inputs.append(path + '.TOC')
+    else:
+      jar_inputs.append(path)
+
+  javac_cmd = [
+      'javac',
+      '-g',
+      '-source', '1.5',
+      '-target', '1.5',
+      '-classpath', os.pathsep.join(classpath),
+      '-d', output_dir,
+      '-Xlint:unchecked',
+      '-Xlint:deprecation',
+      ] + java_files
+
+  def Compile():
+    # Delete the classes directory. This ensures that all .class files in the
+    # output are actually from the input .java files. For example, if a .java
+    # file is deleted or an inner class is removed, the classes directory should
+    # not contain the corresponding old .class file after running this action.
+    build_utils.DeleteDirectory(output_dir)
+    build_utils.MakeDirectory(output_dir)
+    suppress_output = not options.chromium_code
+    build_utils.CheckCallDie(javac_cmd, suppress_output=suppress_output)
+
+  record_path = '%s/javac.md5.stamp' % options.output_dir
+  md5_check.CallAndRecordIfStale(
+      Compile,
+      record_path=record_path,
+      input_paths=java_files + jar_inputs,
+      input_strings=javac_cmd)
+
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option('--src-dirs', help='Directories containing java files.')
+  parser.add_option('--javac-includes',
+      help='A list of file patterns. If provided, only java files that match' +
+        'one of the patterns will be compiled.')
+  parser.add_option('--classpath', help='Classpath for javac.')
+  parser.add_option('--output-dir', help='Directory for javac output.')
+  parser.add_option('--stamp', help='Path to touch on success.')
+  parser.add_option('--chromium-code', type='int', help='Whether code being '
+                    'compiled should be built with stricter warnings for '
+                    'chromium code.')
+
+  options, _ = parser.parse_args()
+
+  DoJavac(options)
+
+  if options.stamp:
+    build_utils.Touch(options.stamp)
+
+
+if __name__ == '__main__':
+  sys.exit(main())
+
+

--- a/app/tools/android/gyp/util/build_utils.py
+++ b/app/tools/android/gyp/util/build_utils.py
@@ -1,0 +1,90 @@
+# Copyright 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import fnmatch
+import os
+import pipes
+import shutil
+import subprocess
+import sys
+import traceback
+
+
+def MakeDirectory(dir_path):
+  try:
+    os.makedirs(dir_path)
+  except OSError:
+    pass
+
+
+def DeleteDirectory(dir_path):
+  if os.path.exists(dir_path):
+    shutil.rmtree(dir_path)
+
+
+def Touch(path):
+  MakeDirectory(os.path.dirname(path))
+  with open(path, 'a'):
+    os.utime(path, None)
+
+
+def FindInDirectory(directory, filter_string):
+  files = []
+  for root, _, filenames in os.walk(directory):
+    matched_files = fnmatch.filter(filenames, filter_string)
+    files.extend((os.path.join(root, f) for f in matched_files))
+  return files
+
+
+def FindInDirectories(directories, filter_string):
+  all_files = []
+  for directory in directories:
+    all_files.extend(FindInDirectory(directory, filter_string))
+  return all_files
+
+
+# This can be used in most cases like subprocess.check_call. The output,
+# particularly when the command fails, better highlights the command's failure.
+# This call will directly exit on a failure in the subprocess so that no python
+# stacktrace is printed after the output of the failed command (and will
+# instead print a python stack trace before the output of the failed command)
+def CheckCallDie(args, suppress_output=False, cwd=None):
+  if not cwd:
+    cwd = os.getcwd()
+
+  if os.name == 'posix':
+    child = subprocess.Popen(args,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd)
+  else:
+    child = subprocess.Popen(args,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, shell=True)
+
+  stdout, _ = child.communicate()
+
+  if child.returncode:
+    stacktrace = traceback.extract_stack()
+    print >> sys.stderr, ''.join(traceback.format_list(stacktrace))
+    # A user should be able to simply copy and paste the command that failed
+    # into their shell.
+    copyable_command = ' '.join(map(pipes.quote, args))
+    copyable_command = ('( cd ' + os.path.abspath(cwd) + '; '
+        + copyable_command + ' )')
+    print >> sys.stderr, 'Command failed:', copyable_command, '\n'
+
+    if stdout:
+      print stdout
+
+    # Directly exit to avoid printing stacktrace.
+    sys.exit(child.returncode)
+
+  else:
+    if stdout and not suppress_output:
+      print stdout
+    return stdout
+
+
+def GetModifiedTime(path):
+  # For a symlink, the modified time should be the greater of the link's
+  # modified time and the modified time of the target.
+  return max(os.lstat(path).st_mtime, os.stat(path).st_mtime)

--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -90,12 +90,20 @@
         {
           'destination': '<(PRODUCT_DIR)/xwalk_app_template/scripts/gyp/',
           'files': [
+            '../build/android/gyp/ant.py',
+            '../build/android/gyp/util',
             './app/tools/android/gyp/dex.py',
             './app/tools/android/gyp/finalize_apk.py',
-            '../build/android/gyp/ant.py',
-            '../build/android/gyp/jar.py',
-            '../build/android/gyp/javac.py',
-            '../build/android/gyp/util/',
+            './app/tools/android/gyp/jar.py',
+            './app/tools/android/gyp/javac.py',
+          ],
+        },
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_app_template/scripts/gyp/util/',
+          'files': [
+            '../build/android/gyp/util/__init__.py',
+            '../build/android/gyp/util/md5_check.py',
+            './app/tools/android/gyp/util/build_utils.py',
           ],
         },
         {


### PR DESCRIPTION
Original customize/build tools are only verified on Linux Host.
They have some environment assumptions for Linux, which would
break the app build on Windows Host. What's more,
there are also some differences for default behavior of build tools,
such as: ant etc. This patch will fill the gap, make app
customize/build tools works on Window Host.
1. Fix the different path separator on different OS host.
2. Fix different default ant behavior on diefferent OS host.
3. Fix different extension for executable binary on different OS host.
4. Fix python subprocess work different on different OS host.

BUG=https://github.com/crosswalk-project/crosswalk/issues/616
