### PR TITLE
[WiDi API] First commit for Presentation API implementation

### DIFF
--- a/experimental/presentation/presentation.gypi
+++ b/experimental/presentation/presentation.gypi
@@ -1,0 +1,9 @@
+{
+  'sources': [
+    'presentation_api.js',
+    'presentation_display_manager.cc',
+    'presentation_display_manager.h',
+    'presentation_extension.cc',
+    'presentation_extension.h',
+  ],
+}

--- a/experimental/presentation/presentation_api.js
+++ b/experimental/presentation/presentation_api.js
@@ -1,0 +1,72 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+var internal = requireNative("internal");
+internal.setupInternalExtension(extension);
+
+var DISPLAY_AVAILABLE_CHANGE_EVENT = "displayavailablechange";
+var _listeners = {}; // Listeners of display available change event
+var _displayAvailable = false;
+
+function addEventListener(name, callback, useCapture /* ignored */) {
+  if (!_listeners[name])
+  	_listeners[name] = [];
+  _listeners[name].push(callback);
+}
+
+function removeEventListener(name, callback) {
+  if (_listeners[name]) {
+  	var index = _listeners[name].indexOf(callback);
+  	if (index != -1)
+	  _listeners[name].splice(index, 1);
+  }
+}
+
+function handleDisplayAvailableChange(isAvailable) {
+	if (_displayAvailable != isAvailable) {
+		_displayAvailable = isAvailable;
+		if (!_listeners[DISPLAY_AVAILABLE_CHANGE_EVENT])
+			return;
+    var length = _listeners[DISPLAY_AVAILABLE_CHANGE_EVENT].length;
+		for (var i = 0; i < length; ++i) {
+			_listeners[DISPLAY_AVAILABLE_CHANGE_EVENT][i].apply(null, null);
+		}
+	}
+}
+
+extension.setMessageListener(function(json) {
+  var msg = JSON.parse(json);
+  if (msg.cmd == "DisplayAvailableChange") {
+    setTimeout(function() {
+      handleDisplayAvailableChange(msg.data);
+    }, 0);
+  } else {
+    console.error("Invalid message : " + msg.cmd);
+  }
+})
+
+exports.addEventListener = addEventListener;
+exports.removeEventListener = removeEventListener;
+exports.__defineSetter__("on" + DISPLAY_AVAILABLE_CHANGE_EVENT,
+  function(callback) {
+	  if (callback)
+	    addEventListener(DISPLAY_AVAILABLE_CHANGE_EVENT, callback);
+	  else
+	    removeEventListener(DISPLAY_AVAILABLE_CHANGE_EVENT,
+                          this.ondisplayavailablechange);
+  }
+);
+
+exports.__defineGetter__("displayAvailable", function() {
+  // If there is at least one listener registered to listen the display available
+  // change, we can rely on the _displayAvailable flag. Otherwise, we need to
+  // send a sync message to query the availability flag from browser process
+  // each time.
+  if (!_listeners[DISPLAY_AVAILABLE_CHANGE_EVENT] ||
+      _listeners[DISPLAY_AVAILABLE_CHANGE_EVENT].length == 0) {
+    var res = extension.internal.sendSyncMessage("QueryDisplayAvailability");
+    _displayAvailable = res == "true" ? true : false;
+  }
+  return _displayAvailable;
+});

