### PR TITLE
[Android] Fix incorrect res ids for apps using cordova xwalk

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -30,32 +30,26 @@ def CleanLibraryProject(out_directory):
 
 def CopyProjectFiles(project_source, out_directory):
   print 'Copying library project files...'
-  # Copy AndroidManifest.xml from template.
-  source_file = os.path.join(project_source, 'xwalk', 'build', 'android',
-                             'xwalkcore_library_template',
-                             'AndroidManifest.xml')
-  target_file = os.path.join(out_directory, LIBRARY_PROJECT_NAME,
-                             'AndroidManifest.xml')
-  shutil.copyfile(source_file, target_file)
-  # Copy Eclipse project properties from template.
-  source_file = os.path.join(project_source, 'xwalk', 'build', 'android',
-                             'xwalkcore_library_template',
-                             'project.properties')
-  target_file = os.path.join(out_directory, LIBRARY_PROJECT_NAME,
-                             'project.properties')
-  shutil.copyfile(source_file, target_file)
-  # Copy Ant build file.
-  source_file = os.path.join(project_source, 'xwalk', 'build', 'android',
-                             'xwalkcore_library_template',
-                             'build.xml')
-  target_file = os.path.join(out_directory, LIBRARY_PROJECT_NAME, 'build.xml')
-  shutil.copyfile(source_file, target_file)
-  # Copy Ant properties file.
-  source_file = os.path.join(project_source, 'xwalk', 'build', 'android',
-                             'xwalkcore_library_template',
-                             'ant.properties')
-  target_file = os.path.join(out_directory, LIBRARY_PROJECT_NAME, 'ant.properties')
-  shutil.copyfile(source_file, target_file)
+  template_folder = os.path.join(project_source, 'xwalk', 'build', 'android',
+                                 'xwalkcore_library_template')
+  files_to_copy = [
+      # AndroidManifest.xml from template.
+      'AndroidManifest.xml',
+      # Eclipse project properties from template.
+      'project.properties',
+      # Ant build file.
+      'build.xml',
+      # Customized Ant build file.
+      'precompile.xml',
+      # Python script to copy R.java.
+      'prepare_r_java.py',
+      # Ant properties file.
+      'ant.properties',
+  ]
+  for f in files_to_copy:
+    source_file = os.path.join(template_folder, f)
+    target_file = os.path.join(out_directory, LIBRARY_PROJECT_NAME, f)
+    shutil.copyfile(source_file, target_file)
 
 
 def CopyChromiumJavaSources(project_source, out_directory):
@@ -105,19 +99,6 @@ def CopyChromiumJavaSources(project_source, out_directory):
   target_path = os.path.join(target_package_directory, 'components',
                              'web_contents_delegate_android')
   shutil.copytree(source_path, target_path)
-
-  source_file = os.path.join(project_source, 'content', 'public', 'android',
-                             'java', 'resource_map', 'org', 'chromium',
-                             'content', 'R.java')
-  target_file = os.path.join(out_directory, LIBRARY_PROJECT_NAME, 'src', 'org',
-                             'chromium', 'content', 'R.java')
-  shutil.copyfile(source_file, target_file)
-
-  source_file = os.path.join(project_source, 'ui', 'android', 'java',
-                             'resource_map', 'org', 'chromium', 'ui', 'R.java')
-  target_file = os.path.join(out_directory, LIBRARY_PROJECT_NAME, 'src', 'org',
-                             'chromium', 'ui', 'R.java')
-  shutil.copyfile(source_file, target_file)
 
 
 def CopyGeneratedSources(out_directory):

--- a/build/android/xwalkcore_library_template/ant.properties
+++ b/build/android/xwalkcore_library_template/ant.properties
@@ -14,4 +14,5 @@
 #  'key.store' for the location of your keystore and
 #  'key.alias' for the name of the key to use.
 # The password will be asked during the build when you use the 'release' target.
+ADDITIONAL_RES_PACKAGES="org.chromium.content org.chromium.ui"
 

--- a/build/android/xwalkcore_library_template/build.xml
+++ b/build/android/xwalkcore_library_template/build.xml
@@ -24,6 +24,8 @@ found in the LICENSE file.
 
 	<import file="custom_rules.xml" optional="true" />
 
+	<import file="precompile.xml" />
+
 	<!-- version-tag: custom -->
 	<import file="${sdk.dir}/tools/ant/build.xml" />
 </project>

--- a/build/android/xwalkcore_library_template/precompile.xml
+++ b/build/android/xwalkcore_library_template/precompile.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2005-2008 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project default="-pre-compile">
+  <script language="javascript">
+    var before = project.getProperty("ADDITIONAL_RES_PACKAGES");
+    project.setProperty("project.additional.packages", before.replaceAll(" ", ";"));
+  </script>
+
+  <!-- Code Generation: Copying R.java to additional packages -->
+  <target name="-pre-compile">
+      <mkdir dir="${gen.absolute.dir}" />
+      <exec executable="python" failonerror="true">
+        <arg line="prepare_r_java.py --app-package ${project.app.package}" />
+        <arg line="--packages ${project.additional.packages}" />
+        <arg line="--gen-path ${gen.absolute.dir}" />
+      </exec>
+  </target>
+</project>

