### PR TITLE
[Android] Handle clearCache message in renderer

### DIFF
--- a/runtime/renderer/android/xwalk_render_process_observer.cc
+++ b/runtime/renderer/android/xwalk_render_process_observer.cc
@@ -23,6 +23,7 @@ bool XWalkRenderProcessObserver::OnControlMessageReceived(
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(XWalkRenderProcessObserver, message)
     IPC_MESSAGE_HANDLER(XWalkViewMsg_SetJsOnlineProperty, OnSetJsOnlineProperty)
+    IPC_MESSAGE_HANDLER(XWalkViewMsg_ClearCache, OnClearCache);
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
   return handled;
@@ -35,6 +36,11 @@ void XWalkRenderProcessObserver::WebKitInitialized() {
 void XWalkRenderProcessObserver::OnSetJsOnlineProperty(bool network_up) {
   if (webkit_initialized_)
     WebKit::WebNetworkStateNotifier::setOnLine(network_up);
+}
+
+void XWalkRenderProcessObserver::OnClearCache() {
+  if (webkit_initialized_)
+    WebKit::WebCache::clear();
 }
 
 }  // namespace xwalk

--- a/runtime/renderer/android/xwalk_render_process_observer.h
+++ b/runtime/renderer/android/xwalk_render_process_observer.h
@@ -24,6 +24,7 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
 
  private:
   void OnSetJsOnlineProperty(bool network_up);
+  void OnClearCache();
 
   bool webkit_initialized_;
 };


### PR DESCRIPTION
This fix is to handle XWalkViewMsg_ClearCache IPC message to clear
cache.

BUG=https://github.com/crosswalk-project/crosswalk/issues/996
