### PR TITLE
[Android] Implement setNetworkAvailable method in XWalkView

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -227,6 +227,10 @@ public class XWalkContent extends FrameLayout {
         return nativeGetVersion(mXWalkContent);
     }
 
+    public void setNetworkAvailable(boolean networkUp) {
+        nativeSetJsOnlineProperty(mXWalkContent, networkUp);
+    }
+
     // For instrumentation test.
     public ContentViewCore getContentViewCoreForTest() {
         return mContentViewCore;
@@ -253,4 +257,5 @@ public class XWalkContent extends FrameLayout {
     private native void nativeClearCache(int nativeXWalkContent, boolean includeDiskFiles);
     private native String nativeDevToolsAgentId(int nativeXWalkContent);
     private native String nativeGetVersion(int nativeXWalkContent);
+    private native void nativeSetJsOnlineProperty(int nativeXWalkContent, boolean networkUp);
 }

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -145,6 +145,7 @@ public class XWalkView extends FrameLayout {
     }
 
     public void setNetworkAvailable(boolean networkUp) {
+        mContent.setNetworkAvailable(networkUp);
     }
 
     public void setInitialScale(int scaleInPercent) {

--- a/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc
+++ b/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc
@@ -80,6 +80,10 @@ void XWalkRenderViewHostExt::SetInitialPageScale(double page_scale_factor) {
                                          page_scale_factor));
 }
 
