### PR TITLE
Update the documentation about Sync Messages

### DIFF
--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -68,7 +68,8 @@ class XWalkExtensionInstance {
   virtual void HandleMessage(scoped_ptr<base::Value> msg) = 0;
 
   // Allow to handle synchronous messages sent from JavaScript code. Renderer
-  // will block until this function returns.
+  // will block until SendSyncReplyToJS is called with the reply. Note that
+  // it may be called from "outside" of the HandleSyncMessage call.
   virtual void HandleSyncMessage(scoped_ptr<base::Value> msg);
 
   void SetPostMessageCallback(
@@ -87,6 +88,7 @@ class XWalkExtensionInstance {
     post_message_.Run(msg.Pass());
   }
 
+  // Unblocks the renderer waiting on a SyncMessage.
   void SendSyncReplyToJS(scoped_ptr<base::Value> reply) {
     send_sync_reply_.Run(reply.Pass());
   }

--- a/extensions/public/XW_Extension_SyncMessage.h
+++ b/extensions/public/XW_Extension_SyncMessage.h
@@ -19,7 +19,9 @@ extern "C" {
 //
 // XW_INTERNAL_SYNC_MESSAGING_INTERFACE: allow JavaScript code to send a
 // synchronous message to extension code and block until response is
-// available.
+// available. The response is made available by calling the SetSyncReply
+// function, that can be done from outside the context of the SyncMessage
+// handler.
 //
 
 #define XW_INTERNAL_SYNC_MESSAGING_INTERFACE_1 \


### PR DESCRIPTION
Now it is made clear that replies to Sync Messages can be sent after
the handler of the call has returned.

This is valid because we can only have one Sync Message going on at
any time (the renderer is blocking).
