### PR TITLE
Clean up in use of DesktopRootWindowHostXWalk

### DIFF
--- a/runtime/browser/ui/desktop_root_window_host_xwalk.cc
+++ b/runtime/browser/ui/desktop_root_window_host_xwalk.cc
@@ -1172,14 +1172,4 @@ void DesktopRootWindowHostXWalk::OnRootWindowHostCloseRequested(
   Close();
 }
 
-// static
-DesktopRootWindowHost* DesktopRootWindowHostXWalk::Create(
-    internal::NativeWidgetDelegate* native_widget_delegate,
-    DesktopNativeWidgetAura* desktop_native_widget_aura,
-    const gfx::Rect& initial_bounds) {
-  return new DesktopRootWindowHostXWalk(native_widget_delegate,
-                                        desktop_native_widget_aura,
-                                        initial_bounds);
-}
-
 }  // namespace views

--- a/runtime/browser/ui/desktop_root_window_host_xwalk.h
+++ b/runtime/browser/ui/desktop_root_window_host_xwalk.h
@@ -42,16 +42,14 @@ namespace corewm {
 class CursorManager;
 }
 
+// The DesktopRootWindowHost is basically the "desktop environment" per
+// screen, which is comparable to the X11 window manager concept.
+
 class VIEWS_EXPORT DesktopRootWindowHostXWalk : public DesktopRootWindowHost,
     public aura::RootWindowHost,
     public aura::RootWindowObserver,
     public base::MessageLoop::Dispatcher {
  public:
-  static DesktopRootWindowHost* Create(
-      internal::NativeWidgetDelegate* native_widget_delegate,
-      DesktopNativeWidgetAura* desktop_native_widget_aura,
-      const gfx::Rect& initial_bounds);
-
   DesktopRootWindowHostXWalk(
       internal::NativeWidgetDelegate* native_widget_delegate,
       DesktopNativeWidgetAura* desktop_native_widget_aura,


### PR DESCRIPTION
DesktopRootWindowHostXWalk serves as our "desktop environment"
per screen, which is somewhat similar to the X11 window manager
concept.

The specialized version of DesktopRootWindowHost (*XWalk) in
our situation, is created as part of DesktopNativeWidgetAura
initialization, but requires build system changes for doing so.

This patch cleans up part of the code, making it very clear
why we manually creates DesktopRootWindowHostXWalk and why it
works. It also removes the ::Create method which is called
by DesktopRootWindowHost because it is wrongly named, and if
named correctly it will conflict with the symbol from *X11.
