### PR TITLE
[Android] Remove the unused build target xwalk_runtime_lib_apk_extensio...

### DIFF
--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -107,7 +107,6 @@
         # Runtime code is also built by this target.
         'xwalk_core_java',
         'xwalk_runtime_lib_apk_pak',
-        'xwalk_runtime_lib_apk_extension',
       ],
       'variables': {
         'apk_name': 'XWalkRuntimeLib',
@@ -116,7 +115,6 @@
         'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
           '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/xwalk.pak',
-          '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/js_api',
         ],
         'asset_location': '<(ant_build_out)/xwalk_runtime_lib/assets',
       },
@@ -133,18 +131,6 @@
           'destination': '<(PRODUCT_DIR)/xwalk_runtime_lib/assets',
           'files': [
             '<(PRODUCT_DIR)/xwalk.pak',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'xwalk_runtime_lib_apk_extension',
-      'type': 'none',
-      'copies': [
-         {
-          'destination': '<(PRODUCT_DIR)/xwalk_runtime_lib/assets',
-          'files': [
-            'runtime/android/runtimelib/assets/js_api',
           ],
         },
       ],


### PR DESCRIPTION
Since the js_api folder in assets is removed, the build target will not be
used any more.
