### PR TITLE
backport: [Android] Implement mixed resources to fix resource not found

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkMixedResources.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkMixedResources.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.app;
+
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+
+/**
+ * XWalkMixedResources is used to combine the resources
+ * from two different packages.
+ * 
+ * TODO(wang16): Add more override functions (e.g. getColor/Boolean).
+ */
+public class XWalkMixedResources extends Resources {
+
+    private Resources mExtend;
+
+    XWalkMixedResources(Resources base, Resources extend) {
+        super(base.getAssets(), base.getDisplayMetrics(),
+                base.getConfiguration());
+        mExtend = extend;
+    }
+
+    @Override
+    public CharSequence getText(int id) throws NotFoundException {
+        try {
+            return mExtend.getText(id);
+        } catch (NotFoundException e) {
+            return super.getText(id);
+        }
+    }
+
+    @Override
+    public Drawable getDrawable(int id) throws NotFoundException {
+        try {
+            return mExtend.getDrawable(id);
+        } catch (NotFoundException e) {
+            return super.getDrawable(id);
+        }
+    }
+}

--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
@@ -32,6 +33,8 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
     private boolean mRemoteDebugging = false;
 
     private AlertDialog mLibraryNotFoundDialog = null;
+    
+    private XWalkMixedResources mMixedResources = null;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -91,6 +94,12 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
         mRuntimeView.onActivityResult(requestCode, resultCode, data);
     }
 
+    @Override
+    public Resources getResources() {
+        if (mMixedResources == null) return super.getResources();
+        return mMixedResources;
+    }
+
     private String getLibraryApkDownloadUrl() {
         int resId = getResources().getIdentifier("xwalk_library_apk_download_url", "string", getPackageName());
         if (resId == 0) return DEFAULT_LIBRARY_APK_URL;
@@ -107,6 +116,8 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
         if (mRuntimeView == null || mRuntimeView.get() == null) {
             mRuntimeView = new XWalkRuntimeClient(this, null, this);
             if (mRuntimeView.get() != null) {
+                mMixedResources = new XWalkMixedResources(super.getResources(),
+                        mRuntimeView.getLibraryContext().getResources());
                 mShownNotFoundDialog = false;
                 if (mLibraryNotFoundDialog != null) mLibraryNotFoundDialog.cancel();
             }


### PR DESCRIPTION
In shared mode, runtime client and library are in different packages.
It makes it easy to meet resource-not-found issue.

To fix that, class XWalkMixedResources is created to combine the two
resources into one. It will try to get resource from library first
and get from client when resource not found in library.

BUG=https://github.com/crosswalk-project/crosswalk/issues/796
