### PR TITLE
[Android] Only put necessary files in official archive

### DIFF
--- a/tools/build/android/FILES.cfg
+++ b/tools/build/android/FILES.cfg
@@ -29,15 +29,15 @@
 FILES = [
   {
     'filename': 'apks/XWalkCoreShell.apk',
-    'buildtype': ['dev', 'official'],
+    'buildtype': ['dev'],
   },
   {
     'filename': 'apks/XWalkRuntimeShell.apk',
-    'buildtype': ['dev', 'official'],
+    'buildtype': ['dev'],
   },
   {
     'filename': 'apks/XWalkRuntimeClientShell.apk',
-    'buildtype': ['dev', 'official'],
+    'buildtype': ['dev'],
   },
   {
     'filename': 'apks/XWalkRuntimeLib.apk',


### PR DESCRIPTION
The official archive will only include:
1. Runtime Library apk;
2. Hello World apk;
3. Application template for developer.

BUG=https://github.com/crosswalk-project/crosswalk/issues/753
