### PR TITLE
[Extensions] Make XWalkExtensionService::Delegate destructor virtual

### DIFF
--- a/extensions/browser/xwalk_extension_service.h
+++ b/extensions/browser/xwalk_extension_service.h
@@ -40,7 +40,7 @@ class XWalkExtensionService : public content::NotificationObserver {
         XWalkExtensionServer* server) {}
 
    protected:
-    ~Delegate() {}
+    virtual ~Delegate() {}
   };
 
   explicit XWalkExtensionService(Delegate* delegate);


### PR DESCRIPTION
Make XWalkExtensionService::Delegate destructor virtual since it is a base class.
