### PR TITLE
[Extensions] Avoid race condition in Extensions registering

### DIFF
--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -117,10 +117,6 @@ void XWalkExtensionService::OnRenderProcessHostCreated(
         external_extensions_path_);
   }
 
-  // Ensures that we register all extensions, including the external ones when
-  // the extension process is disabled.
-  data->in_process_server_->RegisterExtensionsInRenderProcess();
-
   extension_data_map_[host->GetID()] = data;
 }
 

--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -63,6 +63,8 @@ class XWalkExtension {
   // message passing.
   std::string javascript_api_;
 
+  // FIXME(jeez): convert this to std::vector<std::string> to avoid
+  // extra conversions later on.
   base::ListValue entry_points_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkExtension);

--- a/extensions/common/xwalk_extension_messages.cc
+++ b/extensions/common/xwalk_extension_messages.cc
@@ -4,3 +4,29 @@
 
 #define IPC_MESSAGE_IMPL
 #include "xwalk/extensions/common/xwalk_extension_messages.h"
+
+// Generate constructors.
+#include "ipc/struct_constructor_macros.h"
+#include "xwalk/extensions/common/xwalk_extension_messages.h" // NOLINT(*)
+
+// Generate destructors.
+#include "ipc/struct_destructor_macros.h"
+#include "xwalk/extensions/common/xwalk_extension_messages.h" // NOLINT(*)
+
+// Generate param traits write methods.
+#include "ipc/param_traits_write_macros.h"
+namespace IPC {
+#include "xwalk/extensions/common/xwalk_extension_messages.h" // NOLINT(*)
+}  // namespace IPC
+
+// Generate param traits write methods.
+#include "ipc/param_traits_read_macros.h"
+namespace IPC {
+#include "xwalk/extensions/common/xwalk_extension_messages.h" // NOLINT(*)
+}  // namespace IPC
+
+// Generate param traits log methods.
+#include "ipc/param_traits_log_macros.h"
+namespace IPC {
+#include "xwalk/extensions/common/xwalk_extension_messages.h" // NOLINT(*)
+}  // namespace IPC

--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <string>
+#include <vector>
 #include "base/values.h"
 #include "ipc/ipc_channel_handle.h"
 #include "ipc/ipc_message_macros.h"
@@ -12,10 +13,14 @@
 // is not relevant for embedders. It is used only by a tool inside chrome/
 // that we currently don't use.
 // See also https://code.google.com/p/chromium/issues/detail?id=110911.
+#ifndef XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_MESSAGES_H_
+#define XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_MESSAGES_H_
 enum {
   XWalkExtensionMsgStart = LastIPCMsgStart + 1,
   XWalkExtensionClientServerMsgStart
 };
+#endif  // XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_MESSAGES_H_
+
 
 #define IPC_MESSAGE_START XWalkExtensionMsgStart
 
