### PR TITLE
[Android] Add the test cases about onActivityResult.

### DIFF
--- a/app/android/runtime_client_embedded_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_embedded_shell/AndroidManifest.xml
@@ -20,6 +20,9 @@
             <category android:name="android.intent.category.LAUNCHER" />
           </intent-filter>
         </activity>
+        <activity android:name="org.xwalk.test.util.SecondActivity"
+            android:label="SecondActivity">
+        </activity>
         <activity android:name="org.xwalk.runtime.client.embedded.test.XWalkRuntimeClientTestRunnerActivity"
             android:label="XWalkRuntimeClientTestRunnerActivity">
           <intent-filter>

--- a/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestRunnerActivity.java
+++ b/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestRunnerActivity.java
@@ -15,13 +15,18 @@ import android.view.ViewGroup.LayoutParams;
 import android.widget.LinearLayout;
 
 import org.xwalk.app.runtime.XWalkRuntimeClient;
+import org.xwalk.test.util.XWalkRuntimeClientRunnerActivity;
 
 /*
  * This is a lightweight activity for tests that only require XWalk functionality.
  */
-public class XWalkRuntimeClientTestRunnerActivity extends Activity {
+public class XWalkRuntimeClientTestRunnerActivity
+        extends XWalkRuntimeClientRunnerActivity {
     private LinearLayout mLinearLayout;
     private BroadcastReceiver mReceiver;
+    private int mRequestCode;
+    private int mResultCode;
+    private Intent mIntent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -71,6 +76,33 @@ public class XWalkRuntimeClientTestRunnerActivity extends Activity {
             }
         };
         registerReceiver(mReceiver, intentFilter);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        mRequestCode = requestCode;
+        mResultCode = resultCode;
+        mIntent = data;
+    }
+
+    @Override
+    public LinearLayout getLinearLayout() {
+        return mLinearLayout;
+    }
+
+    @Override
+    public Intent getSecondIntent() {
+        return mIntent;
+    }
+
+    @Override
+    public int getResultCode() {
+        return mResultCode;
+    }
+
+    @Override
+    public int getRequestCode() {
+        return mRequestCode;
     }
 
     @Override

--- a/app/android/runtime_client_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_shell/AndroidManifest.xml
@@ -20,6 +20,9 @@
             <category android:name="android.intent.category.LAUNCHER" />
           </intent-filter>
         </activity>
+        <activity android:name="org.xwalk.test.util.SecondActivity"
+            android:label="SecondActivity">
+        </activity>
         <activity android:name="org.xwalk.runtime.client.test.XWalkRuntimeClientTestRunnerActivity"
             android:label="XWalkRuntimeClientTestRunnerActivity">
           <intent-filter>

--- a/app/android/runtime_client_shell/src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestRunnerActivity.java
+++ b/app/android/runtime_client_shell/src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestRunnerActivity.java
@@ -15,13 +15,18 @@ import android.view.ViewGroup.LayoutParams;
 import android.widget.LinearLayout;
 
 import org.xwalk.app.runtime.XWalkRuntimeClient;
+import org.xwalk.test.util.XWalkRuntimeClientRunnerActivity;
 
 /*
  * This is a lightweight activity for tests that only require XWalk functionality.
  */
-public class XWalkRuntimeClientTestRunnerActivity extends Activity {
+public class XWalkRuntimeClientTestRunnerActivity
+        extends XWalkRuntimeClientRunnerActivity {
     private LinearLayout mLinearLayout;
     private BroadcastReceiver mReceiver;
+    private int mRequestCode;
+    private int mResultCode;
+    private Intent mIntent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -71,6 +76,33 @@ public class XWalkRuntimeClientTestRunnerActivity extends Activity {
             }
         };
         registerReceiver(mReceiver, intentFilter);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        mRequestCode = requestCode;
+        mResultCode = resultCode;
+        mIntent = data;
+    }
+
+    @Override
+    public LinearLayout getLinearLayout() {
+        return mLinearLayout;
+    }
+
+    @Override
+    public Intent getSecondIntent() {
+        return mIntent;
+    }
+
+    @Override
+    public int getResultCode() {
+        return mResultCode;
+    }
+
+    @Override
+    public int getRequestCode() {
+        return mRequestCode;
     }
 
     @Override

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/OnActivityResultTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/OnActivityResultTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.test;
+
+import android.content.Context;
+import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.test.util.RuntimeClientApiTestBase;
+
+/**
+ * Test suite for onActivityResult().
+ */
+public class OnActivityResultTest extends XWalkRuntimeClientTestBase {
+
+    @SmallTest
+    @Feature({"OnActivityResult"})
+    public void testOnActivityResult() throws Throwable {
+        RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(
+                        getTestUtil(), this);
+        XWalkRuntimeClientTestRunnerActivity clientActivity = getActivity();
+        Context context = getActivity();
+
+        helper.testOnActivityResult(clientActivity, context);
+    }
+}

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/OnActivityResultTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/OnActivityResultTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.embedded.test;
+
+import android.content.Context;
+import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.test.util.RuntimeClientApiTestBase;
+
+/**
+ * Test suite for onActivityResult().
+ */
+public class OnActivityResultTest extends XWalkRuntimeClientTestBase {
+
+    @SmallTest
+    @Feature({"OnActivityResult"})
+    public void testOnActivityResult() throws Throwable {
+        RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(
+                        getTestUtil(), this);
+        XWalkRuntimeClientTestRunnerActivity clientActivity = getActivity();
+        Context context = getActivity();
+
+        helper.testOnActivityResult(clientActivity, context);
+    }
+}

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
@@ -7,10 +7,15 @@ package org.xwalk.test.util;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.Instrumentation;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import android.os.Bundle;
 import android.test.ActivityInstrumentationTestCase2;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
 
 import java.io.IOException;
 import java.lang.Process;
