### PR TITLE
[Android] Add the dependency about test apk.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -572,7 +572,9 @@
             'xwalk_core_test_apk',
             'xwalk_runtime_shell_apk',
             'xwalk_runtime_client_embedded_shell_apk',
+            'xwalk_runtime_client_embedded_test_apk',
             'xwalk_runtime_client_shell_apk',
+            'xwalk_runtime_client_test_apk',
 
             # For external testing.
             'pack_xwalk_core_library',


### PR DESCRIPTION
On the buildbot, we need to generate the
XWalkRuntimeClientEmbeddedTest.apk and XWalkRuntimeClientTest.apk
before the instrumentation test.
