### PR TITLE
[Android] Don't add permissions for runtime library

### DIFF
--- a/runtime/android/runtimelib/AndroidManifest.xml
+++ b/runtime/android/runtimelib/AndroidManifest.xml
@@ -15,7 +15,4 @@
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.WAKE_LOCK"/>
 </manifest>


### PR DESCRIPTION
Since it's used by web app, the permissions are declared and requested
by web app APKs. Remove them in runtime lib apk.

BUG=#480
