### PR TITLE
[Android] Handle exceptions during the cross package invoking

### DIFF
--- a/app/android/app_hello_world/res/values/strings.xml
+++ b/app/android/app_hello_world/res/values/strings.xml
@@ -9,6 +9,10 @@ found in the LICENSE file.
 <resources>
     <string name="download_from_url">Direct Download</string>
     <string name="download_from_store">Install From Store</string>
-    <string name="download_dialog_title">CrossWalk Runtime Not Found</string>
-    <string name="download_dialog_msg">Please install &quot;CrossWalk Runtime Library&quot; first.</string>
+    <string name="dialog_title_update_runtime_lib">Update for CrossWalk Runtime Library is required</string>
+    <string name="dialog_message_update_runtime_lib">Please update &quot;CrossWalk Runtime Library&quot; first.</string>
+    <string name="dialog_title_update_runtime_lib_warning">Update for CrossWalk Runtime Library is available</string>
+    <string name="dialog_message_update_runtime_lib_warning">An update is recommended for &quot;CrossWalk Runtime Library&quot;.</string>
+    <string name="dialog_title_install_runtime_lib">CrossWalk Runtime Library not found</string>
+    <string name="dialog_message_install_runtime_lib">Please install &quot;CrossWalk Runtime Library&quot; first.</string>
 </resources>

--- a/app/android/app_hello_world/src/org/xwalk/app/hello/world/HelloWorldActivity.java
+++ b/app/android/app_hello_world/src/org/xwalk/app/hello/world/HelloWorldActivity.java
@@ -24,7 +24,7 @@ public class HelloWorldActivity extends XWalkRuntimeActivityBase {
             getRuntimeView().loadAppFromUrl("file:///android_asset/index.html");
         } else {
             TextView msgText = new TextView(this);
-            msgText.setText(R.string.download_dialog_msg);
+            msgText.setText(R.string.dialog_message_install_runtime_lib);
             msgText.setTextSize(36);
             msgText.setTextColor(Color.BLACK);
             setContentView(msgText);

--- a/app/android/app_template/res/values/strings.xml
+++ b/app/android/app_template/res/values/strings.xml
@@ -9,6 +9,10 @@ found in the LICENSE file.
 <resources>
     <string name="download_from_url">Direct Download</string>
     <string name="download_from_store">Install From Store</string>
-    <string name="download_dialog_title">CrossWalk Runtime Not Found</string>
-    <string name="download_dialog_msg">Please install &quot;CrossWalk Runtime Library&quot; first.</string>
+    <string name="dialog_title_update_runtime_lib">Update for CrossWalk Runtime Library is required</string>
+    <string name="dialog_message_update_runtime_lib">Please update &quot;CrossWalk Runtime Library&quot; first.</string>
+    <string name="dialog_title_update_runtime_lib_warning">Update for CrossWalk Runtime Library is available</string>
+    <string name="dialog_message_update_runtime_lib_warning">An update is recommended for &quot;CrossWalk Runtime Library&quot;.</string>
+    <string name="dialog_title_install_runtime_lib">CrossWalk Runtime Library not found</string>
+    <string name="dialog_message_install_runtime_lib">Please install &quot;CrossWalk Runtime Library&quot; first.</string>
 </resources>

--- a/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
+++ b/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
@@ -24,7 +24,7 @@ public class AppTemplateActivity extends XWalkRuntimeActivityBase {
             getRuntimeView().loadAppFromUrl("file:///android_asset/index.html");
         } else {
             TextView msgText = new TextView(this);
-            msgText.setText(R.string.download_dialog_msg);
+            msgText.setText(R.string.dialog_message_install_runtime_lib);
             msgText.setTextSize(36);
             msgText.setTextColor(Color.BLACK);
             setContentView(msgText);

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/CrossPackageWrapper.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/CrossPackageWrapper.java
@@ -60,11 +60,8 @@ public abstract class CrossPackageWrapper {
             } catch (IllegalAccessException e) {
                 handleException(e);
             } catch (InvocationTargetException e) {
-                e.printStackTrace();
                 handleException(e);
             }
-        } else {
-            handleException("No matched constructor found");
         }
         return ret;
     }
@@ -96,7 +93,6 @@ public abstract class CrossPackageWrapper {
         } catch (NoSuchMethodException e) {
             handleException(e);
         }
-        handleException("No match method found");
         return null;
     }
     

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeLibraryException.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeLibraryException.java
@@ -1,0 +1,50 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.app.runtime;
+
+/**
+ * This class is to consolidate the exceptions happen when
+ * the runtime client is trying to invoke runtime library
+ * through reflection.
+ * 
+ * The exception will be set different label to identify which
+ * stage the exception happened in.
+ *
+ * The exception handler for the runtime client will take
+ * different action based on the type of the exception.
+ */
+public class XWalkRuntimeLibraryException extends Exception {
+    public final static int XWALK_RUNTIME_LIBRARY_NOT_INSTALLED = 1;
+    public final static int XWALK_RUNTIME_LIBRARY_NOT_UP_TO_DATE_CRITICAL = 2;
+    public final static int XWALK_RUNTIME_LIBRARY_NOT_UP_TO_DATE_WARNING = 3;
+    public final static int XWALK_RUNTIME_LIBRARY_LOAD_FAILED = 4;
+    public final static int XWALK_RUNTIME_LIBRARY_INVOKE_FAILED = 5;
+    
+    private int mType;
+    private Exception mOriginException;
+    
+    XWalkRuntimeLibraryException(int type, Exception originException) {
+        mType = XWALK_RUNTIME_LIBRARY_NOT_INSTALLED;
+        mOriginException = originException;
+    }
+    
+    XWalkRuntimeLibraryException(int type) {
+        mType = type;
+        mOriginException = null;
+    }
+    
+    XWalkRuntimeLibraryException() {
+        mType = XWALK_RUNTIME_LIBRARY_NOT_INSTALLED;
+        mOriginException = null;
+    }
+    
+    public int getType() {
+        return mType;
+    }
+    
+    public Exception getOriginException() {
+        return mOriginException;
+    }
+}


### PR DESCRIPTION
All exceptions was causing library-not-found dialog to show before.
It was not appropriate.

Now the implementation is that the exception are catagorized into:
1. Runtime library not installed;
2. Runtime library not up-to-date and it's critical;
3. Runtime library not up-to-date but bearable;
4. Error happening before version matching across package;
5. Error happening after version matching across package.
For the first four cases, a dialog will be shown to navigate user to
download/upgrade runtimelib with proper message.
For the last case, since the version is already matched, the exception
should be taken as a normal runtime exception and be thrown out.

BUG=https://github.com/crosswalk-project/crosswalk/issues/735
