### PR TITLE
[BuildFix] Add an explicit dependency on webkit_support.gyp:glue_child

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -50,6 +50,7 @@
         '../url/url.gyp:url_lib',
         '../v8/tools/gyp/v8.gyp:v8',
         '../webkit/common/user_agent/webkit_user_agent.gyp:user_agent',
+        '../webkit/support/webkit_support.gyp:glue_child',
         '../webkit/webkit_resources.gyp:webkit_resources',
         'jsapi/jsapi.gyp:xwalk_jsapi',
         'xwalk_application_lib',


### PR DESCRIPTION
This fix is to add an explicit dependency on webkit_support.gyp:`glue_child` to
`xwalk_runtime` target, otherwise, xwalk will throw an error message
saying 'HeapProfilerStart symbol is not found' at runtime.

BUG=https://github.com/crosswalk-project/crosswalk/issues/859
