### PR TITLE
[Android] Fix the issue of '--app-root' and '--app-local-path'

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -366,7 +366,9 @@ def main(argv):
                    'Please use "--package" option.')
     if not options.name:
       parser.error('The APK name is required! Pleaes use "--name" option.')
-    if not options.app_url and not options.app_root:
+    if not ((options.app_url and not options.app_root
+        and not options.app_local_path) or ((not options.app_url)
+            and options.app_root and options.app_local_path)):
       parser.error('The entry is required. If the entry is a remote url, '
                    'please use "--app-url" option; If the entry is local, '
                    'please use "--app-root" and '

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -74,23 +74,59 @@ class TestMakeApk(unittest.TestCase):
 
   def testEntry(self):
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
-                             '--package=org.xwalk.example'],
-                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    out, _ = proc.communicate()
-    self.assertTrue(out.find('The entry is required.') != -1)
-    Clean('Example')
-    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com'],
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The entry is required.') == -1)
+    self.assertTrue(os.path.exists('Example.apk'))
     Clean('Example')
+
+    test_entry_root = 'test_data/entry'
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-root=%s' % test_entry_root,
+                             '--app-local-path=index.html'],
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The entry is required.') == -1)
+    self.assertTrue(os.path.exists('Example.apk'))
+    Clean('Example')
+
+  def testEntryWithErrors(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The entry is required.') != -1)
+    self.assertFalse(os.path.exists('Example.apk'))
+    Clean('Example')
+
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-url=http://www.intel.com',
+                             '--app-root=.'],
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The entry is required.') != -1)
+    self.assertFalse(os.path.exists('Example.apk'))
+    Clean('Example')
+
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
                              '--package=org.xwalk.example', '--app-root=./'],
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
-    self.assertTrue(out.find('The entry is required.') == -1)
+    self.assertTrue(out.find('The entry is required.') != -1)
+    self.assertFalse(os.path.exists('Example.apk'))
+    Clean('Example')
+
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-local-path=index.html'],
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('The entry is required.') != -1)
+    self.assertFalse(os.path.exists('Example.apk'))
     Clean('Example')
 
   def testIcon(self):

--- a/app/tools/android/test_data/entry/index.html
+++ b/app/tools/android/test_data/entry/index.html
@@ -1,0 +1,3 @@
+<html>
+This is a test for packaging local files.
+</html>


### PR DESCRIPTION
For make_apk.py, if the option '--app-root' is required, it's
necessary to include the option '--app-local-path' as well.
Besides, split the test cases in 'testEntry' into 2 categories:
one is for testing correct cases and another is for failures.
