### PR TITLE
[Extensions] Check for conflicting entry points in the ModuleSystem

### DIFF
--- a/extensions/renderer/xwalk_module_system.h
+++ b/extensions/renderer/xwalk_module_system.h
@@ -89,7 +89,7 @@ class XWalkModuleSystem {
       v8::Local<v8::String> property,
       const v8::PropertyCallbackInfo<v8::Value>& info);
 
-  bool ContainsExtensionModule(const std::string& name);
+  bool ContainsEntryPoint(const std::string& entry_point);
   void MarkModulesWithTrampoline();
   void DeleteExtensionModules();
 


### PR DESCRIPTION
As we may have extensions coming from various processes, think that internal
extensions are run in the Browser Process and external extensions are run in
the Extension Process, the only point when we have all information of all the
extensions that would be run for a context is the module system.

So, if conflicting entry points are found, we log this as an warning and do
not register the extension.
