### PR TITLE
[Android] Fix a missed place when renaming js_api to jsapi

### DIFF
--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -225,7 +225,6 @@
         'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
           '<(PRODUCT_DIR)/xwalk_runtime_client_embedded_shell/assets/xwalk.pak',
-          '<(PRODUCT_DIR)/xwalk_runtime_client_embedded_shell/assets/js_api',
         ],
         'asset_location': '<(ant_build_out)/xwalk_runtime_client_embedded_shell/assets',
       },


### PR DESCRIPTION
It's caused by the conflict of pull request #658 and #759.
