### PR TITLE
[Android] Fix build errors that are introduced by rebasing to version 31

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -27,6 +27,7 @@ sys.path.insert(1, os.path.join(chrome_src, 'tools', 'generate_shim_headers'))
 sys.path.insert(1, os.path.join(chrome_src, 'tools', 'grit'))
 sys.path.insert(1, os.path.join(chrome_src, 'chrome', 'tools', 'build'))
 sys.path.insert(1, os.path.join(chrome_src, 'native_client', 'build'))
+sys.path.insert(1, os.path.join(chrome_src, 'remoting', 'tools', 'build'))
 sys.path.insert(1, os.path.join(chrome_src, 'third_party', 'WebKit',
     'Source', 'core', 'scripts'))
 # TODO(adamk): Remove this line once core.gyp is no longer a directory

--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -74,7 +74,7 @@ public class XWalkContent extends FrameLayout {
                 mContentsClientBridge.getInterceptNavigationDelegate());
 
         // Initialize mWindow which is needed by content
-        mWindow = new WindowAndroid(xwView.getActivity(), xwView.getViewContext());
+        mWindow = new WindowAndroid(xwView.getActivity());
 
         // Initialize ContentView.
         mContentView = ContentView.newInstance(getContext(), mWebContents, mWindow);

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentVideoViewClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentVideoViewClient.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.WindowManager;
 
 import org.chromium.content.browser.ContentVideoViewClient;
