### PR TITLE
[Android] Fix text selection menu being auto-dismissed in some cases 

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -111,7 +111,6 @@ public class XWalkContent extends FrameLayout {
             mContentView.loadUrl(new LoadUrlParams(url));
         }
 
-        mContentView.clearFocus();
         mContentView.requestFocus();
     }
 


### PR DESCRIPTION
In previous xwalk implementation, the load operation will trigger
a pair of clear/request focus operation. Which makes the text selection
context menu hide immediately after it shows sometimes.

The fix is to only request focus when loading url.
