### PR TITLE
[Extensions] Pretty print for JS exceptions in the native code

### DIFF
--- a/extensions/extensions.gypi
+++ b/extensions/extensions.gypi
@@ -39,6 +39,8 @@
     'renderer/xwalk_remote_extension_runner.h',
     'renderer/xwalk_extension_client.cc',
     'renderer/xwalk_extension_client.h',
+    'renderer/xwalk_v8_utils.cc',
+    'renderer/xwalk_v8_utils.h',
   ],
   'conditions': [
     ['OS=="android"',{

--- a/extensions/renderer/xwalk_extension_module.cc
+++ b/extensions/renderer/xwalk_extension_module.cc
@@ -12,6 +12,7 @@
 #include "third_party/WebKit/public/web/WebFrame.h"
 #include "third_party/WebKit/public/web/WebScopedMicrotaskSuppression.h"
 #include "xwalk/extensions/renderer/xwalk_module_system.h"
+#include "xwalk/extensions/renderer/xwalk_v8_utils.h"
 
 namespace xwalk {
 namespace extensions {
@@ -165,7 +166,7 @@ void XWalkExtensionModule::LoadExtensionCode(
   callable_api_code->Call(context->Global(), argc, argv);
   if (try_catch.HasCaught()) {
     LOG(WARNING) << "Exception while loading JS API code for "
-                 << extension_name_;
+        << extension_name_ << ": " << ExceptionToString(try_catch);
   }
 }
 
@@ -186,7 +187,8 @@ void XWalkExtensionModule::HandleMessageFromNative(const base::Value& msg) {
   v8::TryCatch try_catch;
   message_listener->Call(context->Global(), 1, &v8_value);
   if (try_catch.HasCaught())
-    LOG(WARNING) << "Exception when running message listener";
+    LOG(WARNING) << "Exception when running message listener: "
+        << ExceptionToString(try_catch);
 }
 
 // static

--- a/extensions/renderer/xwalk_v8_utils.cc
+++ b/extensions/renderer/xwalk_v8_utils.cc
@@ -1,0 +1,33 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/renderer/xwalk_v8_utils.h"
+
+#include "base/strings/stringprintf.h"
+#include "v8/include/v8.h"
+
+namespace xwalk {
+namespace extensions {
+
+std::string ExceptionToString(const v8::TryCatch& try_catch) {
+  std::string str;
+  v8::HandleScope handle_scope;
+  v8::String::Utf8Value exception(try_catch.Exception());
+  v8::Local<v8::Message> message(try_catch.Message());
+  if (message.IsEmpty()) {
+    str.append(base::StringPrintf("%s\n", *exception));
+  } else {
+    v8::String::Utf8Value filename(message->GetScriptResourceName());
+    int linenum = message->GetLineNumber();
+    int colnum = message->GetStartColumn();
+    str.append(base::StringPrintf(
+        "%s:%i:%i %s\n", *filename, linenum, colnum, *exception));
+    v8::String::Utf8Value sourceline(message->GetSourceLine());
+    str.append(base::StringPrintf("%s\n", *sourceline));
+  }
+  return str;
+}
+
+}  // namespace extensions
+}  // namespace xwalk

--- a/extensions/renderer/xwalk_v8_utils.h
+++ b/extensions/renderer/xwalk_v8_utils.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_RENDERER_XWALK_V8_UTILS_H_
+#define XWALK_EXTENSIONS_RENDERER_XWALK_V8_UTILS_H_
+
+#include <string>
+
+namespace v8 {
+
+class TryCatch;
+
+}
+
+namespace xwalk {
+namespace extensions {
+
+// Helper function that makes v8 exceptions human readable.
+std::string ExceptionToString(const v8::TryCatch& try_catch);
+
+}  // namespace extensions
+}  // namespace xwalk
+
+#endif  // XWALK_EXTENSIONS_RENDERER_XWALK_V8_UTILS_H_

--- a/extensions/renderer/xwalk_v8tools_module.cc
+++ b/extensions/renderer/xwalk_v8tools_module.cc
@@ -6,6 +6,7 @@
 
 #include "base/logging.h"
 #include "third_party/WebKit/public/web/WebScopedMicrotaskSuppression.h"
+#include "xwalk/extensions/renderer/xwalk_v8_utils.h"
 
 namespace xwalk {
 namespace extensions {
@@ -44,7 +45,8 @@ void LifecycleTrackerCleanup(v8::Isolate* isolate,
   v8::TryCatch try_catch;
   v8::Handle<v8::Function>::Cast(function)->Call(context->Global(), 0, NULL);
   if (try_catch.HasCaught())
-    LOG(WARNING) << "Exception when running LifecycleTracker destructor.";
+    LOG(WARNING) << "Exception when running LifecycleTracker destructor: "
+        << ExceptionToString(try_catch);
 
   tracker->Dispose();
 }


### PR DESCRIPTION
Instead of just printing a warning, give the developer the line
number and possible a clue about what is going on.

Before we had:
[0926/203226:WARNING:xwalk_extension_module.cc(190)] Exception when running message listener.

Now we have:
[0926/203226:WARNING:xwalk_extension_module.cc(190)] Exception when running message listener: JS API code for xwalk.sysapps.raw_socket:430:11 ReferenceError: foobar is not defined
    foobar = 1;
