### PR TITLE
[Android] Return the correct context for external extensions

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextWrapper.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextWrapper.java
@@ -9,7 +9,7 @@ import android.content.Context;
 
 /**
  * This is a public class to provide context for extensions.
- * It'll be shared by all extensions.
+ * It'll be shared by all external extensions.
  */
 public class XWalkExtensionContextWrapper extends XWalkExtensionContext {
     private XWalkExtensionContext mOriginContext;
@@ -31,7 +31,11 @@ public class XWalkExtensionContextWrapper extends XWalkExtensionContext {
     }
 
     public Context getContext() {
-        return mOriginContext.getContext();
+        // This is very tricky because for external extensions, we should
+        // use Activity which contains the context for runtime client side.
+        // mOriginContext.getContext() returns the context of library package,
+        // e.g., the package context of runtime side.
+        return mOriginContext.getActivity();
     }
 
     public Activity getActivity() {


### PR DESCRIPTION
The previous implementation returns the context of runtime side which is
a context for library package. This is true for internal extensions. However,
for external extensions, the context should be the same as the activity
because they're inside of runtime client. This is to fix the issue to return
the activity as the context for external extensions.

BUG=#777
