### PR TITLE
[Android] local variable 'xpk_temp_dir' referenced before assignment.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -459,6 +459,7 @@ def main(argv):
     parser.print_help()
     return 0
 
+  xpk_temp_dir = ''
   if options.xpk:
     xpk_name = os.path.splitext(os.path.basename(options.xpk))[0]
     xpk_temp_dir = xpk_name + '_xpk'


### PR DESCRIPTION
In the exception catch code block, 'xpk_temp_dir' is used before assignment.
It would mislead the develper with wrong log. So assign 'xpk_temp_dir'
with empty string at the beginning to fix this issue.

BUG=https://github.com/crosswalk-project/crosswalk/issues/999
