### PR TITLE
Fix build for Windows.

### DIFF
--- a/runtime/browser/xwalk_runtime_browsertest.cc
+++ b/runtime/browser/xwalk_runtime_browsertest.cc
@@ -280,16 +280,8 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, GetWindowTitle) {
   EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
 
   NativeAppWindow* window = runtime()->window();
-#if defined(TOOLKIT_VIEWS) && defined(OS_WIN)
-  const int len = title.length() + 1;  // NULL-terminated string.
-  string16 window_title;
-  ::GetWindowText(window->GetNativeWindow(),
-                  WriteInto(&window_title, len), len);
-  EXPECT_EQ(title, window_title);
-#elif defined(USE_AURA)
   string16 window_title = window->GetNativeWindow()->title();
   EXPECT_EQ(title, window_title);
-#endif
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, OpenLinkInNewRuntime) {


### PR DESCRIPTION
Windows switched to Aura therefore we need to remove the old code
path and use the generic method to access the title. The compilation
failure was due to the fact that NativeWindow type is not anymore
a HWND.

BUG=936
