### PR TITLE
[Android] Update packaging tool and parsing tool to support extended man...

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -50,14 +50,28 @@ def Prepare(options, sanitized_name):
     shutil.copytree(options.app_root, assets_path)
 
 
-def ReplaceNodeValue(doc, node, name, value):
+def EditElementAttribute(doc, node, name, value):
   item = doc.getElementsByTagName(node)[0]
-  item.attributes[name].value = value
+  if item.hasAttribute(name):
+    item.attributes[name].value = value
+  else:
+    item.setAttribute(name, value)
 
 
-def AddAttribute(doc, node, name, value):
-  item = doc.getElementsByTagName(node)[0]
+def AddElementAttribute(doc, node, name, value):
+  root = doc.documentElement
+  item = doc.createElement(node)
   item.setAttribute(name, value)
+  root.appendChild(item)
+
+
+def AddElementAttributeAndText(doc, node, name, value, data):
+  root = doc.documentElement
+  item = doc.createElement(node)
+  item.setAttribute(name, value)
+  text = doc.createTextNode(data)
+  item.appendChild(text)
+  root.appendChild(item)
 
 
 def AddThemeStyle(doc, node, name, value):
@@ -73,6 +87,22 @@ def RemoveThemeStyle(doc, node, name, value):
   item.attributes[name].value = dest_str
 
 
+def CustomizeStringXML(options, sanitized_name):
+  strings_path = os.path.join(sanitized_name, 'res', 'values', 'strings.xml')
+  if not os.path.isfile(strings_path):
+    print ('Please make sure strings_xml'
+           ' exists under app_src folder.')
+    sys.exit(6)
+
+  if options.description:
+    xmldoc = minidom.parse(strings_path)
+    AddElementAttributeAndText(xmldoc, 'string', 'name', 'description',
+                               options.description)
+    strings_file = open(strings_path, 'wb')
+    xmldoc.writexml(strings_file)
+    strings_file.close()
+
+
 def CustomizeXML(options, sanitized_name):
   manifest_path = os.path.join(sanitized_name, 'AndroidManifest.xml')
   if not os.path.isfile(manifest_path):
@@ -80,12 +110,25 @@ def CustomizeXML(options, sanitized_name):
            ' exists under app_src folder.')
     sys.exit(6)
 
+  CustomizeStringXML(options, sanitized_name)
   xmldoc = minidom.parse(manifest_path)
-  ReplaceNodeValue(xmldoc, 'manifest', 'package', options.package)
-  ReplaceNodeValue(xmldoc, 'application', 'android:label', options.name)
+  EditElementAttribute(xmldoc, 'manifest', 'package', options.package)
+  if options.version:
+    EditElementAttribute(xmldoc, 'manifest', 'android:versionName',
+                         options.version)
+  if options.description:
+    EditElementAttribute(xmldoc, 'manifest', 'android:description',
+                         "@string/description")
+  # TODO: Update the permission list after the permission
+  # specification is defined.
+  if options.permissions:
+    if 'geolocation' in options.permissions:
+      AddElementAttribute(xmldoc, 'uses-permission', 'android:name',
+                          'android.permission.LOCATION_HARDWARE')
+  EditElementAttribute(xmldoc, 'application', 'android:label', options.name)
   activity_name = options.package + '.' + sanitized_name + 'Activity'
-  ReplaceNodeValue(xmldoc, 'activity', 'android:name', activity_name)
-  ReplaceNodeValue(xmldoc, 'activity', 'android:label', options.name)
+  EditElementAttribute(xmldoc, 'activity', 'android:name', activity_name)
+  EditElementAttribute(xmldoc, 'activity', 'android:label', options.name)
   if options.fullscreen:
     AddThemeStyle(xmldoc, 'activity', 'android:theme', 'Fullscreen')
   else:
@@ -98,8 +141,8 @@ def CustomizeXML(options, sanitized_name):
     icon_file = ReplaceInvalidChars(icon_file)
     shutil.copyfile(options.icon, os.path.join(drawable_path, icon_file))
     icon_name = os.path.splitext(icon_file)[0]
