### PR TITLE
[Android] Add thread safety checking for XWalkView.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -8,6 +8,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Rect;
+import android.os.Looper;
 import android.util.AttributeSet;
 import android.view.ViewGroup;
 import android.webkit.WebSettings;
@@ -29,6 +30,7 @@ public class XWalkView extends FrameLayout {
     public XWalkView(Context context, Activity activity) {
         super(context, null);
 
+        checkThreadSafety();
         // Make sure mActivity is initialized before calling 'init' method.
         mActivity = activity;
         mContext = context;
@@ -57,6 +59,7 @@ public class XWalkView extends FrameLayout {
     public XWalkView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
+        checkThreadSafety();
         mContext = context;
         init(context, attrs);
     }
@@ -86,6 +89,7 @@ public class XWalkView extends FrameLayout {
     }
 
     public void loadUrl(String url) {
+        checkThreadSafety();
         mContent.loadUrl(url);
     }
 
@@ -102,99 +106,123 @@ public class XWalkView extends FrameLayout {
     }
 
     public void reload() {
+        checkThreadSafety();
         mContent.reload();
     }
 
     public void addJavascriptInterface(Object object, String name) {
+        checkThreadSafety();
         mContent.addJavascriptInterface(object, name);
     }
 
     public String getUrl() {
+        checkThreadSafety();
         return mContent.getUrl();
     }
 
     public String getTitle() {
+        checkThreadSafety();
         return mContent.getTitle();
     }
 
     public void clearCache(boolean includeDiskFiles) {
+        checkThreadSafety();
         mContent.clearCache(includeDiskFiles);
     }
 
     public void clearHistory() {
+        checkThreadSafety();
         mContent.clearHistory();
     }
 
     public boolean canGoBack() {
+        checkThreadSafety();
         return mContent.canGoBack();
     }
 
     public void goBack() {
+        checkThreadSafety();
         mContent.goBack();
     }
 
     public boolean canGoForward() {
+        checkThreadSafety();
         return mContent.canGoForward();
     }
 
     public void goForward() {
+        checkThreadSafety();
         mContent.goForward();
     }
 
     public boolean requestFocus(int direction, Rect previouslyFocusedRect) {
+        checkThreadSafety();
         return false;
     }
 
     public void setLayoutParams(ViewGroup.LayoutParams params) {
+        checkThreadSafety();
         super.setLayoutParams(params);
     }
 
     public XWalkSettings getSettings() {
+        checkThreadSafety();
         return mContent.getSettings();
     }
 
     public String getOriginalUrl() {
+        checkThreadSafety();
         return mContent.getOriginalUrl();
     }
 
     public void setNetworkAvailable(boolean networkUp) {
+        checkThreadSafety();
         mContent.setNetworkAvailable(networkUp);
     }
 
     public void setInitialScale(int scaleInPercent) {
+        checkThreadSafety();
     }
 
     public void setXWalkWebChromeClient(XWalkWebChromeClient client) {
+        checkThreadSafety();
         mContent.setXWalkWebChromeClient(client);
     }
 
     public void setXWalkClient(XWalkClient client) {
+        checkThreadSafety();
         mContent.setXWalkClient(client);
     }
 
     public void stopLoading() {
+        checkThreadSafety();
         mContent.stopLoading();
     }
 
     public void pauseTimers() {
+        checkThreadSafety();
         mContent.pauseTimers();
     }
 
     public void resumeTimers() {
+        checkThreadSafety();
         mContent.resumeTimers();
     }
 
     public void setDownloadListener(DownloadListener listener) {
+        checkThreadSafety();
         mContent.setDownloadListener(listener);
     }
 
     public void setNavigationHandler(XWalkNavigationHandler handler) {
+        checkThreadSafety();
         mContent.setNavigationHandler(handler);
     }
 
     // Enables remote debugging and returns the URL at which the dev tools server is listening
     // for commands.
     public String enableRemoteDebugging() {
+        checkThreadSafety();
         // Chrome looks for "devtools_remote" pattern in the name of a unix domain socket
         // to identify a debugging page
         final String socketName = getContext().getApplicationContext().getPackageName() + "_devtools_remote";
@@ -207,6 +235,7 @@ public class XWalkView extends FrameLayout {
     }
 
     public void disableRemoteDebugging() {
+        checkThreadSafety();
         if (mDevToolsServer ==  null) return;
 
         if (mDevToolsServer.isRemoteDebuggingEnabled()) {
@@ -246,6 +275,17 @@ public class XWalkView extends FrameLayout {
 
     // For instrumentation test.
     public XWalkContent getXWalkViewContentForTest() {
+        checkThreadSafety();
         return mContent;
+    }
+
+    private static void checkThreadSafety() {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            Throwable throwable = new Throwable(
+                "Warning: A XWalkView method was called on thread '" +
+                Thread.currentThread().getName() + "'. " +
+                "All XWalkView methods must be called on the UI thread. ");
+            throw new RuntimeException(throwable);
+        }
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
@@ -41,9 +41,13 @@ public class ExtensionBroadcastTest extends XWalkViewTestBase {
                 mTestContentsClient.onTitleChanged(title);
             }
         }
-
-        getXWalkView().setXWalkClient(new TestXWalkClient());
-        getXWalkView().setXWalkWebChromeClient(new TestXWalkChromeClient());
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkClient(new TestXWalkClient());
+                getXWalkView().setXWalkWebChromeClient(new TestXWalkChromeClient());
+            }
+        });
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEchoTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEchoTest.java
@@ -42,8 +42,13 @@ public class ExtensionEchoTest extends XWalkViewTestBase {
             }
         }
 
-        getXWalkView().setXWalkClient(new TestXWalkClient());
-        getXWalkView().setXWalkWebChromeClient(new TestXWalkChromeClient());
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkClient(new TestXWalkClient());
+                getXWalkView().setXWalkWebChromeClient(new TestXWalkChromeClient());
+            }
+        });
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadUrlTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadUrlTest.java
@@ -32,7 +32,12 @@ public class LoadUrlTest extends XWalkViewTestBase {
                 mTestContentsClient.didFinishLoad(url);
             }
         }