--- a/experimental/presentation/presentation_apitest.cc
+++ b/experimental/presentation/presentation_apitest.cc
@@ -1,0 +1,101 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/test/xwalk_extensions_test_base.h"
+
+#include "xwalk/extensions/browser/xwalk_extension_service.h"
+#include "xwalk/extensions/common/xwalk_extension.h"
+#include "xwalk/experimental/presentation/presentation_display_manager.h"
+#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/test/base/in_process_browser_test.h"
+#include "xwalk/test/base/xwalk_test_utils.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
+#include "ui/gfx/display.h"
+
+using xwalk::extensions::XWalkExtension;
+using xwalk::extensions::XWalkExtensionInstance;
+using xwalk::extensions::XWalkExtensionService;
+using xwalk::experimental::PresentationDisplayManager;
+
+namespace xwalk {
+namespace experimental {
+
+class PresentationExtensionTest : public XWalkExtensionsTestBase {
+ public:
+  // Simulate a new secondary display is arrived from system.
+  void AttachDisplay(const gfx::Display& d) {
+    PresentationDisplayManager::GetForTesting()->AddSecondaryDisplay(d);
+  }
+
+  // Simulate a secondray display is removed from system.
+  void DetachDisplay(const gfx::Display& d) {
+    PresentationDisplayManager::GetForTesting()->RemoveSecondaryDisplay(d);
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(PresentationExtensionTest, DisplayAvailable) {
+  content::RunAllPendingInMessageLoop();
+  GURL url = GetExtensionsTestURL(
+      base::FilePath().AppendASCII("presentation_api"),
+      base::FilePath().AppendASCII("display_available.html"));
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  xwalk_test_utils::NavigateToURL(runtime(), url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}
+
+IN_PROC_BROWSER_TEST_F(PresentationExtensionTest, DisplayAvailableChange) {
+  content::RunAllPendingInMessageLoop();
+  GURL url = GetExtensionsTestURL(
+      base::FilePath().AppendASCII("presentation_api"),
+      base::FilePath().AppendASCII("display_available_change.html"));
+
+  gfx::Display display1(100);
+  gfx::Display display2(200);
+
+  {
+    // Case 1: When the first secondary display is attached, the event
+    // displayavailablechange will be fired.
+    string16 expected_title = ASCIIToUTF16("True:1");
+    content::TitleWatcher title_watcher(
+        runtime()->web_contents(), expected_title);
+    xwalk_test_utils::NavigateToURL(runtime(), url);
+    AttachDisplay(display1);
+    EXPECT_EQ(expected_title, title_watcher.WaitAndGetTitle());
+  }
+
+  {
+    // Case 2: When the second secondary display is attached, the event
+    // displayavailablechange will not be fired.
+    string16 expected_title = ASCIIToUTF16("True:1");
+    AttachDisplay(display2);
+    content::RunAllPendingInMessageLoop();
+    const string16& real_title = runtime()->web_contents()->GetTitle();
+    EXPECT_EQ(expected_title, real_title);
+  }
+
+  {
+    // Case 3: When one of secondary displays is detached, the event
+    // displayavailablechange also won't be fired.
+    string16 expected_title = ASCIIToUTF16("True:1");
+    DetachDisplay(display1);
+    content::RunAllPendingInMessageLoop();
+    const string16& real_title = runtime()->web_contents()->GetTitle();
+    EXPECT_EQ(expected_title, real_title);
+  }
+
+  {
+    // Case 4: when the last secondary display is detached, the event
+    // displayavailablechange  event will be fired.
+    string16 expected_title = ASCIIToUTF16("False:1");
+    content::TitleWatcher title_watcher(
+        runtime()->web_contents(), expected_title);
+    DetachDisplay(display2);
+    EXPECT_EQ(expected_title, title_watcher.WaitAndGetTitle());
+  }
+}
+
+}  // namespace experimental
+}  // namespace xwalk

--- a/experimental/presentation/presentation_apitest.gypi
+++ b/experimental/presentation/presentation_apitest.gypi
@@ -1,0 +1,5 @@
+{
+  'sources': [
+    'presentation_apitest.cc',
+  ],
+}

--- a/experimental/presentation/presentation_display_manager.cc
+++ b/experimental/presentation/presentation_display_manager.cc
@@ -1,0 +1,96 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/experimental/presentation/presentation_display_manager.h"
+
+#include "base/command_line.h"
+#include "content/public/browser/browser_thread.h"
+
+using content::BrowserThread;
+
+namespace xwalk {
+namespace experimental {
+
+// This static variable is only for testing based on the fact there is at most
+// one PresentationDisplayManager instance created at runtime.
+static PresentationDisplayManager* g_display_manager = NULL;
+
+PresentationDisplayManager::PresentationDisplayManager()
+    : initialized_(false),
+      observers_(new ObserverListThreadSafe<Observer>()) {
+  DCHECK(g_display_manager == NULL);
+  g_display_manager = this;
+}
+
+PresentationDisplayManager::~PresentationDisplayManager() {
+  DCHECK(g_display_manager);
+  g_display_manager = NULL;
+}
+
+// static
+PresentationDisplayManager* PresentationDisplayManager::GetForTesting() {
+  return g_display_manager;
+}
+
+void PresentationDisplayManager::EnsureInitialized() {
+  if (!BrowserThread::CurrentlyOn(BrowserThread::UI)) {
+    BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
+        base::Bind(&PresentationDisplayManager::EnsureInitialized,
+                   base::Unretained(this)));
+    return;
+  }
+
+  if (initialized_)
+    return;
+
+  // TODO(hmin): Add platform-specific code for initializing display manager.
+
+  initialized_ = true;
+}
+
+void PresentationDisplayManager::AddObserver(Observer* obs) {
+  observers_->AddObserver(obs);
+}
+
+void PresentationDisplayManager::RemoveObserver(Observer* obs) {
+  observers_->RemoveObserver(obs);
+}
+
+void PresentationDisplayManager::AddSecondaryDisplay(
+    const gfx::Display& display) {
+  secondary_displays_.push_back(display);
+  // Notify its observers when the first secondary display is added.
+  if (secondary_displays_.size() == 1)
+    observers_->Notify(&Observer::OnDisplayAvailabilityChanged, true);
+}
+
+void PresentationDisplayManager::RemoveSecondaryDisplay(
+    const gfx::Display& display) {
+  std::vector<gfx::Display>::iterator it = secondary_displays_.begin();
+  for (; it != secondary_displays_.end(); ++it)
+    if (it->id() == display.id()) break;
+
+  if (it == secondary_displays_.end())
+    return;
+
+  secondary_displays_.erase(it);
+  // Notify its observers when the last secondary display is removed.
+  if (secondary_displays_.size() == 0)
+    observers_->Notify(&Observer::OnDisplayAvailabilityChanged, false);
+}
+
+gfx::Display PresentationDisplayManager::GetDisplayInfo(int display_id) {
+  gfx::Display ret;
+  std::vector<gfx::Display>::iterator it = secondary_displays_.begin();
+  for (; it != secondary_displays_.end(); ++it)
+    if (it->id() != display_id) continue;
+
+  if (it != secondary_displays_.end())
+    ret = *it;
+
+  return ret;
+}
+
+}  // namespace experimental
+}  // namespace xwalk

--- a/experimental/presentation/presentation_display_manager.h
+++ b/experimental/presentation/presentation_display_manager.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXPERIMENTAL_PRESENTATION_PRESENTATION_DISPLAY_MANAGER_H_
+#define XWALK_EXPERIMENTAL_PRESENTATION_PRESENTATION_DISPLAY_MANAGER_H_
+
+#include <vector>
+
+#include "base/memory/ref_counted.h"
+#include "base/observer_list_threadsafe.h"
+#include "ui/gfx/display.h"
+
+namespace xwalk {
+namespace experimental {
+
+// A presentation display manager is responsible for retrieving the secondary
+// displays from system and notifying the secondary display arrival/removal
+// event to its observers.
+class PresentationDisplayManager {
+ public:
+  class Observer {
+   public:
+    virtual ~Observer() {}
+
+    // Called when the availability of presentation display is changed. The
+    // presentation display is available when the first secondary display
+    // connected, and unavailable when the last secondary display is
+    // disconnected.
+    virtual void OnDisplayAvailabilityChanged(bool is_available) = 0;
+  };
+
+  static PresentationDisplayManager* GetForTesting();
+
+  PresentationDisplayManager();
+  virtual ~PresentationDisplayManager();
+
+  // Ensure the display manager is initialized correctly. Can be called on
+  // any thread.
+  virtual void EnsureInitialized();
+
+  // Add/remove an observer for display availability change.
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+
+  // Called on UI thread to retrieve all connected secondary displays.
+  std::vector<gfx::Display> GetSecondaryDisplays() const {
+    return secondary_displays_;
+  }
+
+  // Called on UI thread to retrieve the secondary display info.
+  gfx::Display GetDisplayInfo(int display_id);
+
+ private:
+  friend class PresentationExtensionTest;
+
+  // Add/remove the seconary display.
+  void AddSecondaryDisplay(const gfx::Display& display);
+  void RemoveSecondaryDisplay(const gfx::Display& display);
+
+  std::vector<gfx::Display> secondary_displays_;
+
+  // Indicate if the display manager gets initialized.
+  bool initialized_;
+
+  // The observer can be added on any thread.
+  scoped_refptr<ObserverListThreadSafe<Observer> > observers_;
+};
+
+}  // namespace experimental
+}  // namespace xwalk
+
+#endif  // XWALK_EXPERIMENTAL_PRESENTATION_PRESENTATION_DISPLAY_MANAGER_H_

--- a/experimental/presentation/presentation_extension.cc
+++ b/experimental/presentation/presentation_extension.cc
@@ -1,0 +1,126 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/experimental/presentation/presentation_extension.h"
+
+#include <string>
+
+#include "base/json/json_writer.h"
+#include "base/memory/scoped_ptr.h"
+#include "base/stl_util.h"
+#include "base/values.h"
+#include "content/public/browser/browser_thread.h"
+#include "ipc/ipc_message.h"
+#include "xwalk/experimental/presentation/presentation_display_manager.h"
+
+// This will be generated from presentation_api.js.
+extern const char kSource_presentation_api[];
+
+namespace xwalk {
+namespace experimental {
+
+namespace {
+
+const char kQueryDisplayAvailabilityCmd[] = "QueryDisplayAvailability";
+
+}
+
+using content::BrowserThread;
+using extensions::XWalkExtension;
+using extensions::XWalkExtensionInstance;
+
+PresentationExtension::PresentationExtension()
+  : display_available_(false) {
+  set_name("navigator.experimental.presentation");
+
+  display_manager_.reset(new PresentationDisplayManager);
+  display_manager_->EnsureInitialized();
+  display_manager_->AddObserver(this);
+}
+
+PresentationExtension::~PresentationExtension() {
+  display_manager_->RemoveObserver(this);
+  display_manager_.reset();
+}
+
+const char* PresentationExtension::GetJavaScriptAPI() {
+  return kSource_presentation_api;
+}
+
+XWalkExtensionInstance* PresentationExtension::CreateInstance() {
+  return new PresentationInstance(this);
+}
+
+void PresentationExtension::AddInstance(PresentationInstance* instance) {
+  instance_list_.push_back(instance);
+}
+
+void PresentationExtension::RemoveInstance(PresentationInstance* instance) {
+  std::vector<PresentationInstance*>::iterator it;
+  for (it = instance_list_.begin(); it != instance_list_.end(); ++it)
+    if ((*it) == instance) break;
+
+  if (it != instance_list_.end())
+    instance_list_.erase(it);
+}
+
+void PresentationExtension::OnDisplayAvailabilityChanged(bool is_available) {
+  if (display_available_ == is_available)
+    return;
+
+  display_available_ = is_available;
+
+  for (std::vector<PresentationInstance*>::iterator it = instance_list_.begin();
+      it != instance_list_.end(); ++it) {
+    (*it)->OnDisplayAvailabilityChanged(display_available_);
+  }
+}
+
+//////////////////////////////////////////////////////////////////
+//  PresentationInstance
+//////////////////////////////////////////////////////////////////
+PresentationInstance::PresentationInstance(PresentationExtension* extension)
+  : extension_(extension) {
+  extension_->AddInstance(this);
+}
+
+PresentationInstance::~PresentationInstance() {
+  extension_->RemoveInstance(this);
+}
+
+void PresentationInstance::OnDisplayAvailabilityChanged(bool is_available) {
+  // Dispatch display availabe change to renderer process.
+  base::DictionaryValue value;
+  value.SetString("cmd", "DisplayAvailableChange");
+  value.SetBoolean("data", is_available);
+
+  // Convert the value to JSON-format string.
+  std::string json;
+  base::JSONWriter::Write(&value, &json);
+
+  scoped_ptr<StringValue> message(new StringValue(json));
+  PostMessageToJS(scoped_ptr<base::Value>(message.release()));
+}
+
+void PresentationInstance::HandleMessage(scoped_ptr<base::Value> msg) {
+  NOTIMPLEMENTED();
+}
+
+void PresentationInstance::HandleSyncMessage(scoped_ptr<base::Value> msg) {
+  scoped_ptr<base::Value> response;
+  std::string cmd;
+  if (!msg->GetAsString(&cmd) && cmd != kQueryDisplayAvailabilityCmd) {
+    LOG(WARNING) << "Invalid command received.";
+    response.reset(base::Value::CreateNullValue());
+  } else  {
+    response.reset(base::Value::CreateStringValue(
+            extension_->display_available() ? "true" : "false"));
+  }
+
+  SendSyncReplyToJS(response.Pass());
+}
+
+}  // namespace experimental
+}  // namespace xwalk
+

--- a/experimental/presentation/presentation_extension.h
+++ b/experimental/presentation/presentation_extension.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXPERIMENTAL_PRESENTATION_PRESENTATION_EXTENSION_H_
+#define XWALK_EXPERIMENTAL_PRESENTATION_PRESENTATION_EXTENSION_H_
+
+#include <vector>
+
+#include "xwalk/experimental/presentation/presentation_display_manager.h"
+#include "xwalk/extensions/common/xwalk_extension.h"
+
+namespace xwalk {
+namespace experimental {
+
+class PresentationInstance;
+
+// A XWalk extension for Presentation API spec implementation. It is placed
+// under experimental namespace since the spec is still in editor draft and
+// might be changed in future after a wider discussion.
+//
+// Presentation API spec: http://otcshare.github.io/presentation-spec/index.html
+class PresentationExtension : public extensions::XWalkExtension,
+                           public PresentationDisplayManager::Observer {
+ public:
+  PresentationExtension();
+  virtual ~PresentationExtension();
+
+  // XWalkExtension implementation.
+  virtual const char* GetJavaScriptAPI() OVERRIDE;
+  virtual extensions::XWalkExtensionInstance* CreateInstance() OVERRIDE;
+
+  void AddInstance(PresentationInstance* instance);
+  void RemoveInstance(PresentationInstance* instance);
+
+  bool display_available() const { return display_available_; }
+
+ private:
+  virtual void OnDisplayAvailabilityChanged(bool is_available) OVERRIDE;
+
+  std::vector<PresentationInstance*> instance_list_;
+
+  // All extension instances share one display manager.
+  scoped_ptr<PresentationDisplayManager> display_manager_;
+
+  // Indicates if there is an available display for showing presentation.
+  bool display_available_;
+};
+
+class PresentationInstance : public extensions::XWalkExtensionInstance {
+ public:
+  explicit PresentationInstance(PresentationExtension* extension);
+  virtual ~PresentationInstance();
+
+  virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
+  virtual void HandleSyncMessage(scoped_ptr<base::Value> msg) OVERRIDE;
+
+  void OnDisplayAvailabilityChanged(bool is_available);
+
+ private:
+  PresentationExtension* extension_;
+};
+
+}  // namespace experimental
+}  // namespace xwalk
+
+#endif  // XWALK_EXPERIMENTAL_PRESENTATION_PRESENTATION_EXTENSION_H_

--- a/extensions/test/data/presentation_api/display_available.html
+++ b/extensions/test/data/presentation_api/display_available.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+var presentation = navigator.experimental.presentation;
+if (!presentation.displayAvailable &&
+	  typeof(presentation.displayAvailable) == "boolean")
+	document.title = "Pass"
+else
+	document.title = "Fail"
+</script>
+</body>
+</html>

--- a/extensions/test/data/presentation_api/display_available_change.html
+++ b/extensions/test/data/presentation_api/display_available_change.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+var presentation = navigator.experimental.presentation;
+
+var availableCount = 0;
+var unavailableCount = 0;
+
+window.onload = function() {
+  presentation.addEventListener("displayavailablechange", function() {
+    if (presentation.displayAvailable) {
+      ++availableCount;
+      document.title = "True:" + availableCount;
+    }
+    else {
+      ++unavailableCount;
+      document.title = "False:" + unavailableCount;
+    }
+	});
+}
+
+</script>
+</body>
+</html>

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -21,6 +21,7 @@
 #include "xwalk/application/extension/application_extension.h"
 #include "xwalk/experimental/dialog/dialog_extension.h"
 #include "xwalk/extensions/common/xwalk_extension_server.h"
+#include "xwalk/experimental/presentation/presentation_extension.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/runtime/browser/devtools/remote_debugging_server.h"
 #include "xwalk/runtime/browser/runtime.h"
@@ -393,6 +394,8 @@ void XWalkBrowserMainParts::RegisterInternalExtensionsInServer(
       new ApplicationExtension(runtime_context()->GetApplicationSystem())));
   server->RegisterExtension(scoped_ptr<XWalkExtension>(
       new experimental::DialogExtension(runtime_registry_.get())));
+  server->RegisterExtension(scoped_ptr<XWalkExtension>(
+      new experimental::PresentationExtension));
 #endif
 }
 

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -140,6 +140,7 @@
       'includes': [
         'extensions/extensions.gypi',
         'experimental/dialog/dialog.gypi',
+        'experimental/presentation/presentation.gypi',
         'xwalk_jsapi.gypi',
       ],
       'msvs_settings': {

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -117,6 +117,7 @@
     ],
     'includes': [
       'extensions/extensions_browsertests.gypi',
+      'experimental/presentation/presentation_apitest.gypi',
       'xwalk_jsapi.gypi',
     ],
     'conditions': [


### PR DESCRIPTION
This commit is the first patch to implement Presentation API spec which
is intended to bring wireless display support into Web. Since the spec
is still in Editor spec and might be changed in future, it is placed
under `navigator.experimental.presentation` namespace.

This patch mainly provides an mock implementation for display available
related API with several test cases. Next step is to add Android port
and requestShow API implementation.

SPEC=http://otcshare.github.io/presentation-spec/index.html
BUG=https://github.com/crosswalk-project/crosswalk/issues/577
