### PR TITLE
[Android] Generate chrome version for the frontend url of devtools

### DIFF
--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -21,6 +21,7 @@
 #include "jni/XWalkDevToolsServer_jni.h"
 #include "net/socket/unix_domain_socket_posix.h"
 #include "ui/base/resource/resource_bundle.h"
+#include "xwalk/chrome_version.h"
 
 namespace {
 
@@ -29,8 +30,7 @@ namespace {
 // Currently, the chrome version is hardcoded because of this dependancy.
 const char kFrontEndURL[] =
     "http://chrome-devtools-frontend.appspot.com/static/%s/devtools.html";
-// TODO(girish): Get version from build system.
-const char kChromeVersion[] = "28.0.1500.36";
+const char kChromeVersion[] = CHROME_VERSION_STRING;
 
 // Delegate implementation for the devtools http handler on android. A new
 // instance of this gets created each time devtools is enabled.

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -208,6 +208,7 @@
           'dependencies':[
             'xwalk_core_jar_jni',
             'xwalk_core_native_jni',
+            'generate_chrome_version', # for devtools frontend url
           ],
         }],
         ['OS=="win" and win_use_allocator_shim==1', {
@@ -307,6 +308,35 @@
           },
           'includes': [ '../build/grit_action.gypi' ],
         },
+      ],
+    },
+    {
+      'target_name': 'generate_chrome_version',
+      'type': 'none',
+      'variables': {
+        'generator_py_path': '<(DEPTH)/chrome/tools/build/version.py',
+        'chrome_version_file': '<(DEPTH)/chrome/VERSION',
+        'input_version_header_file' : '<(DEPTH)/chrome/version.h.in',
+      },
+      'actions': [
+        {
+          'action_name': 'chrome_version',
+          'inputs': [
+            '<(chrome_version_file)',
+            '<(input_version_header_file)',
+          ],
+          'outputs':[
+            '<(SHARED_INTERMEDIATE_DIR)/xwalk/chrome_version.h',
+          ],
+          'action': [
+            'python',
+            '<(generator_py_path)',
+            '-f', '<(chrome_version_file)',
+            '-i', '<(input_version_header_file)',
+            '<@(_outputs)',
+          ],
+          'message': 'Generating chrome version header file: @<(_outputs)',
+        }
       ],
     },
     {


### PR DESCRIPTION
Instead of hard-coding the chrome version in devtools server, we generate the
correct chrome version automatically from chrome version information.

BUG=https://github.com/crosswalk-project/crosswalk/issues/687
