### PR TITLE
[Android] Multi-frame support for XWalk extension on Android

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
@@ -30,6 +30,7 @@ public class XWalkExtensionClient extends CrossPackageWrapper {
     private Method mGetExtensionName;
     private Method mGetJsApi;
     private Method mPostMessage;
+    private Method mBroadcastMessage;
 
     protected XWalkExtensionContextClient mContext;
 
@@ -42,6 +43,7 @@ public class XWalkExtensionClient extends CrossPackageWrapper {
         mGetExtensionName = lookupMethod("getExtensionName");
         mGetJsApi = lookupMethod("getJsApi");
         mPostMessage = lookupMethod("postMessage", String.class);
+        mBroadcastMessage = lookupMethod("broadcastMessage", String.class);
     }
 
     /**
@@ -87,18 +89,20 @@ public class XWalkExtensionClient extends CrossPackageWrapper {
      * JavaScript calls into Java code. The message is handled by
      * the extension implementation. The inherited classes should
      * override and add its implementation.
+     * @param extensionInstanceID the ID of extension instance where the message came from.
      * @param message the message from JavaScript code.
      */
-    public void onMessage(String message) {
+    public void onMessage(int extensionInstanceID, String message) {
     }
 
     /**
      * Synchronized JavaScript calls into Java code. Similar to
      * onMessage. The only difference is it's a synchronized
      * message.
+     * @param extensionInstanceID the ID of extension instance where the message came from.
      * @param message the message from JavaScript code.
      */
-    public String onSyncMessage(String message) {
+    public String onSyncMessage(int extensionInstanceID, String message) {
         return "";
     }
 
@@ -106,9 +110,20 @@ public class XWalkExtensionClient extends CrossPackageWrapper {
      * Post messages to JavaScript via extension's context.
      * It's used by child classes to post message from Java side
      * to JavaScript side.
+     * @param extensionInstanceID the ID of extension instance where the message came from.
      * @param message the message to be passed to Javascript.
      */
-    public final void postMessage(String message) {
-        invokeMethod(mPostMessage, mInstance, message);
+    public final void postMessage(int extensionInstanceID, String message) {
+        invokeMethod(mPostMessage, mInstance, extensionInstanceID, message);
+    }
+
+    /**
+     * Broadcast messages to JavaScript via extension's context.
+     * It's used by child classes to broadcast message from Java side
+     * to all JavaScript side instances of the extension.
+     * @param message the message to be passed to Javascript.
+     */
+    public final void broadcastMessage(String message) {
+        invokeMethod(mBroadcastMessage, mInstance, message);
     }
 }

--- a/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
+++ b/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.core.extensions;
 
+import java.util.ArrayList;
 import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
 
@@ -14,41 +15,41 @@ import org.chromium.base.JNINamespace;
 @JNINamespace("xwalk::extensions")
 public abstract class XWalkExtensionAndroid {
     private int mXWalkExtension;
-    private int mXWalkExtensionInstanceID = 0;
+    private ArrayList<Integer> mInstances;
 
     public XWalkExtensionAndroid(String name, String jsApi) {
         mXWalkExtension = nativeCreateExtension(name, jsApi);
+        mInstances = new ArrayList<Integer>();
     }
 
-    public void postMessage(String message) {
-        if (mXWalkExtensionInstanceID != 0) {
-            nativePostMessage(mXWalkExtension, mXWalkExtensionInstanceID, message);
+    public void postMessage(int instanceID, String message) {
+        nativePostMessage(mXWalkExtension, instanceID, message);
+    }
+
+    public void broadcastMessage(String message) {
+        for(Integer i : mInstances) {
+            postMessage(i, message);
         }
     }
 
     @CalledByNative
-    public abstract void handleMessage(String message);
+    public abstract void handleMessage(int instanceID, String message);
 
     @CalledByNative
-    public abstract String handleSyncMessage(String message);
+    public abstract String handleSyncMessage(int instanceID, String message);
 
     @CalledByNative
     public abstract void onDestroy();
 
-    /* FIXME(halton): Internal WebFrame is not exposed in Java side. With that
-     * fact, if multiple instances alive(iframe), there is no way to identify
-     * which instance to send message. We only keep the most recent instance id
-     * in Java. Thus all instances will be able to send messages to Java, but
-     * Java only sned to the most recent.
-     */
     @CalledByNative
     private void onInstanceCreated(int instanceID) {
-        mXWalkExtensionInstanceID = instanceID;
+        if(!mInstances.contains(new Integer(instanceID)))
+            mInstances.add(new Integer(instanceID));
     }
 
     @CalledByNative
-    private void onInstanceRemoved() {
-        mXWalkExtensionInstanceID = 0;
+    private void onInstanceRemoved(int instanceID) {
+        mInstances.remove(new Integer(instanceID));
     }
 
     private native int nativeCreateExtension(String name, String jsApi);

--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -99,7 +99,7 @@ void XWalkExtensionAndroid::RemoveInstance(int instance) {
   }
 
   instances_.erase(instance);
-  Java_XWalkExtensionAndroid_onInstanceRemoved(env, obj.obj());
+  Java_XWalkExtensionAndroid_onInstanceRemoved(env, obj.obj(), instance);
 }
 
 XWalkExtensionAndroidInstance::XWalkExtensionAndroidInstance(
@@ -130,7 +130,7 @@ void XWalkExtensionAndroidInstance::HandleMessage(
     return;
   }
 
-  Java_XWalkExtensionAndroid_handleMessage(env, obj.obj(), buffer);
+  Java_XWalkExtensionAndroid_handleMessage(env, obj.obj(), getID(), buffer);
 }
 
 void XWalkExtensionAndroidInstance::HandleSyncMessage(
@@ -152,7 +152,7 @@ void XWalkExtensionAndroidInstance::HandleSyncMessage(
 
   jstring buffer = env->NewStringUTF(value.c_str());
   ScopedJavaLocalRef<jstring> ret =
-      Java_XWalkExtensionAndroid_handleSyncMessage(env, obj.obj(), buffer);
+      Java_XWalkExtensionAndroid_handleSyncMessage(env, obj.obj(), getID(), buffer);
 
   const char *str = env->GetStringUTFChars(ret.obj(), 0);
   ret_val = base::Value::CreateStringValue(str);

--- a/extensions/common/android/xwalk_extension_android.h
+++ b/extensions/common/android/xwalk_extension_android.h
@@ -66,6 +66,10 @@ class XWalkExtensionAndroidInstance : public XWalkExtensionInstance {
     PostMessageToJS(scoped_ptr<base::Value>(new base::StringValue(msg)));
   }
 
+  int getID() {
+      return id_;
+  }
+
  private:
   virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
   virtual void HandleSyncMessage(scoped_ptr<base::Value> msg) OVERRIDE;

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreExtensionBridge.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreExtensionBridge.java
@@ -26,13 +26,13 @@ class XWalkCoreExtensionBridge extends XWalkExtensionAndroid {
     }
 
     @Override
-    public void handleMessage(String message) {
-        mProvider.onMessage(mExtension, message);
+    public void handleMessage(int instanceID, String message) {
+        mProvider.onMessage(mExtension, instanceID, message);
     }
 
     @Override
-    public String handleSyncMessage(String message) {
-        return mProvider.onSyncMessage(mExtension, message);
+    public String handleSyncMessage(int instanceID, String message) {
+        return mProvider.onSyncMessage(mExtension, instanceID, message);
     }
 
     @Override

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -108,9 +108,15 @@ class XWalkCoreProviderImpl extends XWalkRuntimeViewProvider {
     }
 
     @Override
-    public void postMessage(XWalkExtension extension, String message) {
+    public void postMessage(XWalkExtension extension, int instanceID, String message) {
         XWalkCoreExtensionBridge bridge = (XWalkCoreExtensionBridge)extension.getRegisteredId();
-        bridge.postMessage(message);
+        bridge.postMessage(instanceID, message);
+    }
+
+    @Override
+    public void broadcastMessage(XWalkExtension extension, String message) {
+        XWalkCoreExtensionBridge bridge = (XWalkCoreExtensionBridge)extension.getRegisteredId();
+        bridge.broadcastMessage(message);
     }
 
     // For instrumentation test.

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -79,21 +79,27 @@ public abstract class XWalkRuntimeViewProvider {
      * Pass messages from native extension system to runtime extension system.
      * Might be overrided to do customizations here.
      */
-    public void onMessage(XWalkExtension extension, String message) {
-        extension.onMessage(message);
+    public void onMessage(XWalkExtension extension, int instanceID, String message) {
+        extension.onMessage(instanceID, message);
     }
 
     /**
      * Pass synchronized messages.
      */
-    public String onSyncMessage(XWalkExtension extension, String message) {
-        return extension.onSyncMessage(message);
+    public String onSyncMessage(XWalkExtension extension, int instanceID, String message) {
+        return extension.onSyncMessage(instanceID, message);
     }
 
     /**
      * Pass message from runtime extension system to native and then to JavaScript.
      */
-    public abstract void postMessage(XWalkExtension extension, String message);
+    public abstract void postMessage(XWalkExtension extension, int instanceID, String message);
+
+    /**
+     * Broadcast message from runtime extension system to native and then to JavaScript.
+     * It means Java side will post the message to all instances of the extension.
+     */
+    public abstract void broadcastMessage(XWalkExtension extension, String message);
 
     // For instrumentation test.
     public abstract String getTitleForTest();

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
@@ -60,17 +60,19 @@ public abstract class XWalkExtension {
      * JavaScript calls into Java code. The message is handled by
      * the extension implementation. The inherited classes should
      * override and add its implementation.
+     * @param instanceID the ID of extension instance where the message came from.
      * @param message the message from JavaScript code.
      */
-    public abstract void onMessage(String message);
+    public abstract void onMessage(int instanceID, String message);
 
     /**
      * Synchronized JavaScript calls into Java code. Similar to
      * onMessage. The only difference is it's a synchronized
      * message.
+     * @param instanceID the ID of extension instance where the message came from.
      * @param message the message from JavaScript code.
      */
-    public String onSyncMessage(String message) {
+    public String onSyncMessage(int instanceID, String message) {
         return null;
     }
 
@@ -78,10 +80,21 @@ public abstract class XWalkExtension {
      * Post messages to JavaScript via extension's context.
      * It's used by child classes to post message from Java side
      * to JavaScript side.
+     * @param instanceID the ID of target extension instance.
      * @param message the message to be passed to Javascript.
      */
-    public void postMessage(String message) {
-        mExtensionContext.postMessage(this, message);
+    public void postMessage(int instanceID, String message) {
+        mExtensionContext.postMessage(this, instanceID, message);
+    }
+
+    /**
+     * Broadcast messages to JavaScript via extension's context.
+     * It's used by child classes to broad message from Java side
+     * to all JavaScript side instances of the extension.
+     * @param message the message to be passed to Javascript.
+     */
+    public void broadcastMessage(String message) {
+        mExtensionContext.broadcastMessage(this, message);
     }
 
     /**

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionClientImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionClientImpl.java
@@ -41,13 +41,13 @@ public class XWalkExtensionClientImpl extends XWalkExtension {
     }
 
     @Override
-    public void onMessage(String message) {
-        invokeMethod(mOnMessage, mExtensionClient, message);
+    public void onMessage(int extensionInstanceID, String message) {
+        invokeMethod(mOnMessage, mExtensionClient, extensionInstanceID, message);
     }
 
     @Override
-    public String onSyncMessage(String message) {
-        return (String) invokeMethod(mOnSyncMessage, mExtensionClient, message);
+    public String onSyncMessage(int extensionInstanceID, String message) {
+        return (String) invokeMethod(mOnSyncMessage, mExtensionClient, extensionInstanceID, message);
     }
 
     @Override

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContext.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContext.java
@@ -28,9 +28,17 @@ public abstract class XWalkExtensionContext {
     /**
      * Post message to JavaScript via internal mechanism.
      * @param extension the extension which needs to post message to JavaScript.
+     * @param instanceID the ID of target extension instance.
      * @param message the message to be passed.
      */
-    public abstract void postMessage(XWalkExtension extension, String message);
+    public abstract void postMessage(XWalkExtension extension, int instanceID, String message);
+
+    /**
+     * Broadcast message to all JavaScript instances via internal mechanism.
+     * @param extension the extension which needs to post message to JavaScript.
+     * @param message the message to be passed.
+     */
+    public abstract void broadcastMessage(XWalkExtension extension, String message);
 
     /**
      * Get current Android Context.

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextImpl.java
@@ -35,8 +35,13 @@ public class XWalkExtensionContextImpl extends XWalkExtensionContext {
     }
 
     @Override
-    public void postMessage(XWalkExtension extension, String message) {
-        mManager.postMessage(extension, message);
+    public void postMessage(XWalkExtension extension, int instanceID, String message) {
+        mManager.postMessage(extension, instanceID, message);
+    }
+
+    @Override
+    public void broadcastMessage(XWalkExtension extension, String message) {
+        mManager.broadcastMessage(extension, message);
     }
 
     @Override

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextWrapper.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextWrapper.java
@@ -26,8 +26,12 @@ public class XWalkExtensionContextWrapper extends XWalkExtensionContext {
         mOriginContext.unregisterExtension(extension);
     }
 
-    public void postMessage(XWalkExtension extension, String message) {
-        mOriginContext.postMessage(extension, message);
+    public void postMessage(XWalkExtension extension, int instanceID, String message) {
+        mOriginContext.postMessage(extension, instanceID, message);
+    }
+
+    public void broadcastMessage(XWalkExtension extension, String message) {
+        mOriginContext.broadcastMessage(extension, message);
     }
 
     public Context getContext() {

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
@@ -52,8 +52,12 @@ public class XWalkExtensionManager {
         return mExtensionContextImpl;
     }
 
-    public void postMessage(XWalkExtension extension, String message) {
-        mXwalkProvider.postMessage(extension, message);
+    public void postMessage(XWalkExtension extension, int instanceID, String message) {
+        mXwalkProvider.postMessage(extension, instanceID, message);
+    }
+
+    public void broadcastMessage(XWalkExtension extension, String message) {
+        mXwalkProvider.broadcastMessage(extension, message);
     }
 
     public Object registerExtension(XWalkExtension extension) {

--- a/test/android/core/javatests/assets/broadcast.html
+++ b/test/android/core/javatests/assets/broadcast.html
@@ -1,0 +1,35 @@
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <iframe id="subFrame"></iframe>
+    <script>
+
+      function setTitle(result) {
+        if (result === true) {
+          document.title = "Pass";
+        } else {
+          document.title = "Fail";
+        }
+      }
+
+      var topMsg = "from top-frame";
+      try {
+        broadcast.trigger(topMsg);
+      } catch(e) {
+        console.log(e);
+        setTitle(false);
+      }
+
+      setTimeout(function () {
+        var expected = "From java broadcast:" + topMsg;
+        var topReceivedMsg = document.getElementById("showBroadcast").innerHTML;
+        var iframeDocument = document.getElementById('subFrame').contentDocument;
+        var iframeReceivedMsg = iframeDocument.getElementById("showBroadcast").innerHTML;
+        setTitle(iframeReceivedMsg === expected && topReceivedMsg === expected);
+      }, 1000);
+
+    </script>
+  </body>
+</html>

--- a/test/android/core/javatests/assets/framesEcho.html
+++ b/test/android/core/javatests/assets/framesEcho.html
@@ -1,0 +1,65 @@
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <div id="result">show test result...</div>
+    <iframe id="subFrame"></iframe>
+    <script>
+      var iframe = document.getElementById("subFrame");
+
+      iframe.contentDocument.write("<html>\n"
+        + " <head>\n"
+        + " <script>\n"
+        + "   try {\n"
+        + "     var d = new Date().toString();\n"
+        + "     echo.echo(d, function(msg) {\n"
+        + "       document.write(msg + '<br>');\n"
+        + "       var expected = 'From java:' + d;\n"
+        + "       if (msg === expected) {\n"
+        + "         document.write('Async echo <font color=green>passed</font>.');\n"
+        + "         top.onIframeFinish();\n"
+        + "       } else {\n"
+        + "         document.write('Async echo <font color=red>failed</font>.');\n"
+        + "         top.setTestResult(false);\n"
+        + "       }\n"
+        + "     });\n"
+        + "   } catch(e) {\n"
+        + "     console.log(e);\n"
+        + "     top.setTestResult(false);\n"
+        + "   }\n"
+        + "  <\/script>\n"
+        + "  <\/head>\n"
+        + "</html>");
+
+      function setTestResult(result) {
+        var resultDiv = document.getElementById('result');
+        if (result === true) {
+          document.title = "Pass";
+          resultDiv.innerHTML = "Multi-frame test <font color=green>passed</font>.";
+        } else {
+          document.title = "Fail";
+          resultDiv.innerHTML = "Multi-frame test <font color=green>failed</font>.";
+        }
+      }
+
+      function onIframeFinish() {
+        /**
+        * With unchanged implementation, the "top-frame msg" will be
+        * post to iframe(recent one), the top frame will not get the
+        * echo back message, and set test fail.
+        */
+        var topMsg = "top-frame msg";
+        try {
+          echo.echo(topMsg, function(msg) {
+            var expected = "From java:" + topMsg;
+            setTestResult(msg === expected);
+          });
+        } catch(e) {
+          console.log(e);
+          setTestResult(false);
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcast.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcast.java
@@ -1,0 +1,35 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import org.xwalk.core.extensions.XWalkExtensionAndroid;
+
+public class ExtensionBroadcast extends XWalkExtensionAndroid {
+
+    public ExtensionBroadcast() {
+        super("broadcast",
+              "extension.setMessageListener(function(msg) {"
+              + "    var showBroadcast = document.createElement('div');"
+              + "    showBroadcast.id = 'showBroadcast';"
+              + "    showBroadcast.innerHTML = msg;"
+              + "    document.body.appendChild(showBroadcast);"
+              + "});"
+              + "exports.trigger = function(msg) {"
+              + "  extension.postMessage(msg);"
+              + "};"
+             );
+    }
+
+    public void handleMessage(int instanceID, String message) {
+        broadcastMessage("From java broadcast:" + message);
+    }
+
+    public String handleSyncMessage(int instanceID, String message) {
+        return "From java:" + message;
+    }
+
+    public void onDestroy() {
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.graphics.Bitmap;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.core.XWalkClient;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkWebChromeClient;
+import org.xwalk.core.xwview.test.ExtensionBroadcast;
+
+/**
+ * Test suite for ExtensionBroadcast().
+ */
+public class ExtensionBroadcastTest extends XWalkViewTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        class TestXWalkClient extends XWalkClient {
+            @Override
+            public void onPageStarted(XWalkView view, String url, Bitmap favicon) {
+                mTestContentsClient.onPageStarted(url);
+            }
+
+            @Override
+            public void onPageFinished(XWalkView view, String url) {
+                mTestContentsClient.didFinishLoad(url);
+            }
+        }
+
+        getXWalkView().setXWalkClient(new TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"ExtensionBroadcast"})
+    public void testExtensionBroadcast() throws Throwable {
+        ExtensionBroadcast broadcast = new ExtensionBroadcast();
+
+        loadAssetFile("broadcast.html");
+        Thread.sleep(1000);
+        assertEquals("Pass", getTitleOnUiThread());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEcho.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEcho.java
@@ -26,11 +26,11 @@ public class ExtensionEcho extends XWalkExtensionAndroid {
              );
     }
 
-    public void handleMessage(String message) {
-        postMessage("From java:" + message);
+    public void handleMessage(int instanceID, String message) {
+        postMessage(instanceID, "From java:" + message);
     }
 
-    public String handleSyncMessage(String message) {
+    public String handleSyncMessage(int instanceID, String message) {
         return "From java:" + message;
     }
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEchoTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEchoTest.java
@@ -61,4 +61,15 @@ public class ExtensionEchoTest extends XWalkViewTestBase {
         loadAssetFile("echoSync.html");
         assertEquals("Pass", getTitleOnUiThread());
     }
+
+    @SmallTest
+    @Feature({"ExtensionEcho"})
+    public void testExtensionEchoMultiFrames() throws Throwable {
+        ExtensionEcho echo = new ExtensionEcho();
+
+        loadAssetFile("framesEcho.html");
+
+        Thread.sleep(1000);
+        assertEquals("Pass", getTitleOnUiThread());
+    }
 }

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -67,13 +67,19 @@
         'java_in_dir': 'test/android/core/javatests',
         'is_test_apk': 1,
         'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/broadcast.html',
           '<(PRODUCT_DIR)/xwalk_xwview_test/assets/echo.html',
           '<(PRODUCT_DIR)/xwalk_xwview_test/assets/echoSync.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/framesEcho.html',
           '<(PRODUCT_DIR)/xwalk_xwview_test/assets/index.html',
         ],
         'asset_location': '<(ant_build_out)/xwalk_xwview_test/assets',
       },
       'copies': [
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_xwview_test/assets',
+          'files': ['<(java_in_dir)/assets/broadcast.html'],
+        },
         {
           'destination': '<(PRODUCT_DIR)/xwalk_xwview_test/assets',
           'files': ['<(java_in_dir)/assets/echo.html'],
@@ -84,8 +90,12 @@
         },
         {
           'destination': '<(PRODUCT_DIR)/xwalk_xwview_test/assets',
-          'files': ['<(java_in_dir)/assets/index.html'],
+          'files': ['<(java_in_dir)/assets/framesEcho.html'],
         },
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_xwview_test/assets',
+          'files': ['<(java_in_dir)/assets/index.html'],
+        }
       ],
       'includes': [ '../build/java_apk.gypi' ],
     },


### PR DESCRIPTION
When there are multiple frames in one page, extension instance will
be created for each frame. But as internal WebFrame is not exposed
in Java side, there is no way for Java side to identify which
instance to send message. This patch exposed instanceID up to Java
side when it receives message which can be used to identify the
target instance when post message to JavaScript side. What's more
a new interface "broadcastMessage" was added to meet the requirement
that Java side may need to broadcast message to all exiting instances.

Changed interfaces for Java extension:
1. postMessage(String msg) -> postMessage(int instanceID, String msg)
2. onMessage(String msg)   -> onMessage(int instanceID, String msg)
3. onSyncMessage(String msg) -> onSyncMessage(int instanceID, String msg)
4. new added: broadcastMessage(String msg)

BUG=#705
