### PR TITLE
Revert "[Tizen] add the 'gst-plugins-atomisp-devel' buildrequires to spe...

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -22,7 +22,6 @@ BuildRequires:  bzip2-devel
 BuildRequires:  expat-devel
 BuildRequires:  flex
 BuildRequires:  gperf
-BuildRequires:  gst-plugins-atomisp-devel
 BuildRequires:  libasound-devel
 BuildRequires:  pkgmgr-info-parser-devel
 BuildRequires:  python


### PR DESCRIPTION
...c."

This reverts commit cd8ac2dbb7fa164cf20118bdcbfdc011e81602a8.

The original commit breaks xwalk-tizen build since currently its dependency
upon 'gst-plugins-atomisp-devel' package can't be fulfiled by tizen.org repo.
