### PR TITLE
[Android] Destroy extension when activity is destroyed

### DIFF
--- a/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
+++ b/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
@@ -4,7 +4,10 @@
 
 package org.xwalk.core.extensions;
 
+import android.util.Log;
+
 import java.util.ArrayList;
+
 import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
 
@@ -14,6 +17,7 @@ import org.chromium.base.JNINamespace;
  */
 @JNINamespace("xwalk::extensions")
 public abstract class XWalkExtensionAndroid {
+    private final static String TAG = "XWalkExtensionAndroid";
     private int mXWalkExtension;
     private ArrayList<Integer> mInstances;
 
@@ -22,7 +26,22 @@ public abstract class XWalkExtensionAndroid {
         mInstances = new ArrayList<Integer>();
     }
 
+    public void destroy() {
+        if (mXWalkExtension == 0) {
+            Log.e(TAG, "The extension to be destroyed is invalid!");
+            return;
+        }
+
+        nativeDestroyExtension(mXWalkExtension);
+        mXWalkExtension = 0;
+    }
+
     public void postMessage(int instanceID, String message) {
+        if (mXWalkExtension == 0) {
+            Log.e(TAG, "Can not post a message to an invalid extension!");
+            return;
+        }
+
         nativePostMessage(mXWalkExtension, instanceID, message);
     }
 
@@ -54,4 +73,5 @@ public abstract class XWalkExtensionAndroid {
 
     private native int nativeCreateExtension(String name, String jsApi);
     private native void nativePostMessage(int nativeXWalkExtensionAndroid, int instanceID, String message);
+    private native void nativeDestroyExtension(int nativeXWalkExtensionAndroid);
 }

--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -38,6 +38,17 @@ XWalkExtensionAndroid::~XWalkExtensionAndroid() {
   }
 
   Java_XWalkExtensionAndroid_onDestroy(env, obj.obj());
+
+  // Unregister the extension and clear its all instances.
+  XWalkContentBrowserClient::Get()->main_parts()->UnregisterExtension(
+      scoped_ptr<XWalkExtension>(this));
+
+  for (InstanceMap::iterator it = instances_.begin();
+       it != instances_.end(); ++it) {
+    XWalkExtensionInstance* instance = it->second;
+    delete instance;
+  }
+  instances_.clear();
 }
 
 bool XWalkExtensionAndroid::is_valid() {
@@ -61,6 +72,10 @@ void XWalkExtensionAndroid::PostMessage(JNIEnv* env, jobject obj,
   const char* str = env->GetStringUTFChars(msg, 0);
   it->second->PostMessageWrapper(str);
   env->ReleaseStringUTFChars(msg, str);
+}
+
+void XWalkExtensionAndroid::DestroyExtension(JNIEnv* env, jobject obj) {
+  delete this;
 }
 
 XWalkExtensionInstance* XWalkExtensionAndroid::CreateInstance() {

--- a/extensions/common/android/xwalk_extension_android.h
+++ b/extensions/common/android/xwalk_extension_android.h
@@ -37,6 +37,8 @@ class XWalkExtensionAndroid : public XWalkExtension {
   // JNI interface to post message from Java to JS
   void PostMessage(JNIEnv* env, jobject obj, jint instance, jstring msg);
 
+  void DestroyExtension(JNIEnv* env, jobject obj);
+
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
   void RemoveInstance(int instance);

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreExtensionBridge.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreExtensionBridge.java
@@ -38,6 +38,6 @@ class XWalkCoreExtensionBridge extends XWalkExtensionAndroid {
     @Override
     @CalledByNative
     public void onDestroy() {
-        mProvider.getExtensionContext().unregisterExtension(mExtension);        
+        mProvider.getExtensionContext().unregisterExtension(mExtension);
     }
 }

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -121,6 +121,12 @@ class XWalkCoreProviderImpl extends XWalkRuntimeViewProviderBase {
         bridge.broadcastMessage(message);
     }
 
+    @Override
+    public void destroyExtension(XWalkExtension extension) {
+        XWalkCoreExtensionBridge bridge = (XWalkCoreExtensionBridge)extension.getRegisteredId();
+        bridge.destroy();
+    }
+
     // For instrumentation test.
     @Override
     public String getTitleForTest() {

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -70,6 +70,11 @@ public interface XWalkRuntimeViewProvider {
      */
     public abstract void broadcastMessage(XWalkExtension extension, String message);
 
+    /**
+     * Destroy the extension, including the native resources allocated for it.
+     */
+    public abstract void destroyExtension(XWalkExtension extension);
+
     // For instrumentation test.
     public String getTitleForTest();
     public void setCallbackForTest(Object callback);

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
@@ -83,7 +83,7 @@ public abstract class XWalkExtension {
      * @param instanceID the ID of target extension instance.
      * @param message the message to be passed to Javascript.
      */
-    public void postMessage(int instanceID, String message) {
+    public final void postMessage(int instanceID, String message) {
         mExtensionContext.postMessage(this, instanceID, message);
     }
 
@@ -93,8 +93,16 @@ public abstract class XWalkExtension {
      * to all JavaScript side instances of the extension.
      * @param message the message to be passed to Javascript.
      */
-    public void broadcastMessage(String message) {
+    public final void broadcastMessage(String message) {
         mExtensionContext.broadcastMessage(this, message);
+    }
+
+    /**
+     * Destroy the extension to free its resources occupied.
+     */
+    public final void destroy() {
+        onDestroy();
+        mExtensionContext.destroyExtension(this);
     }
 
     /**
@@ -126,7 +134,7 @@ public abstract class XWalkExtension {
      * Get the registered ID.
      * @return the registered ID object.
      */
-    public Object getRegisteredId() {
+    public final Object getRegisteredId() {
         return mRegisteredId;
     }
 }

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContext.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContext.java
@@ -41,6 +41,13 @@ public abstract class XWalkExtensionContext {
     public abstract void broadcastMessage(XWalkExtension extension, String message);
 
     /**
+     * Destroy the extension.
+     *
+     * @param extension the extension to be destroyed.
+     */
+    public abstract void destroyExtension(XWalkExtension extension);
+
+    /**
      * Get current Android Context.
      * @return the current Android Context.
      */

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextImpl.java
@@ -45,6 +45,11 @@ public class XWalkExtensionContextImpl extends XWalkExtensionContext {
     }
 
     @Override
+    public void destroyExtension(XWalkExtension extension) {
+        mManager.destroyExtension(extension);
+    }
+
+    @Override
     public Context getContext() {
         return mContext;
     }

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextWrapper.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionContextWrapper.java
@@ -34,6 +34,10 @@ public class XWalkExtensionContextWrapper extends XWalkExtensionContext {
         mOriginContext.broadcastMessage(extension, message);
     }
 
+    public void destroyExtension(XWalkExtension extension) {
+        mOriginContext.destroyExtension(extension);
+    }
+
     public Context getContext() {
         // This is very tricky because for external extensions, we should
         // use Activity which contains the context for runtime client side.

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
@@ -63,6 +63,10 @@ public class XWalkExtensionManager {
         mXwalkProvider.broadcastMessage(extension, message);
     }
 
+    public void destroyExtension(XWalkExtension extension) {
+        mXwalkProvider.destroyExtension(extension);
+    }
+
     public Object registerExtension(XWalkExtension extension) {
         mExtensions.add(extension);
         return mXwalkProvider.onExtensionRegistered(extension);
@@ -87,8 +91,9 @@ public class XWalkExtensionManager {
 
     public void onDestroy() {
         for(XWalkExtension extension: mExtensions) {
-            extension.onDestroy();
+            extension.destroy();
         }
+        mExtensions.clear();
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -408,6 +408,17 @@ void XWalkBrowserMainParts::RegisterExtension(
     scoped_ptr<XWalkExtension> extension) {
   extensions_.push_back(extension.release());
 }
+
+void XWalkBrowserMainParts::UnregisterExtension(
+    scoped_ptr<XWalkExtension> extension) {
+  ScopedVector<XWalkExtension>::iterator it = extensions_.begin();
+  for (; it != extensions_.end(); ++it) {
+    if (*it == extension.release()) break;
+  }
+
+  if (it != extensions_.end())
+    extensions_.erase(it);
+}
 #endif
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -55,6 +55,7 @@ class XWalkBrowserMainParts : public content::BrowserMainParts,
   // XWalkBrowserMainParts so they get correctly registered on-demand
   // by XWalkExtensionService each time a in_process Server is created.
   void RegisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
+  void UnregisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
 #else
   RuntimeContext* runtime_context() { return runtime_context_.get(); }
 #endif


### PR DESCRIPTION
This fix is to ensure that XWalkExtension object gets destroyed when the
Activity is destroyed (e.g. press back button).

Since each XWalkExtension object on Java side has a corresponding native
extension object, we need to make sure the native extension object is
also destroyed. Otherwise, the leaked native object will cause unpredictable
program behavior.

BUG=https://github.com/crosswalk-project/crosswalk/issues/1023
