### PR TITLE
[Tizen] Device motion/orientation API

### DIFF
--- a/runtime/browser/tizen/sensor_provider.cc
+++ b/runtime/browser/tizen/sensor_provider.cc
@@ -2,36 +2,27 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "xwalk/runtime/browser/sensor_provider.h"
+#include "xwalk/runtime/browser/tizen/sensor_provider.h"
 
 #include "base/logging.h"
-
-#if defined(OS_TIZEN_MOBILE)
-#include "xwalk/runtime/browser/tizen_platform_sensor.h"
-#endif
+#include "xwalk/runtime/browser/tizen/tizen_platform_sensor.h"
 
 namespace xwalk {
 
 SensorProvider* SensorProvider::GetInstance() {
   if (!instance_) {
-#if defined(OS_TIZEN_MOBILE)
-    instance_ = new TizenPlatformSensor();
-#endif
-    if (instance_ && !instance_->Initialize()) {
-      delete instance_;
-      instance_ = NULL;
-    }
+    instance_.reset(new TizenPlatformSensor());
+    if (!instance_->Initialize())
+      instance_.reset();
   }
-  return instance_;
+  return instance_.get();
 }
 
 SensorProvider::SensorProvider() {
 }
 
 SensorProvider::~SensorProvider() {
-  DCHECK(instance_ == this);
   Finish();
-  instance_ = NULL;
 }
 
 void SensorProvider::AddObserver(Observer* observer) {
@@ -39,7 +30,7 @@ void SensorProvider::AddObserver(Observer* observer) {
 }
 
 void SensorProvider::RemoveObserver(Observer* observer) {
-    observers_.erase(observer);
+  observers_.erase(observer);
 }
 
 void SensorProvider::OnRotationChanged(gfx::Display::Rotation rotation) {
@@ -56,12 +47,22 @@ void SensorProvider::OnOrientationChanged(float alpha,
     (*it)->OnOrientationChanged(alpha, beta, gamma);
 }
 
-void SensorProvider::OnAccelerationChanged(float x, float y, float z) {
+void SensorProvider::OnAccelerationChanged(
+    float raw_x, float raw_y, float raw_z,
+    float x, float y, float z) {
   std::set<Observer*>::iterator it;
   for (it = observers_.begin(); it != observers_.end(); ++it)
-    (*it)->OnOrientationChanged(x, y, z);
+    (*it)->OnAccelerationChanged(raw_x, raw_y, raw_z, x, y, z);
 }
 
-SensorProvider* SensorProvider::instance_ = NULL;
+void SensorProvider::OnRotationRateChanged(float alpha,
+                                           float beta,
+                                           float gamma) {
+  std::set<Observer*>::iterator it;
+  for (it = observers_.begin(); it != observers_.end(); ++it)
+    (*it)->OnRotationRateChanged(alpha, beta, gamma);
+}
+
+scoped_ptr<SensorProvider> SensorProvider::instance_;
 
 }  // namespace xwalk

--- a/runtime/browser/tizen/sensor_provider.h
+++ b/runtime/browser/tizen/sensor_provider.h
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef XWALK_RUNTIME_BROWSER_SENSOR_PROVIDER_H_
-#define XWALK_RUNTIME_BROWSER_SENSOR_PROVIDER_H_
+#ifndef XWALK_RUNTIME_BROWSER_TIZEN_SENSOR_PROVIDER_H_
+#define XWALK_RUNTIME_BROWSER_TIZEN_SENSOR_PROVIDER_H_
 
 #include <set>
 
+#include "base/memory/scoped_ptr.h"
 #include "ui/gfx/display.h"
 
 namespace xwalk {
@@ -15,38 +16,42 @@ class SensorProvider {
  public:
   class Observer {
    public:
+    virtual ~Observer() {}
+
     virtual void OnRotationChanged(gfx::Display::Rotation r) {}
     virtual void OnOrientationChanged(float alpha, float beta, float gamma) {}
-    virtual void OnAccelerationChanged(float x, float y, float z) {}
-
-   protected:
-    virtual ~Observer() {}
+    virtual void OnAccelerationChanged(float raw_x, float raw_y, float raw_z,
+                                       float x, float y, float z) {}
+    virtual void OnRotationRateChanged(float alpha, float beta, float gamma) {}
   };
 
   static SensorProvider* GetInstance();
+
+  virtual ~SensorProvider();
 
   virtual void AddObserver(Observer* observer);
   virtual void RemoveObserver(Observer* observer);
 
  protected:
   SensorProvider();
-  virtual ~SensorProvider();
 
   virtual bool Initialize() = 0;
   virtual void Finish() {}
 
   virtual void OnRotationChanged(gfx::Display::Rotation rotation);
   virtual void OnOrientationChanged(float alpha, float beta, float gamma);
-  virtual void OnAccelerationChanged(float x, float y, float z);
+  virtual void OnAccelerationChanged(float raw_x, float raw_y, float raw_z,
+                                     float x, float y, float z);
+  virtual void OnRotationRateChanged(float alpha, float beta, float gamma);
 
   std::set<Observer*> observers_;
 
  private:
-  static SensorProvider* instance_;
+  static scoped_ptr<SensorProvider> instance_;
 
   DISALLOW_COPY_AND_ASSIGN(SensorProvider);
 };
 
 }  // namespace xwalk
 
-#endif  // XWALK_RUNTIME_BROWSER_SENSOR_PROVIDER_H_
+#endif  // XWALK_RUNTIME_BROWSER_TIZEN_SENSOR_PROVIDER_H_

--- a/runtime/browser/tizen/tizen_data_fetcher_shared_memory.cc
+++ b/runtime/browser/tizen/tizen_data_fetcher_shared_memory.cc
@@ -1,0 +1,139 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <math.h>
+
+#include "xwalk/runtime/browser/tizen/tizen_data_fetcher_shared_memory.h"
+
+namespace xwalk {
+
+TizenDataFetcherSharedMemory::TizenDataFetcherSharedMemory()
+    : motion_buffer_(NULL),
+      orientation_buffer_(NULL) {
+}
+
+TizenDataFetcherSharedMemory::~TizenDataFetcherSharedMemory() {
+  Stop(content::CONSUMER_TYPE_MOTION);
+  Stop(content::CONSUMER_TYPE_ORIENTATION);
+}
+
+void TizenDataFetcherSharedMemory::OnAccelerationChanged(
+    float raw_x, float raw_y, float raw_z,
+    float x, float y, float z) {
+  if (!motion_buffer_)
+    return;
+
+  motion_buffer_->seqlock.WriteBegin();
+  motion_buffer_->data.accelerationIncludingGravityX = raw_x;
+  motion_buffer_->data.hasAccelerationIncludingGravityX = true;
+  motion_buffer_->data.accelerationIncludingGravityY = raw_y;
+  motion_buffer_->data.hasAccelerationIncludingGravityY = true;
+  motion_buffer_->data.accelerationIncludingGravityZ = raw_z;
+  motion_buffer_->data.hasAccelerationIncludingGravityZ = true;
+  if (x != FP_NAN) {
+    motion_buffer_->data.accelerationX = x;
+    motion_buffer_->data.hasAccelerationX = true;
+  }
+  if (y != FP_NAN) {
+    motion_buffer_->data.accelerationY = y;
+    motion_buffer_->data.hasAccelerationY = true;
+  }
+  if (z != FP_NAN) {
+    motion_buffer_->data.accelerationZ = z;
+    motion_buffer_->data.hasAccelerationZ = true;
+  }
+  motion_buffer_->data.allAvailableSensorsAreActive = true;
+  motion_buffer_->seqlock.WriteEnd();
+}
+
+void TizenDataFetcherSharedMemory::OnOrientationChanged(float alpha,
+                                                        float beta,
+                                                        float gamma) {
+  if (!orientation_buffer_)
+    return;
+
+  orientation_buffer_->seqlock.WriteBegin();
+  orientation_buffer_->data.alpha = alpha;
+  orientation_buffer_->data.hasAlpha = true;
+  orientation_buffer_->data.beta = beta;
+  orientation_buffer_->data.hasBeta = true;
+  orientation_buffer_->data.gamma = gamma;
+  orientation_buffer_->data.hasGamma = true;
+  orientation_buffer_->data.allAvailableSensorsAreActive = true;
+  orientation_buffer_->seqlock.WriteEnd();
+}
+
+void TizenDataFetcherSharedMemory::OnRotationRateChanged(float alpha,
+                                                         float beta,
+                                                         float gamma) {
+  if (!motion_buffer_)
+    return;
+
+  motion_buffer_->seqlock.WriteBegin();
+  motion_buffer_->data.rotationRateAlpha = alpha;
+  motion_buffer_->data.hasRotationRateAlpha = true;
+  motion_buffer_->data.rotationRateBeta = beta;
+  motion_buffer_->data.hasRotationRateBeta = true;
+  motion_buffer_->data.rotationRateGamma = gamma;
+  motion_buffer_->data.hasRotationRateGamma = true;
+  motion_buffer_->data.allAvailableSensorsAreActive = true;
+  motion_buffer_->seqlock.WriteEnd();
+}
+
+bool TizenDataFetcherSharedMemory::Start(content::ConsumerType type,
+                                         void* buffer) {
+  DCHECK(buffer);
+
+  bool started = (motion_buffer_ || orientation_buffer_);
+  switch (type) {
+    case content::CONSUMER_TYPE_MOTION:
+      motion_buffer_ =
+          static_cast<content::DeviceMotionHardwareBuffer*>(buffer);
+      break;
+    case content::CONSUMER_TYPE_ORIENTATION:
+      orientation_buffer_ =
+          static_cast<content::DeviceOrientationHardwareBuffer*>(buffer);
+      break;
+    default:
+      NOTREACHED();
+      return false;
+  }
+
+  if (!started && SensorProvider::GetInstance())
+    SensorProvider::GetInstance()->AddObserver(this);
+
+  return true;
+}
+
+bool TizenDataFetcherSharedMemory::Stop(content::ConsumerType type) {
+  switch (type) {
+    case content::CONSUMER_TYPE_MOTION:
+      if (motion_buffer_) {
+        motion_buffer_->seqlock.WriteBegin();
+        motion_buffer_->data.allAvailableSensorsAreActive = false;
+        motion_buffer_->seqlock.WriteEnd();
+        motion_buffer_ = NULL;
+      }
+      break;
+    case content::CONSUMER_TYPE_ORIENTATION:
+      if (orientation_buffer_) {
+        orientation_buffer_->seqlock.WriteBegin();
+        orientation_buffer_->data.allAvailableSensorsAreActive = false;
+        orientation_buffer_->seqlock.WriteEnd();
+        orientation_buffer_ = NULL;
+      }
+      break;
+    default:
+      NOTREACHED();
+      return false;
+  }
+
+  if (!motion_buffer_ && !orientation_buffer_ &&
+      SensorProvider::GetInstance())
+    SensorProvider::GetInstance()->RemoveObserver(this);
+
+  return true;
+}
+
+}  // namespace xwalk

--- a/runtime/browser/tizen/tizen_data_fetcher_shared_memory.h
+++ b/runtime/browser/tizen/tizen_data_fetcher_shared_memory.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_DATA_FETCHER_SHARED_MEMORY_H_
+#define XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_DATA_FETCHER_SHARED_MEMORY_H_
+
+#include "content/browser/device_orientation/data_fetcher_shared_memory.h"
+#include "xwalk/runtime/browser/tizen/sensor_provider.h"
+
+namespace xwalk {
+
+// This class receives sensor data from SensorProvider, and put them into
+// a block of memory which is shared between xwalk and renderer processes.
+class TizenDataFetcherSharedMemory : public content::DataFetcherSharedMemory,
+                                     public SensorProvider::Observer {
+ public:
+  TizenDataFetcherSharedMemory();
+  virtual ~TizenDataFetcherSharedMemory();
+
+ private:
+  // From content::DataFetcherSharedMemory
+  virtual bool Start(content::ConsumerType type, void* buffer) OVERRIDE;
+  virtual bool Stop(content::ConsumerType type) OVERRIDE;
+
+  // From SensorProvider::Observer
+  virtual void OnOrientationChanged(float alpha,
+                                    float beta,
+                                    float roll) OVERRIDE;
+  virtual void OnAccelerationChanged(float raw_x, float raw_y, float raw_z,
+                                     float x, float y, float z) OVERRIDE;
+  virtual void OnRotationRateChanged(float alpha,
+                                     float beta,
+                                     float roll) OVERRIDE;
+
+  content::DeviceMotionHardwareBuffer* motion_buffer_;
+  content::DeviceOrientationHardwareBuffer* orientation_buffer_;
+
+  DISALLOW_COPY_AND_ASSIGN(TizenDataFetcherSharedMemory);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_DATA_FETCHER_SHARED_MEMORY_H_

--- a/runtime/browser/tizen/tizen_platform_sensor.h
+++ b/runtime/browser/tizen/tizen_platform_sensor.h
@@ -13,11 +13,11 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
-#ifndef XWALK_RUNTIME_BROWSER_TIZEN_PLATFORM_SENSOR_H_
-#define XWALK_RUNTIME_BROWSER_TIZEN_PLATFORM_SENSOR_H_
+#ifndef XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_PLATFORM_SENSOR_H_
+#define XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_PLATFORM_SENSOR_H_
 
 #include "base/native_library.h"
-#include "xwalk/runtime/browser/sensor_provider.h"
+#include "xwalk/runtime/browser/tizen/sensor_provider.h"
 
 namespace xwalk {
 
@@ -34,7 +34,8 @@ class TizenPlatformSensor : public SensorProvider {
   void UnloadLibrary();
   gfx::Display::Rotation ToDisplayRotation(int rotation) const;
 
-  int handle_;
+  int accel_handle_;
+  int gyro_handle_;
   base::NativeLibrary dso_;
 
   // Start of codes copied from libslp-sensor
@@ -55,6 +56,10 @@ class TizenPlatformSensor : public SensorProvider {
         (ACCELEROMETER_SENSOR << 16) | 0x0001,
     ACCELEROMETER_ORIENTATION_DATA_SET =
         (ACCELEROMETER_SENSOR << 16) | 0x0002,
+    ACCELEROMETER_LINEAR_ACCELERATION_DATA_SET =
+        (ACCELEROMETER_SENSOR << 16) | 0x0004,
+    ACCELEROMETER_GRAVITY_DATA_SET =
+        (ACCELEROMETER_SENSOR << 16) | 0x0008,
   };
 
   enum accelerometer_event_type {
@@ -69,7 +74,11 @@ class TizenPlatformSensor : public SensorProvider {
     ACCELEROMETER_EVENT_SET_WAKEUP =
         (ACCELEROMETER_SENSOR << 16) | 0x0010,
     ACCELEROMETER_EVENT_ORIENTATION_DATA_REPORT_ON_TIME =
-        (ACCELEROMETER_SENSOR << 16) | 0x0011,
+        (ACCELEROMETER_SENSOR << 16) | 0x0020,
+    ACCELEROMETER_EVENT_LINEAR_ACCELERATION_DATA_REPORT_ON_TIME =
+        (ACCELEROMETER_SENSOR << 16) | 0x0040,
+    ACCELEROMETER_EVENT_GRAVITY_DATA_REPORT_ON_TIME =
+        (ACCELEROMETER_SENSOR << 16) | 0x0080,
   };
 
   enum accelerometer_rotate_state {
@@ -82,6 +91,14 @@ class TizenPlatformSensor : public SensorProvider {
     ROTATION_EVENT_90        = 1,
     ROTATION_EVENT_180       = 3,
     ROTATION_EVENT_270       = 4,
+  };
+
+  enum gyro_data_id {
+    GYRO_BASE_DATA_SET = (GYROSCOPE_SENSOR << 16) | 0x0001,
+  };
+
+  enum gyro_event_type {
+    GYROSCOPE_EVENT_RAW_DATA_REPORT_ON_TIME = (GYROSCOPE_SENSOR << 16) | 0x0001,
   };
 
   typedef enum {
@@ -147,4 +164,4 @@ class TizenPlatformSensor : public SensorProvider {
 
 }  // namespace xwalk
 
-#endif  // XWALK_RUNTIME_BROWSER_TIZEN_PLATFORM_SENSOR_H_
+#endif  // XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_PLATFORM_SENSOR_H_

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -49,7 +49,9 @@
 #endif  // defined(OS_ANDROID)
 
 #if defined(OS_TIZEN_MOBILE)
+#include "content/browser/device_orientation/device_inertial_sensor_service.h"
 #include "xwalk/application/browser/installer/tizen/package_installer.h"
+#include "xwalk/runtime/browser/tizen/tizen_data_fetcher_shared_memory.h"
 #endif  // defined(OS_TIZEN_MOBILE)
 
 namespace {
@@ -359,6 +361,18 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
       return;
     }
   }
+
+#if defined(OS_TIZEN_MOBILE)
+  if (content::DeviceInertialSensorService* sensor_service =
+          content::DeviceInertialSensorService::GetInstance()) {
+    TizenDataFetcherSharedMemory* data_fetcher =
+        new TizenDataFetcherSharedMemory();
+    // As the data fetcher of sensors is implemented outside of Chromium, we
+    // need to make it available to Chromium by "abusing" the test framework.
+    // TODO(zliang7): Find a decent way to inject our sensor fetcher for Tizen.
+    sensor_service->SetDataFetcherForTests(data_fetcher);
+  }
+#endif  // OS_TIZEN_MOBILE
 
   // The new created Runtime instance will be managed by RuntimeRegistry.
   Runtime::CreateWithDefaultWindow(runtime_context_.get(), startup_url_);

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -105,8 +105,6 @@
         'runtime/browser/runtime_select_file_policy.h',
         'runtime/browser/runtime_url_request_context_getter.cc',
         'runtime/browser/runtime_url_request_context_getter.h',
-        'runtime/browser/sensor_provider.cc',
-        'runtime/browser/sensor_provider.h',
         'runtime/browser/ui/color_chooser.cc',
         'runtime/browser/ui/color_chooser.h',
         'runtime/browser/ui/color_chooser_aura.cc',
@@ -150,6 +148,12 @@
       'conditions': [
         [ 'tizen_mobile == 1', {
           'sources': [
+            'runtime/browser/tizen/sensor_provider.cc',
+            'runtime/browser/tizen/sensor_provider.h',
+            'runtime/browser/tizen/tizen_data_fetcher_shared_memory.cc',
+            'runtime/browser/tizen/tizen_data_fetcher_shared_memory.h',
+            'runtime/browser/tizen/tizen_platform_sensor.cc',
+            'runtime/browser/tizen/tizen_platform_sensor.h',
             'runtime/browser/ui/tizen_plug_message_writer.cc',
             'runtime/browser/ui/tizen_plug_message_writer.h',
             'runtime/browser/ui/tizen_system_indicator.cc',
@@ -158,8 +162,6 @@
             'runtime/browser/ui/tizen_system_indicator_watcher.h',
             'runtime/browser/ui/tizen/desktop_root_window_host_tizen_x11.cc',
             'runtime/browser/ui/tizen/desktop_root_window_host_tizen_x11.h',
-            'runtime/browser/tizen_platform_sensor.cc',
-            'runtime/browser/tizen_platform_sensor.h',
           ],
         }],
         ['OS=="android"',{


### PR DESCRIPTION
Chromium has device motion/orientation API support, but not on Tizen.
To leverage chromium's code, an xwalk::DataFetcherSharedMemory object
is created to bridge xwalk and chromium. This object acts as a sensor
event listener of xwalk and writes sensor data into chromium's shared
memory.

SPEC: http://www.w3.org/TR/orientation-event/
