### PR TITLE
Fix change that went in by mistake

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -111,8 +111,8 @@ void SetXWalkCommandLineFlags() {
 #endif
 
   // Always use fixed layout and viewport tag.
-  // command_line->AppendSwitch(switches::kEnableFixedLayout);
-  // command_line->AppendSwitch(xswitches::kEnableViewport);
+  command_line->AppendSwitch(switches::kEnableFixedLayout);
+  command_line->AppendSwitch(xswitches::kEnableViewport);
 
   // Show feedback on touch.
   command_line->AppendSwitch(switches::kEnableGestureTapHighlight);


### PR DESCRIPTION
I'm testing things locally without those flags because they are broken
in my test environment. The problem was reported to Kenneth. Sorry for
the noise.
