### PR TITLE
[Android] Fix xwalk_runtime_lib_apk build failed on canary.

### DIFF
--- a/tools/prepare.py
+++ b/tools/prepare.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+import shutil
+import sys
+
+def Clean(dir_to_clean):
+  if os.path.isdir(dir_to_clean):
+    shutil.rmtree(dir_to_clean)
+
+
+def PrepareFromChromium(target_dir):
+  gyp_dir =  os.path.join(target_dir, 'scripts', 'gyp')
+  if not os.path.exists(gyp_dir):
+    os.makedirs(gyp_dir)
+  shutil.copytree('../build/android/gyp/util', os.path.join(gyp_dir, 'util'))
+  shutil.copy('../build/android/gyp/ant.py', gyp_dir)
+
+
+def PrepareFromXwalk(target_dir):
+  libs_dir = os.path.join(target_dir, 'libs')
+  if not os.path.exists(libs_dir):
+    os.makedirs(libs_dir)
+  src_dir = os.path.join(os.path.dirname(target_dir), 'lib.java')
+  jar_file_list = ['xwalk_app_runtime_activity_java.dex.jar',
+                   'xwalk_app_runtime_activity_java.jar',
+                   'xwalk_app_runtime_client_java.dex.jar',
+                   'xwalk_app_runtime_client_java.jar',
+                   'xwalk_core_java.dex.jar',
+                   'xwalk_core_java.jar']
+  for jar_file in jar_file_list:
+    shutil.copy(os.path.join(src_dir, jar_file), libs_dir)
+
+  native_libs_target_dir = os.path.join(target_dir, 'native_libs', 'libs')
+  native_libs_src_dir = os.path.join(os.path.dirname(target_dir),
+                                     'xwalk_runtime_lib_apk', 'libs')
+  shutil.copytree(native_libs_src_dir, native_libs_target_dir)
+
+  ant_dir =  os.path.join(target_dir, 'scripts', 'ant')
+  if not os.path.exists(ant_dir):
+    os.makedirs(ant_dir)
+  ant_file_list = ['./app/tools/android/ant/apk-codegen.xml',
+                   './app/tools/android/ant/apk-package.xml',
+                   './app/tools/android/ant/apk-package-resources.xml',
+                   './app/tools/android/ant/xwalk-debug.keystore']
+  for ant_file in ant_file_list:
+    shutil.copy(ant_file, ant_dir)
+
+  gyp_dir =  os.path.join(target_dir, 'scripts', 'gyp')
+  if not os.path.exists(gyp_dir):
+    os.makedirs(gyp_dir)
+  gyp_file_list = ['./app/tools/android/gyp/dex.py',
+                   './app/tools/android/gyp/finalize_apk.py',
+                   './app/tools/android/gyp/jar.py',
+                   './app/tools/android/gyp/javac.py']
+  for gyp_file in gyp_file_list:
+    shutil.copy(gyp_file, gyp_dir)
+
+  util_dir = os.path.join(gyp_dir, 'util')
+  if not os.path.exists(util_dir):
+    os.makedirs(util_dir)
+  shutil.copy('./app/tools/android/gyp/util/build_utils.py', util_dir)
+
+  app_src_dir = os.path.join(target_dir, 'app_src')
+  if not os.path.exists(app_src_dir):
+    os.makedirs(app_src_dir)
+  shutil.copy('./app/android/app_template/AndroidManifest.xml', app_src_dir)
+  app_src_folder_list = ['./app/android/app_template/assets',
+                         './app/android/app_template/res',
+                         './app/android/app_template/src']
+  for folder in app_src_folder_list:
+    shutil.copytree(folder, os.path.join(app_src_dir, os.path.basename(folder)))
+
+  packaging_tool_list = ['./app/tools/android/customize.py',
+                         './app/tools/android/make_apk.py',
+                         './app/tools/android/manifest_json_parser.py']
+  for packaging_tool in packaging_tool_list:
+    shutil.copy(packaging_tool, target_dir)
+
+
+def main(args):
+  if len(args) != 1:
+    print 'You must provide only one argument: folder to update'
+    return 1
+  target_dir = args[0]
+  Clean(target_dir)
+  PrepareFromChromium(target_dir)
+  PrepareFromXwalk(target_dir)
+
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv[1:]))

--- a/tools/tar.py
+++ b/tools/tar.py
@@ -5,7 +5,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import sys
 import tarfile
 
