### PR TITLE
[Tizen] Fixes for InputMethod build breaks

### DIFF
--- a/ime/tizen-scim/input_method_scim.cc
+++ b/ime/tizen-scim/input_method_scim.cc
@@ -6,15 +6,15 @@
 #include "input_method_scim.h"
 
 #include "base/logging.h"
-#include "ui/base/events/event_utils.h"
+#include "ui/events/event_utils.h"
 #include "ui/base/ime/input_method_delegate.h"
 #include "ui/base/ime/text_input_client.h"
-#include "ui/base/keycodes/keyboard_code_conversion.h"
+#include "ui/events/keycodes/keyboard_code_conversion.h"
 #include "ui/aura/root_window.h"
 
 #include <X11/X.h>
 #include <X11/Xlib.h>
-#include "ui/base/keycodes/keyboard_code_conversion_x.h"
+#include "ui/events/keycodes/keyboard_code_conversion_x.h"
 
 #include "scim_bridge.h"
 
@@ -152,6 +152,18 @@ void InputMethodSCIM::AddObserver(InputMethodObserver* observer) {
 
 void InputMethodSCIM::RemoveObserver(InputMethodObserver* observer) {
   observers_.RemoveObserver(observer);
+}
+
+void InputMethodSCIM::SetStickyFocusedTextInputClient(ui::TextInputClient*) {
+  // TODO(shalamov): Not implemented.
+}
+
+void InputMethodSCIM::DetachTextInputClient(ui::TextInputClient*) {
+  // TODO(shalamov): Not implemented.
+}
+
+ui::TextInputMode InputMethodSCIM::GetTextInputMode() const {
+  return ui::TEXT_INPUT_MODE_DEFAULT;
 }
 
 }  // namespace ui

--- a/ime/tizen-scim/input_method_scim.h
+++ b/ime/tizen-scim/input_method_scim.h
@@ -53,6 +53,11 @@ class UI_EXPORT InputMethodSCIM : NON_EXPORTED_BASE(public InputMethod) {
   virtual void AddObserver(InputMethodObserver* observer) OVERRIDE;
   virtual void RemoveObserver(InputMethodObserver* observer) OVERRIDE;
 
+  virtual void SetStickyFocusedTextInputClient(ui::TextInputClient*) OVERRIDE;
+  virtual void DetachTextInputClient(ui::TextInputClient*) OVERRIDE;
+  virtual ui::TextInputMode GetTextInputMode() const OVERRIDE;
+
+
  private:
   internal::InputMethodDelegate* delegate_;
   TextInputClient* text_input_client_;

--- a/ime/tizen-scim/scim_bridge.cc
+++ b/ime/tizen-scim/scim_bridge.cc
@@ -9,6 +9,7 @@
 #include "base/message_loop/message_pump_libevent.h"
 #include "content/public/browser/browser_thread.h"
 #include "ui/base/x/x11_util.h"
+#include "ui/gfx/x/x11_types.h"
 
 #define Uses_SCIM_BACKEND
 #define Uses_SCIM_IMENGINE_MODULE
@@ -164,7 +165,7 @@ SCIMBridgeImpl::SCIMBridgeImpl()
     panel_client_fd_(-1),
     im_context_id_(getpid() % 50000),
     im_engine_instance_count_(0),
-    display_(ui::GetXDisplay()),
+    display_(gfx::GetXDisplay()),
     root_window_(GetX11RootWindow())
 {
   // Create input system engine context data that would be sent to the daemon.


### PR DESCRIPTION
InputMethod interface was changed, new virtual methods were
added and need to be implemented. Event related headers were
moved from ui/base/events to ui/events and X11 utility methods
were moved under gfx namespace.