@@ -137,6 +142,29 @@ public class RuntimeClientApiTestBase<T extends Activity> {
         }
     }
 
+    public void createButtonAndClick(final Context context, final XWalkRuntimeClientRunnerActivity activity,
+            final LinearLayout linearLayout) {
+        mTestCase.getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                Button button = new Button(context);
+                button.setText("button");
+                linearLayout.addView(button);
+
+                button.setOnClickListener(new Button.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        Intent newIntent = new Intent(activity, SecondActivity.class);
+                        newIntent.putExtra("From", activity.getClass());
+                        activity.startActivityForResult(newIntent, 2);
+                    }
+                });
+
+                button.performClick();
+            }
+        });
+    }
+
     // For loadAppFromUrl.
     public void testLoadAppFromUrl() throws Throwable {
         final String expectedTitle = "Crosswalk Sample Application";
@@ -253,6 +281,42 @@ public class RuntimeClientApiTestBase<T extends Activity> {
         Pattern pattern = Pattern.compile("\\d+\\.\\d+\\.\\d+\\.\\d+");
         Matcher matcher = pattern.matcher(version);
         mTestCase.assertTrue("The version is invalid.", matcher.find());
+    }
+
+    // For onActivityResult.
+    public void testOnActivityResult(final XWalkRuntimeClientRunnerActivity activity,
+            Context context) throws Throwable {
+        Bundle buddle = null;
+        String extra = null;
+        LinearLayout linearLayout = activity.getLinearLayout();
+        Instrumentation.ActivityMonitor activityMonitor =
+                mTestUtil.getInstrumentation().addMonitor(SecondActivity.class.getName(), null, false);
+
+        createButtonAndClick(context, activity, linearLayout);
+
+        mTestUtil.getInstrumentation().waitForIdleSync();
+        final SecondActivity secondActivity = (SecondActivity)mTestUtil.getInstrumentation(
+                ).waitForMonitorWithTimeout(activityMonitor, mTestUtil.WAIT_TIMEOUT_SECONDS);
+        secondActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                secondActivity.clickButton();
+            }
+        });
+        mTestUtil.getInstrumentation().waitForIdleSync();
+
+        Intent intent = activity.getSecondIntent();
+        int requestCode = activity.getRequestCode();
+        int resultCode = activity.getResultCode();
+        if (intent != null) {
+            buddle = intent.getExtras();
+        }
+
+        if (buddle != null) {
+            extra = buddle.getString("From");
+        }
+        mTestUtil.getTestedView().onActivityResult(requestCode, resultCode, intent);
+        mTestCase.assertEquals(extra, secondActivity.getExtraData());
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/SecondActivity.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/SecondActivity.java
@@ -1,0 +1,56 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.test.util;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+import android.widget.RelativeLayout;
+
+public class SecondActivity extends Activity
+{
+    private Button mButton = null;
+    private String mExtra = "Second";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+
+        RelativeLayout layout = new RelativeLayout(this);
+        mButton = new Button(this);
+        mButton.setText("Cbutton");
+        layout.addView(mButton);
+        setContentView(layout);
+
+        Intent intent = getIntent();
+        final Class className = (Class)intent.getSerializableExtra("From");
+        try {
+            mButton.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v)
+                {
+                    Intent intent = new Intent(SecondActivity.this, className);
+                    intent.putExtra("From", mExtra);
+                    setResult(RESULT_OK, intent);
+                    finish();
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void clickButton() {
+        mButton.performClick();
+    }
+
+    public String getExtraData() {
+        return mExtra;
+    }
+}

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientRunnerActivity.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientRunnerActivity.java
@@ -1,0 +1,35 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.test.util;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.LinearLayout;
+
+public class XWalkRuntimeClientRunnerActivity extends Activity
+{
+    @Override
+    protected void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+    }
+
+    public LinearLayout getLinearLayout() {
+        return null;
+    }
+
+    public Intent getSecondIntent() {
+        return null;
+    }
+
+    public  int getResultCode() {
+        return -1;
+    }
+
+    public int getRequestCode() {
+        return -1;
+    }
+}


### PR DESCRIPTION
This patch contains the test case about onActivityResult in shared
and embedded mode.
Create a activity names "SecondActivity". In the runtime client activity,
it starts activity for result. In the second activity, it will create a new
intent, and transfer data to runtime client activity.

For embedded client test:
1. install XWalkRuntimeClientEmbeddedShell.apk
2. python build/android/test_runner.py instrumentation \
--test-apk=XWalkRuntimeClientEmbeddedTest -v -f testOnActivityResult

For shared client test:
1. install XWalkRuntimeLib.apk
2. install XWalkRuntimeClientShell.apk
3. python build/android/test_runner.py instrumentation \
--test-apk=XWalkRuntimeClientTest -v -f testOnActivityResult