@@ -32,7 +31,6 @@ def main(args):
     tar.close()
   finally:
     os.chdir(cur_cwd)
-  shutil.rmtree(dir_to_tar)
 
 
 if __name__ == '__main__':

--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -92,81 +92,25 @@
       'includes': [ '../build/java_apk.gypi' ],
     },
     {
-      'target_name': 'prepare_xwalk_app_template_from_chromium',
-      'type': 'none',
-      'copies': [
-        {
-          'destination': '<(PRODUCT_DIR)/xwalk_app_template/scripts/gyp/',
-          'files': [
-            '../build/android/gyp/ant.py',
-            '../build/android/gyp/util/',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'prepare_xwalk_app_template_from_xwalk',
+      'target_name': 'prepare_xwalk_app_template',
       'type': 'none',
       'dependencies': [
-        'prepare_xwalk_app_template_from_chromium',
         'xwalk_app_template_apk',
         'xwalk_runtime_lib_apk',
       ],
-      'copies': [
+      'actions': [
         {
-          'destination': '<(PRODUCT_DIR)/xwalk_app_template/libs/',
-          'files': [
-            '<(PRODUCT_DIR)/lib.java/xwalk_app_runtime_activity_java.dex.jar',
-            '<(PRODUCT_DIR)/lib.java/xwalk_app_runtime_activity_java.jar',
-            '<(PRODUCT_DIR)/lib.java/xwalk_app_runtime_client_java.dex.jar',
-            '<(PRODUCT_DIR)/lib.java/xwalk_app_runtime_client_java.jar',
-            '<(PRODUCT_DIR)/lib.java/xwalk_core_java.jar',
+          'action_name': 'prepare_xwalk_app_template',
+          'inputs': [
+            'tools/prepare.py',
           ],
-        },
-        {
-          'destination': '<(PRODUCT_DIR)/xwalk_app_template/scripts/ant',
-          'files': [
-            './app/tools/android/ant/apk-codegen.xml',
-            './app/tools/android/ant/apk-package.xml',
-            './app/tools/android/ant/apk-package-resources.xml',
-            './app/tools/android/ant/xwalk-debug.keystore',
+          'outputs': [
+            # put an inexist file here to do this step every time.
+            '<(PRODUCT_DIR)/xwalk_app_template_1'
           ],
-        },
-        {
-          'destination': '<(PRODUCT_DIR)/xwalk_app_template/scripts/gyp/',
-          'files': [
-            './app/tools/android/gyp/dex.py',
-            './app/tools/android/gyp/finalize_apk.py',
-            './app/tools/android/gyp/jar.py',
-            './app/tools/android/gyp/javac.py',
-          ],
-        },
-        {
-          'destination': '<(PRODUCT_DIR)/xwalk_app_template/scripts/gyp/util/',
-          'files': [
-            './app/tools/android/gyp/util/build_utils.py',
-          ],
-        },
-        {
-          'destination': '<(PRODUCT_DIR)/xwalk_app_template/app_src/',
-          'files': [
-            './app/android/app_template/AndroidManifest.xml',
-            './app/android/app_template/assets',
-            './app/android/app_template/res',
-            './app/android/app_template/src',
-          ],
-        },
-        {
-          'destination': '<(PRODUCT_DIR)/xwalk_app_template/native_libs/',
-          'files': [
-            '<(PRODUCT_DIR)/xwalk_runtime_lib_apk/libs',
-          ],
-        },
-        {
-          'destination': '<(PRODUCT_DIR)/xwalk_app_template/',
-          'files': [
-            './app/tools/android/customize.py',
-            './app/tools/android/make_apk.py',
+          'action': [
+          'python', 'tools/prepare.py',
+            '<(PRODUCT_DIR)/xwalk_app_template'
           ],
         },
       ],
@@ -175,7 +119,7 @@
       'target_name': 'xwalk_app_template',
       'type': 'none',
       'dependencies': [
-        'prepare_xwalk_app_template_from_xwalk',
+        'prepare_xwalk_app_template',
       ],
       'actions': [
         {


### PR DESCRIPTION
Rewrite the "prepare_xwalk_app_template" target with python
due to a bug in gyp system, that "copies" action doesn't respect
the "dependencies".

BUG=https://github.com/crosswalk-project/crosswalk/issues/771
