### PR TITLE
[Android] Add the instrumentation test for external extension.

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
@@ -42,7 +42,7 @@ public class XWalkExtensionClient extends CrossPackageWrapper {
 
         mGetExtensionName = lookupMethod("getExtensionName");
         mGetJsApi = lookupMethod("getJsApi");
-        mPostMessage = lookupMethod("postMessage", String.class);
+        mPostMessage = lookupMethod("postMessage", int.class, String.class);
         mBroadcastMessage = lookupMethod("broadcastMessage", String.class);
     }
 

--- a/test/android/data/echo.html
+++ b/test/android/data/echo.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+try {
+  var d = new Date().toString();
+  echo.echo(d, function(msg) {
+    document.write(msg + "<br>");
+    var expected = "From java:" + d;
+    if (msg === expected) {
+      document.write("Async echo <font color=green>passed</font>.");
+      document.title = "Pass";
+    } else {
+      document.write("Async echo <font color=red>failed</font>.");
+      document.title = "Fail";
+    }
+  });
+} catch(e) {
+  console.log(e);
+  document.title = "Fail";
+}
+</script>
+</body>
+</html>

--- a/test/android/data/echoSync.html
+++ b/test/android/data/echoSync.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+try {
+  var d = new Date().toString();
+  var expected = "From java sync:" + d;
+  var r = echo.echoSync(d);
+  document.write(r + "<br>");
+  if (r === expected) {
+    document.write("Sync echo <font color=green>passed</font>.");
+    document.title = "Pass";
+  } else {
+    document.write("Sync echo <font color=red>failed</font>.");
+    document.title = "Fail";
+  }
+} catch(e) {
+  console.log(e);
+  document.title = "Fail";
+}
+</script>
+</body>
+</html>

--- a/test/android/data/extensions-config.json
+++ b/test/android/data/extensions-config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name":  "echo",
+    "class": "com.example.extension.MyExtension",
+    "jsapi": "myextension/myextension.js"
+  }
+]

--- a/test/android/data/index.html
+++ b/test/android/data/index.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<title>
+Crosswalk Sample Application
+</title>
+</head>
+<body>
+<div style="text-align:center;margin:100">
+<img src='sampapp-icon-helloworld.png'/>
+</div>
+<div style="text-align:center;margin:50;font-size:64;font-weight:bold">
+Welcome to Crosswalk
+</div>
+<div style="text-align:center;margin:20;font-size:48">
+A perfect way for writing<br>
+stand-alone web applications<br>
+for Android
+</div>
+</body>
+</html>

