### PR TITLE
[Tizen][Runtime Model] Fix installer crash if icon is missing from manifest.

### DIFF
--- a/application/browser/installer/tizen/package_installer.cc
+++ b/application/browser/installer/tizen/package_installer.cc
@@ -71,10 +71,8 @@ bool PackageInstaller::Init() {
       std::remove_if(stripped_name_.begin(), stripped_name_.end(), ::isspace),
       stripped_name_.end());
 
-  if (!application_->GetManifest()->GetString(info::kIconKey, &icon_name_)) {
-    LOG(ERROR) << "Fail to get application icon name";
-    return false;
-  }
+  if (!application_->GetManifest()->GetString(info::kIconKey, &icon_name_))
+    LOG(WARNING) << "Fail to get application icon name.";
 
   icon_path_ = base::FilePath(info::kIconDir).AppendASCII(
       package_id_ + info::kSeparator + stripped_name_ +
@@ -125,9 +123,8 @@ bool PackageInstaller::GeneratePkgInfoXml() {
 
 bool PackageInstaller::CopyOrLinkResources() {
   base::FilePath icon = app_dir_.AppendASCII(icon_name_);
-  if (!base::PathExists(icon) ||
-      !base::CopyFile(icon, icon_path_))
-    return false;
+  if (!icon_name_.empty() && base::PathExists(icon))
+    base::CopyFile(icon, icon_path_);
 
   base::FilePath xwalk_path(info::kXwalkPath);
   base::FilePath dir_exec(execute_path_.DirName());

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -321,7 +321,7 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
         scoped_refptr<xwalk::application::PackageInstaller> installer =
             xwalk::application::PackageInstaller::Create(service, id,
                 runtime_context_->GetPath());
-        if (!installer->Uninstall()) {
+        if (!installer || !installer->Uninstall()) {
           LOG(ERROR) << "[ERR] An error occurred during uninstalling on Tizen.";
           return;
         }
@@ -349,7 +349,7 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
           scoped_refptr<xwalk::application::PackageInstaller> installer =
               xwalk::application::PackageInstaller::Create(service, id,
                   runtime_context_->GetPath());
-          if (!installer->Install()) {
+          if (!installer || !installer->Install()) {
             LOG(ERROR) << "[ERR] An error occurred during installing on Tizen.";
             return;
           }


### PR DESCRIPTION
Installation crashes if the icon field is missing from manifest.json.
However, this behavior is not correct.

The installation should not crash even though no icon is provideded.

BUG=https://crosswalk-project.org/jira/browse/XWALK-110
