### PR TITLE
[Android] Add onCloseWindow method to XWalkClient

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkClient.java
@@ -69,6 +69,13 @@ public class XWalkClient {
     }
 
     /**
+     * Notify the host application that a web page is closed by calling
+     * window.close().
+     */
+    public void onCloseWindow(XWalkView view) {
+    }
+
+    /**
      * Notify the host application that the XWalkView will load the resource
      * specified by the given url.
      *

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -214,6 +214,8 @@ public class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onCloseWindow() {
+        if (mXWalkClient != null)
+            mXWalkClient.onCloseWindow(mXWalkView);
     }
 
     @Override

--- a/runtime/android/java/src/org/xwalk/core/XWalkWebContentsDelegateAdapter.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkWebContentsDelegateAdapter.java
@@ -28,7 +28,8 @@ public class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
 
     @Override
     public void closeContents() {
-        // TODO: implement.
+        if (mXWalkContentsClient != null)
+            mXWalkContentsClient.onCloseWindow();
     }
 
     @Override


### PR DESCRIPTION
It allows the XWalkView consumer to have a chance to handle the
window.close() calling from web page by overriding the onCloseWindow
method.
