### PR TITLE
[Extension] Fix build failure on Windows

### DIFF
--- a/extensions/external_extension_sample.gyp
+++ b/extensions/external_extension_sample.gyp
@@ -9,7 +9,13 @@
     'sources': [
       'test/echo_extension.c',
     ],
-    'product_dir': '<(PRODUCT_DIR)/tests/extension/echo_extension/'
+    'conditions': [
+      ['OS=="win"', {
+        'product_dir': '<(PRODUCT_DIR)\\tests\\extension\\echo_extension\\'
+      }, {
+        'product_dir': '<(PRODUCT_DIR)/tests/extension/echo_extension/'
+      }],
+    ], # conditions
   },
   {
     'target_name': 'bad_extension',
@@ -20,7 +26,13 @@
     'sources': [
       'test/bad_extension.c',
     ],
-    'product_dir': '<(PRODUCT_DIR)/tests/extension/bad_extension/'
+    'conditions': [
+      ['OS=="win"', {
+        'product_dir': '<(PRODUCT_DIR)\\tests\\extension\\bad_extension\\'
+      }, {
+        'product_dir': '<(PRODUCT_DIR)/tests/extension/bad_extension/'
+      }],
+    ], # conditions
   },
   {
     'target_name': 'multiple_entry_points_extension',
@@ -31,7 +43,13 @@
     'sources': [
       'test/multiple_entry_points_extension.c',
     ],
-    'product_dir': '<(PRODUCT_DIR)/tests/extension/multiple_extension/'
+    'conditions': [
+      ['OS=="win"', {
+        'product_dir': '<(PRODUCT_DIR)\\tests\\extension\\multiple_extension\\'
+      }, {
+        'product_dir': '<(PRODUCT_DIR)/tests/extension/multiple_extension/'
+      }],
+    ], # conditions
   },
   ],
 }


### PR DESCRIPTION
Use '\' for the product_dir on Windows in external_extension_sample.gyp.
Otherwise, the build system can't handle the path well in some cases,
e.g. creating or deleting them.
It fails the windows build when it starts from zero.
