### PR TITLE
[Android] Use 'jsapi' instead of 'js_api' in extensions-config.json

### DIFF
--- a/app/android/app_hello_world/assets/extensions-config.json
+++ b/app/android/app_hello_world/assets/extensions-config.json
@@ -2,5 +2,5 @@
   name:       "myextension",               // The name of external extension.
   class:      "org.package.MyExtension",   // The name of the class that implements the extension.
   version:    "0.1.0",                     // The version of the extension.
-  js_api:     "myextension.js"             // The path of the JavaScript code stub file.
+  jsapi:     "myextension.js"             // The path of the JavaScript code stub file.
 }]*/

--- a/app/android/app_template/assets/extensions-config.json
+++ b/app/android/app_template/assets/extensions-config.json
@@ -2,5 +2,5 @@
   name:       "myextension",               // The name of external extension.
   class:      "org.package.MyExtension",   // The name of the class that implements the extension.
   version:    "0.1.0",                     // The version of the extension.
-  js_api:     "myextension.js"             // The path of the JavaScript code stub file.
+  jsapi:     "myextension.js"             // The path of the JavaScript code stub file.
 }]*/

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
@@ -130,7 +130,7 @@ public class XWalkExtensionManager {
                 JSONObject jsonObject = jsonFeatures.getJSONObject(i);
                 String name = jsonObject.getString("name");
                 String className =  jsonObject.getString("class");
-                String jsApiFile = jsonObject.getString("js_api");
+                String jsApiFile = jsonObject.getString("jsapi");
 
                 // Load the content of the JavaScript file.
                 String jsApi;


### PR DESCRIPTION
Let's keep the consistency of using the jsapi. No need of '_'.
