### PR TITLE
[Extensions] Build fix for windows

### DIFF
--- a/extensions/renderer/xwalk_extension_renderer_controller.h
+++ b/extensions/renderer/xwalk_extension_renderer_controller.h
@@ -19,7 +19,7 @@ class RenderView;
 }
 
 namespace IPC {
-class ChannelHandle;
+struct ChannelHandle;
 class SyncChannel;
 }
 


### PR DESCRIPTION
IPC::ChannelHandle is a struct, not a class.
