### PR TITLE
[Android] Hotfix in Presentation API extension

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.xwalk.runtime.extension.api.PresentationExtension;
+import org.xwalk.runtime.extension.api.presentation.PresentationExtension;
 import org.xwalk.runtime.XWalkRuntimeViewProvider;
 
 /**
@@ -114,20 +114,20 @@ public class XWalkExtensionManager {
         //    String jsApiContent = "";
         //    try {
         //        jsApiContent = getAssetsFileContent(mContext.getAssets(), Device.JS_API_PATH);
+        //        new Device(jsApiContent, mExtensionContextImpl);
         //    } catch(IOException e) {
         //        Log.e(TAG, "Failed to read js API file of internal extension: Device");
         //    }
-        //    new Device(jsApiContent, mExtensionContextImpl);
         {
             String jsApiContent = "";
             try {
                 jsApiContent = getAssetsFileContent(mContext.getAssets(),
                                                     PresentationExtension.JS_API_PATH);
+                // Load PresentationExtension as an internal extension.
+                new PresentationExtension(PresentationExtension.NAME, jsApiContent, mExtensionContextImpl);
             } catch (IOException e) {
                 Log.e(TAG, "Failed to read JS API file: " + PresentationExtension.JS_API_PATH);
             }
-            // Load PresentationExtension as an internal extension.
-            new PresentationExtension(PresentationExtension.NAME, jsApiContent, mExtensionContextImpl);
         }
     }
 

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package org.xwalk.runtime.extension.api;
+package org.xwalk.runtime.extension.api.presentation;
 
 import android.content.Context;
 import android.hardware.display.DisplayManager;


### PR DESCRIPTION
This patch is to fix 2 issues:
o Place PresentationExtension into ..api.presentation package to follow
  the general pattern in Java. Otherwise, we will get error message when
  import xwalk_core_library into eclipse.
o Don't create PresentationExtension if failing to load the JS binding
  code from assets/

TODO:
1. Figure out why the external extension test crash when passing a empty string to
   create a new XWalkExtension.
2. Ensure the PresentationExtension code can also work on Android 4.0.
