### PR TITLE
[Android] Add Java extension system files to xwalk core library project.

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -198,6 +198,27 @@ def CopyXwalkJavaSource(project_source, out_directory):
   target_path = os.path.join(target_package_directory, 'core', 'extensions')
   shutil.copytree(source_path, target_path)
 
+  if not os.path.exists(os.path.join(target_package_directory, 'runtime')):
+    os.mkdir(os.path.join(target_package_directory, 'runtime'))
+  source_path = os.path.join(project_source, 'xwalk', 'runtime', 'android',
+                             'java', 'src', 'org', 'xwalk', 'runtime', 
+                             'extension')
+  target_path = os.path.join(target_package_directory, 'runtime', 'extension')
+  shutil.copytree(source_path, target_path)
+
+  source_file = os.path.join(project_source, 'xwalk', 'runtime', 'android',
+                             'java', 'src', 'org', 'xwalk', 'runtime', 
+                             'XWalkCoreExtensionBridge.java')
+  target_file = os.path.join(target_package_directory, 'runtime', 
+                             'XWalkCoreExtensionBridge.java')
+  shutil.copyfile(source_file, target_file)
+
+  source_file = os.path.join(project_source, 'xwalk', 'runtime', 'android',
+                             'java', 'src', 'org', 'xwalk', 'runtime', 
+                             'XWalkRuntimeViewProvider.java')
+  target_file = os.path.join(target_package_directory, 'runtime', 
+                             'XWalkRuntimeViewProvider.java')
+  shutil.copyfile(source_file, target_file)
 
 def CopyBinaries(out_directory):
   print 'Copying binaries...'


### PR DESCRIPTION
As extensions are required by apps that developed based on xwalk core
library, the files of Java extension system should be added to the tree
of xwalk core library project.
