### PR TITLE
[Android] Disable hw encoding/decoding acceleration for WebRTC

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -133,6 +133,13 @@ void SetXWalkCommandLineFlags() {
 
   // Enable WebGL for Android.
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
+
+  // Disable HW encoding/decoding acceleration for WebRTC on Android.
+  // FIXME: Remove these switches for Android when Android OS is removed from
+  // GPU accelerated_video_decode blacklist or we stop ignoring the GPU
+  // blacklist.
+  command_line->AppendSwitch(switches::kDisableWebRtcHWDecoding);
+  command_line->AppendSwitch(switches::kDisableWebRtcHWEncoding);
 #endif
 
   // FIXME: Add comment why this is needed on Android and Tizen.


### PR DESCRIPTION
The flag hw encoding/decoding acceleration for WebRTC is enabled by
default, it is controlled through GPU black list, please see:
https://chromiumcodereview.appspot.com/10832356/
But crosswalk is ignoring GPU black list because of enabling WebGL.

Currently, it is also disabled on chrome for Android M31, more information
please see: http://code.google.com/p/chromium/issues/detail?id=305421

Bug: https://crosswalk-project.org/jira/browse/XWALK-41
