### PR TITLE
Initialize params.bounds in NativeAppWindowViews

### DIFF
--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -58,8 +58,8 @@ NativeAppWindowViews::NativeAppWindowViews(
   params.type = views::Widget::InitParams::TYPE_WINDOW_FRAMELESS;
 #else
   params.type = views::Widget::InitParams::TYPE_WINDOW;
-  params.bounds = create_params.bounds;
 #endif
+  params.bounds = create_params.bounds;
 
   window_->Init(params);
 


### PR DESCRIPTION
Initialize params.bounds in NativeAppWindowViews to fix an
issue with the window size on Tizen builds.

Fixes #881.
