### PR TITLE
[Tizen] enable incremental build for trybot

### DIFF
--- a/packaging/README
+++ b/packaging/README
@@ -70,3 +70,29 @@ In order to build an RPM package, one is currently expected to:
 
  5. Run gbs as usual.
     $ gbs build -A i586
+
+Since the normal 'gbs build' is not an incremental build and usually takes a
+couple of hours, it's not acceptable for developer or trybot. The 'incremental_*'
+family scripts can be used to address this requirement. Simply put, it's
+achieved by cheating 'gbs' to work directly in the src tree on hosted system.
+Typically one just needs to:
+
+ 1. Tell script the location of XWALK_PREFIX and gbs root on hosted system.
+    By default they are '../../../' relative to this script, and '~/GBS-ROOT'.
+    If either location is changed afterwards, please re-do this.
+
+    $./incremental_setup.sh /root/of/xwalk/tree ~/GBS-ROOT
+
+    Again, '/root/of/xwalk/tree' here is the top-level directory of the tree
+    which _contains_ the src/ directory.
+
+ 2. Build incrementally whenever change is made under '/root/of/xwalk/tree'.
+
+    $./incremental_build.sh
+
+    Once succeeds, the rpm packages will be generated as usual except that the
+    src rpm package doesn't have the intact source files.
+
+ 3. Clean up if don't want to use it anymore
+
+    $./incremental_teardown.sh

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -84,6 +84,10 @@ This package contains additional support files that are needed for running Cross
 %prep
 %setup -q
 
+%if 0%{?INCREMENTAL:1}
+cp %{SOURCE1001} .
+cd %{INCREMENTAL}
+%endif
 cp %{SOURCE1001} .
 cp %{SOURCE1002} .
 cp %{SOURCE1003} .
@@ -95,12 +99,25 @@ cp -a src/LICENSE LICENSE.chromium
 cp -a src/xwalk/AUTHORS AUTHORS.xwalk
 cp -a src/xwalk/LICENSE LICENSE.xwalk
 
+# Guard against re-patching the patches that WILL be reverted by 'gclient sync'
+if patch -p0  -N --dry-run --silent <%{PATCH1}
+then
 %patch1
 %patch2
 %patch3
+fi
+
+# Guard against re-patching the patches that WON'T be reverted by 'gclient sync'
+if patch -p0  -N --dry-run --silent <%{PATCH4}
+then
 %patch4
+fi
 
 %build
+
+%if 0%{?INCREMENTAL:1}
+cd %{INCREMENTAL}
+%endif
 
 # For ffmpeg on ia32. The original CFLAGS set by the gyp and config files in
 # src/third_party/ffmpeg already pass -O2 -fomit-frame-pointer, but Tizen's
@@ -129,6 +146,10 @@ export GYP_GENERATORS='make'
 make %{?_smp_mflags} -C src BUILDTYPE=Release xwalk
 
 %install
+%if 0%{?INCREMENTAL:1}
+cd %{INCREMENTAL}
+%endif
+
 # Binaries.
 install -p -D %{SOURCE1} %{buildroot}%{_bindir}/xwalk
 install -p -D src/out/Release/xwalk %{buildroot}%{_libdir}/xwalk/xwalk

--- a/packaging/incremental-build.sh
+++ b/packaging/incremental-build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+conf_file=$(cd "$(dirname "$0")"; pwd)/../../../.incremental.conf
+
+if [ ! -f $conf_file ]
+then
+  echo "please run incremental-setup.sh first"
+  exit
+fi
+
+while read line;
+do
+  name=$(echo $line | awk -F '=' '{print $1}')
+  value=$(echo $line | awk -F '=' '{print $2}')
+  echo "$name $value"
+  case $name in
+    "chromium")
+      src_in_host=$value
+    ;;
+    "gbs-root")
+      gbs_root=$value
+    ;;
+    *)
+      echo "invalid setup"
+    ;;
+esac
+done < $conf_file
+
+#build
+cd $src_in_host/src/xwalk
+gbs build --debug --overwrite -B $gbs_root -A i586 --define "INCREMENTAL /incremental"
+cd -