+void XWalkRenderViewHostExt::SetJsOnlineProperty(bool network_up) {
+  Send(new XWalkViewMsg_SetJsOnlineProperty(network_up));
+}
+
 void XWalkRenderViewHostExt::RenderViewGone(base::TerminationStatus status) {
   DCHECK(CalledOnValidThread());
   for (std::map<int, DocumentHasImagesResult>::iterator pending_req =

--- a/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h
+++ b/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h
@@ -60,6 +60,7 @@ class XWalkRenderViewHostExt : public content::WebContentsObserver,
   // Sets the initial page scale. This overrides initial scale set by
   // the meta viewport tag.
   void SetInitialPageScale(double page_scale_factor);
+  void SetJsOnlineProperty(bool network_up);
 
  private:
   // content::WebContentsObserver implementation.

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -134,6 +134,12 @@ ScopedJavaLocalRef<jstring> XWalkContent::GetVersion(JNIEnv* env,
   return base::android::ConvertUTF8ToJavaString(env, XWALK_VERSION);
 }
 
+void XWalkContent::SetJsOnlineProperty(JNIEnv* env,
+                                       jobject obj,
+                                       jboolean network_up) {
+  render_view_host_ext_->SetJsOnlineProperty(network_up);
+}
+
 static jint Init(JNIEnv* env, jobject obj, jobject web_contents_delegate,
     jobject contents_client_bridge) {
   XWalkContent* xwalk_core_content =

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -40,6 +40,8 @@ class XWalkContent {
     return render_view_host_ext_.get();
   };
 
+  void SetJsOnlineProperty(JNIEnv* env, jobject obj, jboolean network_up);
+
  private:
   content::WebContents* CreateWebContents(JNIEnv* env, jobject delegate);
 

--- a/runtime/common/android/xwalk_render_view_messages.h
+++ b/runtime/common/android/xwalk_render_view_messages.h
@@ -74,6 +74,9 @@ IPC_MESSAGE_ROUTED0(XWalkViewMsg_ResetScrollAndScaleState)
 IPC_MESSAGE_ROUTED1(XWalkViewMsg_SetInitialPageScale,
                     double /* page_scale_factor */)
 
+// Set the Javascript online property for network availability change.
+IPC_MESSAGE_CONTROL1(XWalkViewMsg_SetJsOnlineProperty, bool /* network_up */)
+
 //-----------------------------------------------------------------------------
 // RenderView messages
 // These are messages sent from the renderer to the browser process.

--- a/runtime/renderer/android/xwalk_render_process_observer.cc
+++ b/runtime/renderer/android/xwalk_render_process_observer.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/renderer/android/xwalk_render_process_observer.h"
+
+#include "ipc/ipc_message_macros.h"
+#include "third_party/WebKit/public/web/WebCache.h"
+#include "third_party/WebKit/public/web/WebNetworkStateNotifier.h"
+#include "xwalk/runtime/common/android/xwalk_render_view_messages.h"
+
+namespace xwalk {
+
+XWalkRenderProcessObserver::XWalkRenderProcessObserver()
+  : webkit_initialized_(false) {
+}
+
+XWalkRenderProcessObserver::~XWalkRenderProcessObserver() {
+}
+
+bool XWalkRenderProcessObserver::OnControlMessageReceived(
+    const IPC::Message& message) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP(XWalkRenderProcessObserver, message)
+    IPC_MESSAGE_HANDLER(XWalkViewMsg_SetJsOnlineProperty, OnSetJsOnlineProperty)
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+  return handled;
+}
+
+void XWalkRenderProcessObserver::WebKitInitialized() {
+  webkit_initialized_ = true;
+}
+
+void XWalkRenderProcessObserver::OnSetJsOnlineProperty(bool network_up) {
+  if (webkit_initialized_)
+    WebKit::WebNetworkStateNotifier::setOnLine(network_up);
+}
+
+}  // namespace xwalk

--- a/runtime/renderer/android/xwalk_render_process_observer.h
+++ b/runtime/renderer/android/xwalk_render_process_observer.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_RENDERER_ANDROID_XWALK_RENDER_PROCESS_OBSERVER_H_
+#define XWALK_RUNTIME_RENDERER_ANDROID_XWALK_RENDER_PROCESS_OBSERVER_H_
+
+#include "content/public/renderer/render_process_observer.h"
+
+#include "base/compiler_specific.h"
+
+namespace xwalk {
+
+// A RenderProcessObserver implementation used for handling XWalkView
+// specific render-process wide IPC messages.
+class XWalkRenderProcessObserver : public content::RenderProcessObserver {
+ public:
+  XWalkRenderProcessObserver();
+  virtual ~XWalkRenderProcessObserver();
+
+  // content::RenderProcessObserver implementation.
+  virtual bool OnControlMessageReceived(const IPC::Message& message) OVERRIDE;
+  virtual void WebKitInitialized() OVERRIDE;
+
+ private:
+  void OnSetJsOnlineProperty(bool network_up);
+
+  bool webkit_initialized_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_RENDERER_ANDROID_XWALK_RENDER_PROCESS_OBSERVER_H_

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -5,12 +5,14 @@
 #include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
 
 #include "base/strings/utf_string_conversions.h"
+#include "content/public/renderer/render_thread.h"
 #include "third_party/WebKit/public/platform/WebString.h"
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
 #include "xwalk/application/common/constants.h"
 #include "xwalk/application/renderer/application_native_module.h"
 
 #if defined(OS_ANDROID)
+#include "xwalk/runtime/renderer/android/xwalk_render_process_observer.h"
 #include "xwalk/runtime/renderer/android/xwalk_render_view_ext.h"
 #endif
 
@@ -41,6 +43,12 @@ void XWalkContentRendererClient::RenderThreadStarted() {
       ASCIIToUTF16(application::kApplicationScheme));
   WebKit::WebSecurityPolicy::registerURLSchemeAsSecure(application_scheme);
   WebKit::WebSecurityPolicy::registerURLSchemeAsCORSEnabled(application_scheme);
+
+#if defined(OS_ANDROID)
+  content::RenderThread* thread = content::RenderThread::Get();
+  xwalk_render_process_observer_.reset(new XWalkRenderProcessObserver);
+  thread->AddObserver(xwalk_render_process_observer_.get());
+#endif
 }
 
 void XWalkContentRendererClient::RenderViewCreated(

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -13,6 +13,8 @@
 
 namespace xwalk {
 
+class XWalkRenderProcessObserver;
+
 class XWalkContentRendererClient
     : public content::ContentRendererClient,
       public extensions::XWalkExtensionRendererController::Delegate {
@@ -39,6 +41,10 @@ class XWalkContentRendererClient
 
   scoped_ptr<extensions::XWalkExtensionRendererController>
       extension_controller_;
+
+#if defined(OS_ANDROID)
+  scoped_ptr<XWalkRenderProcessObserver> xwalk_render_process_observer_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(XWalkContentRendererClient);
 };

--- a/test/android/core/javatests/assets/navigator.online.html
+++ b/test/android/core/javatests/assets/navigator.online.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<title>navigator.onLine property test</title>
+<script>
+window.onload = function() {
+	document.title = navigator.onLine.toString();
+	window.addEventListener("online", function() {
+		document.title = "online:" + navigator.onLine.toString();
+	}, false);
+
+	window.addEventListener("offline", function() {
+		document.title = "offline:" + navigator.onLine.toString();
+	}, false);
+}
+</script>
+</head>
+</html>

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetNetworkAvailableTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetNetworkAvailableTest.java
@@ -1,0 +1,101 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.graphics.Bitmap;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+import org.chromium.base.test.util.DisabledTest;
+import org.chromium.base.test.util.Feature;
+
+import org.xwalk.core.XWalkClient;
+import org.xwalk.core.XWalkContent;
+import org.xwalk.core.XWalkView;
+
+/**
+ * Test case for XWalkView.setNetworkAvailable method
+ *
+ * Once setNetworkAvailable is called, the navigator.onLine property will be
+ * set, and window.ononline/onoffline event will be fired if the property is
+ * changed.
+ */
+public class SetNetworkAvailableTest extends XWalkViewTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        class TestXWalkClient extends XWalkClient {
+            @Override
+            public void onPageStarted(XWalkView view, String url, Bitmap favicon) {
+                mTestContentsClient.onPageStarted(url);
+            }
+
+            @Override
+            public void onPageFinished(XWalkView view, String url) {
+                mTestContentsClient.didFinishLoad(url);
+            }
+        }
+        getXWalkView().setXWalkClient(new TestXWalkClient());
+    }
+
+    @Feature({"SetNetworkAvailableTest"})
+    @SmallTest
+    public void testSetNetworkAvailableTest() throws Throwable {
+        final String code = "navigator.onLine";
+        loadAssetFile("navigator.online.html");
+        String title = getTitleOnUiThread();
+
+        XWalkView xwView = getXWalkView();
+
+        if ("true".equals(title)) {
+            // Forcing to trigger 'offline' event.
+            xwView.setNetworkAvailable(false);
+
+            /**
+             * Expectations:
+             * 1. navigator.onLine is false;
+             * 2. window.onoffline event is fired.
+             */
+            assertEquals("false", executeJavaScriptAndWaitForResult(code));
+            assertEquals("offline:false", getTitleOnUiThread());
+
+            // Forcing to trigger 'online' event.
+            xwView.setNetworkAvailable(true);
+
+            /**
+             * Expectations:
+             * 1. navigator.onLine is true;
+             * 2. window.ononline event is fired.
+             */
+            assertEquals("true", executeJavaScriptAndWaitForResult(code));
+            assertEquals("online:true", getTitleOnUiThread());
+        }
+
+        if ("false".equals(title)) {
+            // Forcing to trigger 'online' event.
+            xwView.setNetworkAvailable(true);
+
+            /**
+             * Expectations:
+             * 1. navigator.onLine is true;
+             * 2. window.ononline event is fired.
+             */
+            assertEquals("true", executeJavaScriptAndWaitForResult(code));
+            assertEquals("online:true", getTitleOnUiThread());
+
+            // Forcing to trigger 'offline' event.
+            xwView.setNetworkAvailable(false);
+
+            /**
+             * Expectations:
+             * 1. navigator.onLine is false;
+             * 2. window.onoffline event is fired.
+             */
+            assertEquals("false", executeJavaScriptAndWaitForResult(code));
+            assertEquals("offline:false", getTitleOnUiThread());
+        }
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestXWalkViewContentsClient.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestXWalkViewContentsClient.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.chromium.content.browser.test.util.CallbackHelper;
+import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnEvaluateJavaScriptResultHelper;
 import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnPageFinishedHelper;
 import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnPageStartedHelper;
 import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnReceivedErrorHelper;
@@ -20,11 +21,13 @@ class TestXWalkViewContentsClient extends NullContentsClient {
     private final OnPageStartedHelper mOnPageStartedHelper;
     private final OnPageFinishedHelper mOnPageFinishedHelper;
     private final OnReceivedErrorHelper mOnReceivedErrorHelper;
+    private final OnEvaluateJavaScriptResultHelper mOnEvaluateJavaScriptResultHelper;
 
     public TestXWalkViewContentsClient() {
         mOnPageStartedHelper = new OnPageStartedHelper();
         mOnPageFinishedHelper = new OnPageFinishedHelper();
         mOnReceivedErrorHelper = new OnReceivedErrorHelper();
+        mOnEvaluateJavaScriptResultHelper = new OnEvaluateJavaScriptResultHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -37,6 +40,10 @@ class TestXWalkViewContentsClient extends NullContentsClient {
 
     public OnReceivedErrorHelper getOnReceivedErrorHelper() {
         return mOnReceivedErrorHelper;
+    }
+
+    public OnEvaluateJavaScriptResultHelper getOnEvaluateJavaScriptResultHelper() {
+        return mOnEvaluateJavaScriptResultHelper;
     }
 
     @Override

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -15,8 +15,12 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
+import junit.framework.Assert;
+
 import org.chromium.content.browser.LoadUrlParams;
 import org.chromium.content.browser.test.util.CallbackHelper;
+import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnEvaluateJavaScriptResultHelper;
+import org.xwalk.core.XWalkContent;
 import org.xwalk.core.XWalkView;
 
 public class XWalkViewTestBase
@@ -201,5 +205,19 @@ public class XWalkViewTestBase
                 return mXWalkView.canGoForward();
             }
         });
+    }
+
+    protected String executeJavaScriptAndWaitForResult(final String code) throws Exception {
+        final OnEvaluateJavaScriptResultHelper helper = mTestContentsClient.getOnEvaluateJavaScriptResultHelper();
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                XWalkContent content = mXWalkView.getXWalkViewContentForTest();
+                helper.evaluateJavaScript(content.getContentViewCoreForTest(), code);
+            }
+        });
+        helper.waitUntilHasValue();
+        Assert.assertTrue("Failed to retrieve JavaScript evaluation results.", helper.hasValue());
+        return helper.getJsonResultAndClear();
     }
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -204,6 +204,8 @@
             'runtime/common/android/xwalk_message_generator.h',
             'runtime/common/android/xwalk_render_view_messages.cc',
             'runtime/common/android/xwalk_render_view_messages.h',
+            'runtime/renderer/android/xwalk_render_process_observer.cc',
+            'runtime/renderer/android/xwalk_render_process_observer.h',
             'runtime/renderer/android/xwalk_render_view_ext.cc',
             'runtime/renderer/android/xwalk_render_view_ext.h',
           ],

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -68,6 +68,7 @@
         '<(java_in_dir)/assets/echoSync.html',
         '<(java_in_dir)/assets/framesEcho.html',
         '<(java_in_dir)/assets/index.html',
+        '<(java_in_dir)/assets/navigator.online.html',
       ],
       'variables': {
         'apk_name': 'XWalkCoreTest',


### PR DESCRIPTION
The setNetworkAvailable method allows XWalkView embedder to trigger
window.online/offline event and set navigator.onLine property on JS side when
the network connection is up or down. This fix is to implement this method by
adding a render process observer on native side to watch the network availability
change notification from browser process. At present, it is only used by Android
port.

BUG=https://github.com/crosswalk-project/crosswalk/issues/880
TEST=org.xwalk.core.xwview.test.SetNetworkAvailableTest
