### PR TITLE
[Tizen] Fix build break caused by new ffmpeg

### DIFF
--- a/packaging/crosswalk-2.31-disable-ffmpeg-pragmas.patch
+++ b/packaging/crosswalk-2.31-disable-ffmpeg-pragmas.patch
@@ -1,0 +1,36 @@
+From: Alexander Shalamov <alexander.shalamov@intel.com>
+Date: Thu, 10 Oct 2013 13:45:43 +0300
+
+Tizen 2.x platform have gcc version 4.5 which breaks compilation of new ffmpeg.
+Break is caused by pragmas that are used inside functions. This patch modifies
+configuration of ffmpeg (chromium/linux/ia32) and disables pragmas.
+
+diff --git src/third_party/ffmpeg/chromium/config/Chromium/linux/ia32/config.asm src/third_party/ffmpeg/chromium/config/Chromium/linux/ia32/config.asm
+index b5fc20a..1d46271 100644
+--- src/third_party/ffmpeg/chromium/config/Chromium/linux/ia32/config.asm
++++ src/third_party/ffmpeg/chromium/config/Chromium/linux/ia32/config.asm
+@@ -223,7 +223,7 @@
+ %define HAVE_POD2MAN 1
+ %define HAVE_POLL_H 1
+ %define HAVE_POSIX_MEMALIGN 1
+-%define HAVE_PRAGMA_DEPRECATED 1
++%define HAVE_PRAGMA_DEPRECATED 0
+ %define HAVE_PTHREAD_CANCEL 1
+ %define HAVE_RDTSC 0
+ %define HAVE_RSYNC_CONTIMEOUT 1
+diff --git src/third_party/ffmpeg/chromium/config/Chromium/linux/ia32/config.h src/third_party/ffmpeg/chromium/config/Chromium/linux/ia32/config.h
+index b8ee823..1e35b3b 100644
+--- src/third_party/ffmpeg/chromium/config/Chromium/linux/ia32/config.h
++++ src/third_party/ffmpeg/chromium/config/Chromium/linux/ia32/config.h
+@@ -236,7 +236,7 @@
+ #define HAVE_POD2MAN 1
+ #define HAVE_POLL_H 1
+ #define HAVE_POSIX_MEMALIGN 1
+-#define HAVE_PRAGMA_DEPRECATED 1
++#define HAVE_PRAGMA_DEPRECATED 0
+ #define HAVE_PTHREAD_CANCEL 1
+ #define HAVE_RDTSC 0
+ #define HAVE_RSYNC_CONTIMEOUT 1
+-- 
+1.7.9.5
+


### PR DESCRIPTION
Tizen 2.x platform have gcc version 4.5 which breaks compilation of new ffmpeg.
Break is caused by pragmas that are used inside functions. This patch modifies
configuration of ffmpeg (chromium/linux/ia32) and disables pragmas.
