### PR TITLE
[Tizen] packaging: Explicitly specify our Python version as 2.7.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -105,6 +105,7 @@ export CFLAGS=`echo $CFLAGS | sed s,-fno-omit-frame-pointer,,g`
 export GYP_GENERATORS='make'
 ./src/xwalk/gyp_xwalk src/xwalk/xwalk.gyp \
 -Ddisable_nacl=1 \
+-Dpython_ver=2.7 \
 -Duse_aura=1 \
 -Duse_cups=0 \
 -Duse_gconf=0 \


### PR DESCRIPTION
Tizen 2.1 (and possible later versions as well) use Python 2.7 instead of 2.6,
so pass that to Chromium's python_arch.sh.

We were supposed to pass that ever since we started packaging Tizen, but there
are two things to take into account:
- The CPU architecture in python_arch.sh is only used to special-case some
  stuff for MIPS, so this wasn't impacting us negatively before.
- Things were still supposed to work even if we didn't specify
  `python_ver', but my own commit 211783 upstream has shown a bug in the
  file(1) shipped by Tizen 2.1:`file --dereference /does/not/exist' returns
  0 instead of 1, which made python_arch.sh follow a pathological code path.
