### PR TITLE
[Windows] Enable aura on Windows

### DIFF
--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -302,7 +302,7 @@ NativeAppWindow* NativeAppWindow::Create(
 
 // static
 void NativeAppWindow::Initialize() {
-#if !defined(OS_WIN) && defined(USE_AURA)
+#if defined(USE_AURA)
   CHECK(!views::ViewsDelegate::views_delegate);
   gfx::Screen::SetScreenInstance(
       gfx::SCREEN_TYPE_NATIVE, views::CreateDesktopScreen());

--- a/runtime/browser/ui/xwalk_views_delegate.cc
+++ b/runtime/browser/ui/xwalk_views_delegate.cc
@@ -3,10 +3,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#if !defined(OS_WIN) && defined(USE_AURA)
+#if defined(USE_AURA)
+
+#include "grit/xwalk_resources.h"
 
 #include "xwalk/runtime/browser/ui/xwalk_views_delegate.h"
-
 #include "ui/views/widget/desktop_aura/desktop_native_widget_aura.h"
 #include "ui/views/widget/native_widget_aura.h"
 
@@ -51,7 +52,13 @@ void XWalkViewsDelegate::OnBeforeWidgetInit(
   }
 }
 
+#if defined(OS_WIN)
+HICON XWalkViewsDelegate::GetDefaultWindowIcon() const {
+  return LoadIcon(NULL, MAKEINTRESOURCE(IDR_XWALK_ICON_48));
+}
+#endif
+
 }  // namespace xwalk
 
-#endif  // !defined(OS_WIN) && defined(USE_AURA)
+#endif  // defined(USE_AURA)
 

--- a/runtime/browser/ui/xwalk_views_delegate.h
+++ b/runtime/browser/ui/xwalk_views_delegate.h
@@ -5,7 +5,7 @@
 #ifndef XWALK_RUNTIME_BROWSER_UI_XWALK_VIEWS_DELEGATE_H_
 #define XWALK_RUNTIME_BROWSER_UI_XWALK_VIEWS_DELEGATE_H_
 
-#if !defined(OS_WIN) && defined(USE_AURA)
+#if defined(USE_AURA)
 
 #include <string>
 #include "ui/views/views_delegate.h"
@@ -50,6 +50,10 @@ class XWalkViewsDelegate : public views::ViewsDelegate {
   virtual base::TimeDelta GetDefaultTextfieldObscuredRevealDuration() OVERRIDE {
     return base::TimeDelta();
   }
+#if defined(OS_WIN)
+  // Retrieves the default window icon to use for windows if none is specified.
+  virtual HICON GetDefaultWindowIcon() const OVERRIDE;
+#endif
 
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkViewsDelegate);
@@ -57,6 +61,6 @@ class XWalkViewsDelegate : public views::ViewsDelegate {
 
 }  // namespace xwalk
 
-#endif  // !defined(OS_WIN) && defined(USE_AURA)
+#endif  // defined(USE_AURA)
 
 #endif  // XWALK_RUNTIME_BROWSER_UI_XWALK_VIEWS_DELEGATE_H_


### PR DESCRIPTION
The origin MACRO protection for XWalkViewsDelegate
is "#if !defined(OS_WIN) && defined(USE_AURA)", which
is not appropriate on Windows after Windows build also
switches to use aura.

Change the condition to "#if defined(USE_AURA)" and
implement the missing abstract function on Windows.
