### PR TITLE
[Android] Remove the wrong dependence in runtime client test apk.

### DIFF
--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -289,7 +289,6 @@
         '../net/net.gyp:net_java_test_support',
         '../tools/android/forwarder2/forwarder.gyp:forwarder2',
         '../tools/android/md5sum/md5sum.gyp:md5sum',
-        'xwalk_core_shell_apk_java',
         'xwalk_runtime_client_shell_apk_java',
       ],
       'variables': {


### PR DESCRIPTION
This patch will resolve the issue about wrong dependence in the runtime
client test apk.
In file CrossPackageWrapper.java, the constructor function "CrossPackageWrapper()"
has the judgement about the class loaded. In shared mode, the core shell is not
needed for the runtime client test shell.

BUG=#916
