### PR TITLE
[Extensions] Convert 'entry_points' to be a vector of strings.

### DIFF
--- a/extensions/renderer/xwalk_extension_client.cc
+++ b/extensions/renderer/xwalk_extension_client.cc
@@ -78,7 +78,14 @@ void XWalkExtensionClient::OnRegisterExtension(
     const base::ListValue& entry_points) {
   ExtensionCodePoints* codepoint = new ExtensionCodePoints;
   codepoint->api = api;
-  codepoint->entry_points = entry_points.DeepCopy();
+
+  base::ListValue::const_iterator it = entry_points.begin();
+  for (; it != entry_points.end(); ++it) {
+    std::string entry_point;
+    (*it)->GetAsString(&entry_point);
+    codepoint->entry_points.push_back(entry_point);
+  }
+
   extension_apis_[name] = codepoint;
 }
 

--- a/extensions/renderer/xwalk_extension_client.h
+++ b/extensions/renderer/xwalk_extension_client.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <map>
 #include <string>
+#include <vector>
 
 #include "base/memory/scoped_ptr.h"
 #include "base/values.h"
@@ -57,9 +58,7 @@ class XWalkExtensionClient : public IPC::Listener {
 
   struct ExtensionCodePoints {
     std::string api;
-    base::ListValue* entry_points;
-
-    ~ExtensionCodePoints() { delete entry_points; }
+    std::vector<std::string> entry_points;
   };
 
   typedef std::map<std::string, ExtensionCodePoints*> ExtensionAPIMap;

--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -129,7 +129,7 @@ void XWalkModuleSystem::ResetModuleSystemFromContext(
 
 void XWalkModuleSystem::RegisterExtensionModule(
     scoped_ptr<XWalkExtensionModule> module,
-    base::ListValue* entry_points) {
+    const std::vector<std::string>& entry_points) {
   const std::string& extension_name = module->extension_name();
   if (ContainsExtensionModule(extension_name)) {
     LOG(WARNING) << "Can't register Extension Module named for extension '"
@@ -256,12 +256,9 @@ bool XWalkModuleSystem::InstallTrampoline(v8::Handle<v8::Context> context,
     return false;
   }
 
-  base::ListValue::const_iterator it = entry->entry_points->begin();
-  for (; it != entry->entry_points->end(); ++it) {
-    std::string entry_point;
-    (*it)->GetAsString(&entry_point);
-
-    ret = SetTrampolineAccessorForEntryPoint(context, entry_point, entry_ptr);
+  std::vector<std::string>::const_iterator it = entry->entry_points.begin();
+  for (; it != entry->entry_points.end(); ++it) {
+    ret = SetTrampolineAccessorForEntryPoint(context, *it, entry_ptr);
     if (!ret) {
       // TODO(vcgomes): Remove already added trampolines when it fails.
       LOG(WARNING) << "Error installing trampoline for '"
@@ -344,14 +341,9 @@ void XWalkModuleSystem::TrampolineCallback(
 
   DeleteAccessorForEntryPoint(context, entry->name);
 
-  base::ListValue::const_iterator it = entry->entry_points->begin();
-  for (; it != entry->entry_points->end(); ++it) {
-    std::string entry_point;
-    std::vector<std::string> path;
-
-    (*it)->GetAsString(&entry_point);
-
-    DeleteAccessorForEntryPoint(context, entry_point);
+  std::vector<std::string>::const_iterator it = entry->entry_points.begin();
+  for (; it != entry->entry_points.end(); ++it) {
+    DeleteAccessorForEntryPoint(context, *it);
   }
 
   XWalkModuleSystem* module_system = GetModuleSystemFromContext(context);

--- a/extensions/renderer/xwalk_module_system.h
+++ b/extensions/renderer/xwalk_module_system.h
@@ -47,7 +47,7 @@ class XWalkModuleSystem {
   static void ResetModuleSystemFromContext(v8::Handle<v8::Context> context);
 
   void RegisterExtensionModule(scoped_ptr<XWalkExtensionModule> module,
-                               base::ListValue* entry_points);
+                               const std::vector<std::string>& entry_points);
 
   void RegisterNativeModule(const std::string& name,
                             scoped_ptr<XWalkNativeModule> module);
@@ -60,13 +60,13 @@ class XWalkModuleSystem {
  private:
   struct ExtensionModuleEntry {
     ExtensionModuleEntry(const std::string& name, XWalkExtensionModule* module,
-                         base::ListValue* entry_points)
+                         const std::vector<std::string>& entry_points)
     : name(name), module(module), use_trampoline(true),
       entry_points(entry_points) {}
     std::string name;
     XWalkExtensionModule* module;
     bool use_trampoline;
-    base::ListValue* entry_points;
+    std::vector<std::string> entry_points;
     bool operator<(const ExtensionModuleEntry& other) const {
       return name < other.name;
     }


### PR DESCRIPTION
With this, we avoid potencial confusions and problems that could
arise about who owns the entry_points of an extension.
