### PR TITLE
[Tizen][Temp] Enforce device scale factor value to '2.0' on Tizen

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -50,6 +50,7 @@
 
 #if defined(OS_TIZEN_MOBILE)
 #include "content/browser/device_orientation/device_inertial_sensor_service.h"
+#include "ui/gfx/switches.h"
 #include "xwalk/application/browser/installer/tizen/package_installer.h"
 #include "xwalk/runtime/browser/tizen/tizen_data_fetcher_shared_memory.h"
 #endif  // defined(OS_TIZEN_MOBILE)
@@ -115,6 +116,9 @@ void SetXWalkCommandLineFlags() {
   else
     gl_name = gfx::kGLImplementationEGLName;
   command_line->AppendSwitchASCII(switches::kUseGL, gl_name);
+  // Workaround to provide viewport meta tag proper behavior on Tizen.
+  // FIXME: Must be removed when https://codereview.chromium.org/27156003/ is landed.
+  command_line->AppendSwitchASCII(switches::kForceDeviceScaleFactor, "2.0");
 #endif
 
   // Always use fixed layout and viewport tag.


### PR DESCRIPTION
Enforce device scale factor value to '2.0' on Tizen so that viewport meta tag works properly on Tizen devices.
This is a workaround until Aura Linux HIDPI support is in place: https://codereview.chromium.org/27156003/.