--- a/build/android/xwalkcore_library_template/prepare_r_java.py
+++ b/build/android/xwalkcore_library_template/prepare_r_java.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""Copy the generated R.java to additional packages under gen.
+   Besides copying, the script will change the fixed value in
+   new created R.javas to references to the generated R.java.
+
+   The generated R.java looks like:
+     package app_package;
+
+     public final class R {
+         public static final class attr {
+             public static int value=0x70000001;
+         }
+     }
+   After modified, it will be:
+     package additional_package;
+
+     public final class R {
+         public static final class attr {
+             public static int value=app_package.R.attr.value;
+         }
+     }
+"""
+
+import optparse
+import os
+import re
+import sys
+
+# To match line "package app_package;".
+RE_PACKAGE = re.compile('^package ([a-zA-Z_]+(?:|\.[a-zA-Z_]+)*);$')
+# To match line "    public static final class attr {".
+RE_CLASS = re.compile('^(?:|[ ]*)public static final class ([a-zA-Z_]+) {$')
+# To match line "        public static int value=0x70000001;".
+RE_VALUE = re.compile('^([ ]*)public static int ([a-zA-Z_]+)=(0x[0-9a-f]{8});$')
+
+
+def PlaceRJavaInPackage(gen_path, app_package, target_package):
+  r_java = os.path.join(gen_path, app_package.replace('.', os.sep), 'R.java')
+  if not os.path.isfile(r_java):
+    print '%s does not exist' % r_java
+    sys.exit(1)
+
+  target_folder = os.path.join(gen_path, target_package.replace('.', os.sep))
+  if not os.path.isdir(target_folder):
+    os.makedirs(target_folder)
+  target_java_file = open(os.path.join(target_folder, 'R.java'), 'w')
+
+  current_class = None
+  got_package = False
+  for line in open(r_java, 'r').readlines():
+    if not got_package:
+      # Looking for package declaration.
+      match_package = RE_PACKAGE.match(line)
+      if match_package and match_package.groups()[0] == app_package:
+        got_package = True
+        target_java_file.write('package %s;\n' % target_package)
+      else:
+        target_java_file.write(line)
+      continue
+
+    # Trying to match class pattern first.
+    match_class = RE_CLASS.match(line)
+    if match_class:
+      current_class = match_class.groups()[0]
+      target_java_file.write(line)
+      continue
+
+    if current_class:
+      match_value = RE_VALUE.match(line)
+      if match_value:
+        target_java_file.write(
+            '%spublic static int %s=%s.R.%s.%s;\n' % (match_value.groups()[0],
+                                                      match_value.groups()[1],
+                                                      app_package,
+                                                      current_class,
+                                                      match_value.groups()[1]))
+        continue
+
+    target_java_file.write(line)
+
+  target_java_file.close()
+
+
+def main():
+  option_parser = optparse.OptionParser()
+
+  option_parser.add_option('--app-package', default=None,
+      help='The package which provides R.java')
+  option_parser.add_option('--packages', default=None,
+      help='The additional packages which R.java to be placed in, '
+           'delimited by semicolon')
+  option_parser.add_option('--gen-path', default=None,
+      help='Path of the gen folder')
+
+  opts, _ = option_parser.parse_args()
+
+  if opts.packages == None or opts.packages.strip() == '':
+    return 0
+
+  if opts.gen_path == None:
+    print 'gen path not specified'
+    return 1
+
+  if opts.app_package == None:
+    print 'app package not specified'
+    return 1
+
+  for package in opts.packages.strip().split(';'):
+    PlaceRJavaInPackage(opts.gen_path, opts.app_package, package)
+
+  return 0
+
+
+if '__main__' == __name__:
+  sys.exit(main())


### PR DESCRIPTION
Cordova xwalk container is using xwalk core library as an
Android library project.
For Android library project, it will generate the R.java for
it when building the project depends on it (Let's call it app
project). But the R.class will be excluded when generating
classes.jar. Then the resources within both app and library will
be put together to generate R.java for both app and library
package, it is to make sure the ids for them will not be conflicted.

Meanwhile, the dependencies for android java target in gyp system
is not the same. It breaks down the ant tasks and customized them
in very complicated way, each project contains resources will
produce a R.txt which already has allocated ids in it. The project
depends on it will generate R.java based on that to avoid conflicts.

The two things can't work together, but the command line interface
cordova container provides to developer should not be changed.

The solution is here,
Take all resources within xwalk core library as resrouces for library.
An R.java will generated at code-gen step for them. This patch will
overwrite the pre-compile step between code-gen and compile.
The step will copy R.java for core library to package
org.chromium.content and org.chromium.ui, as well as replace the id
values in it with the references to org.xwalk.core.R.

BUG=https://github.com/crosswalk-project/crosswalk/issues/862
