### PR TITLE
Bump chromium-crosswalk in DEPS.xwalk.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '29.0.1547.57'
-chromium_crosswalk_point = '3652d52c45c51f1799330ea5c7cca3a99c909560'
+chromium_crosswalk_point = 'fd8359749ed6058563e047fed121fc07966d8f0d'
 blink_crosswalk_point = 'bcc7da6145656ada9a0840b3f3b73878ed99b389'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
Bring in the fix in chromium to support android sharing
runtime library. XWalkRuntime in shared mode requires
WindowAndroid to have a share library context to get
resources in shared library.
