### PR TITLE
[Android] Copy missing file for XWalk library project after rebasing to 31.

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -194,6 +194,12 @@ def CopyGeneratedSources(out_directory):
                              'chromium', 'base', 'MemoryPressureLevelList.java')
   shutil.copyfile(source_file, target_file)
 
+  source_file = os.path.join(out_directory, 'gen', 'templates',
+                             'org', 'chromium', 'media', 'ImageFormat.java')
+  target_file = os.path.join(out_directory, LIBRARY_PROJECT_NAME, 'src', 'org',
+                             'chromium', 'media', 'ImageFormat.java')
+  shutil.copyfile(source_file, target_file)
+
 
 def CopyXwalkJavaSource(project_source, out_directory):
   print 'Copying XWalk Java sources...'

--- a/build/android/xwalkcore_library_template/project.properties
+++ b/build/android/xwalkcore_library_template/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-17
+target=android-18


### PR DESCRIPTION
- Copy ImageFormat.java to XWalk library project as it's added in version 31 and
  it's essential.
- Change the API level to 18 in project.properties for Eclipse.
- This will require Eclipse/ADT to update the SDK to version 18.

BUG=
