### PR TITLE
[Android] Integration manifest parser with app build tools.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -93,7 +93,7 @@ def CustomizeXML(options):
       os.makedirs(drawable_path)
     icon_file = os.path.basename(options.icon)
     icon_file = ReplaceInvalidChars(icon_file)
-    shutil.copyfile(options.icon, drawable_path + icon_file)
+    shutil.copyfile(options.icon, os.path.join(drawable_path, icon_file))
     icon_name = os.path.splitext(icon_file)[0]
     AddAttribute(xmldoc, 'application',
                  'android:icon', '@drawable/%s' % icon_name)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import optparse
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+
+def Clean(name):
+  if os.path.exists(name):
+    shutil.rmtree(name)
+  if os.path.isfile(name + '.apk'):
+    os.remove(name + '.apk')
+
+
+class TestMakeApk(unittest.TestCase):
+  def setUp(self):
+    target_dir = os.path.join(options.build_dir,
+                              options.target,
+                              'xwalk_app_template')
+    if os.path.exists(target_dir):
+      os.chdir(target_dir)
+    else:
+      unittest.SkipTest('xwalk_app_template folder doesn\'t exist. '
+                        'Skipping all tests in make_apk_test.py')
+
+  def testName(self):
+    proc = subprocess.Popen(['python', 'make_apk.py',
+                             '--package=org.xwalk.example'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The APK name is required!') != -1)
+    Clean('Example')
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example'],
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The APK name is required!') == -1)
+    Clean('Example')
+
+  def testPackage(self):
+    proc = subprocess.Popen(['python', 'make_apk.py',
+                             '--name=Example'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The package name is required!') != -1)
+    Clean('Example')
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example'],
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The package name is required!') == -1)
+    Clean('Example')
+
+  def testEntry(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The entry is required.') != -1)
+    Clean('Example')
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-url=http://www.intel.com'],
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The entry is required.') == -1)
+    Clean('Example')
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example', '--app-root=./'],
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The entry is required.') == -1)
+    Clean('Example')
+
+  def testIcon(self):
+    icon_path = './app_src/res/drawable-xhdpi/crosswalk.png'
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-url=http://www.intel.com',
+                             '--icon=%s' % icon_path],
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(content.find('crosswalk'))
+    self.assertTrue(os.path.exists('Example/res/drawable'))
+    Clean('Example')
+
+  def testFullscreen(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-url=http://www.intel.com', '-f'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('Fullscreen'))
+    Clean('Example')
+
+  def testEnableRemoteDebugging(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-url=http://www.intel.com',
+                             '--enable-remote-debugging'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    activity = 'Example/src/org/xwalk/example/ExampleActivity.java'
+    with open(activity, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(activity))
+    self.assertTrue(content.find('setRemoteDebugging'))
+    Clean('Example')
+
+
+if __name__ == '__main__':
+  parser = optparse.OptionParser()
+  info = ('The build directory for xwalk.'
+          'Such as: --build-dir=src/out')
+  parser.add_option('--build-dir', help=info)
+  info = ('The build target for xwalk.'
+          'Such as: --target=Release')
+  parser.add_option('--target', help=info)
+  options, temp = parser.parse_args()
+  if len(sys.argv) == 1:
+    parser.print_help()
+    sys.exit(1)
+
+  del sys.argv[1:]
+  unittest.main(verbosity=2)

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -4,9 +4,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-""" 
-Parse json-format manifest configuration file and 
-provide the specific fields, which have to be integrated with 
+"""
+Parse JSON-format manifest configuration file and
+provide the specific fields, which have to be integrated with
 packaging tool(e.g. make_apk.py) to generate xml-format manifest file.
 
 Sample usage from shell script:
@@ -22,7 +22,7 @@ import sys
 class ManifestJsonParser(object):
   """ The class is used to parse json-format manifest file, recompose the fields
   and provide the field interfaces required by the packaging tool.
-  
+
   Args:
     input_path: the full path of the json-format manifest file.
   """
@@ -39,40 +39,32 @@ class ManifestJsonParser(object):
       raise Exception('Wrong keyword in json-format manifest file.')
     finally:
       input_file.close()
-   
+
   def _output_items(self):
-    """ The manifest field items are reorganized and returned as a 
+    """ The manifest field items are reorganized and returned as a
     dictionary to support single or multiple values of keys.
-    
+
     Returns:
-      A dictionary to the corresponding items. the dictionary keys are 
-      described as follows, the value is set to "" if the value of the 
-      key is not set. 
+      A dictionary to the corresponding items. the dictionary keys are
+      described as follows, the value is set to "" if the value of the
+      key is not set.
     app_name:         The application name.
     app_version:      The application version.
-    icon_path:        The path of icon.
+    icons:            An array of icons.
     app_url:          The url of application, e.g. hosted app.
     app_root:         The root path of the web, this flag allows to package
                       local web application as apk.
     app_local_path:   The relative path of entry file based on app_root,
-                      this flag should work with "--app-root" together. 
+                      this flag should work with "--app-root" together.
     required_version: The required crosswalk runtime version.
     plugin:           The plug-in information.
     fullscreen:       The fullscreen flag of the application.
-    """                
+    """
     ret_dict = {}
     ret_dict['app_name'] = self.data_src['name']
     ret_dict['app_version'] = self.data_src['version']
     file_path_prefix = os.path.split(self.input_path)[0]
-    origin_icon_path = file_path_prefix
-    # Get the relative path of icons.
-    for key in self.data_src['icons']:
-      icon_rel_path = (os.path.split(self.data_src['icons'][key]))[0]
-      if len(icon_rel_path) != 0:
-        icon_path = os.path.join(origin_icon_path, icon_rel_path)
-      else:
-        icon_path = origin_icon_path
-    ret_dict['icon_path'] = icon_path
+    ret_dict['icons'] = self.data_src['icons']
     app_root = file_path_prefix
     app_url = self.data_src['launch_path']
     if app_url.lower().startswith(('http', 'https')):
@@ -92,61 +84,61 @@ class ManifestJsonParser(object):
     return ret_dict
 
   def ShowItems(self):
-    """Show the processed results, it is used for command-line 
+    """Show the processed results, it is used for command-line
     internal debugging."""
     print "app_name: %s" % self.GetAppName()
     print "app_version: %s" % self.GetAppVersion()
-    print "icon_path: %s" % self.GetIconPath()
+    print "icons: %s" % self.GetIcons()
     print "app_url: %s" % self.GetAppUrl()
     print "app_root: %s" % self.GetAppRoot()
     print "app_local_path: %s" % self.GetAppLocalPath()
     print "required_version: %s" % self.GetRequiredVersion()
     print "plugins: %s" % self.GetPlugins()
     print "fullscreen: %s" % self.GetFullScreenFlag()
-    
+
   def GetAppName(self):
     """Return the application name."""
     return self.ret_dict['app_name']
-    
+
   def GetAppVersion(self):
     """Return the application version."""
     return self.ret_dict['app_version']
-    
-  def GetIconPath(self):
-    """Return the icon path."""
-    return self.ret_dict['icon_path']
-    
+
+  def GetIcons(self):
+    """Return the icons."""
+    return self.ret_dict['icons']
+
   def GetAppUrl(self):
     """Return the URL of the application."""
     return self.ret_dict['app_url']
-    
+
   def GetAppRoot(self):
     """Return the root path of the local web application."""
     return self.ret_dict['app_root']
-  
+
   def GetAppLocalPath(self):
     """Return the local relative path of the local web application."""
     return self.ret_dict['app_local_path']
-    
+
   def GetRequiredVersion(self):
     """Return the required crosswalk runtime version."""
     return self.ret_dict['required_version']
-  
+
   def GetPlugins(self):
     """Return the plug-in path and file name."""
     return self.ret_dict['plugin']
-      
+
   def GetFullScreenFlag(self):
     """Return the set fullscreen flag of the application."""
     return self.ret_dict['fullscreen']
-  
-    
+
+
 def main():
   """Respond to command mode and show the processed field values."""
   parser = optparse.OptionParser()
   info = ('The input json-format file name. Such as: '
           '--jsonfile=manifest.json')
-  parser.add_option('-j', '--jsonfile', action='store', dest='jsonfile', 
+  parser.add_option('-j', '--jsonfile', action='store', dest='jsonfile',
                     help=info)
   opts, _ = parser.parse_args()
   json_parser = ManifestJsonParser(opts.jsonfile)


### PR DESCRIPTION
1. Add "--manifest=/path/to/manifest/file" support in make_apk.py
2. Adjust the icon API in the manifest parser, it shoud provide all
    information of the icon from the manifest.
3. Fix the icon path incorrect issue for "--icon" option.
4. Add unit test for make_apk.py, run it through following steps:
   - Switch to the outside of "src" directory.
   - Run the command "python src/xwalk/app/tools/android/make_apk_test.py
     --build-dir=src/out --target=Release"
