### PR TITLE
Enable Aura build by default

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -104,6 +104,8 @@ if __name__ == '__main__':
   args = delist 
   args.append('-Dproprietary_codecs=1')
 
+  args.append('-Duse_aura=1')
+
   # Triggering media playback dynamically with third-party codecs by owner. 
   if ip_media_codecs == True:
       args.append('-Dffmpeg_branding=Chrome')

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -228,10 +228,12 @@ bool NativeAppWindowViews::CanMaximize() const {
   return resizable_ && maximum_size_.IsEmpty();
 }
 
+#if defined(OS_WIN)
 views::NonClientFrameView* NativeAppWindowViews::CreateNonClientFrameView(
     views::Widget* widget) {
   return new views::NativeFrameView(widget);
 }
+#endif
 
 ////////////////////////////////////////////////////////////
 // views::View implementation

--- a/runtime/browser/ui/native_app_window_views.h
+++ b/runtime/browser/ui/native_app_window_views.h
@@ -65,9 +65,10 @@ class NativeAppWindowViews : public NativeAppWindow,
       gfx::Rect* bounds, ui::WindowShowState* show_state) const OVERRIDE;
   virtual bool CanResize() const OVERRIDE;
   virtual bool CanMaximize() const OVERRIDE;
+#if defined(OS_WIN)
   virtual views::NonClientFrameView* CreateNonClientFrameView(
       views::Widget* widget) OVERRIDE;
-
+#endif
   // views::View implementation.
   virtual void ChildPreferredSizeChanged(views::View* child) OVERRIDE;
   virtual void ViewHierarchyChanged(


### PR DESCRIPTION
Enabled Aura by default for XWalk Linux and Windows builds, also enabled window frame and window header for XWalk Aura windows on Linux desktop.

The NativeAppWindowViews::CreateNonClientFrameView is now overridden only for Windows in order to make visible Aura window frame&header on Linux desktop (NativeAppWindowViews::CreateNonClientFrameView had been overridden to show OS window decoration instead chrome-style UI, however the used views::NativeFrameView works only on Windows). 
