### PR TITLE
Fix the issue that getUserMdeida can't work on Linux, Tizen and Windows ...

### DIFF
--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -319,8 +319,8 @@ void Runtime::RequestMediaAccessPermission(
     content::WebContents* web_contents,
     const content::MediaStreamRequest& request,
     const content::MediaResponseCallback& callback) {
-  // XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission(
-  //     web_contents, request, callback);
+  XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission(
+      web_contents, request, callback);
 }
 
 }  // namespace xwalk


### PR DESCRIPTION
...platform

This is a general fix on Linux, Tizen and Windows platform, since the chromium rebasing
resulted in this issue.
XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission wasn't running.
