### PR TITLE
[Extensions][Android] Remove kXWalkDisableExtensionProcess flag.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -127,10 +127,6 @@ void SetXWalkCommandLineFlags() {
   command_line->AppendSwitch(switches::kEnableGestureTapHighlight);
 
 #if defined(OS_ANDROID)
-  // Disable ExtensionProcess for Android.
-  // External extensions will run in the BrowserProcess (in process mode).
-  command_line->AppendSwitch(switches::kXWalkDisableExtensionProcess);
-
   // Enable WebGL for Android.
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
 #endif


### PR DESCRIPTION
Android is already single process, this flag does take no effect.
Remove it to avoid confusion.
