### PR TITLE
[Android] Disable flaky tests in xwalk_core_test

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/RendererResponsivenessTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/RendererResponsivenessTest.java
@@ -40,8 +40,9 @@ public class RendererResponsivenessTest extends XWalkViewTestBase {
         super.setUp();
     }
 
-    @Feature({"RendererResponsivenessTest"})
-    @MediumTest
+    //@Feature({"RendererResponsivenessTest"})
+    //@MediumTest
+    @DisabledTest
     public void testRendererUnresponsive() throws Throwable {
         getXWalkView().setXWalkClient(new ResponsivenessTestClient() {
             @Override
@@ -73,8 +74,9 @@ public class RendererResponsivenessTest extends XWalkViewTestBase {
         assertEquals(getXWalkView(), unresponsiveHelper.getXWalkView());
     }
 
-    @Feature({"RendererResponsivenessTest"})
-    @MediumTest
+    //@Feature({"RendererResponsivenessTest"})
+    //@MediumTest
+    @DisabledTest
     public void testRendererResponsiveAgain() throws Throwable {
         getXWalkView().setXWalkClient(new ResponsivenessTestClient() {
             /**


### PR DESCRIPTION
The responsiveness tests seem to be failed randomly on buildbot. It might be
caused by the unstable status on testing phone since this test relies on a
timeout to wait for unresponsiveness in 40 seconds. However, there is no way
to ensure it would happen in 40 seconds so that the test can be passed. Locally,
there 2 tests can be passed.