-        getXWalkView().setXWalkClient(new TestXWalkClient());
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkClient(new TestXWalkClient());
+            }
+        });
     }
 
     // @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnUpdateTitleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnUpdateTitleTest.java
@@ -39,8 +39,13 @@ public class OnUpdateTitleTest extends XWalkViewTestBase {
                 mTestContentsClient.onTitleChanged(title);
             }
         }
-        getXWalkView().setXWalkClient(new TestXWalkClient());
-        getXWalkView().setXWalkWebChromeClient(new TestXWalkChromeClient());
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkClient(new TestXWalkClient());
+                getXWalkView().setXWalkWebChromeClient(new TestXWalkChromeClient());
+            }
+        });
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetDatabaseEnabledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetDatabaseEnabledTest.java
@@ -47,13 +47,23 @@ public class SetDatabaseEnabledTest extends XWalkViewTestBase {
                 mTestContentsClient.onLoadResource(url);
             }
         }
-        getXWalkView().setXWalkClient(new TestXWalkClient());
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkClient(new TestXWalkClient());
+            }
+        });
     }
 
     abstract class XWalkViewSettingsTestHelper<T> {
         XWalkViewSettingsTestHelper(boolean requiresJsEnabled) throws Throwable {
             if (requiresJsEnabled) {
-                getXWalkView().getSettings().setJavaScriptEnabled(true);
+                getInstrumentation().runOnMainSync(new Runnable() {
+                    @Override
+                    public void run() {
+                        getXWalkView().getSettings().setJavaScriptEnabled(true);
+                    }
+                });
             }
         }
 
@@ -92,6 +102,7 @@ public class SetDatabaseEnabledTest extends XWalkViewTestBase {
     class XWalkViewSettingsDatabaseTestHelper extends XWalkViewSettingsTestHelper<Boolean> {
         private static final String NO_DATABASE = "No database";
         private static final String HAS_DATABASE = "Has database";
+        private Boolean enabled;
 
         XWalkViewSettingsDatabaseTestHelper() throws Throwable {
             super(true);
@@ -109,13 +120,24 @@ public class SetDatabaseEnabledTest extends XWalkViewTestBase {
 
         @Override
         protected Boolean getCurrentValue() {
-            Boolean enabled = getXWalkView().getSettings().getDatabaseEnabled();
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    enabled = getXWalkView().getSettings().getDatabaseEnabled();
+                }
+            });
             return enabled;
         }
 
         @Override
         protected void setCurrentValue(Boolean value) {
-            getXWalkView().getSettings().setDatabaseEnabled(value);
+            final Boolean enabled = value;
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    getXWalkView().getSettings().setDatabaseEnabled(enabled);
+                }
+            });
         }
 
         @Override

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetNetworkAvailableTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetNetworkAvailableTest.java
@@ -38,7 +38,12 @@ public class SetNetworkAvailableTest extends XWalkViewTestBase {
                 mTestContentsClient.didFinishLoad(url);
             }
         }