-    AddAttribute(xmldoc, 'application',
-                 'android:icon', '@drawable/%s' % icon_name)
+    EditElementAttribute(xmldoc, 'application',
+                         'android:icon', '@drawable/%s' % icon_name)
   elif options.icon and (not os.path.isfile(options.icon)):
     print ('Please make sure the icon file does exist!')
     sys.exit(6)
@@ -258,8 +301,17 @@ def main():
   parser.add_option('--package', help=info)
   info = ('The apk name. Such as: --name=YourApplicationName')
   parser.add_option('--name', help=info)
+  info = ('The version. Such as: --version=TheVersionNumber')
+  parser.add_option('--version', help=info)
+  info = ('The application description. Such as:'
+          '--description=YourApplicationdDescription')
+  parser.add_option('--description', help=info)
   info = ('The path of icon. Such as: --icon=/path/to/your/customized/icon')
   parser.add_option('--icon', help=info)
+  info = ('The permission list. Such as: --permissions="geolocation"'
+          'For more permissions, such as:'
+          '--permissions="geolocation:permission2"')
+  parser.add_option('--permissions', help=info)
   info = ('The url of application. '
           'This flag allows to package website as apk. Such as: '
           '--app-url=http://www.intel.com')

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -45,38 +45,80 @@ class TestMakeApk(unittest.TestCase):
       shutil.rmtree(test_data_dir)
 
   def testName(self):
-    proc = subprocess.Popen(['python', 'make_apk.py',
+    proc = subprocess.Popen(['python', 'make_apk.py', '--version=1.0.0',
                              '--package=org.xwalk.example'],
                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The APK name is required!') != -1)
     Clean('Example')
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
-                             '--package=org.xwalk.example'],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                             '--version=1.0.0', '--package=org.xwalk.example'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The APK name is required!') == -1)
     Clean('Example')
 
+  def testVersion(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example', '--version=1.0.0',
+                             '--app-url=http://www.intel.com'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('versionName') != -1)
+    Clean('Example')
+
+  def testAppDescription(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--package=org.xwalk.example', '--version=1.0.0',
+                             '--description=a sample application',
+                             '--app-url=http://www.intel.com'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('description') != -1)
+    Clean('Example')
+
+  def testPermissions(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0', '--package=org.xwalk.example',
+                             '--permissions="geolocation"',
+                             '--app-url=http://www.intel.com'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('LOCATION_HARDWARE') != -1)
+    Clean('Example')
+
   def testPackage(self):
     proc = subprocess.Popen(['python', 'make_apk.py',
-                             '--name=Example'],
+                             '--name=Example', '--version=1.0.0'],
                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The package name is required!') != -1)
     Clean('Example')
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
-                             '--package=org.xwalk.example'],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                             '--version=1.0.0', '--package=org.xwalk.example'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The package name is required!') == -1)
     Clean('Example')
 
   def testEntry(self):
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com'],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The entry is required.') == -1)
     self.assertTrue(os.path.exists('Example.apk'))
@@ -84,10 +126,11 @@ class TestMakeApk(unittest.TestCase):
 
     test_entry_root = 'test_data/entry'
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-root=%s' % test_entry_root,
                              '--app-local-path=index.html'],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The entry is required.') == -1)
     self.assertTrue(os.path.exists('Example.apk'))
@@ -95,7 +138,7 @@ class TestMakeApk(unittest.TestCase):
 
   def testEntryWithErrors(self):
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
-                             '--package=org.xwalk.example'],
+                             '--version=1.0.0', '--package=org.xwalk.example'],
                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The entry is required.') != -1)
@@ -103,27 +146,30 @@ class TestMakeApk(unittest.TestCase):
     Clean('Example')
 
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com',
                              '--app-root=.'],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The entry is required.') != -1)
     self.assertFalse(os.path.exists('Example.apk'))
     Clean('Example')
 
-    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example', 
+                             '--version=1.0.0',
                              '--package=org.xwalk.example', '--app-root=./'],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The entry is required.') != -1)
     self.assertFalse(os.path.exists('Example.apk'))
     Clean('Example')
 
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-local-path=index.html'],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('The entry is required.') != -1)
     self.assertFalse(os.path.exists('Example.apk'))