--- a/packaging/incremental-setup.sh
+++ b/packaging/incremental-setup.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+echo "Usage: $0 chromium-crosswalk(the dir containing 'src') gbs-build-root(e.g. ~/GBS-ROOT/)"
+echo "Example 1: $0"
+echo "           -- use default arguments: chromium-crosswalk='../../../', gbs-build-root='~/GBS-ROOT/'"
+echo "Example 2: $0 gbs-build-root"
+echo "           -- use default argument: chromium-crosswalk='../../../'"
+echo "Example 3: $0 chromium-crosswalk gbs-build-root"
+
+if [ $(id -u) -ne 0 ]
+then
+  echo "Please re-run $0 as root."
+  exit
+fi
+
+src_in_host="../../../"
+gbs_root="$HOME/GBS-ROOT/"
+conf_file=$(cd "$(dirname "$0")"; pwd)/../../../.incremental.conf
+if [ -f $conf_file ]
+then
+  echo "Please clean the last setup first!"
+  exit
+fi
+
+if [ $# -ge 3 ]
+then
+  echo "Invalid arguments!"
+  exit
+elif [ $# -eq 2 ]
+then
+  src_in_host=$1
+  gbs_root=$2
+elif [ $# -eq 1 ]
+then
+  gbs_root=$1
+fi
+
+if [ -d $src_in_host ]
+then
+  cd $src_in_host
+  src_in_host=$(pwd)
+  cd -
+else
+  echo "invalid path [$src_in_host]!"
+  exit
+fi
+
+if [ ! -d "$src_in_host/src/" ]
+then
+  echo "no 'src' in '$src_in_host'"
+  exit
+fi
+
+if [ -d $gbs_root ]; then
+  cd $gbs_root
+  gbs_root="$(pwd)"
+  src_in_chroot="$(pwd)/local/BUILD-ROOTS/scratch.i586.0/incremental"
+  cd -
+else
+  echo "[$gbs_root] isn't a ready gbs chroot, typically it can be created with the below command:"
+  echo "gbs build -B $gbs_root -A i586"
+  echo "Once it's completed, please re-run this script!"
+  exit
+fi
+
+# bypass the mount-fs checking of gbs tool
+patched=$(grep "#mount_source_check" /usr/bin/depanneur)
+if [ -z "$patched" ]
+then
+  sed -i 's/mount_source_check("$scratch_dir.$i");/#mount_source_check("$scratch_dir.$i");/g' /usr/bin/depanneur
+fi
+
+# umount 'src_in_chroot' in fear that gbs will delete it while initializing the
+# build root.
+patched=$(grep "BUILD_ROOT/incremental" /usr/lib/build/init_buildsystem 2>/dev/null)
+if [ -z "$patched" ]
+then
+  sed -i "128 i\            umount \"\$BUILD_ROOT/incremental\" 2> /dev/null || true" /usr/lib/build/init_buildsystem
+fi
+
+# mount the chromium-crosswalk from host to chroot system
+if [ -d $src_in_chroot ]
+then
+  echo "setup failed -- [$src_in_chroot]:Already used in chroot!"
+  exit
+else
+  mkdir -p $src_in_chroot
+  chmod 777 $src_in_chroot
+  mkdir $src_in_chroot/src
+  chmod 777 $src_in_chroot/src
+  mount --bind $src_in_host/src/ $src_in_chroot/src/
+fi
+
+echo "chromium=$src_in_host" > $conf_file
+echo "gbs-root=$gbs_root" >> $conf_file
+chmod 666 $conf_file
+
+echo "setup completed"

--- a/packaging/incremental-teardown.sh
+++ b/packaging/incremental-teardown.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+conf_file=$(cd "$(dirname "$0")"; pwd)/../../../.incremental.conf
+
+if [ $(id -u) -ne 0 ]
+then
+  echo "Please re-run $0 as root."
+  exit
+fi
+
+if [ ! -f $conf_file ]
+then
+  echo "please run incremental-setup.sh first"
+  exit
+fi
+
+while read line;
+do
+  name=$(echo $line | awk -F '=' '{print $1}')
+  value=$(echo $line | awk -F '=' '{print $2}')
+  case $name in
+    "gbs-root")
+      src_in_chroot="$value/local/BUILD-ROOTS/scratch.i586.0/incremental/"
+    ;;
+    *)
+    ;;
+esac
+done < $conf_file
+
+#umount
+umount $src_in_chroot/src/
+rm -rf $src_in_chroot
+rm $conf_file


### PR DESCRIPTION
Since GBS doesn't support incremental build, it takes about 2 hours for every
build, which is not acceptable for trybot. This commit changed the spec file
to skip its source code clean and prepare steps, and instead work directly on
the original xwalk src tree in host system other than chroot system. Thus the
build is greatly speeded up. The major side effect is that the generated souce
rpm package is not intact. For trybot build it's not a big deal. This chanage
is guarded by a parameter passed from GBS command line, so the normal release
build works as usual with no impact.
