### PR TITLE
[Android] Create the XWalkRenderViewExt object.

### DIFF
--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -9,6 +9,10 @@
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
 #include "xwalk/application/common/constants.h"
 
+#if defined(OS_ANDROID)
+#include "xwalk/runtime/renderer/android/xwalk_render_view_ext.h"
+#endif
+
 namespace xwalk {
 
 namespace {
@@ -36,6 +40,13 @@ void XWalkContentRendererClient::RenderThreadStarted() {
       ASCIIToUTF16(application::kApplicationScheme));
   WebKit::WebSecurityPolicy::registerURLSchemeAsSecure(application_scheme);
   WebKit::WebSecurityPolicy::registerURLSchemeAsCORSEnabled(application_scheme);
+}
+
+void XWalkContentRendererClient::RenderViewCreated(
+    content::RenderView* render_view) {
+#if defined(OS_ANDROID)
+  XWalkRenderViewExt::RenderViewCreated(render_view);
+#endif
 }
 
 void XWalkContentRendererClient::DidCreateScriptContext(

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -24,6 +24,7 @@ class XWalkContentRendererClient
 
   // ContentRendererClient implementation.
   virtual void RenderThreadStarted() OVERRIDE;
+  virtual void RenderViewCreated(content::RenderView* render_view) OVERRIDE;
   virtual void DidCreateScriptContext(
       WebKit::WebFrame* frame, v8::Handle<v8::Context> context,
       int extension_group, int world_id) OVERRIDE;


### PR DESCRIPTION
XWalkRenderViewExt is a class that handles several IPCs from the class
XWalkRenderViewHostExt. To make it work, an object of XWalkRenderViewExt
must be created first.