@@ -39,10 +44,11 @@ IPC_SYNC_MESSAGE_CONTROL0_1(XWalkExtensionProcessHostMsg_GetExtensionProcessChan
 #undef IPC_MESSAGE_START
 #define IPC_MESSAGE_START XWalkExtensionClientServerMsgStart
 
-IPC_MESSAGE_CONTROL3(XWalkExtensionClientMsg_RegisterExtension,  // NOLINT(*)
-                     std::string /* extension */,
-                     std::string /* JS API code for extension */,
-                     base::ListValue /* extension entry points */)
+IPC_STRUCT_BEGIN(XWalkExtensionServerMsg_ExtensionRegisterParams)
+  IPC_STRUCT_MEMBER(std::string, name)
+  IPC_STRUCT_MEMBER(std::string, js_api)
+  IPC_STRUCT_MEMBER(std::vector<std::string>, entry_points)
+IPC_STRUCT_END()
 
 IPC_MESSAGE_CONTROL2(XWalkExtensionServerMsg_CreateInstance,  // NOLINT(*)
                      int64_t /* instance id */,
@@ -60,6 +66,9 @@ IPC_SYNC_MESSAGE_CONTROL2_1(XWalkExtensionServerMsg_SendSyncMessageToNative,  //
                             int64_t /* instance id */,
                             base::ListValue /* input contents */,
                             base::ListValue /* output contents */)
+
+IPC_SYNC_MESSAGE_CONTROL0_1(XWalkExtensionServerMsg_GetExtensions,  // NOLINT(*)
+                            std::vector<XWalkExtensionServerMsg_ExtensionRegisterParams> /* output contents */) // NOLINT(*)
 
 IPC_MESSAGE_CONTROL1(XWalkExtensionServerMsg_DestroyInstance,  // NOLINT(*)
                      int64_t /* instance id */)

--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -39,6 +39,8 @@ bool XWalkExtensionServer::OnMessageReceived(const IPC::Message& message) {
     IPC_MESSAGE_HANDLER_DELAY_REPLY(
         XWalkExtensionServerMsg_SendSyncMessageToNative,
         OnSendSyncMessageToNative)
+    IPC_MESSAGE_HANDLER(XWalkExtensionServerMsg_GetExtensions,
+        OnGetExtensions)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
@@ -169,7 +171,6 @@ bool XWalkExtensionServer::RegisterExtension(
   }
 
   std::string name = extension->name();
-
   extension_symbols_.insert(name);
   extensions_[name] = extension.release();
   return true;
@@ -295,26 +296,31 @@ void XWalkExtensionServer::OnDestroyInstance(int64_t instance_id) {
   Send(new XWalkExtensionClientMsg_InstanceDestroyed(instance_id));
 }
 
-void XWalkExtensionServer::RegisterExtensionsInRenderProcess() {
-  // Having a sender means we have a RenderProcessHost ready.
-  DCHECK(sender_);
-
+void XWalkExtensionServer::OnGetExtensions(
+    std::vector<XWalkExtensionServerMsg_ExtensionRegisterParams>* reply) {
   ExtensionMap::iterator it = extensions_.begin();
   for (; it != extensions_.end(); ++it) {
+    XWalkExtensionServerMsg_ExtensionRegisterParams extension_parameters;
     XWalkExtension* extension = it->second;
-    Send(new XWalkExtensionClientMsg_RegisterExtension(
-        extension->name(), extension->javascript_api(),
-        extension->entry_points()));
+
+    extension_parameters.name = extension->name();
+    extension_parameters.js_api = extension->javascript_api();
+
+    const base::ListValue& entry_points = extension->entry_points();
+    base::ListValue::const_iterator entry_it = entry_points.begin();
+    for (; entry_it != entry_points.end(); ++entry_it) {
+      std::string entry_point;
+      (*entry_it)->GetAsString(&entry_point);
+      extension_parameters.entry_points.push_back(entry_point);
+    }
+
+    reply->push_back(extension_parameters);
   }
 }
 
 void XWalkExtensionServer::Invalidate() {
   base::AutoLock l(sender_lock_);
   sender_ = NULL;
-}
-
-void XWalkExtensionServer::OnChannelConnected(int32 peer_pid) {
-  RegisterExtensionsInRenderProcess();
 }
 
 namespace {

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -9,11 +9,14 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "base/synchronization/lock.h"
 #include "base/values.h"
 #include "ipc/ipc_channel_proxy.h"
 #include "ipc/ipc_listener.h"
+
+struct XWalkExtensionServerMsg_ExtensionRegisterParams;
 
 namespace base {
 class FilePath;
@@ -45,13 +48,11 @@ class XWalkExtensionServer : public IPC::Listener {
 
   // IPC::Listener Implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
-  virtual void OnChannelConnected(int32 peer_pid) OVERRIDE;
 
   void Initialize(IPC::Sender* sender);
   bool Send(IPC::Message* msg);
 
   bool RegisterExtension(scoped_ptr<XWalkExtension> extension);
-  void RegisterExtensionsInRenderProcess();
 
   void Invalidate();
 
@@ -67,6 +68,8 @@ class XWalkExtensionServer : public IPC::Listener {
   void OnPostMessageToNative(int64_t instance_id, const base::ListValue& msg);
   void OnSendSyncMessageToNative(int64_t instance_id,
       const base::ListValue& msg, IPC::Message* ipc_reply);
+  void OnGetExtensions(
+      std::vector<XWalkExtensionServerMsg_ExtensionRegisterParams>* reply);
 
   void PostMessageToJSCallback(int64_t instance_id,
                                scoped_ptr<base::Value> msg);

--- a/extensions/renderer/xwalk_extension_client.h
+++ b/extensions/renderer/xwalk_extension_client.h
@@ -51,7 +51,7 @@ class XWalkExtensionClient : public IPC::Listener {
   scoped_ptr<base::Value> SendSyncMessageToNative(int64_t instance_id,
       scoped_ptr<base::Value> msg);
 
-  void Initialize(IPC::Sender* sender) { sender_ = sender; }
+  void Initialize(IPC::Sender* sender);
 
   // IPC::Listener Implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
@@ -73,8 +73,6 @@ class XWalkExtensionClient : public IPC::Listener {
   // Message Handlers.
   void OnInstanceDestroyed(int64_t instance_id);
   void OnPostMessageToJS(int64_t instance_id, const base::ListValue& msg);
-  void OnRegisterExtension(const std::string& name, const std::string& api,
-                           const base::ListValue& entry_points);
 
   IPC::Sender* sender_;
   ExtensionAPIMap extension_apis_;


### PR DESCRIPTION
This patch inverts the registration order. Now during the Client's
initialization we synchronously ask the Server for the extensions
to register.
