### PR TITLE
Enable impl-side painting by default

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -123,6 +123,9 @@ void SetXWalkCommandLineFlags() {
   // This also enables pinch on Tizen.
   command_line->AppendSwitch(switches::kEnableThreadedCompositing);
 
+  // Paint content on the compositor thread instead of the main thread.
+  command_line->AppendSwitch(cc::switches::kEnableImplSidePainting);
+
   // Show feedback on touch.
   command_line->AppendSwitch(switches::kEnableGestureTapHighlight);
 


### PR DESCRIPTION
Paint content on the compositor thread instead of the main thread, that should improve UX on Tizen.
