### PR TITLE
[Tizen] Fixes for DesktopRootWindowHostTizenX11

### DIFF
--- a/runtime/browser/ui/tizen/desktop_root_window_host_tizen_x11.h
+++ b/runtime/browser/ui/tizen/desktop_root_window_host_tizen_x11.h
@@ -182,6 +182,8 @@ class VIEWS_EXPORT DesktopRootWindowHostTizenX11 : public DesktopRootWindowHost,
   virtual void OnRootWindowHostCloseRequested(
       const aura::RootWindow* root) OVERRIDE;
 
+  virtual void OnRootViewLayout() const OVERRIDE;
+
   base::WeakPtrFactory<DesktopRootWindowHostTizenX11> close_widget_factory_;
 
   // X11 things


### PR DESCRIPTION
New virtual method was added to RWH interface.
MessagePumpAuraX11 was renamed to MessagePumpX11 which caused build
break.
