### PR TITLE
[Tizen] Enable pinch.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -120,6 +120,7 @@ export GYP_GENERATORS='make'
 -Duse_system_libxml=1 \
 -Duse_system_nspr=1 \
 -Denable_xi21_mt=1 \
+-Duse_xi2_mt=0 \
 -Dtizen_mobile=1 \
 -Duse_openssl=1
 


### PR DESCRIPTION
After rebasing 31.0.1650.12, use_xi2_mt is set to 2 by default. However, we use
XInput2.1 on Tizen 2.1, so we can not use use_xi2_mt that is for XInput2.2.

enable_xi21_mt that is introduced by Hongbo Min is exclusive to use_xi2_mt.

BUG=https://crosswalk-project.org/jira/browse/XWALK-58
