### PR TITLE
[Android] Implement default xwalk client in runtime core.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import android.webkit.WebSettings;
 import android.widget.FrameLayout;
 
+import org.xwalk.core.client.XWalkDefaultClient;
 import org.xwalk.core.client.XWalkDefaultDownloadListener;
 import org.xwalk.core.client.XWalkDefaultNavigationHandler;
 import org.xwalk.core.client.XWalkDefaultWebChromeClient;
@@ -73,6 +74,9 @@ public class XWalkView extends FrameLayout {
                         FrameLayout.LayoutParams.MATCH_PARENT,
                         FrameLayout.LayoutParams.MATCH_PARENT));
 
+
+        // Set default XWalkDefaultClient.
+        setXWalkClient(new XWalkDefaultClient(context, this));
         // Set default XWalkWebChromeClient and DownloadListener. The default actions
         // are provided via the following clients if special actions are not needed.
         setXWalkWebChromeClient(new XWalkDefaultWebChromeClient(context, this));

--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultClient.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultClient.java
@@ -1,0 +1,81 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.client;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.net.http.SslError;
+import android.net.Uri;
+import android.os.Message;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+import android.widget.FrameLayout;
+
+import org.xwalk.core.R;
+import org.xwalk.core.SslErrorHandler;
+import org.xwalk.core.XWalkClient;
+import org.xwalk.core.XWalkView;
+
+public class XWalkDefaultClient extends XWalkClient {
+
+    // Strings for displaying Dialog.
+    private static String mAlertTitle;
+    private static String mSslAlertTitle;
+    private static String mOKButton;
+    private static String mCancelButton;
+
+    private Context mContext;
+    private AlertDialog mDialog;
+    private XWalkView mView;
+
+    public XWalkDefaultClient(Context context, XWalkView view) {
+        mContext = context;
+        mView = view;
+    }
+
+    @Override
+    public void onReceivedError(XWalkView view, int errorCode,
+            String description, String failingUrl) {
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mContext);
+        dialogBuilder.setTitle(android.R.string.dialog_alert_title)
+                .setMessage(description)
+                .setCancelable(false)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                });
+        mDialog = dialogBuilder.create();
+        mDialog.show();
+    }
+
+    @Override
+    public void onReceivedSslError(XWalkView view, SslErrorHandler handler,
+            SslError error) {
+        final SslErrorHandler sslHandler = handler;
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mContext);
+        dialogBuilder.setTitle(R.string.ssl_alert_title)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        sslHandler.proceed();
+                        dialog.dismiss();
+                    }
+                })
+                .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        sslHandler.cancel();
+                        dialog.cancel();
+                    }
+                });
+        mDialog = dialogBuilder.create();
+        mDialog.show();
+    }
+}

--- a/runtime/android/java/strings/android_xwalk_strings.grd
+++ b/runtime/android/java/strings/android_xwalk_strings.grd
@@ -17,6 +17,9 @@
       <message desc="Prompt for Downloading no permission toast [CHAR-LIMIT=32]" name="IDS_DOWNLOAD_NO_PERMISSION_TOAST">
         No permission to write, abort.
       </message>
+      <message desc="Title for the Ssl Alert dialog [CHAR-LIMIT=32]" name="IDS_SSL_ALERT_TITLE">
+        Ssl Alert
+      </message>
     </messages>
   </release>
 


### PR DESCRIPTION
1  Add the Ssl alert title to the file of android_xwalk_strings.grd.
2  Create a new class XWalkDefaultClient extended from class XWalkClient.
3  Create the method of onReceivedError() to handle the process of receiving error.
4  Create the method of onReceivedSslError() to handle the process of receiving ssl error.
