### PR TITLE
[Extensions] Fix race condition in Extensions registering.

### DIFF
--- a/extensions/browser/xwalk_extension_process_host.h
+++ b/extensions/browser/xwalk_extension_process_host.h
@@ -6,6 +6,7 @@
 #define XWALK_EXTENSIONS_BROWSER_XWALK_EXTENSION_PROCESS_HOST_H_
 
 #include "base/memory/scoped_ptr.h"
+#include "base/synchronization/waitable_event.h"
 #include "content/public/browser/browser_child_process_host_delegate.h"
 #include "ipc/ipc_channel_handle.h"
 
@@ -52,6 +53,7 @@ class XWalkExtensionProcessHost
 
   // Message Handlers.
   void OnRenderChannelCreated(const IPC::ChannelHandle& channel_id);
+  void OnExtensionsRegistered();
 
   void SendChannelHandleToRenderProcess();
 
@@ -60,6 +62,7 @@ class XWalkExtensionProcessHost
   content::RenderProcessHost* render_process_host_;
 
   bool is_extension_process_channel_ready_;
+  base::WaitableEvent waitable_register_extensions_;
 };
 
 }  // namespace extensions

--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -197,8 +197,6 @@ void XWalkExtensionService::CreateInProcessExtensionServer(
   if (!g_register_extensions_callback.is_null())
     g_register_extensions_callback.Run(this, in_process_server.get());
 
-  in_process_server->RegisterExtensionsInRenderProcess();
-
   data->in_process_server_ = in_process_server.Pass();
 }
 
@@ -206,6 +204,9 @@ void XWalkExtensionService::CreateExtensionProcessHost(
     content::RenderProcessHost* host, ExtensionData* data) {
   scoped_ptr<XWalkExtensionProcessHost> eph(new XWalkExtensionProcessHost());
 
+  // NOTE(jeez): This will block until the ExtensionProcess has finished
+  // loading all extensions. We do that to avoid race conditions.
+  // (i.e.: Navigating _before_ having the extensions loaded)
   if (!external_extensions_path_.empty())
     eph->RegisterExternalExtensions(external_extensions_path_);
 

--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -25,6 +25,8 @@ IPC_MESSAGE_CONTROL1(XWalkExtensionProcessMsg_RegisterExtensions,  // NOLINT(*)
 IPC_MESSAGE_CONTROL1(XWalkExtensionProcessHostMsg_RenderProcessChannelCreated, // NOLINT(*)
                      IPC::ChannelHandle /* channel id */)
 
+IPC_MESSAGE_CONTROL0(XWalkExtensionProcessHostMsg_ExtensionsRegistered) // NOLINT(*)
+
 IPC_MESSAGE_CONTROL1(XWalkViewMsg_ExtensionProcessChannelCreated, // NOLINT(*)
                      IPC::ChannelHandle /* channel id */)
 
@@ -33,11 +35,6 @@ IPC_MESSAGE_CONTROL1(XWalkViewMsg_ExtensionProcessChannelCreated, // NOLINT(*)
 // to ease filtering.
 #undef IPC_MESSAGE_START
 #define IPC_MESSAGE_START XWalkExtensionClientServerMsgStart
-
-IPC_MESSAGE_CONTROL3(XWalkExtensionClientMsg_RegisterExtension,  // NOLINT(*)
-                     std::string /* extension */,
-                     std::string /* JS API code for extension */,
-                     base::ListValue /* extension entry points */)
 
 IPC_MESSAGE_CONTROL2(XWalkExtensionServerMsg_CreateInstance,  // NOLINT(*)
                      int64_t /* instance id */,
@@ -54,6 +51,9 @@ IPC_MESSAGE_CONTROL2(XWalkExtensionClientMsg_PostMessageToJS,  // NOLINT(*)
 IPC_SYNC_MESSAGE_CONTROL2_1(XWalkExtensionServerMsg_SendSyncMessageToNative,  // NOLINT(*)
                             int64_t /* instance id */,
                             base::ListValue /* input contents */,
+                            base::ListValue /* output contents */)
+
+IPC_SYNC_MESSAGE_CONTROL0_1(XWalkExtensionServerMsg_GetExtensionsToRegister,  // NOLINT(*)
                             base::ListValue /* output contents */)
 
 IPC_MESSAGE_CONTROL1(XWalkExtensionServerMsg_DestroyInstance,  // NOLINT(*)

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -45,13 +45,11 @@ class XWalkExtensionServer : public IPC::Listener {
 
   // IPC::Listener Implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
-  virtual void OnChannelConnected(int32 peer_pid) OVERRIDE;
 
   void Initialize(IPC::Sender* sender);
   bool Send(IPC::Message* msg);
 
   bool RegisterExtension(scoped_ptr<XWalkExtension> extension);
-  void RegisterExtensionsInRenderProcess();
 
   void Invalidate();
 
@@ -67,6 +65,7 @@ class XWalkExtensionServer : public IPC::Listener {
   void OnPostMessageToNative(int64_t instance_id, const base::ListValue& msg);
   void OnSendSyncMessageToNative(int64_t instance_id,
       const base::ListValue& msg, IPC::Message* ipc_reply);
+  void OnGetExtensionsToRegister(base::ListValue* extensions);
 
   void PostMessageToJSCallback(int64_t instance_id,
                                scoped_ptr<base::Value> msg);

--- a/extensions/extension_process/xwalk_extension_process.cc
+++ b/extensions/extension_process/xwalk_extension_process.cc
@@ -49,6 +49,8 @@ bool XWalkExtensionProcess::OnMessageReceived(const IPC::Message& message) {
 void XWalkExtensionProcess::OnRegisterExtensions(
     const base::FilePath& path) {
   RegisterExternalExtensionsInDirectory(&extensions_server_, path);
+  browser_process_channel_->Send(
+      new XWalkExtensionProcessHostMsg_ExtensionsRegistered());
 }
 
 void XWalkExtensionProcess::CreateBrowserProcessChannel() {

--- a/extensions/renderer/xwalk_extension_client.h
+++ b/extensions/renderer/xwalk_extension_client.h
@@ -50,7 +50,7 @@ class XWalkExtensionClient : public IPC::Listener {
   scoped_ptr<base::Value> SendSyncMessageToNative(int64_t instance_id,
       scoped_ptr<base::Value> msg);
 
-  void Initialize(IPC::Sender* sender) { sender_ = sender; }
+  void Initialize(IPC::Sender* sender);
 
   // IPC::Listener Implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
@@ -72,8 +72,6 @@ class XWalkExtensionClient : public IPC::Listener {
   // Message Handlers.
   void OnInstanceDestroyed(int64_t instance_id);
   void OnPostMessageToJS(int64_t instance_id, const base::ListValue& msg);
-  void OnRegisterExtension(const std::string& name, const std::string& api,
-                           const base::ListValue& entry_points);
 
   IPC::Sender* sender_;
   ExtensionAPIMap extension_apis_;


### PR DESCRIPTION
Nowadays we are facing a race condition between the moment
we get the first XWalkExtensionRendererController::DidCreateScriptContext()
for a given RenderProcess and the moment we register the external extensions
at XWalkExtensionRendererController's external_extensions_client_.

This patch fixes this by inverting the registration order. Now
during the Client's initialization we synchronously ask the Server
for the extensions to register.

In addition to that, XWalkExtensionProcessMsg_RegisterExtensions
has also become a Sync message so we can guarantee all external
extensions have been loaded way before doing anything else on
the BrowserProcess (more specifically at
XWalkExtensionService::OnRenderProcessCreated()).
