### PR TITLE
Build fixes for Mac.

### DIFF
--- a/application/browser/application_store.h
+++ b/application/browser/application_store.h
@@ -34,7 +34,7 @@ class ApplicationStore: public DBStore::Observer {
   static const char kInstallTime[];
 
   explicit ApplicationStore(xwalk::RuntimeContext* runtime_context);
-  ~ApplicationStore();
+  virtual ~ApplicationStore();
 
   bool AddApplication(scoped_refptr<const Application> application);
 

--- a/application/browser/installer/xpk_extractor.cc
+++ b/application/browser/installer/xpk_extractor.cc
@@ -30,6 +30,10 @@ XPKExtractor::XPKExtractor(const base::FilePath& source_path)
       xpk_package_(XPKPackage::Create(source_path)) {
 }
 
+XPKExtractor::~XPKExtractor() {
+
+}
+
 std::string XPKExtractor::GetPackageID() const {
   return xpk_package_.get()?xpk_package_->Id():"";
 }

--- a/application/browser/installer/xpk_extractor.h
+++ b/application/browser/installer/xpk_extractor.h
@@ -26,6 +26,7 @@ class XPKExtractor
  private:
   friend class base::RefCountedThreadSafe<XPKExtractor>;
   explicit XPKExtractor(const base::FilePath& source_path);
+  virtual ~XPKExtractor();
   bool CreateTempDirectory();
 
   base::FilePath source_path_;

--- a/application/browser/installer/xpk_package.cc
+++ b/application/browser/installer/xpk_package.cc
@@ -70,6 +70,9 @@ XPKPackage::XPKPackage(Header header, ScopedStdioHandle* file)
   id_ = GenerateId(public_key);
 }
 
+XPKPackage::~XPKPackage() {
+}
+
 bool XPKPackage::Validate() {
 // Set the file read position to the beginning of compressed resource file,
 // which is behind the magic header, public key and signature key.

--- a/application/browser/installer/xpk_package.h
+++ b/application/browser/installer/xpk_package.h
@@ -28,6 +28,7 @@ class XPKPackage {
     uint32 signature_size;
   };
   static scoped_ptr<XPKPackage> Create(const base::FilePath& path);
+  virtual ~XPKPackage();
   // Validate the xpk file
   bool IsOk() const { return is_ok_; }
   const std::string& Id() const { return id_; }

--- a/application/common/db_store.cc
+++ b/application/common/db_store.cc
@@ -1,0 +1,18 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/db_store.h"
+
+namespace xwalk {
+namespace application {
+
+DBStore::DBStore(base::FilePath path) : data_path_(path) {
+}
+
+DBStore::~DBStore() {
+}
+
+}  // namespace application
+}  // namespace xwalk
+

--- a/application/common/db_store.h
+++ b/application/common/db_store.h
@@ -29,8 +29,8 @@ class DBStore {
    protected:
     virtual ~Observer() {}
   };
-  explicit DBStore(base::FilePath path) : data_path_(path) {}
-  virtual ~DBStore() {}
+  explicit DBStore(base::FilePath path);
+  virtual ~DBStore();
   virtual bool Insert(const Application* application,
                       const base::Time install_time) = 0;
   const base::DictionaryValue* GetApplications() const { return db_.get(); }

--- a/application/common/db_store_json_impl.cc
+++ b/application/common/db_store_json_impl.cc
@@ -43,8 +43,6 @@ class FileThreadDeserializer
         origin_loop_proxy_(base::MessageLoopProxy::current()) {
   }
 
-  ~FileThreadDeserializer() {}
-
   void Start(const base::FilePath& path) {
     DCHECK(origin_loop_proxy_->BelongsToCurrentThread());
     sequenced_task_runner_->PostTask(
@@ -83,6 +81,7 @@ class FileThreadDeserializer
 
  private:
   friend class base::RefCountedThreadSafe<FileThreadDeserializer>;
+  ~FileThreadDeserializer() {}
 
   bool no_dir_;
   scoped_ptr<base::Value> value_;

--- a/application/common/db_store_json_impl.h
+++ b/application/common/db_store_json_impl.h
@@ -21,7 +21,7 @@ class DBStoreJsonImpl: public DBStore,
     public base::ImportantFileWriter::DataSerializer {
  public:
   explicit DBStoreJsonImpl(base::FilePath path);
-  ~DBStoreJsonImpl();
+  virtual ~DBStoreJsonImpl();
   // Returns instance of SequencedTaskRunner which guarantees that file
   // operations on the same file will be executed in sequenced order.
   static scoped_refptr<base::SequencedTaskRunner> GetTaskRunnerForFile(

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -40,6 +40,7 @@
         'common/install_warning.h',
         'common/manifest.cc',
         'common/manifest.h',
+        'common/db_store.cc',
         'common/db_store.h',
         'common/db_store_json_impl.cc',
         'common/db_store_json_impl.h',


### PR DESCRIPTION
Usual suspects :
[chromium-style] Classes that are ref-counted should have destructors that are declared protected or private.
[chromium-style] Complex destructor has an inline body.
[chromium-style] Overriding method must have "virtual" keyword.
