### PR TITLE
[Extensions] Use type-safe functions to fill the replies

### DIFF
--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -187,8 +187,9 @@ void XWalkExtensionProcessHost::ReplyChannelHandleToRenderProcess() {
       || !pending_reply_for_render_process_)
     return;
 
-  IPC::WriteParam(pending_reply_for_render_process_.get(),
-                  ep_rp_channel_handle_);
+  XWalkExtensionProcessHostMsg_GetExtensionProcessChannel::WriteReplyParams(
+      pending_reply_for_render_process_.get(), ep_rp_channel_handle_);
+
   render_process_host_->Send(pending_reply_for_render_process_.release());
 }
 

--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -201,7 +201,13 @@ void XWalkExtensionServer::SendSyncReplyToJSCallback(
 
   base::ListValue wrapped_reply;
   wrapped_reply.Append(reply.release());
-  IPC::WriteParam(data.pending_reply, wrapped_reply);
+
+  // TODO(cmarcelo): we need to inline WriteReplyParams here because it takes
+  // a copy of the parameter and ListValue is noncopyable. This may be
+  // improved in ipc_message_utils.h so we don't need to inline the code here.
+  XWalkExtensionServerMsg_SendSyncMessageToNative::ReplyParam
+      reply_param(wrapped_reply);
+  IPC::WriteParam(data.pending_reply, reply_param);
   Send(data.pending_reply);
 
   data.pending_reply = NULL;


### PR DESCRIPTION
When using delayed replies for IPC messages, we can hold the
IPC::Message\* with the reply and fill it with values later, before
sending.

We used the more general function IPC::WriteParam, but one drawback is
that it doesn't do any type checking. Message macros / templates already
generate proper functions that will do the necessarily checking, so we
can call the appropriate WriteReplyParams() of the message we are
replying.

In XWalkExtensionServer because ListValue doesn't have a copy
constructor, we construct the typed reply param ourselves and write
it. It is more verbose but also type-safe.
