### PR TITLE
[Extensions] Fix a test to also pass with load on demand

### DIFF
--- a/extensions/test/context_destruction.cc
+++ b/extensions/test/context_destruction.cc
@@ -84,12 +84,12 @@ class XWalkExtensionsContextDestructionTest : public XWalkExtensionsTestBase {
     ASSERT_TRUE(registered);
   }
 
-  // FIXME(cmarcelo): Test here should be exact instead of greater than. To
-  // achieve that we need to ensure that pages that don't use an extensions
-  // won't have an instance created for them.
+  // FIXME(cmarcelo): Test here should be equal instead of
+  // greater-than-or-equal. To achieve that we need to ensure that pages that
+  // don't use an extensions won't have an instance created for them.
   virtual void TearDown() OVERRIDE {
     SPIN_FOR_1_SECOND_OR_UNTIL_TRUE(g_contexts_destroyed >= 2);
-    ASSERT_GT(g_contexts_destroyed, 2);
+    ASSERT_GE(g_contexts_destroyed, 2);
   }
 };
 
@@ -114,5 +114,5 @@ IN_PROC_BROWSER_TEST_F(XWalkExtensionsContextDestructionTest,
   }
 
   // FIXME(cmarcelo): See comment in TearDown().
-  ASSERT_GT(g_contexts_created, 2);
+  ASSERT_GE(g_contexts_created, 2);
 }


### PR DESCRIPTION
The test was "too strict" and covering only the "expected
failure" (greater than comparison) case. Now that we can run Crosswalk
loading extensions on demand, we can pass it properly (equal
comparison).

Once we enable the feature by default in Crosswalk we should make the
test "strict" again, covering only the equal comparison.
