### PR TITLE
[Shared Runtime Process Model] Class skeleton added.

### DIFF
--- a/application/browser/application_daemon.cc
+++ b/application/browser/application_daemon.cc
@@ -1,0 +1,26 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/application_daemon.h"
+
+#include "xwalk/runtime/browser/runtime_context.h"
+
+using xwalk::RuntimeContext;
+
+namespace xwalk {
+namespace application {
+
+ApplicationDaemon::ApplicationDaemon(xwalk::RuntimeContext* runtime_context) {
+}
+
+ApplicationDaemon::~ApplicationDaemon() {
+}
+
+bool ApplicationDaemon::Daemonize() {
+  LOG(ERROR) << "Daemon mode is currently not supported.";
+  return false;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/application_daemon.h
+++ b/application/browser/application_daemon.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_APPLICATION_DAEMON_H_
+#define XWALK_APPLICATION_BROWSER_APPLICATION_DAEMON_H_
+
+#include "xwalk/runtime/browser/runtime_context.h"
+
+namespace xwalk {
+namespace application {
+
+class ApplicationDaemon {
+  public:
+    explicit ApplicationDaemon(xwalk::RuntimeContext* runtime_context);
+    ~ApplicationDaemon();
+
+    // Go into daemon mode, return false if any error occured, for example if
+    // another daemon is already running in the background.
+    bool Daemonize();
+
+  private:
+    DISALLOW_COPY_AND_ASSIGN(ApplicationDaemon);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_APPLICATION_DAEMON_H_

--- a/application/browser/application_daemon_linux.cc
+++ b/application/browser/application_daemon_linux.cc
@@ -1,0 +1,28 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/application_daemon.h"
+
+#include "dbus/bus.h"
+#include "xwalk/application/browser/application_system.h"
+#include "xwalk/runtime/browser/runtime_context.h"
+
+using xwalk::RuntimeContext;
+
+namespace xwalk {
+namespace application {
+
+ApplicationDaemon::ApplicationDaemon(xwalk::RuntimeContext* runtime_context) {
+}
+
+ApplicationDaemon::~ApplicationDaemon() {
+}
+
+bool ApplicationDaemon::Daemonize() {
+  LOG(INFO) << "Daemonize ...";
+  return true;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -17,6 +17,7 @@ ApplicationSystem::ApplicationSystem(RuntimeContext* runtime_context) {
   runtime_context_ = runtime_context;
   process_manager_.reset(new ApplicationProcessManager(runtime_context));
   application_service_.reset(new ApplicationService(runtime_context));
+  application_daemon_.reset(new ApplicationDaemon(runtime_context));
 }
 
 ApplicationSystem::~ApplicationSystem() {

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -9,6 +9,7 @@
 
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_ptr.h"
+#include "xwalk/application/browser/application_daemon.h"
 #include "xwalk/application/browser/application_process_manager.h"
 #include "xwalk/application/browser/application_service.h"
 
@@ -38,10 +39,16 @@ class ApplicationSystem {
     return application_service_.get();
   }
 
+  // Create the daemon object together with application system.
+  ApplicationDaemon* application_daemon() {
+    return application_daemon_.get();
+  }
+
  private:
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationProcessManager> process_manager_;
   scoped_ptr<ApplicationService> application_service_;
+  scoped_ptr<ApplicationDaemon> application_daemon_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationSystem);
 };

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -14,6 +14,8 @@
         '../third_party/zlib/google/zip.gyp:zip',
       ],
       'sources': [
+        'browser/application_daemon.cc',
+        'browser/application_daemon.h',
         'browser/application_store.cc',
         'browser/application_store.h',
         'browser/application_process_manager.cc',
@@ -61,6 +63,17 @@
             'browser/installer/tizen/packageinfo_constants.h',
             'browser/installer/tizen/package_installer.cc',
             'browser/installer/tizen/package_installer.h',
+          ],
+        }],
+        [ 'OS=="linux"', {
+          'dependencies': [
+            'build/system.gyp:dbus_daemon',
+          ],
+          'sources': [
+            'browser/application_daemon_linux.cc',
+          ],
+          'sources!': [
+            'browser/application_daemon.cc',
           ],
         }],
       ],

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -55,5 +55,23 @@
         },
       ],  # targets
     }],
+    [ 'OS=="linux"', {
+      'targets': [
+        {
+          'target_name': 'dbus_daemon',
+          'type': 'none',
+          'variables': {
+            'packages': [
+              'dbus-1',
+            ],
+          },
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags <@(packages))',
+            ],
+          },
+        },
+      ],
+    }],
   ],  # conditions
 }

--- a/runtime/app/xwalk_main.cc
+++ b/runtime/app/xwalk_main.cc
@@ -25,6 +25,8 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t*, int) {
 #else
 
 int main(int argc, const char** argv) {
+  // TODO(Bai): Call daemon() here if xwalk is loaded as a service daemon.
+
 #if defined(OS_MACOSX)
   // Do the delegate work in xwalk_content_main to avoid having to export the
   // delegate types.

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -265,6 +265,8 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
               loopback_ip, port, std::string()));
     }
   } else if (command_line->HasSwitch(switches::kListApplications)) {
+    // TODO(Bai): This part will eventually be removed and the functionality
+    // will be moved to application daemon, providing service through IPC.
     xwalk::application::ApplicationStore::ApplicationMap* apps =
         service->GetInstalledApplications();
     LOG(INFO) << "Application ID                       Application Name";
@@ -276,12 +278,18 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     run_default_message_loop_ = false;
     return;
   }
+  if (command_line->HasSwitch(switches::kDaemon)) {
+    run_default_message_loop_ = system->application_daemon()->Daemonize();
+    return;
+  }
 
   NativeAppWindow::Initialize();
 
   std::string command_name =
       command_line->GetProgram().BaseName().MaybeAsASCII();
 
+  // TODO(Bai): Move these parts into application daemon and provide service
+  // through IPC
 #if defined(OS_TIZEN_MOBILE)
   // On Tizen, applications are launched by a symbolic link
   // named like the application ID.

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -13,6 +13,9 @@ const char kXWalkDataPath[] = "data-path";
 // Specifies the icon file for the app window.
 const char kAppIcon[] = "app-icon";
 
+// Indicate crosswalk runtime will run as a service daemon.
+const char kDaemon[] = "daemon";
+
 // Specifies the window whether launched with fullscreen mode.
 const char kFullscreen[] = "fullscreen";
 

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -12,6 +12,8 @@ extern const char kXWalkDataPath[];
 
 extern const char kAppIcon[];
 
+extern const char kDaemon[];
+
 extern const char kFullscreen[];
 
 extern const char kInstall[];


### PR DESCRIPTION
According to the discussion and the new design for the shared runtime
process model, the previous pull request
(https://github.com/crosswalk-project/crosswalk/pull/750)
is abandoned. This patch is the first step towards the new design goal.
A new switch --daemon is added to let xwalk go into daemon mode.
Loading a simple web page from command line is still okay.
Please refer to
(https://docs.google.com/a/intel.com/document/d/1q2Zl_P949NLe5YnQoLP2OWcZStVJgXyHKZDUwhiUxJQ/edit#)
for more design details.
