### PR TITLE
Bump chromium-crosswalk in DEPS.xwalk.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '29.0.1547.57'
-chromium_crosswalk_point = 'd845fd7564ae03a3763589a2a7aa0a7ce9939b94'
+chromium_crosswalk_point = '4e2b11965ae0ae5f72fb67956289d2fd68c0a4a6'
 blink_crosswalk_point = 'bcc7da6145656ada9a0840b3f3b73878ed99b389'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
Bump chromium-crosswalk in DEPS.xwalk.

Bring in ONLY two process shows in task manager fix for Tizen.
In detail, this PR brings in the fix commit and merge commit.

BUG=#822
