### PR TITLE
[Runtime] Add Manifest keys handler mechanism

### DIFF
--- a/application/common/application.cc
+++ b/application/common/application.cc
@@ -25,6 +25,7 @@
 #include "xwalk/application/common/id_util.h"
 #include "xwalk/application/common/constants.h"
 #include "xwalk/application/common/manifest.h"
+#include "xwalk/application/common/manifest_handler.h"
 #include "content/public/common/url_constants.h"
 #include "url/url_util.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -199,6 +200,10 @@ bool Application::Init(string16* error) {
     return false;
 
   application_url_ = Application::GetBaseURLFromApplicationId(ID());
+
+  if (!ManifestHandlerRegistry::GetInstance()->ParseAppManifest(this, error))
+    return false;
+
   finished_parsing_manifest_ = true;
 #if defined(OS_TIZEN_MOBILE)
   appcore_context_ = tizen::AppcoreContext::Create();

--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -22,6 +22,7 @@
 #include "xwalk/application/common/manifest.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/install_warning.h"
+#include "xwalk/application/common/manifest_handler.h"
 #include "net/base/escape.h"
 #include "net/base/file_stream.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -55,6 +56,15 @@ scoped_refptr<Application> LoadApplication(
                                                              error);
   if (!application.get())
     return NULL;
