### PR TITLE
[Extensions] Remove CHECK() when destroying service

### DIFF
--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -100,11 +100,7 @@ XWalkExtensionService::XWalkExtensionService()
     g_register_extensions_callback.Run(this);
 }
 
-XWalkExtensionService::~XWalkExtensionService() {
-  // This object should already be released and asked to be deleted in the
-  // extension thread.
-  CHECK(!in_process_extensions_server_);
-}
+XWalkExtensionService::~XWalkExtensionService() {}
 
 bool XWalkExtensionService::RegisterExtension(
     scoped_ptr<XWalkExtension> extension) {


### PR DESCRIPTION
When running Crosswalk as a tool for manage packages (--install and
related parameters), the lifetime of Browser Process is different than
when running it for loading an application. In that scenario invariants
we expected do not hold anymore, in particular, we never enter the
codepath that destroys the in process extension server.

A better fix is to ensure that --install (and others) do not even create
XWalkExtensionService in the first place. A new issue was created for
that: https://github.com/crosswalk-project/crosswalk/issues/839.

BUG=https://github.com/crosswalk-project/crosswalk/issues/706
