### PR TITLE
[Tools] Add --cache-dir support to generate_gclient-xwalk.py.

### DIFF
--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -90,6 +90,9 @@ class GClientFileGenerator(object):
     if os.environ.get('XWALK_OS_ANDROID'):
       target_os = ['android']
       gclient_file.write('target_os = %s\n' % target_os)
+    if self._options.cache_dir:
+      gclient_file.write('cache_dir = %s\n' %
+                         pprint.pformat(self._options.cache_dir))
 
 
 def main():
@@ -98,6 +101,12 @@ def main():
   option_parser.add_option('--deps', default=None,
                            help='The deps file contains the dependencies path '
                                 'and url')
+  option_parser.add_option('--cache-dir',
+                           help='Set "cache_dir" in the .gclient file to this '
+                                'directory, so that all git repositories are '
+                                'cached there and shared across multiple '
+                                'clones.')
+
   # pylint: disable=W0612
   options, args = option_parser.parse_args()
 


### PR DESCRIPTION
The first patch is just groundwork to simplify the way we print "\n" (!)

The second one implements a way to set the "cache_dir" option in .gclient files
generated by our Python tool. It's particularly useful for our automation
setup, as it allows many machines to clone huge repositories like
blink-crosswalk in seconds.
