### PR TITLE
[WiDi API] [RE] First commit for Presentation API implementation on Andr...

### DIFF
--- a/experimental/presentation/presentation_api.js
+++ b/experimental/presentation/presentation_api.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2013 Intel Corporation. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+var DISPLAY_AVAILABLE_CHANGE_EVENT = "displayavailablechange";
+var _listeners = {};
+var _displayAvailable = false;
+
+function addEventListener(name, callback, useCapture /* ignored */) {
+  if (typeof name !== "string" || typeof callback !== "function") {
+    console.error("Invalid parameter for presentation.addEventListener!");
+    return;
+  }
+
+  if (!_listeners[name])
+  	_listeners[name] = [];
+  _listeners[name].push(callback);
+}
+
+function removeEventListener(name, callback) {
+  if (typeof name !== "string" || typeof callback !== "function") {
+    console.error("Invalid parameter for presentation.removeEventListener!");
+    return;
+  }
+
+  if (_listeners[name]) {
+  	var index = _listeners[name].indexOf(callback);
+  	if (index != -1)
+  	  _listeners[name].splice(index, 1);
+  }
+}
+
+function handleDisplayAvailableChange(isAvailable) {
+  if (_displayAvailable == isAvailable)
+    return;
+
+  _displayAvailable = isAvailable;
+  if (!_listeners[DISPLAY_AVAILABLE_CHANGE_EVENT])
+    return;
+
+  var length = _listeners[DISPLAY_AVAILABLE_CHANGE_EVENT].length;
+  for (var i = 0; i < length; ++i) {
+    _listeners[DISPLAY_AVAILABLE_CHANGE_EVENT][i].apply(null, null);
+  }
+}
+
+extension.setMessageListener(function(json) {
+  var msg = JSON.parse(json);
+  if (msg.cmd == "DisplayAvailableChange") {
+    /* Using setTimeout here to ensure the error in user-defined event handler
+       would be captured in developer tools. */
+    setTimeout(function() {
+      handleDisplayAvailableChange(msg.data);
+    }, 0);
+  } else {
+    console.error("Invalid message : " + msg.cmd);
+  }
+})
+
+exports.addEventListener = addEventListener;
+exports.removeEventListener = removeEventListener;
+exports.__defineSetter__("on" + DISPLAY_AVAILABLE_CHANGE_EVENT,
+  function(callback) {
+	  if (callback)
+	    addEventListener(DISPLAY_AVAILABLE_CHANGE_EVENT, callback);
+	  else
+	    removeEventListener(DISPLAY_AVAILABLE_CHANGE_EVENT,
+                          this.ondisplayavailablechange);
+  }
+);
+
+exports.__defineGetter__("displayAvailable", function() {
+  /* If there is at least one event listener installed, we can safely use the
+     _displayAvailable flag. Otherwise, we need to send a message to query it */
+  if (!_listeners[DISPLAY_AVAILABLE_CHANGE_EVENT] ||
+      _listeners[DISPLAY_AVAILABLE_CHANGE_EVENT].length == 0) {
+    var res = extension.internal.sendSyncMessage("QueryDisplayAvailability");
+    _displayAvailable = (res == "true" ? true : false);
+  }
+  return _displayAvailable;
+});

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.xwalk.runtime.extension.api.presentation.PresentationExtension;
 import org.xwalk.runtime.XWalkRuntimeViewProvider;
 
 /**
@@ -113,10 +114,21 @@ public class XWalkExtensionManager {
         //    String jsApiContent = "";
         //    try {
         //        jsApiContent = getAssetsFileContent(mContext.getAssets(), Device.JS_API_PATH);
+        //        new Device(jsApiContent, mExtensionContextImpl);
         //    } catch(IOException e) {
         //        Log.e(TAG, "Failed to read js API file of internal extension: Device");
         //    }
-        //    new Device(jsApiContent, mExtensionContextImpl);
+        {
+            String jsApiContent = "";
+            try {
+                jsApiContent = getAssetsFileContent(mContext.getAssets(),
+                                                    PresentationExtension.JS_API_PATH);
+                // Load PresentationExtension as an internal extension.
+                new PresentationExtension(PresentationExtension.NAME, jsApiContent, mExtensionContextImpl);
+            } catch (IOException e) {
+                Log.e(TAG, "Failed to read JS API file: " + PresentationExtension.JS_API_PATH);
+            }
+        }
     }
 
     private void loadExternalExtensions() {

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/DisplayManagerJBMR1.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/DisplayManagerJBMR1.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api;
+
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.view.Display;
+
+/**
+ * A wrapper class for DisplayManager implementation on Android JellyBean MR1 (API Level 17).
+ */
+public class DisplayManagerJBMR1 extends XWalkDisplayManager implements DisplayManager.DisplayListener {
+    private DisplayManager mDisplayManager;
+
+    public DisplayManagerJBMR1(Context context) {
+        mDisplayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+    }
+
+    @Override
+    public Display[] getDisplays() {
+        return mDisplayManager.getDisplays();
+    }
+
+    @Override
+    public Display[] getPresentationDisplays() {
+        String category = DisplayManager.DISPLAY_CATEGORY_PRESENTATION;
+        return mDisplayManager.getDisplays(category);
+    }
+
+    @Override
+    public void registerDisplayListener(XWalkDisplayManager.DisplayListener listener) {
+        super.registerDisplayListener(listener);
+        if (mListeners.size() == 1)
+            mDisplayManager.registerDisplayListener(this, null);
+    }
+
+    @Override
+    public void unregisterDisplayListener(XWalkDisplayManager.DisplayListener listener) {
+        super.unregisterDisplayListener(listener);
+        if (mListeners.size() == 0)
+            mDisplayManager.unregisterDisplayListener(this);
+    }
+
+    @Override
+    public void onDisplayAdded(int displayId) {
+        notifyDisplayAdded(displayId);
+    }
+
+    @Override
+    public void onDisplayRemoved(int displayId) {
+        notifyDisplayRemoved(displayId);
+    }
+
+    @Override
+    public void onDisplayChanged(int displayId) {
+        notifyDisplayChanged(displayId);
+    }
+}
+

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/DisplayManagerNull.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/DisplayManagerNull.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api;
+
+import android.view.Display;
+
+/**
+ * A empty implementation for build version lower than API level 17.
+ */
+public class DisplayManagerNull extends XWalkDisplayManager {
+    private final static Display[] NO_DISPLAYS = {};
+
+    public DisplayManagerNull() {
+    }
+
+    @Override
+    public Display[] getDisplays() {
+        return NO_DISPLAYS;
+    }
+
+    @Override
+    public Display[] getPresentationDisplays() {
+        return NO_DISPLAYS;
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/XWalkDisplayManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/XWalkDisplayManager.java
@@ -1,0 +1,100 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api;
+
+import android.os.Build;
+import android.content.Context;
+import android.view.Display;
+import java.util.ArrayList;
+
+/**
+ * A helper class to abstract the display manager for different Android build version.
+ */
+public abstract class XWalkDisplayManager {
+    protected final ArrayList<DisplayListener> mListeners = new ArrayList<DisplayListener>();
+    private static XWalkDisplayManager mInstance;
+    // Hold the context of single and global application object of the current process.
+    private static Context mContext;
+
+    /**
+     * Return the singleton DisplayManager instance for different android build. 
+     *
+     * TODO(hmin): Need to make it thread-safe.
+     *
+     * @param context The given application context.
+     */
+    public static XWalkDisplayManager getInstance(Context context) {
+        if (mContext != null) {
+            // Would never be happened.
+            assert context.getApplicationContext() == mContext;
+        } else {
+            mContext = context.getApplicationContext();
+        }
+
+        if (mInstance == null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+                mInstance = new DisplayManagerJBMR1(mContext);
+            else
+                mInstance = new DisplayManagerNull();
+        }
+        return mInstance;
+    }
+
+    /**
+     * Get all currently valid logical displays, including the built-in display.
+     */
+    public abstract Display[] getDisplays();
+
+    /**
+     * Get all valid secondary displays, excluding the built-in display. The returned array
+     * is sorted for preference. The first display in the returned array is the most preferred
+     * display for presentation show.
+     */
+    public abstract Display[] getPresentationDisplays();
+
+    public void registerDisplayListener(DisplayListener listener) {
+        mListeners.add(listener);
+    }
+
+    public void unregisterDisplayListener(DisplayListener listener) {
+        mListeners.remove(listener);
+    }
+
+    protected void notifyDisplayAdded(int displayId) {
+        for (DisplayListener listener : mListeners)
+            listener.onDisplayAdded(displayId);
+    }
+
+    protected void notifyDisplayRemoved(int displayId) {
+        for (DisplayListener listener : mListeners)
+            listener.onDisplayRemoved(displayId);
+    }
+
+    protected void notifyDisplayChanged(int displayId) {
+        for (DisplayListener listener : mListeners)
+            listener.onDisplayChanged(displayId);
+    }
+
+
+    /**
+     * Listen for display arrival, removal and change event.
+     */
+    public interface DisplayListener {
+        /**
+         * Called whenever a logical display has been added to the system.
+         */
+        public void onDisplayAdded(int displayId);
+
+        /**
+         * Called whenever a logical display has been removed to the system.
+         */
+        public void onDisplayRemoved(int displayId);
+
+        /**
+         * Called whenever a logical display has been changed
+         */
+        public void onDisplayChanged(int displayId);
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
@@ -1,0 +1,153 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.presentation;
+
+import android.content.Context;
+import android.util.JsonWriter;
+import android.util.Log;
+import android.view.Display;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.xwalk.runtime.extension.api.XWalkDisplayManager;
+import org.xwalk.runtime.extension.XWalkExtension;
+import org.xwalk.runtime.extension.XWalkExtensionContext;
+
+/**
+ * A XWalk extension for Presentation API implementation on Android.
+ */
+public class PresentationExtension extends XWalkExtension {
+    public final static String TAG = "PresentationExtension";
+    public final static String JS_API_PATH = "jsapi/presentation_api.js";
+    public final static String NAME = "navigator.presentation";
+
+    // Tags:
+    private final static String TAG_CMD = "cmd";
+    private final static String TAG_DATA = "data";
+
+    // Command messages.
+    private final static String CMD_DISPLAY_AVAILABLE_CHANGE = "DisplayAvailableChange";
+    private final static String CMD_QUERY_DISPLAY_AVAILABILITY = "QueryDisplayAvailability";
+
+    private XWalkDisplayManager mDisplayManager;
+
+    // The number of available presentation displays on the system.
+    private int mAvailableDisplayCount = 0;
+
+    /**
+     * Listens for the secondary display arrival and removal.
+     *
+     * We rely on onDisplayAdded/onDisplayRemoved callback to trigger the display
+     * availability change event. The presentation display becomes available if
+     * the first secondary display is arrived, and becomes unavailable if one
+     * of the last secondary display is removed.
+     *
+     * Note the display id is a system-wide unique number for each physical connection.
+     * It means that for the same display device, the display id assigned by the system
+     * would be different if it is re-connected again.
+     */
+    private final XWalkDisplayManager.DisplayListener mDisplayListener =
+            new XWalkDisplayManager.DisplayListener() {
+        @Override
+        public void onDisplayAdded(int displayId) {
+            ++mAvailableDisplayCount;
+
+            // Notify that the secondary display for presentation show becomes
+            // available now if the first one is added.
+            if (mAvailableDisplayCount == 1) notifyAvailabilityChanged(true);
+        }
+
+        @Override
+        public void onDisplayRemoved(int displayId) {
+            --mAvailableDisplayCount;
+
+            // Notify that the secondary display for presentation show becomes
+            // unavailable now if the last one is removed already.
+            if (mAvailableDisplayCount == 0) notifyAvailabilityChanged(false);
+        }
+
+        @Override
+        public void onDisplayChanged(int displayId) {
+            // TODO(hmin): Figure out the behaviour when the display is changed.
+        }
+    };
+
+    public PresentationExtension(String name, String jsApi, XWalkExtensionContext context) {
+        super(name, jsApi, context);
+
+        mDisplayManager = XWalkDisplayManager.getInstance(context.getContext());
+    }
+
+    private void notifyAvailabilityChanged(boolean isAvailable) {
+        StringWriter contents = new StringWriter();
+        JsonWriter writer = new JsonWriter(contents);
+
+        try {
+            writer.beginObject();
+            writer.name(TAG_CMD).value(CMD_DISPLAY_AVAILABLE_CHANGE);
+            writer.name(TAG_DATA).value(isAvailable);
+            writer.endObject();
+            writer.close();
+
+            broadcastMessage(contents.toString());
+        } catch (IOException e) {
+            Log.e(TAG, "Error: " + e.toString());
+        }
+    }
+
+    @Override
+    public void onMessage(int instanceId, String message) {
+        // TODO(hmin): handle the message received from the JS side.
+    }
+
+    @Override
+    public String onSyncMessage(int instanceId, String message) {
+        if (message.equals(CMD_QUERY_DISPLAY_AVAILABILITY)) {
+            return mAvailableDisplayCount != 0 ? "true" : "false";
+        } else {
+            Log.e(TAG, "Unexpected sync message received: " + message);
+            return "";
+        }
+    }
+
+    @Override
+    public void onResume() {
+        Display[] displays = mDisplayManager.getPresentationDisplays();
+
+        // If there was available displays but right now no one is available for presentation,
+        // we need to notify the display availability changes and reset the display count.
+        if (displays.length == 0 && mAvailableDisplayCount > 0) {
+            notifyAvailabilityChanged(false);
+            mAvailableDisplayCount = 0;
+        }
+
+        // If there was no available display but right now there is at least one available
+        // display, we need to notify the display availability changes and update the display
+        // count.
+        if (displays.length > 0 && mAvailableDisplayCount == 0) {
+            notifyAvailabilityChanged(true);
+            mAvailableDisplayCount = displays.length;
+        }
+
+        // If there was available displays and right now there is also at least one
+        // available display, we only need to update the display count.
+        if (displays.length > 0 && mAvailableDisplayCount > 0) {
+            mAvailableDisplayCount = displays.length;
+        }
+
+        // Register the listener to display manager.
+        mDisplayManager.registerDisplayListener(mDisplayListener);
+    }
+
+    @Override
+    public void onPause() {
+        mDisplayManager.unregisterDisplayListener(mDisplayListener);
+    }
+
+    @Override
+    public void onDestroy() {
+    }
+}

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -135,6 +135,7 @@
         'xwalk_core_extensions_java',
         # Runtime code is also built by this target.
         'xwalk_core_java',
+        'xwalk_runtime_lib_apk_extension',
         'xwalk_runtime_lib_apk_pak',
       ],
       'variables': {
@@ -143,6 +144,7 @@
         'resource_dir': 'runtime/android/runtimelib/res',
         'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/jsapi/presentation_api.js',
           '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/xwalk.pak',
         ],
         'asset_location': '<(ant_build_out)/xwalk_runtime_lib/assets',
@@ -162,6 +164,18 @@
           'destination': '<(PRODUCT_DIR)/xwalk_runtime_lib/assets',
           'files': [
             '<(PRODUCT_DIR)/xwalk.pak',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'xwalk_runtime_lib_apk_extension',
+      'type': 'none',
+      'copies': [
+        {
+          'destination': '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/jsapi',
+          'files': [
+            'experimental/presentation/presentation_api.js',
           ],
         },
       ],


### PR DESCRIPTION
...oid

RECOMMIT it to add backward compatibility support for Android 4.x device.

NOTE: Since the current implementation relies on the DisplayManager
class introduced from Android 4.2 (API Level 17), as a result, the
Presentation API is only available on Android 4.2+, but won't break
running on the older version.

This commit is the first patch to implement Presentation API spec on
Android. It is intended to bring wireless display support into Web. The
new API is placed under 'navigator.presentation' namespace, and the
'displayavailable' property and its change event is implemented in this
commit by use of DisplayManager in Android SDK.

SPEC=http://otcshare.github.io/presentation-spec/index.html
BUG=https://github.com/crosswalk-project/crosswalk/issues/577
