### PR TITLE
[Android] Add target to pack xwalk core library

### DIFF
--- a/tools/build/android/FILES.cfg
+++ b/tools/build/android/FILES.cfg
@@ -52,4 +52,9 @@ FILES = [
     'buildtype': ['dev', 'official'],
     'direct_archive': 1,
   },
+  {
+    'filename': 'xwalk_core_library.tar.gz',
+    'buildtype': ['dev', 'official'],
+    'direct_archive': 1,
+  },
 ]

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -573,6 +573,7 @@
             'xwalk_runtime_client_shell_apk',
 
             # For external testing.
+            'pack_xwalk_core_library',
             'xwalk_runtime_lib_apk',
             'xwalk_app_hello_world_apk',
             'xwalk_app_template',

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -5,6 +5,30 @@
 {
   'targets': [
     {
+      'target_name': 'pack_xwalk_core_library',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_core_library'
+      ],
+      'actions': [
+        {
+          'action_name': 'pack_xwalk_core_library',
+          'message': 'Packaging XwalkCore Library Project.',
+          'inputs': [
+            '<(DEPTH)/xwalk/tools/tar.py',
+          ],
+          'outputs': [
+            '<(PRODUCT_DIR)/xwalk_core_library.tar.gz',
+            '<(PRODUCT_DIR)/pack_xwalk_core_library_intermediate/always_run',
+          ],
+          'action': [
+            'python', 'tools/tar.py',
+            '<(PRODUCT_DIR)/xwalk_core_library'
+          ],
+        },
+      ],
+    },
+    {
       'target_name': 'xwalk_core_library',
       'type': 'none',
       'dependencies': [


### PR DESCRIPTION
And archive the tarball of xwalk core library.
The tarball will be used by cordova xwalk container.
