### PR TITLE
[Android] Disable Cross-Origin request by default.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -92,7 +92,14 @@ public class XWalkContent extends FrameLayout {
 
         mContentView.setDownloadDelegate(mContentsClientBridge);
 
-        mSettings = new XWalkSettings(getContext(), mWebContents, true);
+        // Set the third argument isAccessFromFileURLsGrantedByDefault to false, so that
+        // the members mAllowUniversalAccessFromFileURLs and mAllowFileAccessFromFileURLs
+        // won't be changed from false to true at the same time in the constructor of
+        // XWalkSettings class.
+        mSettings = new XWalkSettings(getContext(), mWebContents, false);
+        // Enable AllowFileAccessFromFileURLs, so that files under file:// path could be
+        // loaded by XMLHttpRequest.
+        mSettings.setAllowFileAccessFromFileURLs(true);
     }
 
     void doLoadUrl(String url) {

--- a/runtime/android/java/src/org/xwalk/core/XWalkSettings.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkSettings.java
@@ -32,8 +32,8 @@ public class XWalkSettings {
     private boolean mLoadsImagesAutomatically = true;
     private boolean mImagesEnabled = true;
     private boolean mJavaScriptEnabled = true;
-    private boolean mAllowUniversalAccessFromFileURLs = true;
-    private boolean mAllowFileAccessFromFileURLs = true;
+    private boolean mAllowUniversalAccessFromFileURLs = false;
+    private boolean mAllowFileAccessFromFileURLs = false;
     private boolean mJavaScriptCanOpenWindowsAutomatically = true;
     private boolean mSupportMultipleWindows = false;
     private boolean mAppCacheEnabled = true;


### PR DESCRIPTION
Cross-Origin request breaks the web security policy, only same-origin
request could be allowed by default.

BUG=https://github.com/crosswalk-project/crosswalk/issues/790
