### PR TITLE
[Extensions] Make RP synchronously ask for the extension channel handle

### DIFF
--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -28,6 +28,47 @@ using content::BrowserThread;
 namespace xwalk {
 namespace extensions {
 
+// This filter is used by ExtensionProcessHost to intercept when Render Process
+// ask for the Extension Channel handle (that is created by extension process).
+class XWalkExtensionProcessHost::RenderProcessMessageFilter
+    : public IPC::ChannelProxy::MessageFilter {
+ public:
+  explicit RenderProcessMessageFilter(XWalkExtensionProcessHost* eph)
+      : eph_(eph) {}
+
+  // This exists to fulfill the requirement for delayed reply handling, since it
+  // needs to send a message back if the parameters couldn't be correctly read
+  // from the original message received. See DispatchDealyReplyWithSendParams().
+  bool Send(IPC::Message* message) {
+    return eph_->render_process_host_->Send(message);
+  }
+
+ private:
+  // IPC::ChannelProxy::MessageFilter implementation.
+  virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE {
+    bool handled = true;
+    IPC_BEGIN_MESSAGE_MAP(RenderProcessMessageFilter, message)
+      IPC_MESSAGE_HANDLER_DELAY_REPLY(
+          XWalkExtensionProcessHostMsg_GetExtensionProcessChannel,
+          OnGetExtensionProcessChannel)
+      IPC_MESSAGE_UNHANDLED(handled = false)
+    IPC_END_MESSAGE_MAP()
+    return handled;
+  }
+
+  void OnGetExtensionProcessChannel(IPC::Message* reply) {
+    scoped_ptr<IPC::Message> scoped_reply(reply);
+    BrowserThread::PostTask(
+        BrowserThread::UI, FROM_HERE,
+        base::Bind(&XWalkExtensionProcessHost::OnGetExtensionProcessChannel,
+                   base::Unretained(eph_),
+                   base::Passed(&scoped_reply)));
+  }
+
+  virtual ~RenderProcessMessageFilter() {}
+  XWalkExtensionProcessHost* eph_;
+};
+
 #if defined(OS_WIN)
 class ExtensionSandboxedProcessLauncherDelegate
     : public content::SandboxedProcessLauncherDelegate {
@@ -49,8 +90,10 @@ XWalkExtensionProcessHost::XWalkExtensionProcessHost(
     const base::FilePath& external_extensions_path)
     : ep_rp_channel_handle_(""),
       render_process_host_(render_process_host),
+      render_process_message_filter_(new RenderProcessMessageFilter(this)),
       external_extensions_path_(external_extensions_path),
       is_extension_process_channel_ready_(false) {
+  render_process_host_->GetChannel()->AddFilter(render_process_message_filter_);
   BrowserThread::PostTask(BrowserThread::IO, FROM_HERE,
       base::Bind(&XWalkExtensionProcessHost::StartProcess,
       base::Unretained(this)));
@@ -95,6 +138,18 @@ void XWalkExtensionProcessHost::StopProcess() {
   process_.reset();
 }
 
+void XWalkExtensionProcessHost::OnGetExtensionProcessChannel(
+    scoped_ptr<IPC::Message> reply) {
+  pending_reply_for_render_process_ = reply.Pass();
+  ReplyChannelHandleToRenderProcess();
+
+  // We just need to send the channel information once, so the filter is no
+  // longer necessary.
+  render_process_host_->GetChannel()->RemoveFilter(
+      render_process_message_filter_);
+  render_process_message_filter_ = NULL;
+}
+
 bool XWalkExtensionProcessHost::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(XWalkExtensionProcessHost, message)
@@ -116,19 +171,25 @@ void XWalkExtensionProcessHost::OnProcessLaunched() {
 
 void XWalkExtensionProcessHost::OnRenderChannelCreated(
     const IPC::ChannelHandle& handle) {
-  ep_rp_channel_handle_ = handle;
   is_extension_process_channel_ready_ = true;
-
-  SendChannelHandleToRenderProcess();
+  ep_rp_channel_handle_ = handle;
+  ReplyChannelHandleToRenderProcess();
 }
 
-void XWalkExtensionProcessHost::SendChannelHandleToRenderProcess() {
-  // It can be that the RenderProcessHost got created before the EP channel.
-  if (!is_extension_process_channel_ready_)
+void XWalkExtensionProcessHost::ReplyChannelHandleToRenderProcess() {
+  // Replying the channel handle to RP depends on two events:
+  // - EP already notified EPH that new channel was created (for RP<->EP).
+  // - RP already asked for the channel handle.
+  //
+  // The order for this events is not determined, so we call this function from
+  // both, and the second execution will send the reply.
+  if (!is_extension_process_channel_ready_
+      || !pending_reply_for_render_process_)
     return;
 
-  render_process_host_->Send(new XWalkViewMsg_ExtensionProcessChannelCreated(
-      ep_rp_channel_handle_));
+  IPC::WriteParam(pending_reply_for_render_process_.get(),
+                  ep_rp_channel_handle_);
+  render_process_host_->Send(pending_reply_for_render_process_.release());
 }
 
 

--- a/extensions/browser/xwalk_extension_process_host.h
+++ b/extensions/browser/xwalk_extension_process_host.h
@@ -9,14 +9,11 @@
 #include "base/memory/scoped_ptr.h"
 #include "content/public/browser/browser_child_process_host_delegate.h"
 #include "ipc/ipc_channel_handle.h"
+#include "ipc/ipc_channel_proxy.h"
 
 namespace content {
 class BrowserChildProcessHost;
 class RenderProcessHost;
-}
-
-namespace IPC {
-class Message;
 }
 
 namespace xwalk {
@@ -33,8 +30,14 @@ class XWalkExtensionProcessHost
   virtual ~XWalkExtensionProcessHost();
 
  private:
+  class RenderProcessMessageFilter;
+
   void StartProcess();
   void StopProcess();
+
+  // Handler for message from Render Process host, it is a synchronous message,
+  // that will be replied only when the extension process channel is created.
+  void OnGetExtensionProcessChannel(scoped_ptr<IPC::Message> reply);
 
   // content::BrowserChildProcessHostDelegate implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
@@ -44,11 +47,18 @@ class XWalkExtensionProcessHost
   // Message Handlers.
   void OnRenderChannelCreated(const IPC::ChannelHandle& channel_id);
 
-  void SendChannelHandleToRenderProcess();
+  void ReplyChannelHandleToRenderProcess();
 
   scoped_ptr<content::BrowserChildProcessHost> process_;
   IPC::ChannelHandle ep_rp_channel_handle_;
   content::RenderProcessHost* render_process_host_;
+  scoped_ptr<IPC::Message> pending_reply_for_render_process_;
+
+  // We use this filter to know when RP asked for the extension process channel.
+  // Formally ownership is with the render process channel, we keep the pointer
+  // to remove the filter once we reply the message, since this exchange needs
+  // to happen only once.
+  IPC::ChannelProxy::MessageFilter* render_process_message_filter_;
   base::FilePath external_extensions_path_;
 
   bool is_extension_process_channel_ready_;

--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -22,11 +22,16 @@ enum {
 IPC_MESSAGE_CONTROL1(XWalkExtensionProcessMsg_RegisterExtensions,  // NOLINT(*)
                      base::FilePath /* extensions path */)
 
+// This implies that extensions are all loaded and Extension Process
+// is ready to be used.
 IPC_MESSAGE_CONTROL1(XWalkExtensionProcessHostMsg_RenderProcessChannelCreated, // NOLINT(*)
                      IPC::ChannelHandle /* channel id */)
 
-IPC_MESSAGE_CONTROL1(XWalkViewMsg_ExtensionProcessChannelCreated, // NOLINT(*)
-                     IPC::ChannelHandle /* channel id */)
+// Message from Render Process to Browser Process. This message needs
+// to be synchronous because Render Process cannot load anything without having
+// collected the extensions loaded in Extension Process.
+IPC_SYNC_MESSAGE_CONTROL0_1(XWalkExtensionProcessHostMsg_GetExtensionProcessChannel,  // NOLINT(*)
+                            IPC::ChannelHandle /* channel id */)
 
 
 // We use a separated message class for Client<->Server communication

--- a/extensions/extension_process/xwalk_extension_process.cc
+++ b/extensions/extension_process/xwalk_extension_process.cc
@@ -24,7 +24,6 @@ XWalkExtensionProcess::XWalkExtensionProcess()
       base::Thread::Options(base::MessageLoop::TYPE_IO, 0));
 
   CreateBrowserProcessChannel();
-  CreateRenderProcessChannel();
 }
 
 XWalkExtensionProcess::~XWalkExtensionProcess() {
@@ -48,7 +47,9 @@ bool XWalkExtensionProcess::OnMessageReceived(const IPC::Message& message) {
 
 void XWalkExtensionProcess::OnRegisterExtensions(
     const base::FilePath& path) {
-  RegisterExternalExtensionsInDirectory(&extensions_server_, path);
+  if (!path.empty())
+    RegisterExternalExtensionsInDirectory(&extensions_server_, path);
+  CreateRenderProcessChannel();
 }
 
 void XWalkExtensionProcess::CreateBrowserProcessChannel() {

--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -37,8 +37,9 @@ XWalkExtensionRendererController::XWalkExtensionRendererController(
   content::RenderThread* thread = content::RenderThread::Get();
   thread->AddObserver(this);
 
-  in_browser_process_extensions_client_.reset(new XWalkExtensionClient());
-  in_browser_process_extensions_client_->Initialize(thread->GetChannel());
+  IPC::SyncChannel* browser_channel = thread->GetChannel();
+  SetupBrowserProcessClient(browser_channel);
+  SetupExtensionProcessClient(browser_channel);
 
   CommandLine* cmd_line = CommandLine::ForCurrentProcess();
   if (cmd_line->HasSwitch(switches::kXWalkDisableLoadingExtensionsOnDemand)) {
@@ -113,22 +114,27 @@ void XWalkExtensionRendererController::WillReleaseScriptContext(
 
 bool XWalkExtensionRendererController::OnControlMessageReceived(
     const IPC::Message& message) {
-  if (in_browser_process_extensions_client_->OnMessageReceived(message))
-    return true;
-
-  bool handled = true;
-  IPC_BEGIN_MESSAGE_MAP(XWalkExtensionRendererController, message)
-    IPC_MESSAGE_HANDLER(XWalkViewMsg_ExtensionProcessChannelCreated,
-        OnExtensionProcessChannelCreated)
-    IPC_MESSAGE_UNHANDLED(handled = false)
-  IPC_END_MESSAGE_MAP()
-  return handled;
+  return in_browser_process_extensions_client_->OnMessageReceived(message);
 }
 
-void XWalkExtensionRendererController::OnExtensionProcessChannelCreated(
-    const IPC::ChannelHandle& handle) {
-  external_extensions_client_.reset(new XWalkExtensionClient());
+void XWalkExtensionRendererController::OnRenderProcessShutdown() {
+  shutdown_event_.Signal();
+}
 
+void XWalkExtensionRendererController::SetupBrowserProcessClient(
+    IPC::SyncChannel* browser_channel) {
+  in_browser_process_extensions_client_.reset(new XWalkExtensionClient);
+  in_browser_process_extensions_client_->Initialize(browser_channel);
+}
+
+void XWalkExtensionRendererController::SetupExtensionProcessClient(
+    IPC::SyncChannel* browser_channel) {
+  IPC::ChannelHandle handle;
+  browser_channel->Send(
+      new XWalkExtensionProcessHostMsg_GetExtensionProcessChannel(&handle));
+  // FIXME(cmarcelo): Need to account for failure in creating the channel.
+
+  external_extensions_client_.reset(new XWalkExtensionClient);
   extension_process_channel_.reset(new IPC::SyncChannel(handle,
       IPC::Channel::MODE_CLIENT, external_extensions_client_.get(),
       content::RenderThread::Get()->GetIOMessageLoopProxy(), true,
@@ -137,9 +143,6 @@ void XWalkExtensionRendererController::OnExtensionProcessChannelCreated(
   external_extensions_client_->Initialize(extension_process_channel_.get());
 }
 
-void XWalkExtensionRendererController::OnRenderProcessShutdown() {
-  shutdown_event_.Signal();
-}
 
 }  // namespace extensions
 }  // namespace xwalk

--- a/extensions/renderer/xwalk_extension_renderer_controller.h
+++ b/extensions/renderer/xwalk_extension_renderer_controller.h
@@ -61,8 +61,11 @@ class XWalkExtensionRendererController : public content::RenderProcessObserver {
   virtual void OnRenderProcessShutdown() OVERRIDE;
 
  private:
-  // Message Handlers.
-  void OnExtensionProcessChannelCreated(const IPC::ChannelHandle& handle);
+  void SetupBrowserProcessClient(IPC::SyncChannel* browser_channel);
+
+  // We use the browser_channel to ask for the handle to setup the extension
+  // channel and plug the external_extensions_client_ into it.
+  void SetupExtensionProcessClient(IPC::SyncChannel* browser_channel);
 
   scoped_ptr<XWalkExtensionClient> in_browser_process_extensions_client_;
   scoped_ptr<XWalkExtensionClient> external_extensions_client_;


### PR DESCRIPTION
There are situations in which Render Process (RP) gets a navigation
request before it has all the information from the Extension
Process (EP).

Currently we don't enforce any ordering, EP is created, tells Browser
Process (BP) about the new channel handle created for EP<->RP
communication and BP sends this handle to the RP. Before all this
happens, a navigation may occur and a new v8::Context is created without
all the JS code for extensions in EP.

The new code changes so that RP asks BP (synchronously, to ensure
ordering) for the channel handle. This message is handled by
XWalkExtensionProcessHost using a delayed reply handler, allowing it to
launch the process and wait for the channel creation before replying.

Note that in EP we change the order of the channel creation, we first
load the extensions and only then register the channel. This guarantees
that when RP connects to the channel, EP will have everything ready.

This patch should fix the cases at hand -- because we enqueue the
"register extensions" message in the channel and RP process it before
navigations.

To ensure this works regardless implementation details of the IPC, a
follow up change will be necessary: make the XWalkExtensionClient
ask (synchronously, to ensure ordering) for the extensions, instead
waiting for it to be sent from the XWalkExtensionServer. With hindsight
this makes completely sense.
