### PR TITLE
[Mac] Don't use Aura for Mac

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -110,7 +110,7 @@ if __name__ == '__main__':
       args.append('-Dffmpeg_branding=Chrome')
 
   # Enable Aura by default on all platforms except Android
-  if landmine_utils.platform() != 'android':
+  if landmine_utils.platform() != 'android' and landmine_utils.platform() != 'mac':
     args.append('-Duse_aura=1')
 
   # Use the Psyco JIT if available.


### PR DESCRIPTION
Aura is not ready for Mac currently. It has not been enabled for Mac in upstream.
Thus, it fails even during 'gclient sync' due to some duplicate keys in resource files.

More details:

https://crosswalk-project.org/jira/browse/XWALK-85