--- a/test/android/data/myextension/myextension.js
+++ b/test/android/data/myextension/myextension.js
@@ -1,0 +1,15 @@
+var echoListener = null;
+extension.setMessageListener(function(msg) {
+  if (echoListener instanceof Function) {
+    echoListener(msg);
+  };
+});
+// Export API 'echo'.
+exports.echo = function(msg, callback) {
+  echoListener = callback;
+  extension.postMessage(msg);
+};
+// Export API 'echoSync'.
+exports.echoSync = function(msg) {
+  return extension.internal.sendSyncMessage(msg);
+};

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/ExternalExtensionTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/ExternalExtensionTest.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import java.util.concurrent.TimeUnit;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.test.util.OnTitleUpdatedHelper;
+import org.xwalk.test.util.TestXWalkRuntimeClientContentsClient;
+import org.xwalk.test.util.XWalkRuntimeClientUtilInterface;
+
+/**
+ * Test suite for testing external extensions.
+ */
+public class ExternalExtensionTest extends XWalkRuntimeClientTestBase {
+
+    @SmallTest
+    @Feature({"ExternalExtensionAsync"})
+    public void testExternalExtensionAsync() throws Throwable {
+        OnTitleUpdatedHelper helper = getUtilInterface().getContentsClient().getOnTitleUpdatedHelper();
+        int currentCallCount = helper.getCallCount();
+
+        getUtilInterface().loadAssetFile("echo.html");
+
+        helper.waitForCallback(currentCallCount, 1, XWalkRuntimeClientUtilInterface.WAIT_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
+        String title = helper.getTitle();
+        assertEquals("Pass", title);
+    }
+
+    @SmallTest
+    @Feature({"ExternalExtensionSync"})
+    public void testExternalExtensionSync() throws Throwable {
+        getUtilInterface().loadAssetFile("echoSync.html");
+
+        String title = getUtilInterface().getRuntimeView().getTitleForTest();
+        assertEquals("Pass", title);
+    }
+}

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/ExternalExtensionTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/ExternalExtensionTest.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.embedded.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import java.util.concurrent.TimeUnit;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.test.util.OnTitleUpdatedHelper;
+import org.xwalk.test.util.TestXWalkRuntimeClientContentsClient;
+import org.xwalk.test.util.XWalkRuntimeClientUtilInterface;
+
+/**
+ * Test suite for testing external extensions.
+ */
+public class ExternalExtensionTest extends XWalkRuntimeClientTestBase {
+
+    @SmallTest
+    @Feature({"ExternalExtensionAsync"})
+    public void testExternalExtensionAsync() throws Throwable {
+        OnTitleUpdatedHelper helper = getUtilInterface().getContentsClient().getOnTitleUpdatedHelper();
+        int currentCallCount = helper.getCallCount();
+
+        getUtilInterface().loadAssetFile("echo.html");
+
+        helper.waitForCallback(currentCallCount, 1, XWalkRuntimeClientUtilInterface.WAIT_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
+        String title = helper.getTitle();
+        assertEquals("Pass", title);
+    }
+
+    @SmallTest
+    @Feature({"ExternalExtensionSync"})
+    public void testExternalExtensionSync() throws Throwable {
+        getUtilInterface().loadAssetFile("echoSync.html");
+
+        String title = getUtilInterface().getRuntimeView().getTitleForTest();
+        assertEquals("Pass", title);
+    }
+}

--- a/test/android/util/runtime_client/src/com/example/extension/MyExtension.java
+++ b/test/android/util/runtime_client/src/com/example/extension/MyExtension.java
@@ -1,0 +1,23 @@
+package com.example.extension;
+
+import org.xwalk.app.runtime.extension.XWalkExtensionClient;
+import org.xwalk.app.runtime.extension.XWalkExtensionContextClient;
+
+import android.util.Log;
+
+public class MyExtension extends XWalkExtensionClient {
+    // Don't change the parameters in Constructor because XWalk needs to call this constructor.
+    public MyExtension(String name, String JsApiContent, XWalkExtensionContextClient context) {
+        super(name, JsApiContent, context);
+    }
+
+    @Override
+    public void onMessage(int instanceId, String message) {
+        postMessage(instanceId, "From java:" + message);
+    }
+
+    @Override
+    public String onSyncMessage(int instanceId, String message) {
+        return "From java sync:" + message;
+    }
+}

--- a/test/android/util/src/org/xwalk/test/util/XWalkRuntimeClientUtilInterface.java
+++ b/test/android/util/src/org/xwalk/test/util/XWalkRuntimeClientUtilInterface.java
@@ -21,7 +21,7 @@ public class XWalkRuntimeClientUtilInterface {
     Instrumentation mInstrumentation;
     final TestXWalkRuntimeClientContentsClient mTestContentsClient =
             new TestXWalkRuntimeClientContentsClient();
-    protected final static int WAIT_TIMEOUT_SECONDS = 15;
+    public final static int WAIT_TIMEOUT_SECONDS = 15;
 
     public class PageStatusCallback {
         public void onPageStarted(String url) {

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -1,6 +1,18 @@
 {
   'targets': [
     {
+      # Java utils for runtime client related tests.
+      'target_name': 'xwalk_runtime_client_test_utils_java',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_app_runtime_client_java',
+      ],
+      'variables': {
+        'java_in_dir': 'test/android/util/runtime_client',
+      },
+      'includes': [ '../build/java.gypi' ],
+    },
+    {
       'target_name': 'xwalk_core_shell_apk',
       'type': 'none',
       'dependencies': [
@@ -191,17 +203,34 @@
       'dependencies': [
         'xwalk_app_runtime_client_java',
         'xwalk_app_runtime_activity_java',
+        'xwalk_runtime_client_test_utils_java',
       ],
       'variables': {
         'apk_name': 'XWalkRuntimeClientShell',
         'java_in_dir': 'app/android/runtime_client_shell',
         'resource_dir': 'app/android/runtime_client_shell/res',
         'additional_input_paths': [
-          '<(asset_location)/index.html',
-          '<(asset_location)/sampapp-icon-helloworld.png',
+          '<(PRODUCT_DIR)/runtime_client_shell/assets/extensions-config.json',
+          '<(PRODUCT_DIR)/runtime_client_shell/assets/index.html',
+          '<(PRODUCT_DIR)/runtime_client_shell/assets/myextension/myextension.js',
+          '<(PRODUCT_DIR)/runtime_client_shell/assets/sampapp-icon-helloworld.png',
         ],
-        'asset_location': 'app/android/runtime_client_shell/assets',
+        'asset_location': '<(ant_build_out)/runtime_client_shell/assets',
       },
+      'copies': [
+        {
+          'destination': '<(PRODUCT_DIR)/runtime_client_shell/assets',
+          'files': [
+            '<(java_in_dir)/assets/sampapp-icon-helloworld.png',
+            'test/android/data/extensions-config.json',
+            'test/android/data/index.html',
+          ],
+        },
+        {
+          'destination': '<(PRODUCT_DIR)/runtime_client_shell/assets/myextension',
+          'files': ['test/android/data/myextension/myextension.js'],
+        },
+      ],
       'includes': [ '../build/java_apk.gypi' ],
     },
     {
@@ -221,6 +250,7 @@
         'xwalk_app_runtime_activity_java',
         'xwalk_core_java',
         'xwalk_runtime_client_embedded_shell_apk_pak',
+        'xwalk_runtime_client_test_utils_java',
       ],
       'variables': {
         'apk_name': 'XWalkRuntimeClientEmbeddedShell',
@@ -228,20 +258,26 @@
         'resource_dir': 'app/android/runtime_client_embedded_shell/res',
         'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
-          '<(PRODUCT_DIR)/xwalk_runtime_client_embedded_shell/assets/index.html',
-          '<(PRODUCT_DIR)/xwalk_runtime_client_embedded_shell/assets/sampapp-icon-helloworld.png',
-          '<(PRODUCT_DIR)/xwalk_runtime_client_embedded_shell/assets/xwalk.pak',
+          '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/extensions-config.json',
+          '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/index.html',
+          '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/myextension/myextension.js',
+          '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/sampapp-icon-helloworld.png',
+          '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/xwalk.pak',
         ],
-        'asset_location': '<(ant_build_out)/xwalk_runtime_client_embedded_shell/assets',
+        'asset_location': '<(ant_build_out)/runtime_client_embedded_shell/assets',
       },
       'copies': [
         {
-          'destination': '<(PRODUCT_DIR)/xwalk_runtime_client_embedded_shell/assets',
-          'files': ['<(java_in_dir)/assets/sampapp-icon-helloworld.png'],
+          'destination': '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets',
+          'files': [
+            '<(java_in_dir)/assets/sampapp-icon-helloworld.png',
+            'test/android/data/extensions-config.json',
+            'test/android/data/index.html',
+          ],
         },
         {
-          'destination': '<(PRODUCT_DIR)/xwalk_runtime_client_embedded_shell/assets',
-          'files': ['<(java_in_dir)/assets/index.html'],
+          'destination': '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/myextension',
+          'files': ['test/android/data/myextension/myextension.js'],
         },
       ],
       'includes': [ '../build/java_apk.gypi' ],
@@ -254,7 +290,7 @@
       ],
       'copies': [
         {
-          'destination': '<(PRODUCT_DIR)/xwalk_runtime_client_embedded_shell/assets',
+          'destination': '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets',
           'files': [
             '<(PRODUCT_DIR)/xwalk.pak',
           ],
@@ -295,7 +331,21 @@
         'apk_name': 'XWalkRuntimeClientTest',
         'java_in_dir': 'test/android/runtime_client/javatests',
         'is_test_apk': 1,
+        'additional_input_paths': [
+          '<(PRODUCT_DIR)/runtime_client_test/assets/echo.html',
+          '<(PRODUCT_DIR)/runtime_client_test/assets/echoSync.html',
+        ],
+        'asset_location': '<(ant_build_out)/runtime_client_test/assets',
       },
+      'copies': [
+        {
+          'destination': '<(PRODUCT_DIR)/runtime_client_test/assets',
+          'files': [
+            'test/android/data/echo.html',
+            'test/android/data/echoSync.html',
+          ],
+        },
+      ],
       'includes': [ '../build/java_apk.gypi' ],
     },
     {
@@ -322,7 +372,21 @@
         'apk_name': 'XWalkRuntimeClientEmbeddedTest',
         'java_in_dir': 'test/android/runtime_client_embedded/javatests',
         'is_test_apk': 1,
+        'additional_input_paths': [
+          '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/echo.html',
+          '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/echoSync.html',
+        ],
+        'asset_location': '<(ant_build_out)/runtime_client_embedded_test/assets',
       },
+      'copies': [
+        {
+          'destination': '<(PRODUCT_DIR)/runtime_client_embedded_test/assets',
+          'files': [
+            'test/android/data/echo.html',
+            'test/android/data/echoSync.html',
+          ],
+        },
+      ],
       'includes': [ '../build/java_apk.gypi' ],
     },
     {


### PR DESCRIPTION
This patch is to create two unit tests for external extensions for runtime
client. Since there are two modes - shared and embedded modes which are
supported in runtime client, here two copies here.

To avoid duplicated data, a shared directory is created to store data and
some code which should be used by all other instrumentation tests. So
we don't need to copy them everywhere. All testing data should be put
in here in future.

Besides, an external Java extension implementation is needed and
it has to be in test shell apks together with some assets and can't be in
instrumentation test apks because test shells can't access assets in
other assets.

For future, we should avoid duplicated code for embedded shell and shared
shell. This is a TODO.

BUG=#986
