### PR TITLE
Use unsigned int for data comparison inside ASSERT_GE()

### DIFF
--- a/application/test/application_main_document_browsertest.cc
+++ b/application/test/application_main_document_browsertest.cc
@@ -61,7 +61,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationMainDocumentBrowserTest, MainDocument) {
   content::RunAllPendingInMessageLoop();
   const xwalk::RuntimeList& runtimes = RuntimeRegistry::Get()->runtimes();
   // At least the main document's runtime exist after launch.
-  ASSERT_GE(runtimes.size(), 1);
+  ASSERT_GE(runtimes.size(), 1U);
 
   Runtime* main_runtime = runtimes[0];
   xwalk::RuntimeContext* runtime_context = main_runtime->runtime_context();


### PR DESCRIPTION
Buildbot reports warning message "C4018: '>=' : signed/unsigned
mismatch" if the arguments of function ASSERT_GE() have different types.
Since runtimes.size() returns an unsigned int value, this CL changes the
other value to the same type for comparison.
