### PR TITLE
[Add] Add new APIs to XWalkClient for renderer responsiveness

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkClient.java
@@ -86,6 +86,22 @@ public class XWalkClient {
     }
 
     /**
+     * Notify the host application that the renderer of XWalkView is hung.
+     *
+     * @param view The XWalkView on which the render is hung.
+     */
+    public void onRendererUnresponsive(XWalkView view) {
+    }
+
+    /**
+     * Notify the host application that the renderer of XWalkView is no longer hung.
+     *
+     * @param view The XWalkView which becomes responsive now.
+     */
+    public void onRendererResponsive(XWalkView view) {
+    }
+
+    /**
      * Notify the host application of a resource request and allow the
      * application to return the data.  If the return value is null, the XWalkView
      * will continue to load the resource as usual.  Otherwise, the return

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClient.java
@@ -161,6 +161,10 @@ public abstract class XWalkContentsClient extends ContentViewClient {
 
     public abstract void onReceivedError(int errorCode, String description, String failingUrl);
 
+    public abstract void onRendererUnresponsive();
+
+    public abstract void onRendererResponsive();
+
     final public void onUpdateTitle(String title) {
         onTitleChanged(title);
     }

--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -210,6 +210,18 @@ public class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
+    public void onRendererUnresponsive() {
+        if (mXWalkClient != null && mXWalkView != null)
+            mXWalkClient.onRendererUnresponsive(mXWalkView);
+    }
+
+    @Override
+    public void onRendererResponsive() {
+        if (mXWalkClient != null && mXWalkView != null)
+            mXWalkClient.onRendererResponsive(mXWalkView);
+    }
+
+    @Override
     public void onFormResubmission(Message dontResend, Message resend) {
         dontResend.sendToTarget();
     }

--- a/runtime/android/java/src/org/xwalk/core/XWalkWebContentsDelegate.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkWebContentsDelegate.java
@@ -20,6 +20,12 @@ public abstract class XWalkWebContentsDelegate extends WebContentsDelegateAndroi
     public abstract void activateContents();
 
     @CalledByNative
+    public abstract void rendererUnresponsive();
+
+    @CalledByNative
+    public abstract void rendererResponsive();
+
+    @CalledByNative
     public void updatePreferredSize(int widthCss, int heightCss) {
     }
 }

--- a/runtime/android/java/src/org/xwalk/core/XWalkWebContentsDelegateAdapter.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkWebContentsDelegateAdapter.java
@@ -36,4 +36,16 @@ public class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
     public void activateContents() {
         // TODO: implement.
     }
+
+    @Override
+    public void rendererUnresponsive() {
+        if (mXWalkContentsClient != null)
+            mXWalkContentsClient.onRendererUnresponsive();
+    }
+
+    @Override
+    public void rendererResponsive() {
+        if (mXWalkContentsClient != null)
+            mXWalkContentsClient.onRendererResponsive();
+    }
 }

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -97,6 +97,22 @@ void XWalkWebContentsDelegate::RequestMediaAccessPermission(
       web_contents, request, callback);
 }
 
+void XWalkWebContentsDelegate::RendererUnresponsive(WebContents* source) {
+  JNIEnv* env = AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> obj = GetJavaDelegate(env);
+  if (obj.is_null())
+    return;
+  Java_XWalkWebContentsDelegate_rendererUnresponsive(env, obj.obj());
+}
+
+void XWalkWebContentsDelegate::RendererResponsive(WebContents* source) {
+  JNIEnv* env = AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> obj = GetJavaDelegate(env);
+  if (obj.is_null())
+    return;
+  Java_XWalkWebContentsDelegate_rendererResponsive(env, obj.obj());
+}
+
 bool RegisterXWalkWebContentsDelegate(JNIEnv* env) {
   return RegisterNativesImpl(env);
 }

--- a/runtime/browser/android/xwalk_web_contents_delegate.h
+++ b/runtime/browser/android/xwalk_web_contents_delegate.h
@@ -37,6 +37,10 @@ class XWalkWebContentsDelegate
       content::WebContents* web_contents,
       const content::MediaStreamRequest& request,
       const content::MediaResponseCallback& callback) OVERRIDE;
+
+  virtual void RendererUnresponsive(content::WebContents* source) OVERRIDE;
+  virtual void RendererResponsive(content::WebContents* source) OVERRIDE;
+
  private:
   scoped_ptr<content::JavaScriptDialogManager> javascript_dialog_manager_;
   DISALLOW_COPY_AND_ASSIGN(XWalkWebContentsDelegate);

--- a/test/android/core/javatests/assets/renderHung.html
+++ b/test/android/core/javatests/assets/renderHung.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<script>
+
+function deadLoopForever() {
+	while(true) {};
+}
+
+function deadLoopFor40secs() {
+  var startTime = Date.now();
+  while (Date.now() - startTime < 40000) {}
+}
+
+</script>
+</head>
+</html>
+

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/NullContentsClient.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/NullContentsClient.java
@@ -184,4 +184,12 @@ public class NullContentsClient extends XWalkContentsClient {
     @Override
     public void onTitleChanged(String title) {
     }
+
+    @Override
+    public void onRendererResponsive() {
+    }
+
+    @Override
+    public void onRendererUnresponsive() {
+    }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/RendererResponsivenessTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/RendererResponsivenessTest.java
@@ -1,0 +1,133 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.graphics.Bitmap;
+import android.test.suitebuilder.annotation.MediumTest;
+import android.util.Log;
+import android.test.TouchUtils;
+import android.test.InstrumentationTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import org.chromium.content.browser.test.util.CallbackHelper;
+import org.chromium.base.test.util.DisabledTest;
+import org.chromium.base.test.util.Feature;
+import org.chromium.content.browser.ContentView;
+import org.chromium.content.browser.ContentViewCore;
+
+import org.xwalk.core.XWalkClient;
+import org.xwalk.core.XWalkContent;
+import org.xwalk.core.XWalkView;
+
+/**
+ * Renderer responsiveness tests:
+ *
+ * Internally, a hang monitor timer will start for each renderer when there is
+ * an input event sent to the renderer. If the ACK for handling the input event
+ * is not received in 30 seconds, the renderer is deemed to be unresponsive to
+ * user interaction.
+ */
+public class RendererResponsivenessTest extends XWalkViewTestBase {
+    private OnRendererResponsivenessHelper responsiveHelper = new OnRendererResponsivenessHelper();
+    private OnRendererResponsivenessHelper unresponsiveHelper = new OnRendererResponsivenessHelper();
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Feature({"RendererResponsivenessTest"})
+    @MediumTest
+    public void testRendererUnresponsive() throws Throwable {
+        getXWalkView().setXWalkClient(new ResponsivenessTestClient() {
+            @Override
+            public void onRendererUnresponsive(XWalkView view) {
+                unresponsiveHelper.notifyCalled(view);
+            }
+        });
+
+        loadAssetFile("renderHung.html");
+
+        int currentCallCount = unresponsiveHelper.getCallCount();
+
+        XWalkContent content = getXWalkView().getXWalkViewContentForTest();
+        content.getContentViewCoreForTest().evaluateJavaScript("deadLoopForever();", null);
+
+        /**
+         * Send an input event to xwalk view. Internally, if no ACK message is received
+         * for handling this input event in 30 seconds, onRendererUnresponsive callback
+         * would be called.
+         */
+        TouchUtils.clickView(this, getXWalkView());
+
+        /**
+         * The timeout for responsiveness checking is 30 seconds, so here the timeout
+         * for callback is set to 40 seconds to ensure the onRendererResponsive
+         * to be called.
+         */
+        unresponsiveHelper.waitForCallback(currentCallCount, 1, 40, TimeUnit.SECONDS);
+        assertEquals(getXWalkView(), unresponsiveHelper.getXWalkView());
+    }
+
+    @Feature({"RendererResponsivenessTest"})
+    @MediumTest
+    public void testRendererResponsiveAgain() throws Throwable {
+        getXWalkView().setXWalkClient(new ResponsivenessTestClient() {
+            /**
+             * Called once the renderer become responsive again.
+             */
+            @Override
+            public void onRendererResponsive(XWalkView view) {
+                responsiveHelper.notifyCalled(view);
+            }
+        });
+
+        loadAssetFile("renderHung.html");
+
+        int currentCallCount = responsiveHelper.getCallCount();
+        XWalkContent content = getXWalkView().getXWalkViewContentForTest();
+        content.getContentViewCoreForTest().evaluateJavaScript("deadLoopFor40secs();", null);
+
+        /**
+         * Send an input event to start the hung monitor.
+         */
+        TouchUtils.clickView(this, getXWalkView());
+
+        /**
+         * Wait for onRendererResponsive to called. The dead loop is designed to run
+         * 40 seconds, and here we wait for 50 seconds to ensure it has enough time to
+         * call onRendererResponsive callback.
+         */
+        responsiveHelper.waitForCallback(currentCallCount, 1, 50, TimeUnit.SECONDS);
+        assertEquals(getXWalkView(), responsiveHelper.getXWalkView());
+    }
+
+    private final class OnRendererResponsivenessHelper extends CallbackHelper {
+        private XWalkView mView;
+
+        public void notifyCalled(XWalkView view) {
+            mView = view;
+            notifyCalled();
+        }
+        public XWalkView getXWalkView() {
+            assert getCallCount() > 0;
+            return mView;
+        }
+    }
+
+    private class ResponsivenessTestClient extends XWalkClient {
+        @Override
+        public void onPageStarted(XWalkView view, String url, Bitmap favicon) {
+            mTestContentsClient.onPageStarted(url);
+        }
+
+        @Override
+        public void onPageFinished(XWalkView view, String url) {
+            mTestContentsClient.didFinishLoad(url);
+        }
+    };
+}

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -69,6 +69,7 @@
         '<(java_in_dir)/assets/framesEcho.html',
         '<(java_in_dir)/assets/index.html',
         '<(java_in_dir)/assets/navigator.online.html',
+        '<(java_in_dir)/assets/renderHung.html',
       ],
       'variables': {
         'apk_name': 'XWalkCoreTest',


### PR DESCRIPTION
This fix is to add 2 new APIs to XWalkClient for renderer
responsiveness. Internally, xwalk will start a timer to check if the
renderer become unresponsive if no ACK message for handling input event
is received from the renderer in 30 seconds. In this case, the callback
onRendererUnresponsive will be called. If it becomes responsive again,
the callback onRendererResponsive will be called.

BUG=https://github.com/crosswalk-project/crosswalk/issues/913
TEST=org.xwalk.core.xwview.test.RendererResponsivenessTest
