### PR TITLE
[Mac] Fix build

### DIFF
--- a/extensions/extension_process/xwalk_extension_process_main.cc
+++ b/extensions/extension_process/xwalk_extension_process_main.cc
@@ -4,7 +4,7 @@
 
 #include "xwalk/extensions/extension_process/xwalk_extension_process_main.h"
 
-#if defined(OS_POSIX)
+#if defined(OS_LINUX)
 #include <signal.h>
 #include <sys/prctl.h>
 #endif
@@ -23,7 +23,7 @@ int XWalkExtensionProcessMain(const content::MainFunctionParams& parameters) {
   // FIXME(jeez): This fixes the zombie-process-on-^C issue that we are facing
   // on Linux. However, we must find a cleaner way of doing this, perhaps using
   // something from Chromium and ensuring this process dies when its parent die.
-#if defined(OS_POSIX)
+#if defined(OS_LINUX)
   prctl(PR_SET_PDEATHSIG, SIGTERM);
 #endif
 


### PR DESCRIPTION
Use <sys/prctl.h> and prctl() only on Linux (OS_LINUX) and not Posix (OS_POSIX).

This seems to be the way Chromium guards the items.
