### PR TITLE
[Android] Add custom version tag in build.xml for xwalk_core_library

### DIFF
--- a/build/android/xwalkcore_library_template/build.xml
+++ b/build/android/xwalkcore_library_template/build.xml
@@ -24,5 +24,6 @@ found in the LICENSE file.
 
 	<import file="custom_rules.xml" optional="true" />
 
+	<!-- version-tag: custom -->
 	<import file="${sdk.dir}/tools/ant/build.xml" />
 </project>


### PR DESCRIPTION
The custom version tag is to prevent the build.xml being updated
by tools like 'android update project'.
It is needed by the cli for xwalk cordova container.
