### PR TITLE
[Extensions] Add DidCreateModuleSystem hook

### DIFF
--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -29,8 +29,10 @@ namespace extensions {
 
 const GURL kAboutBlankURL = GURL("about:blank");
 
-XWalkExtensionRendererController::XWalkExtensionRendererController()
-    : shutdown_event_(false, false) {
+XWalkExtensionRendererController::XWalkExtensionRendererController(
+    Delegate* delegate)
+    : shutdown_event_(false, false),
+      delegate_(delegate) {
   content::RenderThread* thread = content::RenderThread::Get();
   thread->AddObserver(this);
   // TODO(cmarcelo): Once we have a better solution for the internal
@@ -55,6 +57,8 @@ void XWalkExtensionRendererController::DidCreateScriptContext(
 
   module_system->RegisterNativeModule(
       "v8tools", scoped_ptr<XWalkNativeModule>(new XWalkV8ToolsModule));
+
+  delegate_->DidCreateModuleSystem(module_system);
 
   in_browser_process_extensions_client_->CreateRunnersForModuleSystem(
       module_system);

--- a/extensions/renderer/xwalk_extension_renderer_controller.h
+++ b/extensions/renderer/xwalk_extension_renderer_controller.h
@@ -31,13 +31,22 @@ namespace xwalk {
 namespace extensions {
 
 class XWalkExtensionClient;
+class XWalkModuleSystem;
 
 // Renderer controller for XWalk extensions keeps track of the extensions
 // registered into the system. It also watches for new render views to attach
 // the extensions handlers to them.
 class XWalkExtensionRendererController : public content::RenderProcessObserver {
  public:
-  XWalkExtensionRendererController();
+  struct Delegate {
+    // Allows external code to register extra modules to the module
+    // system. It will be called for every module system created.
+    virtual void DidCreateModuleSystem(XWalkModuleSystem* module_system) = 0;
+   protected:
+    ~Delegate() {}
+  };
+
+  explicit XWalkExtensionRendererController(Delegate* delegate);
   virtual ~XWalkExtensionRendererController();
 
   // To be called in XWalkContentRendererClient so we can create and
@@ -60,6 +69,7 @@ class XWalkExtensionRendererController : public content::RenderProcessObserver {
 
   base::WaitableEvent shutdown_event_;
   scoped_ptr<IPC::SyncChannel> extension_process_channel_;
+  Delegate* delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkExtensionRendererController);
 };

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -8,7 +8,6 @@
 #include "third_party/WebKit/public/platform/WebString.h"
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
 #include "xwalk/application/common/constants.h"
-#include "xwalk/extensions/renderer/xwalk_extension_renderer_controller.h"
 
 namespace xwalk {
 
@@ -30,7 +29,8 @@ XWalkContentRendererClient::~XWalkContentRendererClient() {
 }
 
 void XWalkContentRendererClient::RenderThreadStarted() {
-  extension_controller_.reset(new extensions::XWalkExtensionRendererController);
+  extension_controller_.reset(
+      new extensions::XWalkExtensionRendererController(this));
 
   WebKit::WebString application_scheme(
       ASCIIToUTF16(application::kApplicationScheme));
@@ -48,5 +48,8 @@ void XWalkContentRendererClient::WillReleaseScriptContext(
     WebKit::WebFrame* frame, v8::Handle<v8::Context> context, int world_id) {
   extension_controller_->WillReleaseScriptContext(frame, context);
 }
+
+void XWalkContentRendererClient::DidCreateModuleSystem(
+    extensions::XWalkModuleSystem* module_system) {}
 
 }  // namespace xwalk

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -9,14 +9,13 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/platform_file.h"
 #include "content/public/renderer/content_renderer_client.h"
+#include "xwalk/extensions/renderer/xwalk_extension_renderer_controller.h"
 
 namespace xwalk {
 
-namespace extensions {
-class XWalkExtensionRendererController;
-}
-
-class XWalkContentRendererClient : public content::ContentRendererClient {
+class XWalkContentRendererClient
+    : public content::ContentRendererClient,
+      public extensions::XWalkExtensionRendererController::Delegate {
  public:
   static XWalkContentRendererClient* Get();
 
@@ -33,6 +32,10 @@ class XWalkContentRendererClient : public content::ContentRendererClient {
                                         int world_id) OVERRIDE;
 
  private:
+  // XWalkExtensionRendererController::Delegate implementation.
+  virtual void DidCreateModuleSystem(
+      extensions::XWalkModuleSystem* module_system) OVERRIDE;
+
   scoped_ptr<extensions::XWalkExtensionRendererController>
       extension_controller_;
 


### PR DESCRIPTION
Added an interface to be implement by the users of
XWalkExtensionRendererController, with a function that is called
everytime we create a XWalkModuleSystem. This allows the users of
extensions to add their own (native) modules to that module system.

This need was prompted by pull request #612.