-        getXWalkView().setXWalkClient(new TestXWalkClient());
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkClient(new TestXWalkClient());
+            }
+        });
     }
 
     @Feature({"SetNetworkAvailableTest"})
@@ -48,11 +53,16 @@ public class SetNetworkAvailableTest extends XWalkViewTestBase {
         loadAssetFile("navigator.online.html");
         String title = getTitleOnUiThread();
 
-        XWalkView xwView = getXWalkView();
+        final XWalkView xwView = getXWalkView();
 
         if ("true".equals(title)) {
-            // Forcing to trigger 'offline' event.
-            xwView.setNetworkAvailable(false);
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    // Forcing to trigger 'offline' event.
+                    xwView.setNetworkAvailable(false);
+                }
+            });
 
             /**
              * Expectations:
@@ -62,8 +72,13 @@ public class SetNetworkAvailableTest extends XWalkViewTestBase {
             assertEquals("false", executeJavaScriptAndWaitForResult(code));
             assertEquals("offline:false", getTitleOnUiThread());
 
-            // Forcing to trigger 'online' event.
-            xwView.setNetworkAvailable(true);
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    // Forcing to trigger 'online' event.
+                    xwView.setNetworkAvailable(true);
+                }
+            });
 
             /**
              * Expectations:
@@ -75,8 +90,13 @@ public class SetNetworkAvailableTest extends XWalkViewTestBase {
         }
 
         if ("false".equals(title)) {
-            // Forcing to trigger 'online' event.
-            xwView.setNetworkAvailable(true);
+             getInstrumentation().runOnMainSync(new Runnable() {
+                 @Override
+                 public void run() {
+                     // Forcing to trigger 'online' event.
+                     xwView.setNetworkAvailable(true);
+                 }
+             });
 
             /**
              * Expectations:
@@ -86,8 +106,13 @@ public class SetNetworkAvailableTest extends XWalkViewTestBase {
             assertEquals("true", executeJavaScriptAndWaitForResult(code));
             assertEquals("online:true", getTitleOnUiThread());
 
-            // Forcing to trigger 'offline' event.
-            xwView.setNetworkAvailable(false);
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    // Forcing to trigger 'offline' event.
+                    xwView.setNetworkAvailable(false);
+                }
+            });
 
             /**
              * Expectations:

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
@@ -23,22 +23,31 @@ public class RuntimeClientApiTestBase<T extends Activity> {
 
     // For loadAppFromUrl.
     public void testLoadAppFromUrl() throws Throwable {
-        String expectedTitle = "Crosswalk Sample Application";
+        final String expectedTitle = "Crosswalk Sample Application";
 
         mTestUtil.loadUrlSync("file:///android_asset/index.html");
-
-        String title = mTestUtil.getTestedView().getTitleForTest();
-        mTestCase.assertEquals(expectedTitle, title);
+        mTestCase.getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                String title = mTestUtil.getTestedView().getTitleForTest();
+                mTestCase.assertEquals(expectedTitle, title);
+            }
+        });
     }
 
     // For loadAppFromManifest.
     public void testLoadAppFromManifest() throws Throwable {
-        String expectedTitle = "Crosswalk Sample Application";
+        final String expectedTitle = "Crosswalk Sample Application";
 
         mTestUtil.loadManifestSync("file:///android_asset/manifest.json");
 
-        String title = mTestUtil.getTestedView().getTitleForTest();
-        mTestCase.assertEquals(expectedTitle, title);
+        mTestCase.getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                String title = mTestUtil.getTestedView().getTitleForTest();
+                mTestCase.assertEquals(expectedTitle, title);
+            }
+        });
     }
 
     // For internal extension implemention of DeviceCapabilities.
@@ -56,7 +65,12 @@ public class RuntimeClientApiTestBase<T extends Activity> {
     // For external extension mechanism: sync mode.
     public void testExternalExtensionSync() throws Throwable {
         mTestUtil.loadAssetFile("echoSync.html");
-        String title = mTestUtil.getTestedView().getTitleForTest();
-        mTestCase.assertEquals("Pass", title);
+        mTestCase.getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                String title = mTestUtil.getTestedView().getTitleForTest();
+                mTestCase.assertEquals("Pass", title);
+            }
+        });
     }
 }


### PR DESCRIPTION
All XWalkView methods must be called on the UI thread.
Throw an exception when XWalkView methods are called from
other thread.

BUG=https://crosswalk-project.org/jira/browse/XWALK-98
