### PR TITLE
[Android] Fix the crash when running some WebAPI components

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkViewDelegate.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkViewDelegate.java
@@ -36,8 +36,6 @@ class XWalkViewDelegate {
         if (!CommandLine.isInitialized())
             CommandLine.init(null);
 
-        ResourceExtractor.setMandatoryPaksToExtract(MANDATORY_PAKS);
-        ResourceExtractor.setExtractImplicitLocaleForTesting(false);
         // If context's applicationContext is not the same package with itself,
         // It's a cross package invoking, load core library from library apk.
         // Only load the native library from /data/data if the Android version is
@@ -55,6 +53,13 @@ class XWalkViewDelegate {
         }
         loadLibrary();
         DeviceUtils.addDeviceSpecificUserAgentSwitch(context);
+
+        ResourceExtractor.setMandatoryPaksToExtract(MANDATORY_PAKS);
+        ResourceExtractor.setExtractImplicitLocaleForTesting(false);
+        // Use MixContext to initialize the ResourceExtractor, as the pak file
+        // is in the library apk if in shared apk mode.
+        ResourceExtractor.get(context);
+
         startBrowserProcess(context);
         sInitialized = true;
     }


### PR DESCRIPTION
Root cause: The crash of these WebAPI test cases are all caused
by the failure to access the i10n strings loaded from pak file.
In shared apk mode, the pak should be loaded from the Library apk
instead of App apk, for which we should use the Context of Library
apk for ResourceExtractor(under Content layer) to extract the pak
file. But after rebasing to V31, ResourceExtractor gets the Context
by mContext.getApplicationContext, which results that it gets the
wrong Context of App apk.

Fix: Force to initilize Context of ResourceExtractor before start
the browser process.

Bug:https://github.com/crosswalk-project/crosswalk/issues/941