+import org.chromium.content.browser.ContentVideoViewControls;
 import org.xwalk.core.XWalkWebChromeClient.CustomViewCallback;
 
 public class XWalkContentVideoViewClient implements ContentVideoViewClient {
@@ -37,16 +38,12 @@ public class XWalkContentVideoViewClient implements ContentVideoViewClient {
     }
 
     @Override
-    public void keepScreenOn(boolean screenOn) {
-        if (screenOn) {
-            mActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        } else {
-            mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        }
+    public View getVideoLoadingProgressView() {
+        return mContentsClient.getVideoLoadingProgressView();
     }
 
     @Override
-    public View getVideoLoadingProgressView() {
-        return mContentsClient.getVideoLoadingProgressView();
+    public ContentVideoViewControls createControls() {
+        return null;
     }
 }

--- a/runtime/android/java/src/org/xwalk/core/XWalkViewDelegate.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkViewDelegate.java
@@ -10,7 +10,7 @@ import android.os.Build;
 import org.chromium.base.PathUtils;
 import org.chromium.base.ThreadUtils;
 import org.chromium.content.app.LibraryLoader;
-import org.chromium.content.browser.AndroidBrowserProcess;
+import org.chromium.content.browser.BrowserStartupController;
 import org.chromium.content.browser.DeviceUtils;
 import org.chromium.content.browser.ResourceExtractor;
 import org.chromium.content.common.CommandLine;
@@ -74,10 +74,12 @@ class XWalkViewDelegate {
             public void run() {
                 try {
                     LibraryLoader.ensureInitialized();
-                    AndroidBrowserProcess.init(context,
-                            AndroidBrowserProcess.MAX_RENDERERS_SINGLE_PROCESS);
                 } catch (ProcessInitException e) {
                     throw new RuntimeException("Cannot initialize Crosswalk Core", e);
+                }
+                if (!BrowserStartupController.get(context).startBrowserProcessesSync(
+                            BrowserStartupController.MAX_RENDERERS_SINGLE_PROCESS)) {
+                    throw new RuntimeException("Cannot initialize Crosswalk Core");
                 }
             }
         });

--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -34,7 +34,8 @@ const char kChromeVersion[] = CHROME_VERSION_STRING;
 
 // Delegate implementation for the devtools http handler on android. A new
 // instance of this gets created each time devtools is enabled.
-class XWalkDevToolsServerDelegate : public content::DevToolsHttpHandlerDelegate {
+class XWalkDevToolsServerDelegate
+  : public content::DevToolsHttpHandlerDelegate {
  public:
   explicit XWalkDevToolsServerDelegate() {
   }
@@ -68,10 +69,10 @@ class XWalkDevToolsServerDelegate : public content::DevToolsHttpHandlerDelegate 
     return std::string();
   }
 
-  virtual scoped_refptr<net::StreamListenSocket> CreateSocketForTethering(
+  virtual scoped_ptr<net::StreamListenSocket> CreateSocketForTethering(
       net::StreamListenSocket::Delegate* delegate,
       std::string* name) OVERRIDE {
-    return NULL;
+    return scoped_ptr<net::StreamListenSocket>();
   }
 
  private:
@@ -108,7 +109,7 @@ void XWalkDevToolsServer::Start() {
   protocol_handler_ = content::DevToolsHttpHandler::Start(
       new net::UnixDomainSocketWithAbstractNamespaceFactory(
           socket_name_,
-          "", // fallback socket name
+          "",  // fallback socket name
           base::Bind(&CanUserConnectToDevTools)),
       base::StringPrintf(kFrontEndURL, kChromeVersion),
       new XWalkDevToolsServerDelegate());
@@ -153,7 +154,8 @@ static void SetRemoteDebuggingEnabled(JNIEnv* env,
                                       jobject obj,
                                       jint server,
                                       jboolean enabled) {
-  XWalkDevToolsServer* devtools_server = reinterpret_cast<XWalkDevToolsServer*>(server);
+  XWalkDevToolsServer* devtools_server =
+      reinterpret_cast<XWalkDevToolsServer*>(server);
   if (enabled) {
     devtools_server->Start();
   } else {

--- a/runtime/browser/runtime_file_select_helper.cc
+++ b/runtime/browser/runtime_file_select_helper.cc
@@ -5,6 +5,7 @@
 #include "xwalk/runtime/browser/runtime_file_select_helper.h"
 
 #include <string>
+#include <utility>
 
 #include "base/bind.h"
 #include "base/file_util.h"
@@ -402,8 +403,8 @@ void RuntimeFileSelectHelper::RunFileChooserOnUIThread(
 
 #if defined(OS_ANDROID)
   // Android needs the original MIME types and an additional capture value.
-  std::vector<string16> accept_types(params.accept_types);
-  accept_types.push_back(params.capture);
+  std::pair<std::vector<string16>, bool> accept_types =
+      std::make_pair(params.accept_types, params.capture);
 #endif
 
   select_file_dialog_->SelectFile(

--- a/runtime/browser/runtime_javascript_dialog_manager.cc
+++ b/runtime/browser/runtime_javascript_dialog_manager.cc
@@ -59,4 +59,14 @@ void RuntimeJavaScriptDialogManager::RunBeforeUnloadDialog(
 #endif
 }
 
+void RuntimeJavaScriptDialogManager::CancelActiveAndPendingDialogs(
+    content::WebContents* web_contents) {
+  NOTIMPLEMENTED();
+}
+
+void RuntimeJavaScriptDialogManager::WebContentsDestroyed(
+    content::WebContents* web_contents) {
+  NOTIMPLEMENTED();
+}
+
 }  // namespace xwalk

--- a/runtime/browser/runtime_javascript_dialog_manager.h
+++ b/runtime/browser/runtime_javascript_dialog_manager.h
@@ -26,10 +26,15 @@ class RuntimeJavaScriptDialogManager : public content::JavaScriptDialogManager {
       const DialogClosedCallback& callback,
       bool* did_suppress_message) OVERRIDE;
 
-  virtual void RunBeforeUnloadDialog(content::WebContents* web_contents,
-                                     const string16& message_text,
-                                     bool is_reload,
-                                     const DialogClosedCallback& callback) OVERRIDE;
+  virtual void RunBeforeUnloadDialog(
+      content::WebContents* web_contents,
+      const string16& message_text,
+      bool is_reload,
+      const DialogClosedCallback& callback) OVERRIDE;
+  virtual void CancelActiveAndPendingDialogs(
+      content::WebContents* web_contents) OVERRIDE;
+  virtual void WebContentsDestroyed(
+      content::WebContents* web_contents) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RuntimeJavaScriptDialogManager);

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -118,9 +118,6 @@ void SetXWalkCommandLineFlags() {
   command_line->AppendSwitch(switches::kEnableGestureTapHighlight);
 
 #if defined(OS_ANDROID)
-  // Enable WebGL on all platforms (enabled on non-Android by default).
-  command_line->AppendSwitch(switches::kEnableExperimentalWebGL);
-
   // Disable ExtensionProcess for Android.
   // External extensions will run in the BrowserProcess (in process mode).
   command_line->AppendSwitch(switches::kXWalkDisableExtensionProcess);

--- a/runtime/renderer/android/xwalk_render_view_ext.cc
+++ b/runtime/renderer/android/xwalk_render_view_ext.cc
@@ -105,7 +105,7 @@ void PopulateHitTestData(const GURL& absolute_link_url,
     data->img_src = absolute_image_url;
 
   const bool is_javascript_scheme =
-      absolute_link_url.SchemeIs(chrome::kJavaScriptScheme);
+      absolute_link_url.SchemeIs(content::kJavaScriptScheme);
   const bool has_link_url = !absolute_link_url.is_empty();
   const bool has_image_url = !absolute_image_url.is_empty();
 
@@ -177,8 +177,8 @@ bool XWalkRenderViewExt::allowImage(WebKit::WebFrame* frame,
 
   // For compatibility, only blacklist network schemes instead of whitelisting.
   const GURL url(image_url);
-  return !(url.SchemeIs(chrome::kHttpScheme) ||
-           url.SchemeIs(chrome::kHttpsScheme) ||
+  return !(url.SchemeIs(content::kHttpScheme) ||
+           url.SchemeIs(content::kHttpsScheme) ||
            url.SchemeIs(chrome::kFtpScheme));
 }
 


### PR DESCRIPTION
Some changes that have been made in upstream version 31 break XWalk for Android.
Fix the break in XWalk, including:
- Replacing AndroidBrowserProcess to BrowserStartupController.
- Changes in DevToolsServer/JavaScriptDialogManager.
- Some namespace changes.
- Removing override method ContentVideoViewClient.keepScreenOn as interface has changed.
- Removing kEnableExperimentalWebGL switch since this switch is no loger used from
  version 31 for Android port.

BUG=
TEST=Build
