### PR TITLE
[Tizen] Integrate crosswalk with Tizen input method system.

### DIFF
--- a/ime/tizen-scim/README
+++ b/ime/tizen-scim/README
@@ -1,0 +1,7 @@
+The Tizen OS uses Smart Common Input Method (SCIM) and Input System Framework (ISF)
+to manage input method systems. In order to integrate Crosswalk with Tizen ISF,
+it is required to implement InputMethod interface provided by Chromium.
+
+This directory contains InputMethod interface realization as well as 
+"scim bridge" that connects Tizen input method subsystem with Chromium
+InputMethod interface.

--- a/ime/tizen-scim/input_method_scim.cc
+++ b/ime/tizen-scim/input_method_scim.cc
@@ -1,0 +1,157 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "input_method_scim.h"
+
+#include "base/logging.h"
+#include "ui/base/events/event_utils.h"
+#include "ui/base/ime/input_method_delegate.h"
+#include "ui/base/ime/text_input_client.h"
+#include "ui/base/keycodes/keyboard_code_conversion.h"
+#include "ui/aura/root_window.h"
+
+#include <X11/X.h>
+#include <X11/Xlib.h>
+#include "ui/base/keycodes/keyboard_code_conversion_x.h"
+
+#include "scim_bridge.h"
+
+namespace {
+
+uint32 EventFlagsFromXFlags(unsigned int flags) {
+  return (flags & LockMask ? ui::EF_CAPS_LOCK_DOWN : 0U)
+         | (flags & ControlMask ? ui::EF_CONTROL_DOWN : 0U)
+         | (flags & ShiftMask ? ui::EF_SHIFT_DOWN : 0U)
+         | (flags & Mod1Mask ? ui::EF_ALT_DOWN : 0U);
+}
+
+}  // namespace
+
+namespace ui {
+
+InputMethodSCIM::InputMethodSCIM(internal::InputMethodDelegate* delegate)
+    : delegate_(NULL),
+      text_input_client_(NULL),
+      scim_bridge_(new SCIMBridge()){
+  SetDelegate(delegate);
+}
+
+InputMethodSCIM::~InputMethodSCIM(){
+}
+
+void InputMethodSCIM::SetDelegate(internal::InputMethodDelegate* delegate) {
+  delegate_ = delegate;
+}
+
+void InputMethodSCIM::SetFocusedTextInputClient(TextInputClient* client) {
+  if (client && client->GetAttachedWindow()) {
+    aura::RootWindow* rw = client->GetAttachedWindow()->GetRootWindow();
+      if (rw) {
+        scim_bridge_->SetFocusedWindow(rw->GetAcceleratedWidget());
+        scim_bridge_->Init();
+      }
+  }
+
+  text_input_client_ = client;
+  FOR_EACH_OBSERVER(InputMethodObserver, observers_,
+                    OnTextInputStateChanged(client));
+}
+
+TextInputClient* InputMethodSCIM::GetTextInputClient() const {
+  return text_input_client_;
+}
+
+bool InputMethodSCIM::DispatchKeyEvent(const base::NativeEvent& native_event) {
+  bool handled = false;
+  DCHECK(native_event);
+  if (native_event->type == KeyRelease) {
+    // On key release, just dispatch it.
+    handled = delegate_->DispatchKeyEventPostIME(native_event);
+  } else {
+    const uint32 state = EventFlagsFromXFlags(native_event->xkey.state);
+    // Send a RawKeyDown event first.
+    handled = delegate_->DispatchKeyEventPostIME(native_event);
+    if (text_input_client_) {
+      // then send a Char event via ui::TextInputClient.
+      const KeyboardCode key_code = ui::KeyboardCodeFromNative(native_event);
+      uint16 ch = 0;
+      if (!(state & ui::EF_CONTROL_DOWN))
+        ch = ui::GetCharacterFromXEvent(native_event);
+      if (!ch)
+        ch = ui::GetCharacterFromKeyCode(key_code, state);
+      if (ch)
+        text_input_client_->InsertChar(ch, state);
+    }
+  }
+  return handled;
+}
+
+bool InputMethodSCIM::DispatchFabricatedKeyEvent(const ui::KeyEvent& event) {
+  bool handled = delegate_->DispatchFabricatedKeyEventPostIME(
+      event.type(), event.key_code(), event.flags());
+  if (event.type() == ET_KEY_PRESSED && text_input_client_) {
+    if (uint16 ch = event.GetCharacter())
+      text_input_client_->InsertChar(ch, event.flags());
+  }
+  return handled;
+}
+
+void InputMethodSCIM::Init(bool focused) {}
+void InputMethodSCIM::OnFocus() {}
+void InputMethodSCIM::OnBlur() {}
+bool InputMethodSCIM::OnUntranslatedIMEMessage(const base::NativeEvent& event,
+                                               NativeEventResult* result) {
+  return false;
+}
+
+void InputMethodSCIM::OnTextInputTypeChanged(const TextInputClient* client) {
+
+  if (client) {
+    scim_bridge_->TextInputChanged(client->GetTextInputType());
+  }
+
+  FOR_EACH_OBSERVER(InputMethodObserver, observers_,
+                    OnTextInputStateChanged(client));
+}
+
+void InputMethodSCIM::OnCaretBoundsChanged(const TextInputClient* client) {}
+void InputMethodSCIM::CancelComposition(const TextInputClient* client) {}
+void InputMethodSCIM::OnInputLocaleChanged() {}
+
+std::string InputMethodSCIM::GetInputLocale() {
+  // TODO: Fetch locale from SCIM.
+  return "";
+}
+
+base::i18n::TextDirection InputMethodSCIM::GetInputTextDirection() {
+  // TODO: Fetch input text direction from SCIM.
+  return base::i18n::UNKNOWN_DIRECTION;
+}
+
+bool InputMethodSCIM::IsActive() {
+  return true;
+}
+
+bool InputMethodSCIM::IsCandidatePopupOpen() const {
+  return false;
+}
+
+ui::TextInputType InputMethodSCIM::GetTextInputType() const {
+  return ui::TEXT_INPUT_TYPE_NONE;
+}
+
+bool InputMethodSCIM::CanComposeInline() const {
+  return true;
+}
+
+void InputMethodSCIM::AddObserver(InputMethodObserver* observer) {
+  observers_.AddObserver(observer);
+}
+
+void InputMethodSCIM::RemoveObserver(InputMethodObserver* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+}  // namespace ui

--- a/ime/tizen-scim/input_method_scim.h
+++ b/ime/tizen-scim/input_method_scim.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_BASE_IME_INPUT_METHOD_SCIM_H_
+#define UI_BASE_IME_INPUT_METHOD_SCIM_H_
+
+#include <string>
+
+#include "base/basictypes.h"
+#include "base/compiler_specific.h"
+#include "base/observer_list.h"
+#include "base/memory/scoped_ptr.h"
+#include "ui/base/ime/input_method.h"
+#include "ui/base/ime/input_method_observer.h"
+#include "ui/base/ui_export.h"
+
+namespace ui {
+
+class InputMethodObserver;
+class KeyEvent;
+class TextInputClient;
+class SCIMBridge;
+
+// SCIM InputMethod implementation for minimum input support.
+class UI_EXPORT InputMethodSCIM : NON_EXPORTED_BASE(public InputMethod) {
+ public:
+  explicit InputMethodSCIM(internal::InputMethodDelegate* delegate);
+  virtual ~InputMethodSCIM();
+
+  // Overriden from InputMethod.
+  virtual void SetDelegate(internal::InputMethodDelegate* delegate) OVERRIDE;
+  virtual void Init(bool focused) OVERRIDE;
+  virtual void OnFocus() OVERRIDE;
+  virtual void OnBlur() OVERRIDE;
+  virtual bool OnUntranslatedIMEMessage(const base::NativeEvent& event,
+                                        NativeEventResult* result) OVERRIDE;
+  virtual void SetFocusedTextInputClient(TextInputClient* client) OVERRIDE;
+  virtual TextInputClient* GetTextInputClient() const OVERRIDE;
+  virtual bool DispatchKeyEvent(const base::NativeEvent& native_event) OVERRIDE;
+  virtual bool DispatchFabricatedKeyEvent(const ui::KeyEvent& event) OVERRIDE;
+  virtual void OnTextInputTypeChanged(const TextInputClient* client) OVERRIDE;
+  virtual void OnCaretBoundsChanged(const TextInputClient* client) OVERRIDE;
+  virtual void CancelComposition(const TextInputClient* client) OVERRIDE;
+  virtual void OnInputLocaleChanged() OVERRIDE;
+  virtual std::string GetInputLocale() OVERRIDE;
+  virtual base::i18n::TextDirection GetInputTextDirection() OVERRIDE;
+  virtual bool IsActive() OVERRIDE;
+  virtual ui::TextInputType GetTextInputType() const OVERRIDE;
+  virtual bool CanComposeInline() const OVERRIDE;
+  virtual bool IsCandidatePopupOpen() const OVERRIDE;
+  virtual void AddObserver(InputMethodObserver* observer) OVERRIDE;
+  virtual void RemoveObserver(InputMethodObserver* observer) OVERRIDE;
+
+ private:
+  internal::InputMethodDelegate* delegate_;
+  TextInputClient* text_input_client_;
+  ObserverList<InputMethodObserver> observers_;
+  scoped_ptr<SCIMBridge> scim_bridge_;
+
+  DISALLOW_COPY_AND_ASSIGN(InputMethodSCIM);
+};
+
+}  // namespace ui
+
+#endif  // UI_BASE_IME_INPUT_METHOD_SCIM_H_

--- a/ime/tizen-scim/scim_bridge.cc
+++ b/ime/tizen-scim/scim_bridge.cc
@@ -1,0 +1,432 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "scim_bridge.h"
+
+#include "base/logging.h"
+#include "base/message_loop/message_loop.h"
+#include "base/message_loop/message_pump_libevent.h"
+#include "content/public/browser/browser_thread.h"
+#include "ui/base/x/x11_util.h"
+
+#define Uses_SCIM_BACKEND
+#define Uses_SCIM_IMENGINE_MODULE
+#define Uses_SCIM_HELPER_MODULE
+#define Uses_SCIM_PANEL_CLIENT
+
+#include <scim.h>
+#include <x11/scim_x11_utils.h>
+#include <isf_imcontrol_client.h>
+
+#include <X11/Xlib.h>
+#include <X11/XKBlib.h>
+#include <X11/Xlibint.h>
+
+using namespace scim;
+
+const String kScimFrontendSocketIpc = "socket";
+const String kScimDummyConfig = "dummy";
+const String kScimSimpleConfig = "simple";
+const String kScimConnectionTester = "ConnectionTester";
+const String kScimSocketFrontend = "SocketFrontEnd";
+const String kScimFactoryEncoding = "UTF-8";
+const char* kISFActiveWindowAtom  = "_ISF_ACTIVE_WINDOW";
+const char* kWindowAtomType = "WINDOW";
+
+typedef struct {
+    int language;
+    int layout;
+    int return_key_type;
+    Window client_window;
+    int imdata_size;
+    int cursor_pos;
+    bool return_key_disabled;
+    bool prediction_allow;
+    bool password_mode;
+    bool caps_mode;
+    int layout_variation;
+    int reserved[248];
+} InputSystemEngineContext;
+
+namespace ui {
+
+class SCIMBridgeImpl : base::MessageLoopForIO::Watcher {
+
+public:
+
+  SCIMBridgeImpl();
+  ~SCIMBridgeImpl();
+
+  void Init();
+  bool IsInitialized() {return is_initialized_;}
+  void ShowInputMethodPanel();
+  void HideInputMethodPanel();
+  void SetFocusedWindow(unsigned long xid);
+
+private:
+  bool IsDaemonRunning();
+  void StartDaemon();
+  void InitConfigModule();
+  void InitBackend();
+  void InitPanelClient();
+  void ConnectPanelClientSignals();
+  void DisconnectPanelClient();
+  void InitIMEngineFactory();
+
+  // SCIM PanelClient callbacks.
+  void OnUpdateClientId(int context, int client_id);
+  void OnProcessHelperEvent(int context,
+                              const String &target_uuid,
+                              const String &helper_uuid,
+                              const Transaction &trans);
+  void OnResetKeyboardIse(int context);
+  void OnHidePreeditString(int context);
+  void OnProcessKeyEvent(int context, const KeyEvent &key);
+  void OnCommitString(int context, const WideString &wstr);
+
+  void SendXKeyEvent(const KeyEvent &key);
+  void SetInputMethodActiveWindow();
+
+  void OnFileCanReadWithoutBlocking(int fd) OVERRIDE;
+  void OnFileCanWriteWithoutBlocking(int fd) OVERRIDE {}
+  void WatchSCIMFd();
+  void HandleScimEvent();
+
+private:
+  bool is_initialized_;
+  std::string language_code_;
+  String config_module_name_;
+  scoped_ptr<ConfigModule> config_module_;
+  ConfigPointer config_;
+  std::vector<String> config_list_;
+  std::vector<String> scim_modules_;
+  BackEndPointer backend_;
+  scoped_ptr<PanelClient> panel_client_;
+  int panel_client_id_;
+  int panel_client_fd_;
+  base::MessageLoopForIO::FileDescriptorWatcher read_fd_controller_;
+  IMEngineInstancePointer im_engine_instance_;
+  scoped_ptr<IMControlClient> imcontrol_client_;
+  InputSystemEngineContext ise_context_;
+  unsigned int im_context_id_;
+  int im_engine_instance_count_;
+
+  Display* display_;
+  Window window_;
+  Window root_window_;
+
+  DISALLOW_COPY_AND_ASSIGN(SCIMBridgeImpl);
+};
+
+SCIMBridge::SCIMBridge() : impl_(new SCIMBridgeImpl()) {
+}
+
+SCIMBridge::~SCIMBridge() {
+}
+
+void SCIMBridge::Init() {
+  if (impl_->IsInitialized())
+    return;
+
+  if (!content::BrowserThread::CurrentlyOn(content::BrowserThread::IO)) {
+    content::BrowserThread::PostTask(content::BrowserThread::IO,
+                            FROM_HERE,
+                            base::Bind(&SCIMBridgeImpl::Init,
+                                       base::Unretained(impl_.get())));
+  }
+}
+
+void SCIMBridge::SetFocusedWindow(unsigned long xid) {
+  impl_->SetFocusedWindow(xid);
+}
+
+void SCIMBridge::TextInputChanged(ui::TextInputType type) {
+  // TODO: set proper ise_context_ fields according to type
+  if (type == ui::TEXT_INPUT_TYPE_NONE) {
+    content::BrowserThread::PostTask(content::BrowserThread::IO,
+                            FROM_HERE,
+                            base::Bind(&SCIMBridgeImpl::HideInputMethodPanel,
+                                       base::Unretained(impl_.get())));
+
+  } else {
+    content::BrowserThread::PostTask(content::BrowserThread::IO,
+                            FROM_HERE,
+                            base::Bind(&SCIMBridgeImpl::ShowInputMethodPanel,
+                                       base::Unretained(impl_.get())));
+  }
+}
+
+SCIMBridgeImpl::SCIMBridgeImpl()
+  : is_initialized_(false),
+    config_module_name_(kScimSimpleConfig),
+    panel_client_id_(0),
+    panel_client_fd_(-1),
+    im_context_id_(getpid() % 50000),
+    im_engine_instance_count_(0),
+    display_(ui::GetXDisplay()),
+    root_window_(GetX11RootWindow())
+{
+  // Create input system engine context data that would be sent to the daemon.
+  // TODO: Add SCIM enums.
+  ise_context_.language = 0;
+  ise_context_.layout = 0;
+  ise_context_.return_key_type = 0;
+  ise_context_.imdata_size = 0;
+  ise_context_.return_key_disabled = false;
+  ise_context_.prediction_allow = true;
+  ise_context_.password_mode = false;
+  ise_context_.caps_mode = false;
+  ise_context_.layout_variation = 0;
+  ise_context_.return_key_disabled = false;
+}
+
+SCIMBridgeImpl::~SCIMBridgeImpl() {
+  if (panel_client_)
+    DisconnectPanelClient();
+}
+
+void SCIMBridgeImpl::Init() {
+  language_code_ = scim_get_locale_language(scim_get_current_locale());
+  imcontrol_client_.reset(new IMControlClient());
+  imcontrol_client_->open_connection();
+
+  StartDaemon();
+  InitConfigModule();
+  InitBackend();
+  InitIMEngineFactory();
+  InitPanelClient();
+  ConnectPanelClientSignals();
+  is_initialized_ = true;
+}
+
+void SCIMBridgeImpl::ShowInputMethodPanel() {
+  int ise_packet_length = sizeof(ise_context_);
+  void* ise_packet = calloc(1, ise_packet_length);
+  memcpy(ise_packet, (void *)&ise_context_, ise_packet_length);
+
+  panel_client_->prepare(im_context_id_);
+  panel_client_->focus_in(im_context_id_,
+                          im_engine_instance_->get_factory_uuid());
+  panel_client_->send();
+
+  imcontrol_client_->prepare();
+  int input_panel_show = 0;
+  imcontrol_client_->show_ise(panel_client_id_, im_context_id_, ise_packet,
+      ise_packet_length, &input_panel_show);
+  imcontrol_client_->send();
+
+  free(ise_packet);
+}
+
+void SCIMBridgeImpl::HideInputMethodPanel() {
+  imcontrol_client_->prepare();
+  imcontrol_client_->hide_ise(panel_client_id_, im_context_id_);
+  imcontrol_client_->send();
+}
+
+bool SCIMBridgeImpl::IsDaemonRunning() {
+  uint32_t uid;
+  SocketClient client;
+  SocketAddress address;
+  address.set_address(scim_get_default_socket_frontend_address());
+
+  if (!client.connect(address))
+      return false;
+
+  return scim_socket_open_connection(uid, kScimConnectionTester,
+                                     kScimSocketFrontend, client, 1000);
+}
+
+void SCIMBridgeImpl::StartDaemon() {
+  if (!IsDaemonRunning()) {
+    std::vector<String> helper_modules;
+    std::vector<String> imengine_modules;
+
+    scim_get_imengine_module_list(imengine_modules);
+    scim_get_helper_module_list(helper_modules);
+
+    std::vector<String>::iterator it;
+
+    for (it = imengine_modules.begin(); it != imengine_modules.end(); it++) {
+      if (*it != kScimFrontendSocketIpc)
+          scim_modules_.push_back(*it);
+    }
+
+    for (it = helper_modules.begin(); it != helper_modules.end(); it++)
+      scim_modules_.push_back(*it);
+
+    const String engines =
+        (scim_modules_.size() > 0 ? scim_combine_string_list(scim_modules_, ',')
+                                  : "none");
+    const char *argv [] = { "--no-stay", 0 };
+    scim_launch(true, config_module_name_, engines, kScimFrontendSocketIpc,
+        (char **)argv);
+  }
+}
+
+void SCIMBridgeImpl::InitConfigModule() {
+  config_module_.reset(new ConfigModule(config_module_name_));
+  if (config_module_->valid()) {
+      config_ = config_module_->create_config();
+  } else {
+    LOG(WARNING) << "Cannot init scim config module: " << config_module_name_;
+    config_module_.reset();
+    config_ = new DummyConfig();
+    config_module_name_ = kScimDummyConfig;
+  }
+}
+
+void SCIMBridgeImpl::InitBackend() {
+  backend_ = new CommonBackEnd(config_, scim_modules_);
+  if (!backend_.null()) {
+    backend_->initialize(config_, scim_modules_, false, false);
+  } else {
+    LOG(ERROR) << "Cannot create backend";
+  }
+}
+
+void SCIMBridgeImpl::InitPanelClient() {
+  if (!panel_client_.get())
+    panel_client_.reset(new PanelClient());
+
+  if (panel_client_->open_connection(config_->get_name(),
+                                     display_->display_name) >= 0) {
+      panel_client_fd_ = panel_client_->get_connection_number();
+      content::BrowserThread::PostTask(content::BrowserThread::IO,
+                              FROM_HERE,
+                              base::Bind(&SCIMBridgeImpl::WatchSCIMFd,
+                                         base::Unretained(this)));
+
+      panel_client_->prepare(im_context_id_);
+      panel_client_->register_input_context(im_context_id_,
+                                      im_engine_instance_->get_factory_uuid());
+      panel_client_->send();
+  } else {
+    LOG(ERROR) << "Cannot get panel client connection";
+  }
+}
+
+void SCIMBridgeImpl::ConnectPanelClientSignals() {
+  // FIXME: attach rest of the signals
+  panel_client_->signal_connect_update_client_id(
+      slot(this, &SCIMBridgeImpl::OnUpdateClientId));
+  panel_client_->signal_connect_process_helper_event(
+      slot(this, &SCIMBridgeImpl::OnProcessHelperEvent));
+  panel_client_->signal_connect_reset_keyboard_ise(
+      slot(this, &SCIMBridgeImpl::OnResetKeyboardIse));
+  panel_client_->signal_connect_hide_preedit_string(
+      slot(this, &SCIMBridgeImpl::OnHidePreeditString));
+  panel_client_->signal_connect_process_key_event(
+      slot(this, &SCIMBridgeImpl::OnProcessKeyEvent));
+  panel_client_->signal_connect_commit_string(
+      slot(this, &SCIMBridgeImpl::OnCommitString));
+}
+
+void SCIMBridgeImpl::DisconnectPanelClient() {
+  panel_client_->close_connection();
+  read_fd_controller_.StopWatchingFileDescriptor();
+}
+
+void SCIMBridgeImpl::InitIMEngineFactory() {
+  IMEngineFactoryPointer factory =
+      backend_->get_default_factory(language_code_, kScimFactoryEncoding);
+  if (factory.null()) {
+      LOG(ERROR) << "Cannot get default IM engine factory";
+      return;
+  }
+
+  im_engine_instance_ = factory->create_instance(kScimFactoryEncoding,
+      im_engine_instance_count_++);
+
+  if (im_engine_instance_.null()) {
+     LOG(ERROR) << "Cannot get default IM engine instance";
+     return;
+  }
+
+  // TODO: connect im_engine_instance_ signals
+}
+
+void SCIMBridgeImpl::OnUpdateClientId(int, int client_id) {
+  panel_client_id_ = client_id;
+}
+
+void SCIMBridgeImpl::OnProcessHelperEvent(int context,
+                                        const String &target_uuid,
+                                        const String &helper_uuid,
+                                        const Transaction &trans) {
+  if (im_engine_instance_->get_factory_uuid() == target_uuid) {
+    panel_client_->prepare(im_context_id_);
+    im_engine_instance_->process_helper_event(helper_uuid, trans);
+    panel_client_->send();
+  }
+}
+
+void SCIMBridgeImpl::OnResetKeyboardIse(int context) {
+  // TODO: implement
+  LOG(INFO) << "SCIMBridgeImpl::OnResetKeyboardIse - not implemented";
+}
+
+void SCIMBridgeImpl::OnHidePreeditString(int context) {
+  // TODO: implement
+  LOG(INFO) << "SCIMBridgeImpl::OnHidePreeditString - not implemented";
+}
+
+void SCIMBridgeImpl::OnProcessKeyEvent(int context, const KeyEvent &key) {
+  content::BrowserThread::PostTask(content::BrowserThread::UI,
+                          FROM_HERE,
+                          base::Bind(&SCIMBridgeImpl::SendXKeyEvent,
+                                     base::Unretained(this), key));
+}
+
+void SCIMBridgeImpl::OnCommitString(int context, const WideString &wstr) {
+  // TODO: implement
+  LOG(INFO) << "SCIMBridgeImpl::OnCommitString - not implemented";
+}
+
+void SCIMBridgeImpl::SendXKeyEvent(const KeyEvent &key) {
+  ::KeyCode keycode = 0;
+  ::KeySym keysym = 0;
+  XKeyEvent event = scim_x11_keyevent_scim_to_x11(display_, key);
+  event.same_screen = True;
+  event.window = window_;
+  keysym = XStringToKeysym(key.get_key_string().c_str());
+  if (keysym == NoSymbol)
+    return;
+  keycode = XKeysymToKeycode(display_, keysym);
+  if (XkbKeycodeToKeysym(display_, keycode, 0, 1) == keysym)
+    event.state |= ShiftMask;
+  XSendEvent(display_, window_, True, event.type, (XEvent *)&event);
+}
+
+void SCIMBridgeImpl::SetInputMethodActiveWindow() {
+  SetIntProperty(root_window_, kISFActiveWindowAtom, kWindowAtomType, window_);
+}
+
+void SCIMBridgeImpl::SetFocusedWindow(unsigned long xid) {
+  window_ = xid;
+  ise_context_.client_window = xid;
+  SetInputMethodActiveWindow();
+}
+
+void SCIMBridgeImpl::OnFileCanReadWithoutBlocking(int fd) {
+  if (panel_client_fd_ == fd)
+    HandleScimEvent();
+}
+
+void SCIMBridgeImpl::HandleScimEvent() {
+  if (panel_client_->has_pending_event()
+      && !panel_client_->filter_event()) {
+        LOG(INFO) << "Reconnecting scim PanelClient";
+        DisconnectPanelClient();
+        InitPanelClient();
+   }
+}
+
+void SCIMBridgeImpl::WatchSCIMFd() {
+  base::MessageLoopForIO::current()->WatchFileDescriptor(
+          panel_client_fd_, true, base::MessageLoopForIO::WATCH_READ,
+          &read_fd_controller_, this);
+}
+
+}

--- a/ime/tizen-scim/scim_bridge.h
+++ b/ime/tizen-scim/scim_bridge.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/basictypes.h"
+#include "base/memory/scoped_ptr.h"
+#include "ui/base/ime/text_input_type.h"
+
+#ifndef UI_BASE_IME_TIZEN_SCIM_BRIDGE_H_
+#define UI_BASE_IME_TIZEN_SCIM_BRIDGE_H_
+
+namespace ui {
+
+class SCIMBridgeImpl;
+
+class SCIMBridge {
+
+public:
+  SCIMBridge();
+  ~SCIMBridge();
+
+  void Init();
+  void SetFocusedWindow(unsigned long);
+  void TextInputChanged(ui::TextInputType);
+
+private:
+  scoped_ptr<SCIMBridgeImpl> impl_;
+  DISALLOW_COPY_AND_ASSIGN(SCIMBridge);
+};
+
+}
+
+#endif  // UI_BASE_IME_TIZEN_SCIM_BRIDGE_H_
+

--- a/packaging/crosswalk-1.29-include-tizen-ime-files.patch
+++ b/packaging/crosswalk-1.29-include-tizen-ime-files.patch
@@ -1,0 +1,84 @@
+Author: Alexander Shalamov <alexander.shalamov@intel.com>
+This patch includes Tizen specific IME files when into chromium
+IME module when Tizen crosswalk packages are built.
+
+diff --git src/build/linux/system.gyp src/build/linux/system.gyp
+index 867553f..ea9705f 100644
+--- src/build/linux/system.gyp
++++ src/build/linux/system.gyp
+@@ -832,5 +832,26 @@
+         }],
+       ],
+     },
++    {
++      'target_name': 'scim',
++      'type': 'none',
++      'toolsets': ['host', 'target'],
++      'variables': {
++        'scim_libs': 'scim',
++      },
++      'direct_dependent_settings': {
++        'cflags': [
++          '<!@(<(pkg-config) --cflags <(scim_libs))',
++        ],
++      },
++      'link_settings': {
++        'ldflags': [
++          '<!@(<(pkg-config) --libs-only-L --libs-only-other <(scim_libs))',
++        ],
++        'libraries': [
++          '<!@(<(pkg-config) --libs-only-l <(scim_libs))', '-lscim-x11utils-1.0',
++        ],
++      },
++    },
+   ],
+ }
+diff --git src/ui/base/ime/ime.gypi src/ui/base/ime/ime.gypi
+index 5f2adc1..b420fa7 100644
+--- src/ui/base/ime/ime.gypi
++++ src/ui/base/ime/ime.gypi
+@@ -84,5 +84,19 @@
+         'input_method_tsf.h',
+       ],
+     }],
++    ['tizen_mobile == 1', {
++      'sources': [
++        '<(DEPTH)/xwalk/ime/tizen-scim/input_method_scim.cc',
++        '<(DEPTH)/xwalk/ime/tizen-scim/input_method_scim.h',
++        '<(DEPTH)/xwalk/ime/tizen-scim/scim_bridge.cc',
++        '<(DEPTH)/xwalk/ime/tizen-scim/scim_bridge.h',
++      ],
++      'dependencies': [
++        '../build/linux/system.gyp:scim',
++      ],
++      'export_dependent_settings': [
++        '../build/linux/system.gyp:scim',
++      ],
++    }],
+   ],
+ }
+diff --git src/ui/base/ime/input_method_factory.cc src/ui/base/ime/input_method_factory.cc
+index 018823f..812c0a5 100644
+--- src/ui/base/ime/input_method_factory.cc
++++ src/ui/base/ime/input_method_factory.cc
+@@ -13,6 +13,8 @@
+ #include "base/win/metro.h"
+ #include "ui/base/ime/input_method_imm32.h"
+ #include "ui/base/ime/input_method_tsf.h"
++#elif defined(OS_TIZEN_MOBILE)
++#include "xwalk/ime/tizen-scim/input_method_scim.h"
+ #else
+ #include "ui/base/ime/fake_input_method.h"
+ #endif
+@@ -45,6 +47,8 @@ InputMethod* CreateInputMethod(internal::InputMethodDelegate* delegate,
+   return new InputMethodIBus(delegate);
+ #elif defined(OS_WIN)
+   return CreateInputMethodWinInternal(delegate, widget);
++#elif defined(OS_TIZEN_MOBILE)
++  return new InputMethodScim(delegate);
+ #else
+   return new FakeInputMethod(delegate);
+ #endif
+-- 
+1.7.9.5
+

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -15,6 +15,7 @@ Source1004:     install_into_pkginfo_db.py
 Patch1:         %{name}-1.29-do-not-look-for-gtk2-when-using-aura.patch
 Patch2:         %{name}-1.29-look-for-pvr-libGLESv2.so.patch
 Patch3:         %{name}-1.29-revert-nss-commits.patch
+Patch4:         %{name}-1.29-include-tizen-ime-files.patch
 
 BuildRequires:  bison
 BuildRequires:  bzip2-devel
@@ -88,6 +89,7 @@ cp -a src/xwalk/LICENSE LICENSE.xwalk
 %patch1
 %patch2
 %patch3 -p1
+%patch4
 
 %build
 


### PR DESCRIPTION
Crosswalk needs to be integrated with Tizen input framework,
so that users could e.g., enter text into input field element.
This CL integrates chromium input method system with Tizen IME
using SCIM / ISF (Input Service Framework) interfaces. SCIM is
running as a daemon and communicates with clients over socket.
Whenever client is asking to show input panel (VKB), input panel
is shown and key presses are sent back to the client over socket.
