### PR TITLE
[Android] Support shared library mode for XWalkRuntime when using Window...

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -74,7 +74,7 @@ public class XWalkContent extends FrameLayout {
                 mContentsClientBridge.getInterceptNavigationDelegate());
 
         // Initialize mWindow which is needed by content
-        mWindow = new WindowAndroid(xwView.getActivity());
+        mWindow = new WindowAndroid(xwView.getActivity(), xwView.getViewContext());
 
         // Initialize ContentView.
         mContentView = ContentView.newInstance(getContext(), mWebContents, mWindow);

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -22,12 +22,14 @@ public class XWalkView extends FrameLayout {
     private XWalkContent mContent;
     private XWalkDevToolsServer mDevToolsServer;
     private Activity mActivity;
+    private Context mContext;
 
     public XWalkView(Context context, Activity activity) {
         super(context, null);
 
         // Make sure mActivity is initialized before calling 'init' method.
         mActivity = activity;
+        mContext = context;
         init(context, null);
     }
 
@@ -43,12 +45,17 @@ public class XWalkView extends FrameLayout {
         return null;
     }
 
+    public Context getViewContext() {
+        return mContext;
+    }
+
     /**
      * Constructors for inflating via XML.
      */
     public XWalkView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
+        mContext = context;
         init(context, attrs);
     }
 


### PR DESCRIPTION
...Android.

XWalkRuntime in shared mode requires WindowAndroid to have a share library context
to get resources in shared library.  Use the library context to construct WindowAndroid
in XWalkView.

BUG=https://github.com/crosswalk-project/crosswalk/issues/678 , 666
