### PR TITLE
[Android] Fix the incorrect context usage for HttpAuthDataBase.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultClient.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultClient.java
@@ -36,7 +36,7 @@ public class XWalkDefaultClient extends XWalkClient {
     private HttpAuthDatabase mDatabase;
 
     public XWalkDefaultClient(Context context, XWalkView view) {
-        mDatabase = HttpAuthDatabase.getInstance(context);
+        mDatabase = HttpAuthDatabase.getInstance(context.getApplicationContext());
         mContext = context;
         mView = view;
     }


### PR DESCRIPTION
The database file should be in the app's data directory. However,
if using the context of runtime lib package, Android doesn't allow
to create it. Fix it by using the application context which is for
the runtime client side.

BUG=#1002
