### PR TITLE
The return value indicating 'already installed' should be false.

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -58,7 +58,7 @@ bool ApplicationService::Install(const base::FilePath& path, std::string* id) {
     if (app_store_->Contains(app_id)) {
       *id = app_id;
       LOG(INFO) << "Already installed: " << app_id;
-      return true;
+      return false;
     }
 
     base::FilePath temp_dir;


### PR DESCRIPTION
I suppose this place should be 'false' because actually the Installation is 'failed' due to 'it's already installed', isn't it?
