### PR TITLE
[Extensions] Flip flag to enable loading extensions on demand

### DIFF
--- a/extensions/common/xwalk_extension_switches.cc
+++ b/extensions/common/xwalk_extension_switches.cc
@@ -10,8 +10,8 @@ namespace switches {
 // plan is to switch the flag meaning when the full feature is
 // implemented. One release later, after stabilization, we completely
 // remove this flag since we expect this feature not to be optional.
-const char kXWalkEnableLoadingExtensionsOnDemand[] =
-    "enable-loading-extensions-on-demand";
+const char kXWalkDisableLoadingExtensionsOnDemand[] =
+    "disable-loading-extensions-on-demand";
 
 // TODO(cmarcelo): Currently we are disabling it by default, once Extension
 // Process patches land, we'll change this to be "disable-extension-process"

--- a/extensions/common/xwalk_extension_switches.h
+++ b/extensions/common/xwalk_extension_switches.h
@@ -8,7 +8,7 @@
 // This file contains switches that are used inside extensions/ code.
 namespace switches {
 
-extern const char kXWalkEnableLoadingExtensionsOnDemand[];
+extern const char kXWalkDisableLoadingExtensionsOnDemand[];
 extern const char kXWalkDisableExtensionProcess[];
 extern const char kXWalkExtensionProcess[];
 

--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -41,8 +41,8 @@ XWalkExtensionRendererController::XWalkExtensionRendererController(
   in_browser_process_extensions_client_->Initialize(thread->GetChannel());
 
   CommandLine* cmd_line = CommandLine::ForCurrentProcess();
-  if (cmd_line->HasSwitch(switches::kXWalkEnableLoadingExtensionsOnDemand)) {
-    LOG(INFO) << "LOADING EXTENSIONS ON DEMAND.";
+  if (cmd_line->HasSwitch(switches::kXWalkDisableLoadingExtensionsOnDemand)) {
+    LOG(INFO) << "DISABLING LOADING EXTENSIONS ON DEMAND.";
   }
 }
 

--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -284,7 +284,7 @@ v8::Handle<v8::Object> XWalkModuleSystem::RequireNative(
 void XWalkModuleSystem::Initialize() {
   CommandLine* cmd_line = CommandLine::ForCurrentProcess();
   const bool on_demand_enabled =
-      cmd_line->HasSwitch(switches::kXWalkEnableLoadingExtensionsOnDemand);
+      !cmd_line->HasSwitch(switches::kXWalkDisableLoadingExtensionsOnDemand);
 
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope handle_scope(isolate);

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -105,8 +105,9 @@ void XWalkContentBrowserClient::AppendExtraCommandLineSwitches(
     CommandLine* command_line, int child_process_id) {
   CommandLine* browser_process_cmd_line = CommandLine::ForCurrentProcess();
   if (browser_process_cmd_line->HasSwitch(
-          switches::kXWalkEnableLoadingExtensionsOnDemand)) {
-    command_line->AppendSwitch(switches::kXWalkEnableLoadingExtensionsOnDemand);
+          switches::kXWalkDisableLoadingExtensionsOnDemand)) {
+    command_line->AppendSwitch(
+        switches::kXWalkDisableLoadingExtensionsOnDemand);
   }
 }
 


### PR DESCRIPTION
Now that it works, we can flip the flag to be enabled by default.
