### PR TITLE
Use a TitleWatcher to make test less flaky

### DIFF
--- a/extensions/test/extension_in_iframe.cc
+++ b/extensions/test/extension_in_iframe.cc
@@ -112,8 +112,9 @@ IN_PROC_BROWSER_TEST_F(XWalkExtensionsIFrameTest,
       base::FilePath().AppendASCII("iframe_using_document_write.html"));
 
   for (int i = 0; i < 5; i++) {
+    content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
     xwalk_test_utils::NavigateToURL(runtime(), url);
-    EXPECT_EQ(kPassString, runtime()->web_contents()->GetTitle());
+    EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
   }
 }
 


### PR DESCRIPTION
In the IFrameUsingDocumentWriteShouldNotCrash test, sometimes the title
wasn't immediatly updated after navigation. The best choice is to make
use of a title watcher instead of directly comparing.