@@ -132,10 +178,11 @@ class TestMakeApk(unittest.TestCase):
   def testIcon(self):
     icon_path = './app_src/res/drawable-xhdpi/crosswalk.png'
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com',
                              '--icon=%s' % icon_path],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     _, _ = proc.communicate()
     manifest = 'Example/AndroidManifest.xml'
     with open(manifest, 'r') as content_file:
@@ -146,6 +193,7 @@ class TestMakeApk(unittest.TestCase):
 
   def testFullscreen(self):
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com', '-f'],
                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -159,6 +207,7 @@ class TestMakeApk(unittest.TestCase):
 
   def testEnableRemoteDebugging(self):
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com',
                              '--enable-remote-debugging'],
@@ -174,6 +223,7 @@ class TestMakeApk(unittest.TestCase):
   def testKeystore(self):
     keystore_path = os.path.join('test_data', 'keystore', 'xwalk-test.keystore')
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com',
                              '--keystore-path=%s' % keystore_path,
@@ -209,6 +259,7 @@ class TestMakeApk(unittest.TestCase):
     # Test with an existed extension.
     extension_path = 'test_data/extensions/myextension'
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com',
                              '--extensions=%s' % extension_path],
@@ -232,6 +283,7 @@ class TestMakeApk(unittest.TestCase):
     # Test with a non-existed extension.
     extension_path = 'test_data/extensions/myextension'
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com',
                              '--extensions=%s1' % extension_path],
@@ -243,6 +295,7 @@ class TestMakeApk(unittest.TestCase):
 
   def testMode(self):
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com'],
                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -251,6 +304,7 @@ class TestMakeApk(unittest.TestCase):
     shared_mode_size = os.path.getsize('Example.apk')
     Clean('Example')
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--version=1.0.0',
                              '--package=org.xwalk.example',
                              '--app-url=http://www.intel.com',
                              '--mode=embedded'],
@@ -264,7 +318,7 @@ class TestMakeApk(unittest.TestCase):
   def testXPK(self):
     xpk_file = os.path.join('test_data', 'xpk', 'example.xpk')
     proc = subprocess.Popen(['python', 'make_apk.py', '--xpk=%s' % xpk_file],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     _, _ = proc.communicate()
     self.assertTrue(os.path.exists('Example'))
     self.assertTrue(os.path.isfile('Example.apk'))
@@ -273,7 +327,7 @@ class TestMakeApk(unittest.TestCase):
   def testXPKWithError(self):
     xpk_file = os.path.join('test_data', 'xpk', 'error.xpk')
     proc = subprocess.Popen(['python', 'make_apk.py', '--xpk=%s' % xpk_file],
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     error_msg = 'XPK doesn\'t contain manifest file'
     self.assertTrue(out.find(error_msg) != -1)

--- a/app/tools/android/test_data/manifest/manifest.json
+++ b/app/tools/android/test_data/manifest/manifest.json
@@ -1,16 +1,13 @@
 {
   "name": "Example",
-  "app": {
-    "launch": {
-      "local_path": "http://www.intel.com"
-    }
-  },
   "version": "1.0.0",
+  "launch_path": "http://www.intel.com",
   "description": "a sample description",
+  "origin": "app://app.id",
   "icons": {
   },
   "default_locale": "en",
-  "permissions": [],
+  "permissions": ["geolocation"],
   "required_version": "1.28.1.0",
   "plugin": [],
   "fullscreen":"true"


### PR DESCRIPTION
...ifest fields.

1  These changes are used to support the parsing and packaging of the extended
   manifest fields including launch_path, application version, description and
   permissions based on current manifest specification.
2  In the packaging tool and parsing tool, the parsing and packaging process are
   added for the following fields: launch_path, application version, application
   description and permissions(geolocation). both the manifest json file paring
   and the command-line method parsing and packaging processes are extended for
   these fields. For the field of description, the /path/to/res/values/strings.xml
   and the corresponding field in /path/to/AndroidManifest.xml are associatively
   processed.
3  Add the corresponding test cases for the fields.

BUG=#1017, #768
