### PR TITLE
Fix the issue File Download Crash in Debug mode

### DIFF
--- a/runtime/browser/runtime_download_manager_delegate.cc
+++ b/runtime/browser/runtime_download_manager_delegate.cc
@@ -96,8 +96,14 @@ bool RuntimeDownloadManagerDelegate::ShouldOpenDownload(
   return true;
 }
 
+void RuntimeDownloadManagerDelegate::GetNextId(
+    const content::DownloadIdCallback& callback) {
+  static uint32 next_id = content::DownloadItem::kInvalidId + 1;
+  callback.Run(next_id++);
+}
+
 void RuntimeDownloadManagerDelegate::GenerateFilename(
-    int32 download_id,
+    uint32 download_id,
     const content::DownloadTargetCallback& callback,
     const base::FilePath& generated_name,
     const base::FilePath& suggested_directory) {
@@ -115,7 +121,7 @@ void RuntimeDownloadManagerDelegate::GenerateFilename(
 }
 
 void RuntimeDownloadManagerDelegate::OnDownloadPathGenerated(
-    int32 download_id,
+    uint32 download_id,
     const content::DownloadTargetCallback& callback,
     const base::FilePath& suggested_path) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
@@ -132,7 +138,7 @@ void RuntimeDownloadManagerDelegate::OnDownloadPathGenerated(
 }
 
 void RuntimeDownloadManagerDelegate::ChooseDownloadPath(
-    int32 download_id,
+    uint32 download_id,
     const content::DownloadTargetCallback& callback,
     const base::FilePath& suggested_path) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));

--- a/runtime/browser/runtime_download_manager_delegate.h
+++ b/runtime/browser/runtime_download_manager_delegate.h
@@ -27,6 +27,7 @@ class RuntimeDownloadManagerDelegate
   virtual bool ShouldOpenDownload(
       content::DownloadItem* item,
       const content::DownloadOpenDelayedCallback& callback) OVERRIDE;
+  virtual void GetNextId(const content::DownloadIdCallback& callback) OVERRIDE;
 
   // Inhibits prompting and sets the default download path.
   void SetDownloadBehaviorForTesting(
@@ -39,14 +40,14 @@ class RuntimeDownloadManagerDelegate
  private:
   friend class base::RefCountedThreadSafe<RuntimeDownloadManagerDelegate>;
 
-  void GenerateFilename(int32 download_id,
+  void GenerateFilename(uint32 download_id,
                         const content::DownloadTargetCallback& callback,
                         const base::FilePath& generated_name,
                         const base::FilePath& suggested_directory);
-  void OnDownloadPathGenerated(int32 download_id,
+  void OnDownloadPathGenerated(uint32 download_id,
                                const content::DownloadTargetCallback& callback,
                                const base::FilePath& suggested_path);
-  void ChooseDownloadPath(int32 download_id,
+  void ChooseDownloadPath(uint32 download_id,
                           const content::DownloadTargetCallback& callback,
                           const base::FilePath& suggested_path);
 


### PR DESCRIPTION
Crosswalk hits DCHECK_NE(content::DownloadItem::kInvalidId, id) failed, since
chromium upstream improved the code, we needed to override the virtual function
GetNextId().
Please see: https://codereview.chromium.org/15584002
This CL also fixed FileDownload error in Linux trybots.

https://github.com/crosswalk-project/crosswalk/issues/888
