### PR TITLE
[Extensions] Add --enable-loading-extensions-on-demand switch

### DIFF
--- a/extensions/common/xwalk_extension_switches.cc
+++ b/extensions/common/xwalk_extension_switches.cc
@@ -6,6 +6,13 @@
 
 namespace switches {
 
+// TODO(cmarcelo): We are developing this feature behind a flag. The
+// plan is to switch the flag meaning when the full feature is
+// implemented. One release later, after stabilization, we completely
+// remove this flag since we expect this feature not to be optional.
+const char kXWalkEnableLoadingExtensionsOnDemand[] =
+    "enable-loading-extensions-on-demand";
+
 // TODO(cmarcelo): Currently we are disabling it by default, once Extension
 // Process patches land, we'll change this to be "disable-extension-process"
 // so that it will be enabled by default. Remember to forcely disable it for

--- a/extensions/common/xwalk_extension_switches.h
+++ b/extensions/common/xwalk_extension_switches.h
@@ -8,6 +8,7 @@
 // This file contains switches that are used inside extensions/ code.
 namespace switches {
 
+extern const char kXWalkEnableLoadingExtensionsOnDemand[];
 extern const char kXWalkDisableExtensionProcess[];
 extern const char kXWalkExtensionProcess[];
 

--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -4,6 +4,7 @@
 
 #include "xwalk/extensions/renderer/xwalk_extension_renderer_controller.h"
 
+#include "base/command_line.h"
 #include "base/values.h"
 #include "content/public/renderer/render_thread.h"
 #include "content/public/renderer/v8_value_converter.h"
@@ -15,6 +16,7 @@
 #include "third_party/WebKit/public/web/WebScopedMicrotaskSuppression.h"
 #include "v8/include/v8.h"
 #include "xwalk/extensions/common/xwalk_extension_messages.h"
+#include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/extensions/renderer/xwalk_extension_client.h"
 #include "xwalk/extensions/renderer/xwalk_extension_module.h"
 #include "xwalk/extensions/renderer/xwalk_module_system.h"
@@ -40,6 +42,11 @@ XWalkExtensionRendererController::XWalkExtensionRendererController(
 
   in_browser_process_extensions_client_.reset(new XWalkExtensionClient());
   in_browser_process_extensions_client_->Initialize(thread->GetChannel());
+
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kXWalkEnableLoadingExtensionsOnDemand)) {
+    LOG(INFO) << "LOADING EXTENSIONS ON DEMAND.";
+  }
 }
 
 XWalkExtensionRendererController::~XWalkExtensionRendererController() {

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -10,6 +10,7 @@
 #include "base/path_service.h"
 #include "base/platform_file.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
+#include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
 #include "xwalk/runtime/browser/geolocation/xwalk_access_token_store.h"
 #include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
@@ -98,6 +99,15 @@ XWalkContentBrowserClient::CreateRequestContextForStoragePartition(
   return static_cast<RuntimeContext*>(browser_context)->
       CreateRequestContextForStoragePartition(
           partition_path, in_memory, protocol_handlers);
+}
+
+void XWalkContentBrowserClient::AppendExtraCommandLineSwitches(
+    CommandLine* command_line, int child_process_id) {
+  CommandLine* browser_process_cmd_line = CommandLine::ForCurrentProcess();
+  if (browser_process_cmd_line->HasSwitch(
+          switches::kXWalkEnableLoadingExtensionsOnDemand)) {
+    command_line->AppendSwitch(switches::kXWalkEnableLoadingExtensionsOnDemand);
+  }
 }
 
 content::QuotaPermissionContext*

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -48,6 +48,8 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
       const base::FilePath& partition_path,
       bool in_memory,
       content::ProtocolHandlerMap* protocol_handlers) OVERRIDE;
+  virtual void AppendExtraCommandLineSwitches(CommandLine* command_line,
+                                              int child_process_id) OVERRIDE;
   virtual content::QuotaPermissionContext*
       CreateQuotaPermissionContext() OVERRIDE;
   virtual content::AccessTokenStore* CreateAccessTokenStore() OVERRIDE;


### PR DESCRIPTION
Runtime switch to protect the implementation of on demand loading of
extensions ("lazy load") until it's done, when we change the semantics
to be --disable.

In the release this feature debuts, we keep the disable switch to allow
QA disable if needed. After we succesfully ship one stable Crosswalk
with the feature (it will be Crosswalk 2), the current plan is to remove
the switch, because we don't intend to keep the codepath for the
non-lazy behavior.
