### PR TITLE
[Android] Define the class XWalkRuntimeViewProvider as an interface.

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -17,7 +17,7 @@ import org.xwalk.runtime.extension.XWalkExtension;
  * The implementation class for runtime core. It calls the methods provided
  * by runtime core and customizes the behaviors for runtime.
  */
-class XWalkCoreProviderImpl extends XWalkRuntimeViewProvider {
+class XWalkCoreProviderImpl extends XWalkRuntimeViewProviderBase {
     private Context mContext;
     private XWalkView mXwalkView;
 
@@ -27,6 +27,7 @@ class XWalkCoreProviderImpl extends XWalkRuntimeViewProvider {
         init(context, activity);
     }
 
+    @Override
     public void init(Context context, Activity activity) {
         // TODO(yongsheng): do customizations for XWalkView. There will
         // be many callback classes which are needed to be implemented.

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -15,58 +15,31 @@ import org.xwalk.runtime.extension.XWalkExtensionContextImpl;
 import org.xwalk.runtime.extension.XWalkExtensionManager;
 
 /**
- * The abstract class to provide the bridge between XWalkRuntimeView and the
+ * The interface to provide the bridge between XWalkRuntimeView and the
  * real implementation like runtime core.
  *
  * This class is also used by XWalkExtensionManager to get the capability to
  * build runtime extension system.
  */
-public abstract class XWalkRuntimeViewProvider {
-    private Context mContext;
-    private Activity mActivity;
-    private XWalkExtensionManager mExtensionManager;
-    private XWalkExtensionContextImpl mExtensionContext;
+public interface XWalkRuntimeViewProvider {
+    // For the embedded mode, the two arguments are the same.
+    public void init(Context context, Activity activity);
+    public XWalkExtensionContext getExtensionContext();
 
-    XWalkRuntimeViewProvider(Context context, Activity activity) {
-        mContext = context;
-        mActivity = activity;
-        mExtensionManager = new XWalkExtensionManager(context, activity, this);
-    }
+    // For handling life cycle and activity result.
+    public void onCreate();
+    public void onResume();
+    public void onPause();
+    public void onDestroy();
+    public void onActivityResult(int requestCode, int resultCode, Intent data);
 
-    public void init(Context context, Activity activity) {
-        mExtensionManager.loadExtensions();
-    }
-
-    public XWalkExtensionContext getExtensionContext() {
-        return mExtensionManager.getExtensionContext();
-    }
-
-    public void onCreate() {
-
-    }
-
-    public void onResume() {
-        mExtensionManager.onResume();
-    }
-
-    public void onPause() {
-        mExtensionManager.onPause();
-    }
-
-    public void onDestroy() {
-        mExtensionManager.onDestroy();
-    }
-
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        mExtensionManager.onActivityResult(requestCode, resultCode, data);
-    }
-
-    public abstract String getVersion();
-    public abstract View getView();
-    public abstract void loadAppFromUrl(String url);
-    public abstract void loadAppFromManifest(String manifestUrl);
-    public abstract String enableRemoteDebugging(String frontEndUrl, String socketName);
-    public abstract void disableRemoteDebugging();
+    // For RuntimeView APIs.
+    public String getVersion();
+    public View getView();
+    public void loadAppFromUrl(String url);
+    public void loadAppFromManifest(String manifestUrl);
+    public String enableRemoteDebugging(String frontEndUrl, String socketName);
+    public void disableRemoteDebugging();
 
     /*
      * Once runtime extension is created, notify the internal mechanism so that
@@ -79,16 +52,12 @@ public abstract class XWalkRuntimeViewProvider {
      * Pass messages from native extension system to runtime extension system.
      * Might be overrided to do customizations here.
      */
-    public void onMessage(XWalkExtension extension, int instanceID, String message) {
-        extension.onMessage(instanceID, message);
-    }
+    public void onMessage(XWalkExtension extension, int instanceID, String message);
 
     /**
      * Pass synchronized messages.
      */
-    public String onSyncMessage(XWalkExtension extension, int instanceID, String message) {
-        return extension.onSyncMessage(instanceID, message);
-    }
+    public String onSyncMessage(XWalkExtension extension, int instanceID, String message);
 
     /**
      * Pass message from runtime extension system to native and then to JavaScript.
@@ -102,6 +71,6 @@ public abstract class XWalkRuntimeViewProvider {
     public abstract void broadcastMessage(XWalkExtension extension, String message);
 
     // For instrumentation test.
-    public abstract String getTitleForTest();
-    public abstract void setCallbackForTest(Object callback);
+    public String getTitleForTest();
+    public void setCallbackForTest(Object callback);
 }

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProviderBase.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProviderBase.java
@@ -1,0 +1,76 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.view.View;
+
+import org.xwalk.runtime.extension.XWalkExtension;
+import org.xwalk.runtime.extension.XWalkExtensionContext;
+import org.xwalk.runtime.extension.XWalkExtensionContextImpl;
+import org.xwalk.runtime.extension.XWalkExtensionManager;
+
+/**
+ * The abstract class to provide the common implementation for inherited classes.
+ * Here is to use XWalkExtensionManager to manage extension system.
+ */
+public abstract class XWalkRuntimeViewProviderBase implements XWalkRuntimeViewProvider {
+    private Context mContext;
+    private Activity mActivity;
+    private XWalkExtensionManager mExtensionManager;
+    private XWalkExtensionContextImpl mExtensionContext;
+
+    XWalkRuntimeViewProviderBase(Context context, Activity activity) {
+        mContext = context;
+        mActivity = activity;
+        mExtensionManager = new XWalkExtensionManager(context, activity, this);
+    }
+
+    @Override
+    public void init(Context context, Activity activity) {
+        mExtensionManager.loadExtensions();
+    }
+
+    @Override
+    public XWalkExtensionContext getExtensionContext() {
+        return mExtensionManager.getExtensionContext();
+    }
+
+    @Override
+    public void onCreate() {
+    }
+
+    @Override
+    public void onResume() {
+        mExtensionManager.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        mExtensionManager.onPause();
+    }
+
+    @Override
+    public void onDestroy() {
+        mExtensionManager.onDestroy();
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        mExtensionManager.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public void onMessage(XWalkExtension extension, int instanceID, String message) {
+        extension.onMessage(instanceID, message);
+    }
+
+    @Override
+    public String onSyncMessage(XWalkExtension extension, int instanceID, String message) {
+        return extension.onSyncMessage(instanceID, message);
+    }
+}


### PR DESCRIPTION
It's an abstract class and some shared implementations are included
and will be used by inherited classes. However, xwalk core library needs
an interface which will be implemented by the container.
To meet this requirement, split this class into two: one interface containing
all methods and the base class to contain some shared implementations like
managing extensions.
