### PR TITLE
[Windows] Fix runtime is using wrong content_app target

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -28,7 +28,7 @@
         '../base/base.gyp:base_i18n',
         '../base/third_party/dynamic_annotations/dynamic_annotations.gyp:dynamic_annotations',
         '../content/content.gyp:content',
-        '../content/content.gyp:content_app_browser',
+        '../content/content.gyp:content_app_both',
         '../content/content.gyp:content_browser',
         '../content/content.gyp:content_common',
         '../content/content.gyp:content_gpu',


### PR DESCRIPTION
On Windows, upstream is trying to provide alternative to split
chrome.dll into several parts. Therefore, target content_app
is now content_app_browser, content_app_child, content_app_both.
It's not relevant with xwalk, xwalk should use content_app_both
to obtain all it need for content app.
