### PR TITLE
[WiDi API] Implement navigator.presentation.requestShow API on Android

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -286,6 +286,10 @@ public class XWalkContent extends FrameLayout {
         mXWalkContent = 0;
     }
 
+    public int getRoutingID() {
+        return nativeGetRoutingID(mXWalkContent);
+    }
+
     private native int nativeInit(XWalkWebContentsDelegate webViewContentsDelegate,
             XWalkContentsClientBridge bridge);
     private static native void nativeDestroy(int nativeXWalkContent);
@@ -296,4 +300,5 @@ public class XWalkContent extends FrameLayout {
     private native String nativeGetVersion(int nativeXWalkContent);
     private native void nativeSetJsOnlineProperty(int nativeXWalkContent, boolean networkUp);
     private native boolean nativeSetManifest(int nativeXWalkContent, String path, String manifest);
+    private native int nativeGetRoutingID(int nativeXWalkContent);
 }

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -270,6 +270,10 @@ public class XWalkView extends FrameLayout {
         return mContent.getVersion();
     }
 
+    public int getContentID() {
+        return mContent.getRoutingID();
+    }
+
     // TODO(shouqun): requestFocusFromTouch, setVerticalScrollBarEnabled are
     // from android.view.View;
 

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
@@ -5,12 +5,19 @@
 package org.xwalk.runtime.extension.api.presentation;
 
 import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.JsonReader;
 import android.util.JsonWriter;
 import android.util.Log;
 import android.view.Display;
+import android.view.ViewGroup;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
+
+import org.chromium.base.ThreadUtils;
 
 import org.xwalk.runtime.extension.api.XWalkDisplayManager;
 import org.xwalk.runtime.extension.XWalkExtension;
