### PR TITLE
[Android] Fix the invalid arguments issue in XWalkRuntimeClient.onActivi...

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
@@ -170,7 +170,7 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
      * @param data the data to contain the result data
      */
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        invokeMethod(mOnActivityResult, requestCode, resultCode, data);
+        invokeMethod(mOnActivityResult, mInstance, requestCode, resultCode, data);
     }
 
     /**


### PR DESCRIPTION
...tyResult.

Missing the instance argument in onActivityResult, this causes exception while
onActivityResult is called.

BUG=https://github.com/crosswalk-project/crosswalk/issues/732
