### PR TITLE
Fix issue getUserMedia can't work when based chromium rebased to 31

### DIFF
--- a/runtime/browser/media/media_capture_devices_dispatcher.cc
+++ b/runtime/browser/media/media_capture_devices_dispatcher.cc
@@ -96,9 +96,7 @@ const MediaStreamDevices&
 XWalkMediaCaptureDevicesDispatcher::GetAudioCaptureDevices() {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
   if (!devices_enumerated_) {
-    BrowserThread::PostTask(
-        BrowserThread::IO, FROM_HERE,
-        base::Bind(&content::EnsureMonitorCaptureDevices));
+    content::EnsureMonitorCaptureDevices();
     devices_enumerated_ = true;
   }
   return audio_devices_;
@@ -108,9 +106,7 @@ const MediaStreamDevices&
 XWalkMediaCaptureDevicesDispatcher::GetVideoCaptureDevices() {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
   if (!devices_enumerated_) {
-    BrowserThread::PostTask(
-        BrowserThread::IO, FROM_HERE,
-        base::Bind(&content::EnsureMonitorCaptureDevices));
+    content::EnsureMonitorCaptureDevices();
     devices_enumerated_ = true;
   }
   return video_devices_;

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -121,7 +121,7 @@ void XWalkContentBrowserClient::RenderProcessHostCreated(
 }
 
 content::MediaObserver* XWalkContentBrowserClient::GetMediaObserver() {
-  return NULL; // XWalkMediaCaptureDevicesDispatcher::GetInstance();
+  return XWalkMediaCaptureDevicesDispatcher::GetInstance();
 }
 
 #if defined(OS_ANDROID)


### PR DESCRIPTION
Crosswalk debug mode crashed when it accessed getUserMedia API, and release mode
also can't work.

The root cause was listed as followed:
1. Chromium upstream improved related code,
   please see: https://codereview.chromium.org/17508005/
2. It is an error from rebasing, GetMediaObserver callback was changed to be NULL.
