### PR TITLE
[Android] Fix ExtensionBroadcast test

### DIFF
--- a/test/android/core/javatests/assets/broadcast.html
+++ b/test/android/core/javatests/assets/broadcast.html
@@ -17,6 +17,7 @@
         + "      if (messageReceivedInIframe != null)\n"
         + "      top.window.verifyResult();\n"
         + "    }\n"
+        + "   broadcast.setHandler(messageHandler);\n"
         + "  <\/script>\n"
         + "  <\/head>\n"
         + "</html>\n");
@@ -45,6 +46,7 @@
         if (iframe.contentWindow.messageReceivedInIframe != null)
           verifyResult();
       }
+      broadcast.setHandler(messageHandler);
     </script>
   </body>
 </html>

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcast.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcast.java
@@ -10,9 +10,9 @@ public class ExtensionBroadcast extends XWalkExtensionAndroid {
 
     public ExtensionBroadcast() {
         super("broadcast",
-              "extension.setMessageListener(function(msg) {"
-              + "    messageHandler(msg);"
-              + "});"
+              "exports.setHandler = function(handler) {"
+              + "  extension.setMessageListener(handler);"
+              + "};"
               + "exports.trigger = function(msg) {"
               + "  extension.postMessage(msg);"
               + "};"

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
@@ -8,7 +8,6 @@ import android.graphics.Bitmap;
 import android.test.suitebuilder.annotation.SmallTest;
 import android.util.Log;
 
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 
 import org.xwalk.core.XWalkClient;
@@ -39,11 +38,8 @@ public class ExtensionBroadcastTest extends XWalkViewTestBase {
         getXWalkView().setXWalkClient(new TestXWalkClient());
     }
 
-    // @SmallTest
-    // @Feature({"ExtensionBroadcast"})
-    // This test case failed on buildbot, so disabled it temporally.
-    // It will be enabled later.
-    @DisabledTest
+    @SmallTest
+    @Feature({"ExtensionBroadcast"})
     public void testExtensionBroadcast() throws Throwable {
         ExtensionBroadcast broadcast = new ExtensionBroadcast();
 


### PR DESCRIPTION
With load on demand enabled (the default now) instances are only created when
needed. This test is failing because it assumes that a new Extension instance
is created for the iframe, and as the code running in the iframe doesn't need
the any instances they are not created.

This fixes substitutes the assumption that the instance will be created, when
the context is created by explicitly calling the extension.
