### PR TITLE
[Android] Add the test case about enableRemoteDebugging.

### DIFF
--- a/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestRunnerActivity.java
+++ b/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestRunnerActivity.java
@@ -5,16 +5,23 @@
 package org.xwalk.runtime.client.embedded.test;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.LinearLayout;
+
+import org.xwalk.app.runtime.XWalkRuntimeClient;
 
 /*
  * This is a lightweight activity for tests that only require XWalk functionality.
  */
 public class XWalkRuntimeClientTestRunnerActivity extends Activity {
     private LinearLayout mLinearLayout;
+    private BroadcastReceiver mReceiver;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -44,8 +51,31 @@ public class XWalkRuntimeClientTestRunnerActivity extends Activity {
         mLinearLayout.removeAllViews();
     }
 
+    public void registerBroadcastReceiver(final XWalkRuntimeClient runtimeView) {
+        IntentFilter intentFilter = new IntentFilter("org.xwalk.intent");
+        mReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                Bundle bundle = intent.getExtras();
+                if (bundle == null) return;
+
+                if (bundle.containsKey("remotedebugging")) {
+                    String extra = bundle.getString("remotedebugging");
+                    if (extra.equals("true")) {
+                        String mPackageName = getApplicationContext().getPackageName();
+                        runtimeView.enableRemoteDebugging("", mPackageName);
+                    } else if (extra.equals("false")) {
+                        runtimeView.disableRemoteDebugging();
+                    }
+                }
+            }
+        };
+        registerReceiver(mReceiver, intentFilter);
+    }
+
     @Override
     public void onDestroy() {
         super.onDestroy();
+        unregisterReceiver(mReceiver);
     }
 }

--- a/app/android/runtime_client_shell/src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestRunnerActivity.java
+++ b/app/android/runtime_client_shell/src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestRunnerActivity.java
@@ -5,16 +5,23 @@
 package org.xwalk.runtime.client.test;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.LinearLayout;
+
+import org.xwalk.app.runtime.XWalkRuntimeClient;
 
 /*
  * This is a lightweight activity for tests that only require XWalk functionality.
  */
 public class XWalkRuntimeClientTestRunnerActivity extends Activity {
     private LinearLayout mLinearLayout;
+    private BroadcastReceiver mReceiver;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -44,8 +51,31 @@ public class XWalkRuntimeClientTestRunnerActivity extends Activity {
         mLinearLayout.removeAllViews();
     }
 
+    public void registerBroadcastReceiver(final XWalkRuntimeClient runtimeView) {
+        IntentFilter intentFilter = new IntentFilter("org.xwalk.intent");
+        mReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                Bundle bundle = intent.getExtras();
+                if (bundle == null) return;
+
+                if (bundle.containsKey("remotedebugging")) {
+                    String extra = bundle.getString("remotedebugging");
+                    if (extra.equals("true")) {
+                        String mPackageName = getApplicationContext().getPackageName();
+                        runtimeView.enableRemoteDebugging("", mPackageName);
+                    } else if (extra.equals("false")) {
+                        runtimeView.disableRemoteDebugging();
+                    }
+                }
+            }
+        };
+        registerReceiver(mReceiver, intentFilter);
+    }
+
     @Override
     public void onDestroy() {
         super.onDestroy();
+        unregisterReceiver(mReceiver);
     }
 }

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/EnableRemoteDebuggingTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/EnableRemoteDebuggingTest.java
@@ -1,0 +1,36 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.test;
+
+import android.content.Context;
+import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.test.util.RuntimeClientApiTestBase;
+
+/**
+ * Test suite for enableRemoteDebugging().
+ */
+public class EnableRemoteDebuggingTest extends XWalkRuntimeClientTestBase {
+    @SmallTest
+    @Feature({"EnableRemoteDebugging"})
+    public void testEnableRemoteDebugging() throws Throwable {
+        Context context = getActivity();
+        RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(
+                        getTestUtil(), this);
+        helper.testEnableRemoteDebugging(getActivity(), context);
+    }
+
+    @SmallTest
+    @Feature({"DisableRemoteDebugging"})
+    public void testDisableRemoteDebugging() throws Throwable {
+        Context context = getActivity();
+        RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(
+                        getTestUtil(), this);
+        helper.testDisableRemoteDebugging(getActivity(), context);
+    }
+}

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestBase.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestBase.java
@@ -23,5 +23,6 @@ public class XWalkRuntimeClientTestBase
     @Override
     public void postSetUp() {
         getActivity().addView(getTestUtil().getTestedView().getViewForTest());
+        getActivity().registerBroadcastReceiver(getTestUtil().getTestedView());
     }
 }

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/EnableRemoteDebuggingTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/EnableRemoteDebuggingTest.java
@@ -1,0 +1,36 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.embedded.test;
+
+import android.content.Context;
+import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.test.util.RuntimeClientApiTestBase;
+
+/**
+ * Test suite for enableRemoteDebugging().
+ */
+public class EnableRemoteDebuggingTest extends XWalkRuntimeClientTestBase {
+    @SmallTest
+    @Feature({"EnableRemoteDebugging"})
+    public void testEnableRemoteDebugging() throws Throwable {
+        Context context = getActivity();
+        RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(
+                        getTestUtil(), this);
+        helper.testEnableRemoteDebugging(getActivity(), context);
+    }
+
+    @SmallTest
+    @Feature({"DisableRemoteDebugging"})
+    public void testDisableRemoteDebugging() throws Throwable {
+        Context context = getActivity();
+        RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(
+                        getTestUtil(), this);
+        helper.testDisableRemoteDebugging(getActivity(), context);
+    }
+}

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestBase.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestBase.java
@@ -23,5 +23,6 @@ public class XWalkRuntimeClientTestBase
     @Override
     public void postSetUp() {
         getActivity().addView(getTestUtil().getTestedView().getViewForTest());
+        getActivity().registerBroadcastReceiver(getTestUtil().getTestedView());
     }
 }

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
@@ -6,8 +6,14 @@
 package org.xwalk.test.util;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
 import android.test.ActivityInstrumentationTestCase2;
 
