### PR TITLE
Fix main document browser test timeout issue

### DIFF
--- a/application/test/application_main_document_browsertest.cc
+++ b/application/test/application_main_document_browsertest.cc
@@ -75,11 +75,9 @@ IN_PROC_BROWSER_TEST_F(ApplicationMainDocumentBrowserTest, MainDocument) {
   ASSERT_TRUE(!main_runtime->window());
 
   // There should exist 2 runtimes(one for generated main document, one for the
-  // window created by main document). As WindowedNotificationObserver::Wait()
-  // will call the callback function once when inovke, so add one more for the
-  // Wait() to consume.
-  int count = 2 - runtimes.size() + 1;
-  if (count > 1) {
+  // window created by main document).
+  int count = 2 - runtimes.size();
+  if (count) {
     content::WindowedNotificationObserver(
         xwalk::NOTIFICATION_RUNTIME_OPENED,
         base::Bind(&WaitForRuntimeCountCallback, &count)).Wait();


### PR DESCRIPTION
Chromium M31 changed WindowedNotificationObserver::Wait implementation, now
callback will not be called when condition is not meet. So we don't need add 1
for Runtime couting anymore.
