### PR TITLE
[Android] Enable WebGL for Android port.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -125,6 +125,9 @@ void SetXWalkCommandLineFlags() {
   // Disable ExtensionProcess for Android.
   // External extensions will run in the BrowserProcess (in process mode).
   command_line->AppendSwitch(switches::kXWalkDisableExtensionProcess);
+
+  // Enable WebGL for Android.
+  command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
 #endif
 
   // FIXME: Add comment why this is needed on Android and Tizen.


### PR DESCRIPTION
This is a workaround because some platforms do not support the
GL extension 'GL_{ARB,EXT}_robustness' and the reset notification.
But the pass rate is pretty good for IA platforms. Suggest to
enable WebGL.

BUG=#831
