### PR TITLE
[Extensions] Pass more data in EPH construction time

### DIFF
--- a/extensions/browser/xwalk_extension_process_host.h
+++ b/extensions/browser/xwalk_extension_process_host.h
@@ -5,13 +5,10 @@
 #ifndef XWALK_EXTENSIONS_BROWSER_XWALK_EXTENSION_PROCESS_HOST_H_
 #define XWALK_EXTENSIONS_BROWSER_XWALK_EXTENSION_PROCESS_HOST_H_
 
+#include "base/files/file_path.h"
 #include "base/memory/scoped_ptr.h"
 #include "content/public/browser/browser_child_process_host_delegate.h"
 #include "ipc/ipc_channel_handle.h"
-
-namespace base {
-class FilePath;
-}
 
 namespace content {
 class BrowserChildProcessHost;
@@ -31,19 +28,13 @@ namespace extensions {
 class XWalkExtensionProcessHost
     : public content::BrowserChildProcessHostDelegate {
  public:
-  XWalkExtensionProcessHost();
+  XWalkExtensionProcessHost(content::RenderProcessHost* render_process_host,
+                            const base::FilePath& external_extensions_path);
   virtual ~XWalkExtensionProcessHost();
-
-  void RegisterExternalExtensions(const base::FilePath& extension_path);
-
-  void OnRenderProcessHostCreated(content::RenderProcessHost* host);
 
  private:
   void StartProcess();
   void StopProcess();
-
-  // Thread-safe function to send message to the associated extension process.
-  void Send(IPC::Message* msg);
 
   // content::BrowserChildProcessHostDelegate implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
@@ -58,6 +49,7 @@ class XWalkExtensionProcessHost
   scoped_ptr<content::BrowserChildProcessHost> process_;
   IPC::ChannelHandle ep_rp_channel_handle_;
   content::RenderProcessHost* render_process_host_;
+  base::FilePath external_extensions_path_;
 
   bool is_extension_process_channel_ready_;
 };

--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -204,14 +204,8 @@ void XWalkExtensionService::CreateInProcessExtensionServer(
 
 void XWalkExtensionService::CreateExtensionProcessHost(
     content::RenderProcessHost* host, ExtensionData* data) {
-  scoped_ptr<XWalkExtensionProcessHost> eph(new XWalkExtensionProcessHost());
-
-  if (!external_extensions_path_.empty())
-    eph->RegisterExternalExtensions(external_extensions_path_);
-
-  eph->OnRenderProcessHostCreated(host);
-
-  data->extension_process_host_ = eph.Pass();
+  data->extension_process_host_ = make_scoped_ptr(
+      new XWalkExtensionProcessHost(host, external_extensions_path_));
 }
 
 }  // namespace extensions


### PR DESCRIPTION
After changes to support multiple Extension Processes, we are creating
ExtensionProcessHost (EPH) right when RenderProcessHost is created, so
we can pass RPH directly to EPH. This simplify the logic of sending the
channel handle back.

We also pass the register extension path and send it right after the
process is launched, instead of creating a new task for this.

The members ep_rp_channel_handle_ and
is_extension_process_channel_ready_ are currently unnecessary but will
be helpful in follow up changes, so they remained.