@@ -27,15 +34,31 @@ public class PresentationExtension extends XWalkExtension {
     // Tags:
     private final static String TAG_CMD = "cmd";
     private final static String TAG_DATA = "data";
+    private final static String TAG_REQUEST_ID = "requestId";
 
-    // Command messages.
+    // Command messages:
     private final static String CMD_DISPLAY_AVAILABLE_CHANGE = "DisplayAvailableChange";
     private final static String CMD_QUERY_DISPLAY_AVAILABILITY = "QueryDisplayAvailability";
+    private final static String CMD_REQUEST_SHOW = "RequestShow";
+    private final static String CMD_SHOW_SUCCEEDED = "ShowSucceeded";
+    private final static String CMD_SHOW_FAILED = "ShowFailed";
+
+    // Error messages:
+    private final static String ERROR_INVALID_ACCESS = "InvalidAccessError";
+    private final static String ERROR_INVALID_STATE = "InvalidStateError";
+    private final static String ERROR_NOT_FOUND = "NotFoundError";
+    private final static String ERROR_NOT_SUPPORTED = "NotSupportedError";
 
     private XWalkDisplayManager mDisplayManager;
 
     // The number of available presentation displays on the system.
     private int mAvailableDisplayCount = 0;
+
+    // The presentation content and view to be showed on the secondary display.
+    // Currently, only one presentation is allowed to show at the same time.
+    private XWalkPresentationContent mPresentationContent;
+    private XWalkPresentationContent.PresentationDelegate mPresentationDelegate;
+    private PresentationView mPresentationView;
 
     /**
      * Listens for the secondary display arrival and removal.
@@ -66,7 +89,15 @@ public class PresentationExtension extends XWalkExtension {
 
             // Notify that the secondary display for presentation show becomes
             // unavailable now if the last one is removed already.
-            if (mAvailableDisplayCount == 0) notifyAvailabilityChanged(false);
+            if (mAvailableDisplayCount == 0) {
+                notifyAvailabilityChanged(false);
+                // Destroy the presentation content if there is no available secondary display
+                // any more.
+                if (mPresentationContent != null) {
+                    mPresentationContent.close();
+                    mPresentationContent = null;
+                }
+            }
         }
 
         @Override
@@ -79,6 +110,12 @@ public class PresentationExtension extends XWalkExtension {
         super(name, jsApi, context);
 
         mDisplayManager = XWalkDisplayManager.getInstance(context.getContext());
+    }
+
+    private Display getPreferredDisplay() {
+        Display[] displays = mDisplayManager.getPresentationDisplays();
+        if (displays.length > 0) return displays[0];
+        else return null;
     }
 
     private void notifyAvailabilityChanged(boolean isAvailable) {
@@ -98,9 +135,138 @@ public class PresentationExtension extends XWalkExtension {
         }
     }
 
+    private void notifyRequestShowSucceed(int instanceId, int requestId, int presentationId) {
+        StringWriter contents = new StringWriter();
+        JsonWriter writer = new JsonWriter(contents);
+
+        try {
+            writer.beginObject();
+            writer.name(TAG_CMD).value(CMD_SHOW_SUCCEEDED);
+            writer.name(TAG_REQUEST_ID).value(requestId);
+            writer.name(TAG_DATA).value(presentationId);
+            writer.endObject();
+            writer.close();
+
+            postMessage(instanceId, contents.toString());
+        } catch (IOException e) {
+            Log.e(TAG, "Error: " + e.toString());
+        }
+    }
+
+    private void notifyRequestShowFail(int instanceId, int requestId, String errorMessage) {
+        StringWriter contents = new StringWriter();
+        JsonWriter writer = new JsonWriter(contents);
+
+        try {
+            writer.beginObject();
+            writer.name(TAG_CMD).value(CMD_SHOW_FAILED);
+            writer.name(TAG_REQUEST_ID).value(requestId);
+            writer.name(TAG_DATA).value(errorMessage);
+            writer.endObject();
+            writer.close();
+
+            postMessage(instanceId, contents.toString());
+        } catch (IOException e) {
+            Log.e(TAG, "Error: " + e.toString());
+        }
+    }
+
     @Override
     public void onMessage(int instanceId, String message) {
-        // TODO(hmin): handle the message received from the JS side.
+        StringReader contents = new StringReader(message);
+        JsonReader reader = new JsonReader(contents);
+
+        int requestId = -1;
+        String cmd = null;
+        String url = null;
+        try {
+            reader.beginObject();
+            while (reader.hasNext()) {
+                String name = reader.nextName();
+                if (name.equals(TAG_CMD)) {
+                    cmd = reader.nextString();
+                } else if (name.equals(TAG_REQUEST_ID)) {
+                    requestId = reader.nextInt();
+                } else if (name.equals("url")) {
+                    url = reader.nextString();
+                } else {
+                    reader.skipValue();
+                }
+            }
+            reader.endObject();
+            reader.close();
+
+            if (cmd != null && cmd.equals(CMD_REQUEST_SHOW) && requestId >= 0) {
+                handleRequestShow(instanceId, url, requestId);
+            }
+        } catch (IOException e) {
+            Log.d(TAG, "Error: " + e);
+        }
+    }
+
+    private void handleRequestShow(final int instanceId, final String url, final int requestId) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            notifyRequestShowFail(instanceId, requestId, ERROR_NOT_SUPPORTED);
+            return;
+        }
+
+        if (mAvailableDisplayCount == 0) {
+            Log.d(TAG, "No available presentation display is found.");
+            notifyRequestShowFail(instanceId, requestId, ERROR_NOT_FOUND);
+            return;
+        }
+
+        // We have to post the runnable task for presentation view creation to
+        // UI thread since extension API is not running on UI thread.
+        ThreadUtils.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Display preferredDisplay = getPreferredDisplay();
+
+                // No availble display is found.
+                if (preferredDisplay == null) {
+                    notifyRequestShowFail(instanceId, requestId, ERROR_NOT_FOUND);
+                    return;
+                }
+
+                // Only one presentation is allowed to show on the presentation display. Notify
+                // the JS side that an error occurs if there is already one presentation showed.
+                if (mPresentationContent != null) {
+                    notifyRequestShowFail(instanceId, requestId, ERROR_INVALID_ACCESS);
+                    return;
+                }
+
+                mPresentationContent = new XWalkPresentationContent(
+                        mExtensionContext.getContext(),
+                        mExtensionContext.getActivity(),
+                        new XWalkPresentationContent.PresentationDelegate() {
+                    @Override
+                    public void onContentLoaded(XWalkPresentationContent content) {
+                        notifyRequestShowSucceed(instanceId, requestId, content.getPresentationId());
+                    }
+
+                    @Override
+                    public void onContentClosed(XWalkPresentationContent content) {
+                        if (content == mPresentationContent) {
+                            mPresentationContent = null;
+                            if (mPresentationView != null) mPresentationView.cancel();
+                        }
+                    }
+                });
+
+                String targetUrl = url;
+                if (!url.startsWith("http://") && !url.startsWith("https://")) {
+                    targetUrl = "file:///android_asset/" + url;
+                }
+
+                // Start to load the content from the target url.
+                mPresentationContent.load(targetUrl);
+
+                // Update the presentation view in order that the content could be presented
+                // on the preferred display.
+                updatePresentationView(preferredDisplay);
+            }
+        });
     }
 
     @Override
@@ -122,6 +288,10 @@ public class PresentationExtension extends XWalkExtension {
         if (displays.length == 0 && mAvailableDisplayCount > 0) {
             notifyAvailabilityChanged(false);
             mAvailableDisplayCount = 0;
+            if (mPresentationContent != null) {
+                mPresentationContent.close();
+                mPresentationContent = null;
+            }
         }
 
         // If there was no available display but right now there is at least one available
@@ -138,12 +308,80 @@ public class PresentationExtension extends XWalkExtension {
             mAvailableDisplayCount = displays.length;
         }
 
+        if (mPresentationContent != null) {
+            mPresentationContent.onResume();
+        }
+
+        updatePresentationView(getPreferredDisplay());
+
         // Register the listener to display manager.
         mDisplayManager.registerDisplayListener(mDisplayListener);
     }
 
+    private void updatePresentationView(Display preferredDisplay) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1 ||
+                preferredDisplay == null) {
+            return;
+        }
+
+        // No presentation content is ready for use.
+        if (mPresentationView == null && mPresentationContent == null) {
+            return;
+        }
+
+        // If the presentation view is showed on another display, we need to dismiss it
+        // and re-create a new one.
+        if (mPresentationView != null && mPresentationView.getDisplay() != preferredDisplay) {
+            mPresentationView.dismiss();
+            mPresentationView = null;
+        }
+
+        // If the presentation view is not NULL and its associated display is not changed,
+        // the displaying system will automatically restore the content on the view once
+        // the Activity gets resumed.
+        if (mPresentationView == null && mPresentationContent != null) {
+            // Remove the content view from its previous view hierarchy if have.
+            ViewGroup parent = (ViewGroup)mPresentationContent.getContentView().getParent();
+            if (parent != null) parent.removeView(mPresentationContent.getContentView());
+
+            mPresentationView = PresentationView.createInstance(mExtensionContext.getContext(), preferredDisplay);
+            mPresentationView.setContentView(mPresentationContent.getContentView());
+            mPresentationView.setPresentationListener(new PresentationView.PresentationListener() {
+                @Override
+                public void onDismiss(PresentationView view) {
+                    // We need to pause the content if the view is dismissed from the screen
+                    // to avoid unnecessary overhead to update the content, e.g. stop animation
+                    // and JS execution.
+                    if (view == mPresentationView) {
+                        if (mPresentationContent != null) mPresentationContent.onPause();
+                        mPresentationView = null;
+                    }
+                }
+
+                @Override
+                public void onShow(PresentationView view) {
+                    // The presentation content may be paused due to the presentation view was
+                    // dismissed, we need to resume it when the new view is showed.
+                    if (view == mPresentationView && mPresentationContent != null) {
+                        mPresentationContent.onResume();
+                    }
+                }
+            });
+        }
+
+        mPresentationView.show();
+    }
+
     @Override
     public void onPause() {
+        if (mPresentationView != null) {
+            mPresentationView.dismiss();
+            mPresentationView = null;
+        }
+
+        if (mPresentationContent != null) mPresentationContent.onPause();
+
+        // No need to listen display changes when the activity is paused.
         mDisplayManager.unregisterDisplayListener(mDisplayListener);
     }
 

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationView.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationView.java
@@ -1,0 +1,64 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.presentation;
+
+import android.os.Build;
+import android.content.Context;
+import android.view.Display;
+import android.view.View;
+
+/**
+ * A helper class to abstract the presentation view for different android build version.
+ *
+ * A PresentationView is a special kind of UI widget whose purpose is to present content
+ * on a secondary display. A PresentationView is associated with the target Display at
+ * creation time and configures its context and resource configuration according to the
+ * display's metrics.
+ */
+public abstract class PresentationView {
+    protected PresentationListener mListener;
+
+    /**
+     * Return an instance of PresentationView according to the build version.
+     */
+    public static PresentationView createInstance(Context context, Display display) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return new PresentationViewJBMR1(context, display);
+        } else {
+            return new PresentationViewNull();
+        }
+    }
+
+    public abstract void show();
+
+    public abstract void dismiss();
+
+    public abstract void cancel();
+
+    public abstract void setContentView(View contentView);
+
+    public abstract Display getDisplay();
+
+    public void setPresentationListener(PresentationListener listener) {
+        mListener = listener;
+    }
+
+    /**
+     * Interface used to allow the creator of a PresentationView to run some code
+     * when it is showed or dismissed.
+     */
+    public interface PresentationListener {
+        /**
+         * Invoked when the presentation view is showed.
+         */
+        public void onShow(PresentationView view);
+
+        /**
+         * Invoked when the presentation view is dismissed.
+         */
+        public void onDismiss(PresentationView view);
+    }
+}
+

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationViewJBMR1.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationViewJBMR1.java
@@ -1,0 +1,74 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.presentation;
+
+import android.app.Presentation;
+import android.os.Build;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.view.Display;
+import android.view.View;
+
+/**
+ * A wrapper class of android.app.Presentation class introduced from API level 17.
+ */
+public class PresentationViewJBMR1 extends PresentationView
+        implements DialogInterface.OnShowListener, DialogInterface.OnDismissListener {
+
+    private Presentation mPresentation;
+
+    public PresentationViewJBMR1(Context context, Display display) {
+        mPresentation = new Presentation(context, display);
+    }
+
+    @Override
+    public void show() {
+        mPresentation.show();
+    }
+
+    @Override
+    public void dismiss() {
+        mPresentation.dismiss();
+    }
+
+    @Override
+    public void cancel() {
+        mPresentation.cancel();
+    }
+
+    @Override
+    public void setContentView(View contentView) {
+        mPresentation.setContentView(contentView);
+    }
+
+    @Override
+    public Display getDisplay() {
+        return mPresentation.getDisplay();
+    }
+
+    @Override
+    public void setPresentationListener(PresentationView.PresentationListener listener) {
+        super.setPresentationListener(listener);
+
+        if (mListener != null) {
+            mPresentation.setOnShowListener(this);
+            mPresentation.setOnDismissListener(this);
+        } else {
+            mPresentation.setOnShowListener(null);
+            mPresentation.setOnDismissListener(null);
+        }
+    }
+
+    @Override
+    public void onShow(DialogInterface dialog) {
+        if (mListener != null) mListener.onShow(this);
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        if (mListener != null) mListener.onDismiss(this);
+    }
+}
+

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationViewNull.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationViewNull.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.presentation;
+
+import android.view.Display;
+import android.view.View;
+
+/**
+ * A empty implementation for build version lower than API level 17.
+ */
+public class PresentationViewNull extends PresentationView {
+
+    public PresentationViewNull() {
+    }
+
+    @Override
+    public void show() {
+    }
+
+    @Override
+    public void dismiss() {
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    @Override
+    public void setContentView(View contentView) {
+    }
+
+    @Override
+    public Display getDisplay() {
+        return null;
+    }
+}
+

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/XWalkPresentationContent.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/XWalkPresentationContent.java
@@ -1,0 +1,102 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.presentation;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.View;
+
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkClient;
+
+/**
+ * Represents the content to be presented on the secondary display.
+ */
+public class XWalkPresentationContent {
+    public final int INVALID_PRESENTATION_ID = -1;
+
+    private int mPresentationId = INVALID_PRESENTATION_ID;
+    private XWalkView mContentView;
+    private Context mContext;
+    private Activity mActivity;
+    private PresentationDelegate mDelegate;
+
+    private final XWalkClient mXWalkClient = new XWalkClient() {
+        @Override
+        public void onPageFinished(XWalkView view, String url) {
+            mPresentationId = mContentView.getContentID();
+            onContentLoaded();
+        }
+
+        @Override
+        public void onCloseWindow(XWalkView view) {
+            // The content was closed already. Web need to invalidate the
+            // presentation id now.
+            mPresentationId = INVALID_PRESENTATION_ID;
+            onContentClosed();
+        }
+    };
+
+    public XWalkPresentationContent(Context context, Activity activity, PresentationDelegate delegate) {
+        mContext = context;
+        mActivity = activity;
+        mDelegate = delegate;
+    }
+
+    public void load(final String url) {
+        if (mContentView == null) {
+            mContentView = new XWalkView(mContext, mActivity);
+            mContentView.setXWalkClient(mXWalkClient);
+        }
+        mContentView.loadUrl(url);
+    }
+
+    public int getPresentationId() {
+        return mPresentationId;
+    }
+
+    public View getContentView() {
+        return mContentView;
+    }
+
+    public void close() {
+        // TODO(hmin): Add code to destroy XWalkView instance.
+        // mContentView.destroy();
+        mPresentationId = INVALID_PRESENTATION_ID;
+        mContentView = null;
+    }
+
+    public void onPause() {
+        mContentView.onPause();
+    }
+
+    public void onResume() {
+        mContentView.onResume();
+    }
+
+    private void onContentLoaded() {
+        if (mDelegate != null) mDelegate.onContentLoaded(this);
+    }
+
+    private void onContentClosed() {
+        if (mDelegate != null) mDelegate.onContentClosed(this);
+    }
+
+    /**
+     * Interface to hook into XWalkPresentationContent instance.
+     */
+    public interface PresentationDelegate {
+        /**
+         * Called when the presentation content is loaded.
+         */
+        public void onContentLoaded(XWalkPresentationContent content);
+
+        /**
+         * Called when the presentation content is closed.
+         */
+        public void onContentClosed(XWalkPresentationContent content);
+    }
+}

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -194,6 +194,11 @@ jboolean XWalkContent::SetManifest(JNIEnv* env,
   return true;
 }
 
+jint XWalkContent::GetRoutingID(JNIEnv* env, jobject obj) {
+  DCHECK(web_contents_.get());
+  return web_contents_->GetRoutingID();
+}
+
 static jint Init(JNIEnv* env, jobject obj, jobject web_contents_delegate,
     jobject contents_client_bridge) {
   XWalkContent* xwalk_core_content =

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -35,6 +35,7 @@ class XWalkContent {
   ScopedJavaLocalRef<jstring> DevToolsAgentId(JNIEnv* env, jobject obj);
   void Destroy(JNIEnv* env, jobject obj);
   ScopedJavaLocalRef<jstring> GetVersion(JNIEnv* env, jobject obj);
+  jint GetRoutingID(JNIEnv* env, jobject obj);
 
   XWalkRenderViewHostExt* render_view_host_ext() {
     return render_view_host_ext_.get();


### PR DESCRIPTION
This patch is to implement navigator.presentation.requestShow for
showing a new HTML page on the secondary display.

IMPLEMENTATION NOTES:
o Web messaging can be used for communication between the opener window
  and presentation window.
o Only one presentation is allowed to be created. If there is already a
  presentation showing, an attempt to call requestShow will fail.
o A presentation will be dismissed in case of:
1. window.close is called to close the presentation DOM window, or
2. The presentation display is disconnected, and there is no available
    display for presentation show any more.
   o The DOM window object for presentation is retrieved from the routing id
   of RenderView. It follows the way chrome.app.window.create does.

TODOS:
o Add `destroy` into XWalkView to destroy an XWalkView instance.
o Add `Promise` support for requestShow API instead of using callback.
o Make it backward-compatible on Android

SPEC=http://otcshare.github.io/presentation-spec/index.html
BUG=https://github.com/crosswalk-project/crosswalk/issues/577
