### PR TITLE
[Extensions] Add a test that another extension depends on another

### DIFF
--- a/extensions/test/data/another.html
+++ b/extensions/test/data/another.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+try {
+  if (another.value !== true) {
+    console.log("another.value is not true!");
+    document.title = "Fail";
+  } else {
+    document.title = "Pass";
+  }
+} catch(e) {
+    console.log(e);
+    document.title = "Fail";
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
In this test an extension ("another") depends on two other extensions ("outer" and "outer.inner"),
by using objects that are provided by those extensions.
