### PR TITLE
[Android] Adjust the parameters for extension's two methods for reflecti...

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionClientImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionClientImpl.java
@@ -32,8 +32,8 @@ public class XWalkExtensionClientImpl extends XWalkExtension {
         super(name, jsApi, context);
 
         mExtensionClient = extensionClient;
-        mOnMessage = lookupMethod("onMessage", String.class);
-        mOnSyncMessage = lookupMethod("onSyncMessage", String.class);
+        mOnMessage = lookupMethod("onMessage", int.class, String.class);
+        mOnSyncMessage = lookupMethod("onSyncMessage", int.class, String.class);
         mOnResume = lookupMethod("onResume");
         mOnPause = lookupMethod("onPause");
         mOnDestroy = lookupMethod("onDestroy");


### PR DESCRIPTION
...on.

The onMessage and onSyncMessage are changed due to the support for multiple
instances for extension mechanism. However, the Java extension mechanism
doesn't change its parameters when looking up the methods for external
extensions. The unit test for external extensions will be added soon.

BUG=
