### PR TITLE
[Extensions] Remove GetJavaScriptAPI() virtual function

### DIFF
--- a/application/extension/application_extension.cc
+++ b/application/extension/application_extension.cc
@@ -24,10 +24,7 @@ ApplicationExtension::ApplicationExtension(
     application::ApplicationSystem* application_system)
   : application_system_(application_system) {
   set_name("xwalk.app");
-}
-
-const char* ApplicationExtension::GetJavaScriptAPI() {
-  return kSource_application_api;
+  set_javascript_api(kSource_application_api);
 }
 
 XWalkExtensionInstance* ApplicationExtension::CreateInstance() {

--- a/application/extension/application_extension.h
+++ b/application/extension/application_extension.h
@@ -28,7 +28,6 @@ class ApplicationExtension : public XWalkExtension {
       application::ApplicationSystem* application_system);
 
   // XWalkExtension implementation.
-  virtual const char* GetJavaScriptAPI() OVERRIDE;
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
  private:

--- a/experimental/dialog/dialog_extension.cc
+++ b/experimental/dialog/dialog_extension.cc
@@ -23,15 +23,12 @@ DialogExtension::DialogExtension(RuntimeRegistry* runtime_registry)
   : runtime_registry_(runtime_registry),
     owning_window_(NULL) {
   set_name("xwalk.experimental.dialog");
+  set_javascript_api(kSource_dialog_api);
   runtime_registry_->AddObserver(this);
 }
 
 DialogExtension::~DialogExtension() {
   runtime_registry_->RemoveObserver(this);
-}
-
-const char* DialogExtension::GetJavaScriptAPI() {
-  return kSource_dialog_api;
 }
 
 XWalkExtensionInstance* DialogExtension::CreateInstance() {

--- a/experimental/dialog/dialog_extension.h
+++ b/experimental/dialog/dialog_extension.h
@@ -32,7 +32,6 @@ class DialogExtension : public XWalkExtension,
   virtual ~DialogExtension();
 
   // XWalkExtension implementation.
-  virtual const char* GetJavaScriptAPI() OVERRIDE;
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
   // RuntimeRegistryObserver implementation.

--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -25,7 +25,7 @@ XWalkExtensionAndroid::XWalkExtensionAndroid(JNIEnv* env, jobject obj,
   env->ReleaseStringUTFChars(name, str);
 
   str = env->GetStringUTFChars(js_api, 0);
-  js_api_ = str;
+  set_javascript_api(str);
   env->ReleaseStringUTFChars(js_api, str);
 }
 
@@ -41,7 +41,7 @@ XWalkExtensionAndroid::~XWalkExtensionAndroid() {
 }
 
 bool XWalkExtensionAndroid::is_valid() {
-  if (instances_.empty() || js_api_.empty()) {
+  if (instances_.empty() || javascript_api().empty()) {
     return false;
   }
 
@@ -61,10 +61,6 @@ void XWalkExtensionAndroid::PostMessage(JNIEnv* env, jobject obj,
   const char* str = env->GetStringUTFChars(msg, 0);
   it->second->PostMessageWrapper(str);
   env->ReleaseStringUTFChars(msg, str);
-}
-
-const char* XWalkExtensionAndroid::GetJavaScriptAPI() {
-  return js_api_.c_str();
 }
 
 XWalkExtensionInstance* XWalkExtensionAndroid::CreateInstance() {

--- a/extensions/common/android/xwalk_extension_android.h
+++ b/extensions/common/android/xwalk_extension_android.h
@@ -37,7 +37,6 @@ class XWalkExtensionAndroid : public XWalkExtension {
   // JNI interface to post message from Java to JS
   void PostMessage(JNIEnv* env, jobject obj, jint instance, jstring msg);
 
-  virtual const char* GetJavaScriptAPI() OVERRIDE;
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
   void RemoveInstance(int instance);
@@ -48,7 +47,6 @@ class XWalkExtensionAndroid : public XWalkExtension {
   typedef std::map<int, XWalkExtensionAndroidInstance*> InstanceMap;
   InstanceMap instances_;
   JavaObjectWeakGlobalRef java_ref_;
-  std::string js_api_;
   int next_instance_id_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkExtensionAndroid);

--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -34,14 +34,10 @@ class XWalkExtension {
  public:
   virtual ~XWalkExtension();
 
-  // Returns the JavaScript API code that will be executed in the render
-  // process. It allows the extension provide a function or object based
-  // interface on top of the message passing.
-  virtual const char* GetJavaScriptAPI() = 0;
-
   virtual XWalkExtensionInstance* CreateInstance() = 0;
 
   std::string name() const { return name_; }
+  std::string javascript_api() const { return javascript_api_; }
 
   // Returns a list of entry points for which the extension should be loaded
   // when accessed. Entry points are used when the extension needs to have
@@ -51,6 +47,9 @@ class XWalkExtension {
  protected:
   XWalkExtension();
   void set_name(const std::string& name) { name_ = name; }
+  void set_javascript_api(const std::string& javascript_api) {
+    javascript_api_ = javascript_api;
+  }
   void set_entry_points(const std::vector<std::string>& entry_points) {
     entry_points_.AppendStrings(entry_points);
   }
@@ -58,6 +57,11 @@ class XWalkExtension {
  private:
   // Name of extension, used for dispatching messages.
   std::string name_;
+
+  // JavaScript API code that will be executed in the render process. It allows
+  // the extension provide a function or object based interface on top of the
+  // message passing.
+  std::string javascript_api_;
 
   base::ListValue entry_points_;
 

--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -303,7 +303,7 @@ void XWalkExtensionServer::RegisterExtensionsInRenderProcess() {
   for (; it != extensions_.end(); ++it) {
     XWalkExtension* extension = it->second;
     Send(new XWalkExtensionClientMsg_RegisterExtension(
-        extension->name(), extension->GetJavaScriptAPI(),
+        extension->name(), extension->javascript_api(),
         extension->entry_points()));
   }
 }

--- a/extensions/common/xwalk_external_extension.cc
+++ b/extensions/common/xwalk_external_extension.cc
@@ -65,10 +65,6 @@ bool XWalkExternalExtension::is_valid() {
   return initialized_;
 }
 
-const char* XWalkExternalExtension::GetJavaScriptAPI() {
-  return js_api_.c_str();
-}
-
 XWalkExtensionInstance* XWalkExternalExtension::CreateInstance() {
   XW_Instance xw_instance =
       XWalkExternalAdapter::GetInstance()->GetNextXWInstance();
@@ -90,7 +86,7 @@ void XWalkExternalExtension::CoreSetExtensionName(const char* name) {
 
 void XWalkExternalExtension::CoreSetJavaScriptAPI(const char* js_api) {
   RETURN_IF_INITIALIZED("SetJavaScriptAPI from CoreInterface");
-  js_api_ = std::string(js_api);
+  set_javascript_api(std::string(js_api));
 }
 
 void XWalkExternalExtension::CoreRegisterInstanceCallbacks(

--- a/extensions/common/xwalk_external_extension.h
+++ b/extensions/common/xwalk_external_extension.h
@@ -41,7 +41,6 @@ class XWalkExternalExtension : public XWalkExtension {
   friend class XWalkExternalInstance;
 
   // XWalkExtension implementation.
-  virtual const char* GetJavaScriptAPI() OVERRIDE;
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
   // XW_CoreInterface_1 (from XW_Extension.h) implementation.
@@ -68,7 +67,6 @@ class XWalkExternalExtension : public XWalkExtension {
   XW_HandleMessageCallback handle_msg_callback_;
   XW_HandleSyncMessageCallback handle_sync_msg_callback_;
 
-  std::string js_api_;
   bool initialized_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkExternalExtension);

--- a/extensions/test/conflicting_entry_points.cc
+++ b/extensions/test/conflicting_entry_points.cc
@@ -53,12 +53,8 @@ class CleanExtension : public XWalkExtension {
   CleanExtension() : XWalkExtension() {
     set_name("clean");
     set_entry_points(std::vector<std::string>(1, std::string("FromClean")));
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    static const char* kAPI = "exports.clean_loaded = true;"
-                              "window.FromClean = true;";
-    return kAPI;
+    set_javascript_api("exports.clean_loaded = true;"
+                       "window.FromClean = true;");
   }
 
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE {
@@ -71,11 +67,7 @@ class ConflictsWithNameExtension : public XWalkExtension {
   ConflictsWithNameExtension() : XWalkExtension() {
     set_name("conflicts_with_name");
     set_entry_points(std::vector<std::string>(1, std::string("clean")));
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    static const char* kAPI = "window.clean = 'fail';";
-    return kAPI;
+    set_javascript_api("window.clean = 'fail';");
   }
 
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE {
@@ -90,11 +82,7 @@ class ConflictsWithEntryPointExtension
   ConflictsWithEntryPointExtension() : XWalkExtension() {
     set_name("conflicts_with_entry_point");
     set_entry_points(std::vector<std::string>(1, std::string("FromClean")));
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    static const char* kAPI = "window.FromClean = 'fail';";
-    return kAPI;
+    set_javascript_api("window.FromClean = 'fail';");
   }
 
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE {

--- a/extensions/test/context_destruction.cc
+++ b/extensions/test/context_destruction.cc
@@ -62,15 +62,11 @@ class OnceExtension : public XWalkExtension {
   OnceExtension()
       : XWalkExtension() {
     set_name("once");
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    static const char* kAPI =
+    set_javascript_api(
         "exports.read = function(callback) {"
         "  extension.setMessageListener(callback);"
         "  extension.postMessage('PING');"
-        "};";
-    return kAPI;
+        "};");
   }
 
   virtual XWalkExtensionInstance* CreateInstance() {

--- a/extensions/test/extension_in_iframe.cc
+++ b/extensions/test/extension_in_iframe.cc
@@ -44,14 +44,10 @@ class CounterExtension : public XWalkExtension {
   CounterExtension()
       : XWalkExtension() {
     set_name("counter");
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    static const char* kAPI =
+    set_javascript_api(
         "exports.count = function() {"
         "  extension.postMessage('PING');"
-        "};";
-    return kAPI;
+        "};");
   }
 
   virtual XWalkExtensionInstance* CreateInstance() {

--- a/extensions/test/internal_extension_browsertest.cc
+++ b/extensions/test/internal_extension_browsertest.cc
@@ -22,10 +22,7 @@ using namespace xwalk::jsapi::test; // NOLINT
 
 TestExtension::TestExtension() {
   set_name("test");
-}
-
-const char* TestExtension::GetJavaScriptAPI() {
-  return kSource_internal_extension_browsertest_api;
+  set_javascript_api(kSource_internal_extension_browsertest_api);
 }
 
 XWalkExtensionInstance* TestExtension::CreateInstance() {

--- a/extensions/test/internal_extension_browsertest.h
+++ b/extensions/test/internal_extension_browsertest.h
@@ -18,8 +18,6 @@ class TestExtension : public xwalk::extensions::XWalkExtension {
  public:
   TestExtension();
 
-  virtual const char* GetJavaScriptAPI() OVERRIDE;
-
   virtual xwalk::extensions::XWalkExtensionInstance* CreateInstance() OVERRIDE;
 };
 

--- a/extensions/test/nested_namespace.cc
+++ b/extensions/test/nested_namespace.cc
@@ -36,12 +36,7 @@ class OuterExtension : public XWalkExtension {
  public:
   OuterExtension() : XWalkExtension() {
     set_name("outer");
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    static const char* kAPI =
-        "exports.value = true";
-    return kAPI;
+    set_javascript_api("exports.value = true");
   }
 
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE {
@@ -61,12 +56,7 @@ class InnerExtension : public XWalkExtension {
  public:
   InnerExtension() : XWalkExtension() {
     set_name("outer.inner");
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    static const char* kAPI =
-        "exports.value = true";
-    return kAPI;
+    set_javascript_api("exports.value = true");
   }
 
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE {

--- a/extensions/test/v8tools_module.cc
+++ b/extensions/test/v8tools_module.cc
@@ -31,18 +31,14 @@ class TestV8ToolsExtension : public XWalkExtension {
   TestV8ToolsExtension()
       : XWalkExtension() {
     set_name("test_v8tools");
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    static const char* kAPI =
+    set_javascript_api(
         "var v8tools = requireNative('v8tools');"
         "exports.forceSetProperty = function(obj, key, value) {"
         "  v8tools.forceSetProperty(obj, key, value);"
         "};"
         "exports.lifecycleTracker = function() {"
         "  return v8tools.lifecycleTracker();"
-        "};";
-    return kAPI;
+        "};");
   }
 
   virtual XWalkExtensionInstance* CreateInstance() {

--- a/extensions/test/xwalk_extensions_browsertest.cc
+++ b/extensions/test/xwalk_extensions_browsertest.cc
@@ -72,10 +72,7 @@ class EchoExtension : public XWalkExtension {
  public:
   EchoExtension() : XWalkExtension() {
     set_name("echo");
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    return kEchoAPI;
+    set_javascript_api(kEchoAPI);
   }
 
   virtual XWalkExtensionInstance* CreateInstance() {
@@ -87,10 +84,7 @@ class DelayedEchoExtension : public XWalkExtension {
  public:
   DelayedEchoExtension() : XWalkExtension() {
     set_name("echo");
-  }
-
-  virtual const char* GetJavaScriptAPI() {
-    return kEchoAPI;
+    set_javascript_api(kEchoAPI);
   }
 
   virtual XWalkExtensionInstance* CreateInstance() {
@@ -104,7 +98,6 @@ class ExtensionWithInvalidName : public XWalkExtension {
     set_name("invalid name with spaces");
   }
 
-  virtual const char* GetJavaScriptAPI() { return ""; }
   virtual XWalkExtensionInstance* CreateInstance() { return NULL; }
 };
 

--- a/runtime/extension/runtime_extension.cc
+++ b/runtime/extension/runtime_extension.cc
@@ -13,10 +13,7 @@ namespace xwalk {
 
 RuntimeExtension::RuntimeExtension() {
   set_name("xwalk.runtime");
-}
-
-const char* RuntimeExtension::GetJavaScriptAPI() {
-  return kSource_runtime_api;
+  set_javascript_api(kSource_runtime_api);
 }
 
 XWalkExtensionInstance* RuntimeExtension::CreateInstance() {

--- a/runtime/extension/runtime_extension.h
+++ b/runtime/extension/runtime_extension.h
@@ -20,8 +20,6 @@ class RuntimeExtension : public XWalkExtension {
  public:
   RuntimeExtension();
 
-  virtual const char* GetJavaScriptAPI() OVERRIDE;
-
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 };
 


### PR DESCRIPTION
XWalkExtension expected subclasses to override a virtual function
GetJavaScriptAPI() that would return a "const char*" null terminated
string.

This patch removes that function and adds a set_javascript_api() for
subclasses to call during construction time. XWalkExtension stores the
javascript_api code in a similar way than it does for the name.

In practice, this matches what the external extension adapter was doing
anyway, and remove a few lines of boilterplate from every test case. It
will also be helpful when we start to use ResourceBundle for JS files
inside Crosswalk.
