### PR TITLE
[Android] Support embedded mode in packaging tool.

### DIFF
--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -240,6 +240,25 @@ class TestMakeApk(unittest.TestCase):
     error_msg = 'Error: can\'t find the extension directory'
     self.assertTrue(out.find(error_msg) != -1)
     self.assertTrue(out.find('Exiting with error code: 9') != -1)
+
+  def testMode(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-url=http://www.intel.com'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    self.assertTrue(os.path.exists('Example.apk'))
+    shared_mode_size = os.path.getsize('Example.apk')
+    Clean('Example')
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example',
+                             '--app-url=http://www.intel.com',
+                             '--mode=embedded'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    self.assertTrue(os.path.exists('Example.apk'))
+    embeded_mode_size = os.path.getsize('Example.apk')
+    self.assertTrue(shared_mode_size < embeded_mode_size)
     Clean('Example')
 
 if __name__ == '__main__':

--- a/tools/prepare.py
+++ b/tools/prepare.py
@@ -30,8 +30,7 @@ def PrepareFromXwalk(target_dir):
                    'xwalk_app_runtime_activity_java.jar',
                    'xwalk_app_runtime_client_java.dex.jar',
                    'xwalk_app_runtime_client_java.jar',
-                   'xwalk_core_java.dex.jar',
-                   'xwalk_core_java.jar']
+                   'xwalk_core_embedded.dex.jar']
   for jar_file in jar_file_list:
     shutil.copy(os.path.join(src_dir, jar_file), libs_dir)
 
@@ -39,6 +38,12 @@ def PrepareFromXwalk(target_dir):
   native_libs_src_dir = os.path.join(os.path.dirname(target_dir),
                                      'xwalk_runtime_lib_apk', 'libs')
   shutil.copytree(native_libs_src_dir, native_libs_target_dir)
+
+  native_libs_java_des_dir = os.path.join(target_dir, 'native_libs_java')
+  native_libs_java_src_dir = os.path.join(os.path.dirname(target_dir),
+                                          'xwalk_runtime_lib_apk',
+                                          'native_libraries_java')
+  shutil.copytree(native_libs_java_src_dir, native_libs_java_des_dir)
 
   ant_dir =  os.path.join(target_dir, 'scripts', 'ant')
   if not os.path.exists(ant_dir):
@@ -75,12 +80,32 @@ def PrepareFromXwalk(target_dir):
   for folder in app_src_folder_list:
     shutil.copytree(folder, os.path.join(app_src_dir, os.path.basename(folder)))
 
+  pak_file_src_path = os.path.join(os.path.dirname(target_dir),
+                                   'xwalk_runtime_lib', 'assets', 'xwalk.pak')
+  pak_file_des_dir = os.path.join(target_dir, 'native_libs_res')
+  if not os.path.exists(pak_file_des_dir):
+    os.makedirs(pak_file_des_dir)
+  shutil.copy(pak_file_src_path, os.path.join(pak_file_des_dir, 'xwalk.pak'))
+
   packaging_tool_list = ['./app/tools/android/customize.py',
                          './app/tools/android/make_apk.py',
                          './app/tools/android/manifest_json_parser.py']
   for packaging_tool in packaging_tool_list:
     shutil.copy(packaging_tool, target_dir)
 
+  resources_for_embeded = ['ui_java', 'xwalk_core_java', 'content_java']
+  res_src_dir = os.path.join(os.path.dirname(target_dir), 'gen')
+  res_target_dir = os.path.join(target_dir, 'gen')
+  for resource in resources_for_embeded:
+    shutil.copytree(os.path.join(res_src_dir, resource),
+                    os.path.join(res_target_dir, resource))
+  java_res_for_embeded = {'../ui/android/java/res': 'ui',
+                          'runtime/android/java/res': 'runtime',
+                          '../content/public/android/java/res': 'content'}
+  java_res_des_dir = os.path.join(target_dir, 'libs_res')
+  for key in java_res_for_embeded:
+    shutil.copytree(os.path.join(os.getcwd(), key),
+                    os.path.join(java_res_des_dir, java_res_for_embeded[key]))
 
 def main(args):
   if len(args) != 1:

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -49,6 +49,35 @@
       'includes': ['../build/java.gypi'],
     },
     {
+      'target_name': 'xwalk_core_embedded',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_core_java',
+      ],
+      'actions': [
+        {
+          'action_name': 'xwalk_core_embedded',
+          'variables': {
+            'dex_input_paths': [
+              '<(PRODUCT_DIR)/lib.java/base_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/content_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/eyesfree_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/guava_javalib.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/jsr_305_javalib.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/media_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/navigation_interception_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/net_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/ui_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/web_contents_delegate_android_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/xwalk_core_extensions_java.dex.jar',
+              '<(PRODUCT_DIR)/lib.java/xwalk_core_java.dex.jar' ],
+            'output_path': '<(PRODUCT_DIR)/lib.java/xwalk_core_embedded.dex.jar',
+          },
+          'includes': [ '../build/android/dex_action.gypi' ],
+        },
+      ],
+    },
+    {
       'target_name': 'xwalk_core_jar_jni',
       'type': 'none',
       'variables': {

--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -97,6 +97,7 @@
       'dependencies': [
         'xwalk_app_template_apk',
         'xwalk_runtime_lib_apk',
+        'xwalk_core_embedded',
       ],
       'actions': [
         {
@@ -109,7 +110,7 @@
             '<(PRODUCT_DIR)/xwalk_app_template_1'
           ],
           'action': [
-          'python', 'tools/prepare.py',
+            'python', 'tools/prepare.py',
             '<(PRODUCT_DIR)/xwalk_app_template'
           ],
         },


### PR DESCRIPTION
Some developers want to package web app with independent
xwalk's runtime library, and don't care the size of it
too much.

Pacakaging tool would copy all the xwalk's runtime library
into target application package, which includes the
.so, .jar, .apk file etc. By default, packaging tool
uses shared mode for web application.

Sample Usage:
python make_apk.py --name=Intel --package=org.xwalk.example
--app-url=http://www.intel.com --mode=embedded

BUG=https://github.com/crosswalk-project/crosswalk/issues/765
