### PR TITLE
[Android] Implement APIs for external extensions

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
@@ -1,0 +1,114 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.app.runtime.extension;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import java.lang.reflect.Method;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.xwalk.app.runtime.CrossPackageWrapper;
+
+/**
+ * This class is to encapsulate the reflection detail of
+ * invoking XWalkExtension class in the shared library APK.
+ *
+ * Each external extension should inherit this class and implements
+ * below methods. It's created and registered by runtime side via the
+ * configuration information in extensions-config.json.
+ */
+public class XWalkExtensionClient extends CrossPackageWrapper {
+
+    private final static String EXTENSION_CLASS_NAME = "org.xwalk.runtime.extension.XWalkExtensionClientImpl";
+    private Object mInstance;
+    private Method mGetExtensionName;
+    private Method mGetJsApi;
+    private Method mPostMessage;
+
+    protected XWalkExtensionContextClient mContext;
+
+    public XWalkExtensionClient(String name, String jsApi, XWalkExtensionContextClient context) {
+        super(context.getActivity(), EXTENSION_CLASS_NAME, null /* ExceptionHalder */, String.class, String.class,
+                context.getInstance().getClass(), Object.class);
+        mContext = context;
+        mInstance = this.createInstance(name, jsApi, context.getInstance(), this);
+
+        mGetExtensionName = lookupMethod("getExtensionName");
+        mGetJsApi = lookupMethod("getJsApi");
+        mPostMessage = lookupMethod("postMessage", String.class);
+    }
+
+    /**
+     * Get the extension name which is set when it's created.
+     */
+    public final String getExtensionName() {
+        return (String)invokeMethod(mGetExtensionName, mInstance);
+    }
+
+    /**
+     * Get the JavaScript stub code which is set when it's created.
+     */
+    public final String getJsApi() {
+        return (String)invokeMethod(mGetJsApi, mInstance);
+    }
+
+    /**
+     * Called when this app is onResume.
+     */
+    public void onResume() {
+    }
+
+    /**
+     * Called when this app is onPause.
+     */
+    public void onPause() {
+    }
+
+    /**
+     * Called when this app is onDestroy.
+     */
+    public void onDestroy() {
+    }
+
+    /**
+     * Tell extension that one activity exists so that it can know the result
+     * of the exit code.
+     */
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    }
+
+    /**
+     * JavaScript calls into Java code. The message is handled by
+     * the extension implementation. The inherited classes should
+     * override and add its implementation.
+     * @param message the message from JavaScript code.
+     */
+    public void onMessage(String message) {
+    }
+
+    /**
+     * Synchronized JavaScript calls into Java code. Similar to
+     * onMessage. The only difference is it's a synchronized
+     * message.
+     * @param message the message from JavaScript code.
+     */
+    public String onSyncMessage(String message) {
+        return "";
+    }
+
+    /**
+     * Post messages to JavaScript via extension's context.
+     * It's used by child classes to post message from Java side
+     * to JavaScript side.
+     * @param message the message to be passed to Javascript.
+     */
+    public final void postMessage(String message) {
+        invokeMethod(mPostMessage, mInstance, message);
+    }
+}

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionContextClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionContextClient.java
@@ -1,0 +1,66 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.app.runtime.extension;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.util.AttributeSet;
+import android.widget.FrameLayout;
+
+import java.lang.reflect.Method;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.xwalk.app.runtime.CrossPackageWrapper;
+
+/**
+ * This is the extension context used by external extensions. It'll be created
+ * by runtime side.
+ */
+public final class XWalkExtensionContextClient extends CrossPackageWrapper {
+    private final static String EXTENSION_CLASS_NAME =
+            "org.xwalk.runtime.extension.XWalkExtensionContextWrapper";
+    private Object mInstance;
+    private Method mGetContext;
+    private Method mGetActivity;
+
+    /**
+     * It's called by runtime side.
+     */
+    public XWalkExtensionContextClient(Activity activity, Object instance) {
+        super(activity, EXTENSION_CLASS_NAME, null, String.class, String.class,
+                instance.getClass());
+
+        mInstance = instance;
+        mGetActivity = lookupMethod("getActivity");
+        mGetContext = lookupMethod("getContext");
+    }
+
+    /**
+     * Get the current Android Activity. Used by XWalkExtensionClient.
+     * @return the current Android Activity.
+     */
+    public Activity getActivity() {
+        return (Activity) invokeMethod(mGetActivity, mInstance);
+    }
+
+    /**
+     * Get the current Android Context. Used by XWalkExtensionClient.
+     * @return the current Android Context.
+     */
+    public Context getContext() {
+        return (Context) invokeMethod(mGetContext, mInstance);
+    }
+
+    /**
+     * Get the object of the runtime side.
+     * @return the object of the runtime side.
+     */
+    public Object getInstance() {
+        return mInstance;
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
@@ -57,15 +57,15 @@ public abstract class XWalkExtension {
     }
 
     /**
-     * JavaScript call into Java code. The message contains
-     * the JavaScript function name and parameters.
-     * The message format should be like below:
+     * JavaScript calls into Java code. The message is handled by
+     * the extension implementation. The inherited classes should
+     * override and add its implementation.
      * @param message the message from JavaScript code.
      */
     public abstract void onMessage(String message);
 
     /**
-     * Synchronized JavaScript call into Java code. Similar to
+     * Synchronized JavaScript calls into Java code. Similar to
      * onMessage. The only difference is it's a synchronized
      * message.
      * @param message the message from JavaScript code.
@@ -76,6 +76,8 @@ public abstract class XWalkExtension {
 
     /**
      * Post messages to JavaScript via extension's context.
+     * It's used by child classes to post message from Java side
+     * to JavaScript side.
      * @param message the message to be passed to Javascript.
      */
     public void postMessage(String message) {
@@ -101,7 +103,7 @@ public abstract class XWalkExtension {
     }
 
     /**
-     * Tell extension that one activity exists so that it can know the result code
+     * Tell extension that one activity exists so that it can know the result
      * of the exit code.
      */
     public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionClientImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionClientImpl.java
@@ -1,0 +1,105 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * The public base class of xwalk external extensions. It acts a bridge class from
+ * runtime to runtime client. The objects of class 'XWalkExtensionClient' in runtime
+ * client side will be passed into this class because we need to call its methods.
+ */
+public class XWalkExtensionClientImpl extends XWalkExtension {
+
+    private static final String TAG = XWalkExtensionClientImpl.class.getName();
+    private Object mExtensionClient;
+    private Method mOnMessage;
+    private Method mOnSyncMessage;
+    private Method mOnResume;
+    private Method mOnPause;
+    private Method mOnDestroy;
+    private Method mOnActivityResult;
+
+    public XWalkExtensionClientImpl(String name, String jsApi,
+            XWalkExtensionContextWrapper context, Object extensionClient) {
+        super(name, jsApi, context);
+
+        mExtensionClient = extensionClient;
+        mOnMessage = lookupMethod("onMessage", String.class);
+        mOnSyncMessage = lookupMethod("onSyncMessage", String.class);
+        mOnResume = lookupMethod("onResume");
+        mOnPause = lookupMethod("onPause");
+        mOnDestroy = lookupMethod("onDestroy");
+        mOnActivityResult = lookupMethod("onActivityResult", int.class, int.class, Intent.class);
+    }
+
+    @Override
+    public void onMessage(String message) {
+        invokeMethod(mOnMessage, mExtensionClient, message);
+    }
+
+    @Override
+    public String onSyncMessage(String message) {
+        return (String) invokeMethod(mOnSyncMessage, mExtensionClient, message);
+    }
+
+    @Override
+    public void onResume() {
+        invokeMethod(mOnResume, mExtensionClient);
+    }
+
+    @Override
+    public void onPause() {
+        invokeMethod(mOnPause, mExtensionClient);
+    }
+
+    @Override
+    public void onDestroy() {
+        invokeMethod(mOnDestroy, mExtensionClient);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        invokeMethod(mOnActivityResult, mExtensionClient, requestCode, resultCode, data);
+    }
+
+    private Method lookupMethod(String method, Class<?>... parameters) {
+        Class<?> clientClass = mExtensionClient.getClass();
+        try {
+            return clientClass.getMethod(method, parameters);
+        } catch (NoSuchMethodException e) {
+            handleException(e);
+        }
+        return null;
+    }
+
+    private static Object invokeMethod(Method method, Object instance, Object... parameters) {
+        Object result = null;
+        if (method != null) {
+            try {
+                result = method.invoke(instance, parameters);
+            } catch (IllegalArgumentException e) {
+                handleException(e);
+            } catch (IllegalAccessException e) {
+                handleException(e);
+            } catch (InvocationTargetException e) {
+                handleException(e);
+            } catch (NullPointerException e) {
+                handleException(e);
+            }
+        }
+        return result;
+    }
+
+    private static void handleException(Exception e) {
+        Log.e(TAG, "Error in calling methods of external extensions. " + e.toString());
+        e.printStackTrace();
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextWrapper.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextWrapper.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension;
+
+import android.app.Activity;
+import android.content.Context;
+
+/**
+ * This is a public class to provide context for extensions.
+ * It'll be shared by all extensions.
+ */
+public class XWalkExtensionContextWrapper extends XWalkExtensionContext {
+    private XWalkExtensionContext mOriginContext;
+
+    public XWalkExtensionContextWrapper(XWalkExtensionContext context) {
+        mOriginContext = context;
+    }
+
+    public Object registerExtension(XWalkExtension extension) {
+        return mOriginContext.registerExtension(extension);
+    }
+
+    public void unregisterExtension(XWalkExtension extension) {
+        mOriginContext.unregisterExtension(extension);
+    }
+
+    public void postMessage(XWalkExtension extension, String message) {
+        mOriginContext.postMessage(extension, message);
+    }
+
+    public Context getContext() {
+        return mOriginContext.getContext();
+    }
+
+    public Activity getActivity() {
+        return mOriginContext.getActivity();
+    }
+}


### PR DESCRIPTION
Similar to native extensions system, we need to allow web developers
or others to write their own extensions. Due to the shared mode, there
are some client classes in runtime client side which are used by
external extensions.
1. XWalkExtensionClient: the base class for external extensions.
2. XWalkExtensionContextClient: the context to be used by extensions to
   help get the context.
3. Configuration system: define a configuration system to specify what
   kind of extensions to be loaded and created by crosswalk.

So for web developers, an external extension is implemented with below steps:
1. Write the JavaScript code stub same as the native extension system.
2. A new class inherited from XWalkExtensionClient implements the methods
used by JavaScript.
3. Configure the extension in extensions-config.json, like:
[
 {
   "name": "myextension",
   "class": "com.example.MyExtension",
   "js_api": "myextension.js"
 }
}

Web developers don't have to create and register their extensions. Instead,
crosswalk runtime will load and create them according to the configuration
system.
