### PR TITLE
[Runtime] Implement Non-persistent main document

### DIFF
--- a/application/browser/application_process_manager.h
+++ b/application/browser/application_process_manager.h
@@ -15,6 +15,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/time/time.h"
 #include "xwalk/application/common/application.h"
+#include "xwalk/runtime/browser/runtime_registry.h"
 
 class GURL;
 
@@ -31,7 +32,7 @@ class Manifest;
 
 // This manages dynamic state of running applications. By now, it only launches
 // one application, later it will manages all event pages' lifecycle.
-class ApplicationProcessManager {
+class ApplicationProcessManager : public RuntimeRegistryObserver {
  public:
   explicit ApplicationProcessManager(xwalk::RuntimeContext* runtime_context);
   ~ApplicationProcessManager();
@@ -41,13 +42,20 @@ class ApplicationProcessManager {
 
   Runtime* GetMainDocumentRuntime() const { return main_runtime_; }
 
+  // RuntimeRegistryObserver implementation.
+  virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE;
+  virtual void OnRuntimeRemoved(Runtime* runtime) OVERRIDE;
+  virtual void OnRuntimeAppIconChanged(Runtime* runtime) OVERRIDE {}
+
  private:
   bool RunMainDocument(const Application* application);
   bool RunFromLocalPath(const Application* application);
+  void CloseMainDocument();
 
   xwalk::RuntimeContext* runtime_context_;
   xwalk::Runtime* main_runtime_;
   base::WeakPtrFactory<ApplicationProcessManager> weak_ptr_factory_;
+  std::set<Runtime*> runtimes_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationProcessManager);
 };

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -262,6 +262,9 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
   runtime_registry_.reset(new RuntimeRegistry);
   extension_service_.reset(new extensions::XWalkExtensionService(this));
 
+  runtime_registry_->AddObserver(
+      runtime_context_->GetApplicationSystem()->process_manager());
+
   RegisterExternalExtensions();
 
   xwalk::application::ApplicationSystem* system =
@@ -399,6 +402,8 @@ bool XWalkBrowserMainParts::MainMessageLoopRun(int* result_code) {
 }
 
 void XWalkBrowserMainParts::PostMainMessageLoopRun() {
+  runtime_registry_->RemoveObserver(
+      runtime_context_->GetApplicationSystem()->process_manager());
 #if defined(OS_ANDROID)
   base::MessageLoopForUI::current()->Start();
 #else


### PR DESCRIPTION
The following CL is to implement https://crosswalk-project.org/jira/browse/XWALK-2.

This CL mainly introduces two IPC communication pairs to support non-persistent main document, 'ShouldSuspend'/'ShouldSuspendAck' as well as 'Suspend'/'SuspendAck'.

The first pair of message is to make sure main document is idle before unloading. If we find the main document is not
idle between the first pair of IPC communication, the second IPC pair will be canceled, that is to say, the main document won't enter suspending(closing) state. The second IPC pair will give render process a chance to do simple clean up task before main document is finally closed.

The CL makes ApplicationProcessManager as an Observer for Runtime objects. Therefore, whenever a Runtime object is added or removed, the ApplicationProcessManager could be notified.

It also add the command line option to set main document idle time and suspending time, which gives user oppotunity to change and may also help testing.
