### PR TITLE
[Android] Implement the method of OnReceiveHttpAuthRequest().

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/HttpAuthDatabase.java
+++ b/runtime/android/java/src/org/xwalk/core/HttpAuthDatabase.java
@@ -28,13 +28,9 @@ import android.util.Log;
  */
 public class HttpAuthDatabase {
 
-    private static final String DATABASE_FILE = "http_auth.db";
-
     private static final String LOGTAG = HttpAuthDatabase.class.getName();
 
     private static final int DATABASE_VERSION = 1;
-
-    private static HttpAuthDatabase sInstance = null;
 
     private SQLiteDatabase mDatabase = null;
 
@@ -70,17 +66,6 @@ public class HttpAuthDatabase {
                 initOnBackgroundThread(context, databaseFile);
             }
         }.start();
-    }
-
-    /**
-     * @deprecated Retained for merge convenience. TODO(joth): remove in next patch.
-     */
-    @Deprecated
-    public static synchronized HttpAuthDatabase getInstance(Context context) {
-        if (sInstance == null) {
-            sInstance = new HttpAuthDatabase(context, DATABASE_FILE);
-        }
-        return sInstance;
     }
 
     /**

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkClientForTest.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkClientForTest.java
@@ -6,10 +6,13 @@ package org.xwalk.runtime;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.net.http.SslError;
 
 import java.lang.reflect.Method;
 
 import org.xwalk.core.client.XWalkDefaultClient;
+import org.xwalk.core.HttpAuthHandler;
+import org.xwalk.core.SslErrorHandler;
 import org.xwalk.core.XWalkView;
 
 public class XWalkClientForTest extends XWalkDefaultClient {
@@ -25,8 +28,39 @@ public class XWalkClientForTest extends XWalkDefaultClient {
         if (mCallbackForTest != null) {
             try {
                 Class objectClass = mCallbackForTest.getClass();
-                Method onReceivedError = objectClass.getMethod("onReceivedError", int.class, String.class, String.class);
+                Method onReceivedError = objectClass.getMethod(
+                        "onReceivedError", int.class, String.class, String.class);
                 onReceivedError.invoke(mCallbackForTest, errorCode, description, failingUrl);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void onReceivedSslError(XWalkView view, SslErrorHandler handler,
+            SslError error) {
+        if (mCallbackForTest != null) {
+            try {
+                Class objectClass = mCallbackForTest.getClass();
+                Method onReceivedSslError = objectClass.getMethod(
+                        "onReceivedSslError", SslErrorHandler.class, SslError.class);
+                onReceivedSslError.invoke(mCallbackForTest, handler, error);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void onReceivedHttpAuthRequest(XWalkView view, HttpAuthHandler handler,
+            String hosts, String realm) {
+        if (mCallbackForTest != null) {
+            try {
+                Class objectClass = mCallbackForTest.getClass();
+                Method onReceivedHttpAuthRequest = objectClass.getMethod(
+                        "onReceivedHttpAuthRequest", HttpAuthHandler.class, String.class, String.class);
+                onReceivedHttpAuthRequest.invoke(mCallbackForTest, handler, hosts, realm);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/runtime/android/java/strings/android_xwalk_strings.grd
+++ b/runtime/android/java/strings/android_xwalk_strings.grd
@@ -20,6 +20,15 @@
       <message desc="Title for the Ssl Alert dialog [CHAR-LIMIT=32]" name="IDS_SSL_ALERT_TITLE">
         Ssl Alert
       </message>
+      <message desc="Title for the http authentication dialog [CHAR-LIMIT=32]" name="IDS_HTTP_AUTH_TITLE">
+        Sign in
+      </message>
+      <message desc="Prompt for the http authentication user name [CHAR-LIMIT=32]" name="IDS_HTTP_AUTH_USER_NAME">
+        Username
+      </message>
+      <message desc="Prompt for the http authentication pasword [CHAR-LIMIT=32]" name="IDS_HTTP_AUTH_PASSWORD">
+        Password
+      </message>
     </messages>
   </release>
 


### PR DESCRIPTION
1. Some web page has the requirement of http authentication, support
   this requirement by providing the method of OnReceiveHttpAuthRequest().
2. Update the http authentication database interfaces by removing the previous
   method of getInstance() and directly calling the constructor function
   of the class HttpAuthDatabase.

BUG=#788
