### PR TITLE
[Android] Make devtools server be singleton in application wide

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -199,7 +199,7 @@ public class XWalkView extends FrameLayout {
         // to identify a debugging page
         final String socketName = getContext().getApplicationContext().getPackageName() + "_devtools_remote";
         if (mDevToolsServer == null) {
-            mDevToolsServer = new XWalkDevToolsServer(socketName);
+            mDevToolsServer = XWalkDevToolsServer.getInstance(socketName);
             mDevToolsServer.setRemoteDebuggingEnabled(true);
         }
         // devtools/page is hardcoded in devtools_http_handler_impl.cc (kPageUrlPrefix)
@@ -212,7 +212,6 @@ public class XWalkView extends FrameLayout {
         if (mDevToolsServer.isRemoteDebuggingEnabled()) {
             mDevToolsServer.setRemoteDebuggingEnabled(false);
         }
-        mDevToolsServer.destroy();
         mDevToolsServer = null;
     }
 


### PR DESCRIPTION
Currently each XWalkView instance will create a XWalkDevToolsServer
instance, it doesn't make sense if considering multiple XWalkView instances
in one application. It'd better to share one devtools server for remote
debugging to avoid unncessary native resource allocation.

This patch is to make XWalkDevToolsServer be singleton and add reference
count to it for native object release.

BUG=https://crosswalk-project.org/jira/browse/XWALK-105
