### PR TITLE
[Tizen] Screen rotation

### DIFF
--- a/runtime/browser/tizen/tizen_sensor_observer.cc
+++ b/runtime/browser/tizen/tizen_sensor_observer.cc
@@ -1,0 +1,71 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/tizen/tizen_sensor_observer.h"
+
+#include "ui/aura/root_window.h"
+#include "ui/views/view.h"
+#include "ui/views/widget/widget.h"
+
+#include "xwalk/runtime/browser/ui/native_app_window_views.h"
+
+namespace xwalk {
+
+TizenSensorObserver::TizenSensorObserver(NativeAppWindowViews* window)
+    : window_(window) {
+  if (SensorProvider::GetInstance())
+    SensorProvider::GetInstance()->AddObserver(this);
+}
+
+TizenSensorObserver::~TizenSensorObserver() {
+  if (SensorProvider::GetInstance())
+    SensorProvider::GetInstance()->RemoveObserver(this);
+}
+
+gfx::Transform TizenSensorObserver::GetTransform(
+    gfx::Display::Rotation rotation) const {
+  gfx::Size host_size = window_->GetBounds().size();
+  gfx::Transform transform;
+  switch (rotation) {
+    case gfx::Display::ROTATE_0:
+      break;
+    case gfx::Display::ROTATE_90:
+      transform.Translate(host_size.width() - 1, 0);
+      transform.Rotate(90);
+      break;
+    case gfx::Display::ROTATE_180:
+      transform.Translate(host_size.width() - 1, host_size.height() - 1);
+      transform.Rotate(180);
+      break;
+    case gfx::Display::ROTATE_270:
+      transform.Translate(0, host_size.height() - 1);
+      transform.Rotate(270);
+      break;
+    default:
+      NOTREACHED();
+  }
+  return transform;
+}
+
+void TizenSensorObserver::OnRotationChanged(
+    gfx::Display::Rotation rotation) {
+  // Set transform for root window
+  aura::RootWindow* root = window_->GetNativeWindow()->GetRootWindow();
+  if (!root)
+    return;
+  root->SetTransform(GetTransform(rotation));
+
+  // Change the size of root view
+  gfx::Size host_size = window_->GetBounds().size();
+  gfx::Size size;
+  if (rotation == gfx::Display::ROTATE_90 ||
+      rotation == gfx::Display::ROTATE_270) {
+    size = gfx::Size(host_size.height(), host_size.width());
+  } else {
+    size = gfx::Size(host_size.width(), host_size.height());
+  }
+  window_->GetWidget()->GetRootView()->SetSize(size);
+}
+
+}  // namespace xwalk

--- a/runtime/browser/tizen/tizen_sensor_observer.h
+++ b/runtime/browser/tizen/tizen_sensor_observer.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_SENSOR_OBSERVER_H_
+#define XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_SENSOR_OBSERVER_H_
+
+#include "ui/gfx/transform.h"
+
+#include "xwalk/runtime/browser/tizen/sensor_provider.h"
+
+namespace xwalk {
+
+class NativeAppWindowViews;
+
+class TizenSensorObserver : public SensorProvider::Observer {
+ public:
+  explicit TizenSensorObserver(NativeAppWindowViews* window);
+  virtual ~TizenSensorObserver();
+
+ private:
+  virtual void OnRotationChanged(gfx::Display::Rotation rotation) OVERRIDE;
+
+  gfx::Transform GetTransform(gfx::Display::Rotation rotation) const;
+
+  NativeAppWindowViews* window_;
+
+  DISALLOW_IMPLICIT_CONSTRUCTORS(TizenSensorObserver);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_SENSOR_OBSERVER_H_

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -32,6 +32,7 @@
 #endif
 
 #if defined(OS_TIZEN_MOBILE)
+#include "xwalk/runtime/browser/tizen/tizen_sensor_observer.h"
 #include "xwalk/runtime/browser/ui/tizen_system_indicator.h"
 #endif
 
@@ -57,7 +58,8 @@ NativeAppWindowViews::NativeAppWindowViews(
 #if defined(OS_TIZEN_MOBILE)
   params.type = views::Widget::InitParams::TYPE_WINDOW_FRAMELESS;
   // On Tizen apps are sized to the work area.
-  gfx::Rect bounds = gfx::Screen::GetNativeScreen()->GetPrimaryDisplay().work_area();
+  gfx::Rect bounds =
+      gfx::Screen::GetNativeScreen()->GetPrimaryDisplay().work_area();
   params.bounds = bounds;
 #else
   params.type = views::Widget::InitParams::TYPE_WINDOW;
@@ -69,6 +71,7 @@ NativeAppWindowViews::NativeAppWindowViews(
 #if defined(OS_TIZEN_MOBILE)
   // Set the bounds manually to avoid inset.
   window_->SetBounds(bounds);
+  sensor_observer_.reset(new TizenSensorObserver(this));
 #else
   window_->CenterWindow(create_params.bounds.size());
 #endif

--- a/runtime/browser/ui/native_app_window_views.h
+++ b/runtime/browser/ui/native_app_window_views.h
@@ -13,6 +13,10 @@
 #include "ui/views/widget/widget_delegate.h"
 #include "ui/views/widget/widget_observer.h"
 
+#if defined(OS_TIZEN_MOBILE)
+#include "xwalk/runtime/browser/tizen/sensor_provider.h"
+#endif
+
 namespace views {
 class WebView;
 class Widget;
@@ -48,12 +52,13 @@ class NativeAppWindowViews : public NativeAppWindow,
   virtual bool IsMinimized() const OVERRIDE;
   virtual bool IsFullscreen() const OVERRIDE;
 
+  virtual views::Widget* GetWidget() OVERRIDE;
+  virtual const views::Widget* GetWidget() const OVERRIDE;
+
  private:
   // WidgetDelegate implementation.
   virtual views::View* GetInitiallyFocusedView() OVERRIDE;
   virtual views::View* GetContentsView() OVERRIDE;
-  virtual views::Widget* GetWidget() OVERRIDE;
-  virtual const views::Widget* GetWidget() const OVERRIDE;
   virtual string16 GetWindowTitle() const OVERRIDE;
   virtual void DeleteDelegate() OVERRIDE;
   virtual gfx::ImageSkia GetWindowAppIcon() OVERRIDE;
@@ -97,6 +102,10 @@ class NativeAppWindowViews : public NativeAppWindow,
   gfx::Size minimum_size_;
   gfx::Size maximum_size_;
   bool resizable_;
+
+#if defined(OS_TIZEN_MOBILE)
+  scoped_ptr<SensorProvider::Observer> sensor_observer_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(NativeAppWindowViews);
 };

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -160,6 +160,8 @@
             'runtime/browser/tizen/tizen_data_fetcher_shared_memory.h',
             'runtime/browser/tizen/tizen_platform_sensor.cc',
             'runtime/browser/tizen/tizen_platform_sensor.h',
+            'runtime/browser/tizen/tizen_sensor_observer.cc',
+            'runtime/browser/tizen/tizen_sensor_observer.h',
             'runtime/browser/ui/tizen_plug_message_writer.cc',
             'runtime/browser/ui/tizen_plug_message_writer.h',
             'runtime/browser/ui/tizen_system_indicator.cc',


### PR DESCRIPTION
Rotate crosswalk windows when the rotation of device is changed.
This is not the W3C screen orientation API implementation. But the
API implementation will be based on this change to offer lock/unlock
functionalities.