+
+  std::vector<InstallWarning> warnings;
+  if (!ManifestHandlerRegistry::GetInstance()->ValidateAppManifest(
+          application, error, &warnings))
+    return NULL;
+  if (!warnings.empty()) {
+    LOG(WARNING) << "There are some warnings when validating the application "
+                 << application->ID();
+  }
 
   return application;
 }

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -1,0 +1,157 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handler.h"
+
+#include <set>
+
+#include "base/stl_util.h"
+
+namespace xwalk {
+namespace application {
+
+ManifestHandler::~ManifestHandler() {
+}
+
+bool ManifestHandler::Validate(scoped_refptr<const Application> application,
+                               std::string* error,
+                               std::vector<InstallWarning>* warnings) const {
+  return true;
+}
+
+bool ManifestHandler::AlwaysParseForType(Manifest::Type type) const {
+  return false;
+}
+
+bool ManifestHandler::AlwaysValidateForType(Manifest::Type type) const {
+  return false;
+}
+
+std::vector<std::string> ManifestHandler::PrerequisiteKeys() const {
+  return std::vector<std::string>();
+}
+
+ManifestHandlerRegistry* ManifestHandlerRegistry::registry_ = NULL;
+
+ManifestHandlerRegistry::ManifestHandlerRegistry(
+    const std::vector<ManifestHandler*>& handlers) {
+  for (std::vector<ManifestHandler*>::const_iterator it = handlers.begin();
+       it != handlers.end(); ++it) {
+    Register(*it);
+  }
+
+  ReorderHandlersGivenDependencies();
+}
+
+ManifestHandlerRegistry::~ManifestHandlerRegistry() {
+}
+
+// static
+ManifestHandlerRegistry* ManifestHandlerRegistry::GetInstance() {
+  if (!registry_) {
+    std::vector<ManifestHandler*> handlers;
+    // FIXME: Add manifest handlers here like this:
+    // handlers.push_back(new xxxHandler);
+
+    registry_ = new ManifestHandlerRegistry(handlers);
+  }
+  return registry_;
+}
+
+void ManifestHandlerRegistry::Register(ManifestHandler* handler) {
+  const std::vector<std::string>& keys = handler->Keys();
+  for (size_t i = 0; i < keys.size(); ++i) {
+    handlers_[keys[i]] = handler;
+  }
+}
+
+bool ManifestHandlerRegistry::ParseAppManifest(
+    scoped_refptr<Application> application, string16* error) {
+  std::map<int, ManifestHandler*> handlers_by_order;
+  for (ManifestHandlerMap::iterator iter = handlers_.begin();
+       iter != handlers_.end(); ++iter) {
+    ManifestHandler* handler = iter->second;
+    if (application->GetManifest()->HasPath(iter->first) ||
+        handler->AlwaysParseForType(application->GetType())) {
+      handlers_by_order[order_map_[handler]] = handler;
+    }
+  }
+  for (std::map<int, ManifestHandler*>::iterator iter =
+           handlers_by_order.begin();
+       iter != handlers_by_order.end(); ++iter) {
+    if (!(iter->second)->Parse(application, error))
+      return false;
+  }
+  return true;
+}
+
+bool ManifestHandlerRegistry::ValidateAppManifest(
+    scoped_refptr<const Application> application,
+    std::string* error,
+    std::vector<InstallWarning>* warnings) {
+  for (ManifestHandlerMap::iterator iter = handlers_.begin();
+       iter != handlers_.end(); ++iter) {
+    ManifestHandler* handler = iter->second;
+    if ((application->GetManifest()->HasPath(iter->first) ||
+         handler->AlwaysValidateForType(application->GetType())) &&
+        !handler->Validate(application, error, warnings))
+      return false;
+  }
+  return true;
+}
+
+// static
+void ManifestHandlerRegistry::SetInstanceForTesting(
+    ManifestHandlerRegistry* registry) {
+    registry_ = registry;
+}
+
+void ManifestHandlerRegistry::ReorderHandlersGivenDependencies() {
+  std::set<ManifestHandler*> unsorted_handlers;
+  for (ManifestHandlerMap::const_iterator iter = handlers_.begin();
+       iter != handlers_.end(); ++iter) {
+    unsorted_handlers.insert(iter->second);
+  }
+
+  int order = 0;
+  while (true) {
+    std::set<ManifestHandler*> next_unsorted_handlers;
+    for (std::set<ManifestHandler*>::const_iterator iter =
+             unsorted_handlers.begin();
+         iter != unsorted_handlers.end(); ++iter) {
+      ManifestHandler* handler = *iter;
+      const std::vector<std::string>& prerequisites =
+          handler->PrerequisiteKeys();
+      int unsatisfied = prerequisites.size();
+      for (size_t i = 0; i < prerequisites.size(); ++i) {
+        ManifestHandlerMap::const_iterator prereq_iter =
+            handlers_.find(prerequisites[i]);
+        CHECK(prereq_iter != handlers_.end())
+            << "Application manifest handler depends on unrecognized key "
+            << prerequisites[i];
+        // Prerequisite is in our map.
+        if (ContainsKey(order_map_, prereq_iter->second))
+          unsatisfied--;
+      }
+      if (unsatisfied == 0) {
+        order_map_[handler] = order;
+        order++;
+      } else {
+        // Put in the list for next time.
+        next_unsorted_handlers.insert(handler);
+      }
+    }
+    if (next_unsorted_handlers.size() == unsorted_handlers.size())
+      break;
+    unsorted_handlers.swap(next_unsorted_handlers);
+  }
+
+  // If there are any leftover unsorted handlers, they must have had
+  // circular dependencies.
+  CHECK_EQ(unsorted_handlers.size(), 0) << "Application manifest handlers have "
+                                        << "circular dependencies!";
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handler.h
+++ b/application/common/manifest_handler.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "base/memory/linked_ptr.h"
+#include "base/strings/string16.h"
+#include "xwalk/application/common/application.h"
+
+namespace xwalk {
+namespace application {
+
+class ManifestHandler {
+ public:
+  virtual ~ManifestHandler();
+
+  // Returns false in case of failure and sets writes error message
+  // in |error| if present.
+  virtual bool Parse(scoped_refptr<Application> application,
+                     string16* error) = 0;
+
+  // Returns false in case of failure and sets writes error message
+  // in |error| if present.
+  virtual bool Validate(scoped_refptr<const Application> application,
+                        std::string* error,
+                        std::vector<InstallWarning>* warnings) const;
+
+  // If false (the default), only parse the manifest if a registered
+  // key is present in the manifest. If true, always attempt to parse
+  // the manifest for this application type, even if no registered keys
+  // are present. This allows specifying a default parsed value for
+  // application that don't declare our key in the manifest.
+  virtual bool AlwaysParseForType(Manifest::Type type) const;
+
+  // Same as AlwaysParseForType, but for Validate instead of Parse.
+  virtual bool AlwaysValidateForType(Manifest::Type type) const;
+
+  // The list of keys that, if present, should be parsed before calling our
+  // Parse (typically, because our Parse needs to read those keys).
+  // Defaults to empty.
+  virtual std::vector<std::string> PrerequisiteKeys() const;
+
+  // The keys to register handler for (in Register).
+  virtual std::vector<std::string> Keys() const = 0;
+};
+
+class ManifestHandlerRegistry {
+ public:
+  ~ManifestHandlerRegistry();
+
+  static ManifestHandlerRegistry* GetInstance();
+
+  bool ParseAppManifest(
+       scoped_refptr<Application> application, string16* error);
+  bool ValidateAppManifest(scoped_refptr<const Application> application,
+                           std::string* error,
+                           std::vector<InstallWarning>* warnings);
+
+ private:
+  friend class ScopedTestingManifestHandlerRegistry;
+  explicit ManifestHandlerRegistry(
+       const std::vector<ManifestHandler*>& handlers);
+
+  // Register a manifest handler for keys, which are provided by Keys() method
+  // in ManifestHandler implementer.
+  void Register(ManifestHandler* handler);
+
+  void ReorderHandlersGivenDependencies();
+
+  // Sets a new global registry, for testing purposes.
+  static void SetInstanceForTesting(ManifestHandlerRegistry* registry);
+
+  typedef std::map<std::string, ManifestHandler*> ManifestHandlerMap;
+  typedef std::map<ManifestHandler*, int> ManifestHandlerOrderMap;
+
+  ManifestHandlerMap handlers_;
+
+  // Handlers are executed in order; lowest order first.
+  ManifestHandlerOrderMap order_map_;
+
+  static ManifestHandlerRegistry* registry_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLER_H_

--- a/application/common/manifest_handler_unittest.cc
+++ b/application/common/manifest_handler_unittest.cc
@@ -1,0 +1,318 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/memory/scoped_ptr.h"
+#include "base/stl_util.h"
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/manifest_handler.h"
+#include "xwalk/application/common/install_warning.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace xwalk {
+namespace application {
+
+namespace {
+
+std::vector<std::string> SingleKey(const std::string& key) {
+  return std::vector<std::string>(1, key);
+}
+
+}  // namespace
+
+class ScopedTestingManifestHandlerRegistry {
+ public:
+  ScopedTestingManifestHandlerRegistry(
+      const std::vector<ManifestHandler*>& handlers)
+      : registry_(
+          new ManifestHandlerRegistry(handlers)),
+        prev_registry_(ManifestHandlerRegistry::GetInstance()) {
+    ManifestHandlerRegistry::SetInstanceForTesting(registry_.get());
+  }
+
+  ~ScopedTestingManifestHandlerRegistry() {
+    ManifestHandlerRegistry::SetInstanceForTesting(prev_registry_);
+  }
+
+  scoped_ptr<ManifestHandlerRegistry> registry_;
+  ManifestHandlerRegistry* prev_registry_;
+};
+
+class ManifestHandlerTest : public testing::Test {
+ public:
+  class ParsingWatcher {
+   public:
+    // Called when a manifest handler parses.
+    void Record(const std::string& name) {
+      parsed_names_.push_back(name);
+    }
+
+    const std::vector<std::string>& parsed_names() {
+      return parsed_names_;
+    }
+
+    // Returns true if |name_before| was parsed before |name_after|.
+    bool ParsedBefore(const std::string& name_before,
+                      const std::string& name_after) {
+      size_t prev_iterator = parsed_names_.size();
+      size_t next_iterator = 0;
+      for (size_t i = 0; i < parsed_names_.size(); ++i) {
+        if (parsed_names_[i] == name_before)
+          prev_iterator = i;
+        if (parsed_names_[i] == name_after)
+          next_iterator = i;
+      }
+
+      if (prev_iterator < next_iterator)
+        return true;
+
+      return false;
+    }
+
+   private:
+    // The order of manifest handlers that we watched parsing.
+    std::vector<std::string> parsed_names_;
+  };
+
+  class TestManifestHandler : public ManifestHandler {
+   public:
+    TestManifestHandler(const std::string& name,
+                        const std::vector<std::string>& keys,
+                        const std::vector<std::string>& prereqs,
+                        ParsingWatcher* watcher)
+        : name_(name), keys_(keys), prereqs_(prereqs), watcher_(watcher) {
+    }
+
+    virtual ~TestManifestHandler() {}
+
+    virtual bool Parse(
+        scoped_refptr<Application> application, string16* error) OVERRIDE {
+      watcher_->Record(name_);
+      return true;
+    }
+
+    virtual std::vector<std::string> PrerequisiteKeys() const OVERRIDE {
+      return prereqs_;
+    }
+
+    virtual std::vector<std::string> Keys() const OVERRIDE {
+      return keys_;
+    }
+
+   protected:
+    std::string name_;
+    std::vector<std::string> keys_;
+    std::vector<std::string> prereqs_;
+    ParsingWatcher* watcher_;
+  };
+
+  class FailingTestManifestHandler : public TestManifestHandler {
+   public:
+    FailingTestManifestHandler(const std::string& name,
+                               const std::vector<std::string>& keys,
+                               const std::vector<std::string>& prereqs,
+                               ParsingWatcher* watcher)
+        : TestManifestHandler(name, keys, prereqs, watcher) {
+    }
+    virtual bool Parse(
+        scoped_refptr<Application> application, string16* error) OVERRIDE {
+      *error = ASCIIToUTF16(name_);
+      return false;
+    }
+  };
+
+  class AlwaysParseTestManifestHandler : public TestManifestHandler {
+   public:
+    AlwaysParseTestManifestHandler(const std::string& name,
+                                   const std::vector<std::string>& keys,
+                                   const std::vector<std::string>& prereqs,
+                                   ParsingWatcher* watcher)
+        : TestManifestHandler(name, keys, prereqs, watcher) {
+    }
+
+    virtual bool AlwaysParseForType(Manifest::Type type) const OVERRIDE {
+      return true;
+    }
+  };
+
+  class TestManifestValidator : public ManifestHandler {
+   public:
+    TestManifestValidator(bool return_value,
+                          bool always_validate,
+                          std::vector<std::string> keys)
+        : return_value_(return_value),
+          always_validate_(always_validate),
+          keys_(keys) {
+    }
+
+    virtual bool Parse(
+        scoped_refptr<Application> application, string16* error) OVERRIDE {
+      return true;
+    }
+
+    virtual bool Validate(
+        scoped_refptr<const Application> application,
+        std::string* error,
+        std::vector<InstallWarning>* warnings) const OVERRIDE {
+      return return_value_;
+    }
+
+    virtual bool AlwaysValidateForType(Manifest::Type type) const OVERRIDE {
+      return always_validate_;
+    }
+
+    virtual std::vector<std::string> Keys() const OVERRIDE {
+      return keys_;
+    }
+
+ protected:
+    bool return_value_;
+    bool always_validate_;
+    std::vector<std::string> keys_;
+  };
+};
+
+TEST_F(ManifestHandlerTest, DependentHandlers) {
+  std::vector<ManifestHandler*> handlers;
+  ParsingWatcher watcher;
+  std::vector<std::string> prereqs;
+  handlers.push_back(
+      new TestManifestHandler("A", SingleKey("a"), prereqs, &watcher));
+  handlers.push_back(
+      new TestManifestHandler("B", SingleKey("b"), prereqs, &watcher));
+  handlers.push_back(
+      new TestManifestHandler("J", SingleKey("j"), prereqs, &watcher));
+  handlers.push_back(
+      new AlwaysParseTestManifestHandler(
+          "K", SingleKey("k"), prereqs, &watcher));
+  prereqs.push_back("c.d");
+  std::vector<std::string> keys;
+  keys.push_back("c.e");
+  keys.push_back("c.z");
+  handlers.push_back(
+      new TestManifestHandler("C.EZ", keys, prereqs, &watcher));
+  prereqs.clear();
+  prereqs.push_back("b");
+  prereqs.push_back("k");
+  handlers.push_back(
+      new TestManifestHandler("C.D", SingleKey("c.d"), prereqs, &watcher));
+  ScopedTestingManifestHandlerRegistry registry(handlers);
+
+  base::DictionaryValue manifest;
+  manifest.SetString("name", "no name");
+  manifest.SetString("version", "0");
+  manifest.SetInteger("manifest_version", 2);
+  manifest.SetInteger("a", 1);
+  manifest.SetInteger("b", 2);
+  manifest.SetInteger("c.d", 3);
+  manifest.SetInteger("c.e", 4);
+  manifest.SetInteger("c.f", 5);
+  manifest.SetInteger("g", 6);
+  std::string error;
+  scoped_refptr<Application> application = Application::Create(
+      base::FilePath(),
+      Manifest::INVALID_TYPE,
+      manifest,
+      "",
+      &error);
+  EXPECT_TRUE(application.get());
+  // A, B, C.EZ, C.D, K
+  EXPECT_EQ(5u, watcher.parsed_names().size());
+  EXPECT_TRUE(watcher.ParsedBefore("B", "C.D"));
+  EXPECT_TRUE(watcher.ParsedBefore("K", "C.D"));
+  EXPECT_TRUE(watcher.ParsedBefore("C.D", "C.EZ"));
+}
+
+TEST_F(ManifestHandlerTest, FailingHandlers) {
+  scoped_ptr<ScopedTestingManifestHandlerRegistry> registry(
+      new ScopedTestingManifestHandlerRegistry(
+          std::vector<ManifestHandler*>()));
+  // Can't use ApplicationBuilder, because this application will fail to
+  // be parsed.
+  base::DictionaryValue manifest_a;
+  manifest_a.SetString("name", "no name");
+  manifest_a.SetString("version", "0");
+  manifest_a.SetInteger("manifest_version", 2);
+  manifest_a.SetInteger("a", 1);
+
+  // Succeeds when "a" is not recognized.
+  std::string error;
+  scoped_refptr<Application> application = Application::Create(
+      base::FilePath(),
+      Manifest::INVALID_TYPE,
+      manifest_a,
+      "",
+      &error);
+  EXPECT_TRUE(application.get());
+
+  // Register a handler for "a" that fails.
+  std::vector<ManifestHandler*> handlers;
+  ParsingWatcher watcher;
+  handlers.push_back(
+      new FailingTestManifestHandler(
+          "A", SingleKey("a"), std::vector<std::string>(), &watcher));
+  registry.reset();
+  registry.reset(new ScopedTestingManifestHandlerRegistry(handlers));
+
+  application = Application::Create(
+      base::FilePath(),
+      Manifest::INVALID_TYPE,
+      manifest_a,
+      "",
+      &error);
+  EXPECT_FALSE(application.get());
+  EXPECT_EQ("A", error);
+}
+
+TEST_F(ManifestHandlerTest, Validate) {
+  scoped_ptr<ScopedTestingManifestHandlerRegistry> registry(
+      new ScopedTestingManifestHandlerRegistry(
+          std::vector<ManifestHandler*>()));
+  base::DictionaryValue manifest;
+  manifest.SetString("name", "no name");
+  manifest.SetString("version", "0");
+  manifest.SetInteger("manifest_version", 2);
+  manifest.SetInteger("a", 1);
+  manifest.SetInteger("b", 2);
+  std::string error;
+  scoped_refptr<Application> application = Application::Create(
+      base::FilePath(),
+      Manifest::COMMAND_LINE,
+      manifest,
+      "",
+      &error);
+  EXPECT_TRUE(application.get());
+
+  std::vector<ManifestHandler*> handlers;
+  std::vector<InstallWarning> warnings;
+  // Always validates and fails.
+  handlers.push_back(
+      new TestManifestValidator(false, true, SingleKey("c")));
+  registry.reset();
+  registry.reset(new ScopedTestingManifestHandlerRegistry(handlers));
+  EXPECT_FALSE(
+      registry->registry_->ValidateAppManifest(application, &error, &warnings));
+
+  handlers.push_back(
+      new TestManifestValidator(false, false, SingleKey("c")));
+  registry.reset();
+  registry.reset(new ScopedTestingManifestHandlerRegistry(handlers));
+  EXPECT_TRUE(
+      registry->registry_->ValidateAppManifest(application, &error, &warnings));
+
+  // Validates "a" and fails.
+  handlers.push_back
+      (new TestManifestValidator(false, true, SingleKey("a")));
+  registry.reset();
+  registry.reset(new ScopedTestingManifestHandlerRegistry(handlers));
+  EXPECT_FALSE(
+      registry->registry_->ValidateAppManifest(application, &error, &warnings));
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -45,6 +45,8 @@
         'common/install_warning.h',
         'common/manifest.cc',
         'common/manifest.h',
+        'common/manifest_handler.cc',
+        'common/manifest_handler.h',
         'common/db_store.cc',
         'common/db_store.h',
         'common/db_store_sqlite_impl.cc',

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -62,6 +62,7 @@
       'application/common/application_unittest.cc',
       'application/common/application_file_util_unittest.cc',
       'application/common/id_util_unittest.cc',
+      'application/common/manifest_handler_unittest.cc',
       'application/common/manifest_unittest.cc',
       'application/common/db_store_sqlite_impl_unittest.cc',
       'runtime/common/xwalk_content_client_unittest.cc',


### PR DESCRIPTION
The key handler can parse specific member in manifest.json for more
information, and save these information into the Application object, by
this, it will be easier to use without parsing these information every
time. The mechanism also can treat dependence relationship between
Manifest keys, it make sure that a high priority key will be always
parsed before a low one, means that when parsing the low priority key,
all required information has been prepared yet.

The key handler also can validate if the key value is allowed for this
application.

All keys handlers should be registered in
RegisterApplicationManifestHandlers().
