### PR TITLE
[Android] Disabled the testClearHistory testReload temporarily.

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearHistoryTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearHistoryTest.java
@@ -7,12 +7,14 @@ package org.xwalk.core.xwview.test;
 
 import android.graphics.Bitmap;
 import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.core.XWalkClient;
 import org.xwalk.core.XWalkView;
 
 /**
- * Test suite for loadUrl().
+ * Test suite for clearHistory().
  */
 public class ClearHistoryTest extends XWalkViewTestBase {
     @Override
@@ -33,14 +35,19 @@ public class ClearHistoryTest extends XWalkViewTestBase {
         getXWalkView().setXWalkClient(new TestXWalkClient());
     }
 
-    @SmallTest
-    @Feature({"ClearHistory"})
+    // TODO(guangzhen): Since the device issue, it can not access the network,
+    // so disabled this test temporarily. It will be enabled later.
+    // @SmallTest
+    // @Feature({"ClearHistory"})
+    @DisabledTest
     public void testClearHistory() throws Throwable {
+        /*
         final String url1 = "http://www.webkit.org/";
         final String url2 = "http://www.baidu.com/";
         loadUrlSync(url1);
         loadUrlSync(url2);
         clearHistoryOnUiThread();
         assertFalse(canGoBackOnUiThread());
+        */
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ReloadTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ReloadTest.java
@@ -8,6 +8,7 @@ package org.xwalk.core.xwview.test;
 import android.graphics.Bitmap;
 import android.test.suitebuilder.annotation.SmallTest;
 
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.chromium.net.test.util.TestWebServer;
 import org.xwalk.core.XWalkClient;
@@ -47,9 +48,13 @@ public class ReloadTest extends XWalkViewTestBase {
         super.tearDown();
     }
 
-    @SmallTest
-    @Feature({"reload"})
-    public void testNormalUrl() throws Throwable {
+    // TODO(guangzhen): Since the device issue, it can not access the network,
+    // so disabled this test temporarily. It will be enabled later.
+    // @SmallTest
+    // @Feature({"reload"})
+    @DisabledTest
+    public void testReloadUrl() throws Throwable {
+        /*
         String title1 = "title1";
         String title2 = "title2";
         String html1 = "<html><head><title>" + title1 + "</title></head></html><body></body>";
@@ -61,5 +66,6 @@ public class ReloadTest extends XWalkViewTestBase {
         //TODO(guangzhen) When reload finished, immediately call getTitle will get wrong title.
         Thread.sleep(1000);
         assertEquals(title2, getTitleOnUiThread());
+        */
     }
 }


### PR DESCRIPTION
Since the device issue, it can not access the network,
so disabled testClearHistory & testReload temporarily.
It will be enabled later.
