### PR TITLE
[Android] Add the test case about getVersion.

### DIFF
--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/GetVersionTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/GetVersionTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.test.util.RuntimeClientApiTestBase;
+
+/**
+ * Test suite for getVersion().
+ */
+public class GetVersionTest extends XWalkRuntimeClientTestBase {
+
+    @SmallTest
+    @Feature({"GetVersion"})
+    public void testGetVersion() throws Throwable {
+        RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(
+                        getTestUtil(), this);
+        helper.testGetVersion();
+    }
+}

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/GetVersionTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/GetVersionTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.embedded.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.test.util.RuntimeClientApiTestBase;
+
+/**
+ * Test suite for getVersion().
+ */
+public class GetVersionTest extends XWalkRuntimeClientTestBase {
+
+    @SmallTest
+    @Feature({"GetVersion"})
+    public void testGetVersion() throws Throwable {
+        RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(
+                        getTestUtil(), this);
+        helper.testGetVersion();
+    }
+}

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
@@ -17,6 +17,8 @@ import java.lang.Process;
 import java.lang.Runtime;
 import java.lang.StringBuffer;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -242,6 +244,15 @@ public class RuntimeClientApiTestBase<T extends Activity> {
         mTestUtil.loadUrlSync(mUrl);
         int index = getSocketNameIndex();
         mTestCase.assertTrue (index < 0);
+    }
+
+    // For getVersion.
+    public void testGetVersion() throws Throwable {
+        String version = mTestUtil.getTestedView().getVersion();
+
+        Pattern pattern = Pattern.compile("\\d+\\.\\d+\\.\\d+\\.\\d+");
+        Matcher matcher = pattern.matcher(version);
+        mTestCase.assertTrue("The version is invalid.", matcher.find());
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)


### PR DESCRIPTION
This patch contains the test about getVersion in shared and
embedded mode.
Get the version, confirm it's validity by regular expression.

For embedded client test:
1. install XWalkRuntimeClientEmbeddedShell.apk
2. python build/android/test_runner.py instrumentation \
--test-apk=XWalkRuntimeClientEmbeddedTest -v -f testGetVersion

For shared client test:
1. install XWalkRuntimeLib.apk
2. install XWalkRuntimeClientShell.apk
3. python build/android/test_runner.py instrumentation \
--test-apk=XWalkRuntimeClientTest -v -f testGetVersion