+import java.io.IOException;
+import java.lang.Process;
+import java.lang.Runtime;
+import java.lang.StringBuffer;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -18,6 +24,8 @@ public class RuntimeClientApiTestBase<T extends Activity> {
     private XWalkRuntimeClientTestUtilBase mTestUtil;
     private ActivityInstrumentationTestCase2<T> mTestCase;
     private Timer mTimer = new Timer();
+    private String mSocketName;
+    private String mUrl = "http://www.bing.com";
     enum Relation {
         EQUAL,
         GREATERTHAN,
@@ -54,6 +62,46 @@ public class RuntimeClientApiTestBase<T extends Activity> {
                 compareTitle(prevTitle, title, msg, relation);
             }
         }, milliSeconds);
+    }
+
+    public void sendBroadCast(Activity activity, Context context, String extra) throws Throwable {
+        mSocketName = activity.getPackageName();
+        Intent intent = new Intent().setAction("org.xwalk.intent").putExtra("remotedebugging", extra);
+        context.sendBroadcast(intent);
+    }
+
+    public int getSocketNameIndex() {
+        try {
+            // Try to find the abstract socket name opened for remote debugging
+            // from the output of 'cat /proc/net/unix' command. Actually, the
+            // best way to test DevToolsServer is to connect the server socket
+            // by android.net.LocalSocket and communicate with it (e.g. send
+            // http request to query all inspectable pages). However, since
+            // the socket of devtools server is enforced to be connected only
+            // if the user is authenticated. On a non-rooted device, it only
+            // authenticates 'shell' user which is reserved for adb connecction.
+            Process process = Runtime.getRuntime().exec("cat /proc/net/unix");
+
+            final int BUFFER_SIZE = 1024;
+            byte[] bytes = new byte[BUFFER_SIZE];
+            StringBuffer buffer = new StringBuffer(4 * BUFFER_SIZE);
+
+            int bytesReceived = process.getInputStream().read(bytes, 0, BUFFER_SIZE);
+            while (bytesReceived > 0) {
+                String tmp = new String(bytes, 0, bytesReceived);
+                buffer.append(tmp);
+                bytesReceived = process.getInputStream().read(bytes, 0, BUFFER_SIZE);
+            }
+
+            process.destroy();
+
+            String contents = new String(buffer);
+            int index = contents.indexOf(mSocketName + "_devtools_remote");
+            return index;
+        } catch (IOException e) {
+            mTestCase.fail("error occurs in testDevTools: " + e);
+            return 0;
+        }
     }
 
     // For loadAppFromUrl.
@@ -128,5 +176,22 @@ public class RuntimeClientApiTestBase<T extends Activity> {
         title = mTestUtil.getTestedView().getTitleForTest();
         msg = "The second title should be greater than the first title.";
         compareTitleAfterTimer(title, 200, msg, Relation.GREATERTHAN);
+    }
+
+    // For enable the remote debugging.
+    public void testEnableRemoteDebugging(Activity activity, Context context) throws Throwable {
+        sendBroadCast(activity, context, "true");
+        mTestUtil.loadUrlSync(mUrl);
+        int index = getSocketNameIndex();
+        mTestCase.assertTrue (index != -1);
+        sendBroadCast(activity, context, "false");
+    }
+
+    //  For disable the remote debugging.
+    public void testDisableRemoteDebugging(Activity activity, Context context) throws Throwable {
+        sendBroadCast(activity, context, "false");
+        mTestUtil.loadUrlSync(mUrl);
+        int index = getSocketNameIndex();
+        mTestCase.assertTrue (index < 0);
     }
 }


### PR DESCRIPTION
This patch contains the test case about enableRemoteDebugging on
embedded and shared mode.
Enable the enableRemoteDebugging by the broadcast. From the
output of 'cat /proc/net/unix' command, find the abstract socket
name opened for remote debugging.

For embedded client test:
1. install XWalkRuntimeClientEmbeddedShell.apk
2. python build/android/test_runner.py instrumentation \
--test-apk=XWalkRuntimeClientEmbeddedTest -v -f testEnableRemoteDebugging

For shared client test:
1. install XWalkRuntimeLib.apk
2. install XWalkRuntimeClientShell.apk
3. python build/android/test_runner.py instrumentation \
--test-apk=XWalkRuntimeClientTest -v -f testEnableRemoteDebugging
