### PR TITLE
[Tizen] move the gyp variable 'tizen_mobile' from xwalk to chromium

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -9,16 +9,11 @@
     # result, multi-touch support works with these simulated touch events
     # dispatched from floating device.
     'enable_xi21_mt%': 0,
-
-    'tizen_mobile%': 0,
   },
   'target_defaults': {
     'conditions': [
       ['enable_xi21_mt==1', {
         'defines': ['ENABLE_XI21_MT=1'],
-      }],
-      ['tizen_mobile==1', {
-        'defines': ['OS_TIZEN_MOBILE=1'],
       }],
     ],
   },


### PR DESCRIPTION
move this variable from xwalk/build/common.gypi to build/common.gypi so that it
can still guard the tizen-specific changes in chromium in case of purely building
chromium other than xwalk.
