### PR TITLE
XWalkExtensionClient: do not warn in expected situations

### DIFF
--- a/extensions/renderer/xwalk_extension_client.cc
+++ b/extensions/renderer/xwalk_extension_client.cc
@@ -62,9 +62,15 @@ bool XWalkExtensionClient::OnMessageReceived(const IPC::Message& message) {
 void XWalkExtensionClient::OnPostMessageToJS(int64_t instance_id,
     const base::ListValue& msg) {
   RunnerMap::const_iterator it = runners_.find(instance_id);
-  if (it == runners_.end() || !it->second) {
+  if (it == runners_.end()) {
     LOG(WARNING) << "Can't PostMessage to invalid Extension instance id: "
         << instance_id;
+    return;
+  }
+
+  if (!it->second) {
+    // See OnInstanceDestroyed(). This message could have arrived before
+    // we notified Server about its destruction, we can simply ignore it.
     return;
   }
 


### PR DESCRIPTION
Once XWalkExtensionClient decides to destroy an instance, it deletes
it but keeps it's id around waiting for server confirmation. The id is
associated with a NULL instance in the map.

When we send the DestroyInstance message to the server, it's already
marked that way in the client. So we may receive a pending PostMessage
from the server. In this case, we shouldn't warn, but simply ignore,
since there's no JS to send the message anymore.

We keep the warning for the case where after server confirmed the
destruction, we get another message. This will indicate a real problem
either in extension implementation or in the system.
