### PR TITLE
[Android] Add loadAssetFileAndWaitForTitle and apply in XWalkCoreTest cases

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
@@ -35,7 +35,15 @@ public class ExtensionBroadcastTest extends XWalkViewTestBase {
             }
         }
 
+        class TestXWalkChromeClient extends XWalkWebChromeClient {
+            @Override
+            public void onReceivedTitle(XWalkView view, String title) {
+                mTestContentsClient.onTitleChanged(title);
+            }
+        }
+
         getXWalkView().setXWalkClient(new TestXWalkClient());
+        getXWalkView().setXWalkWebChromeClient(new TestXWalkChromeClient());
     }
 
     @SmallTest
@@ -43,7 +51,7 @@ public class ExtensionBroadcastTest extends XWalkViewTestBase {
     public void testExtensionBroadcast() throws Throwable {
         ExtensionBroadcast broadcast = new ExtensionBroadcast();
 
-        loadAssetFile("broadcast.html");
+        loadAssetFileAndWaitForTitle("broadcast.html");
         assertEquals("Pass", getTitleOnUiThread());
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEchoTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEchoTest.java
@@ -8,7 +8,6 @@ import android.graphics.Bitmap;
 import android.test.suitebuilder.annotation.SmallTest;
 import android.util.Log;
 
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 
 import org.xwalk.core.XWalkClient;
@@ -40,7 +39,6 @@ public class ExtensionEchoTest extends XWalkViewTestBase {
             @Override
             public void onReceivedTitle(XWalkView view, String title) {
                 mTestContentsClient.onTitleChanged(title);
-                assertEquals("Pass", title);
             }
         }
 
@@ -53,7 +51,8 @@ public class ExtensionEchoTest extends XWalkViewTestBase {
     public void testExtensionEcho() throws Throwable {
         ExtensionEcho echo = new ExtensionEcho();
 
-        loadAssetFile("echo.html");
+        loadAssetFileAndWaitForTitle("echo.html");
+        assertEquals("Pass", getTitleOnUiThread());
     }
 
     @SmallTest
@@ -65,15 +64,12 @@ public class ExtensionEchoTest extends XWalkViewTestBase {
         assertEquals("Pass", getTitleOnUiThread());
     }
 
-    // @SmallTest
-    // @Feature({"ExtensionEcho"})
-    // This test case failed on buildbot, so disabled it temporally.
-    // It will be enabled later.
-    @DisabledTest
+    @SmallTest
+    @Feature({"ExtensionEcho"})
     public void testExtensionEchoMultiFrames() throws Throwable {
         ExtensionEcho echo = new ExtensionEcho();
 
-        loadAssetFile("framesEcho.html");
+        loadAssetFileAndWaitForTitle("framesEcho.html");
         assertEquals("Pass", getTitleOnUiThread());
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnTitleUpdatedHelper.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnTitleUpdatedHelper.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import org.chromium.content.browser.test.util.CallbackHelper;
+
+public class OnTitleUpdatedHelper extends CallbackHelper {
+    private String mTitle;
+
+    public void notifyCalled(String title) {
+        mTitle = title;
+        notifyCalled();
+    }
+
+    public String getTitle() {
+        assert getCallCount() > 0;
+        return mTitle;
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestXWalkViewContentsClient.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestXWalkViewContentsClient.java
@@ -22,12 +22,14 @@ class TestXWalkViewContentsClient extends NullContentsClient {
     private final OnPageFinishedHelper mOnPageFinishedHelper;
     private final OnReceivedErrorHelper mOnReceivedErrorHelper;
     private final OnEvaluateJavaScriptResultHelper mOnEvaluateJavaScriptResultHelper;
+    private final OnTitleUpdatedHelper mOnTitleUpdatedHelper;
 
     public TestXWalkViewContentsClient() {
         mOnPageStartedHelper = new OnPageStartedHelper();
         mOnPageFinishedHelper = new OnPageFinishedHelper();
         mOnReceivedErrorHelper = new OnReceivedErrorHelper();
         mOnEvaluateJavaScriptResultHelper = new OnEvaluateJavaScriptResultHelper();
+        mOnTitleUpdatedHelper = new OnTitleUpdatedHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -46,9 +48,14 @@ class TestXWalkViewContentsClient extends NullContentsClient {
         return mOnEvaluateJavaScriptResultHelper;
     }
 
+    public OnTitleUpdatedHelper getOnTitleUpdatedHelper() {
+        return mOnTitleUpdatedHelper;
+    }
+
     @Override
     public void onTitleChanged(String title) {
         mChangedTitle = title;
+        mOnTitleUpdatedHelper.notifyCalled(title);
     }
 
     public String getChangedTitle() {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -126,6 +126,17 @@ public class XWalkViewTestBase
         loadDataSync(fileContent, "text/html", false);
     }
 
+    public void loadAssetFileAndWaitForTitle(String fileName) throws Exception {
+        CallbackHelper getTitleHelper = mTestContentsClient.getOnTitleUpdatedHelper();
+        int currentCallCount = getTitleHelper.getCallCount();
+        String fileContent = getFileContent(fileName);
+
+        loadDataSync(fileContent, "text/html", false);
+
+        getTitleHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
+    }
+
     protected XWalkView getXWalkView() {
         return mXWalkView;
     }


### PR DESCRIPTION
Instrumentation tests may fail because the titles may be verified
before they are changed. This commit introduced a new interface named
"loadAssetFileAndWaitForTitle" to wait until the title be changed.

BUG=#984 (Partially)
