### PR TITLE
[Extensions] Use ContainsKey() from base/stl_util.h

### DIFF
--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -149,7 +149,7 @@ bool XWalkExtensionServer::RegisterExtension(
     return false;
   }
 
-  if (extension_symbols_.find(extension->name()) != extension_symbols_.end()) {
+  if (ContainsKey(extension_symbols_, extension->name())) {
     LOG(WARNING) << "Ignoring extension with name already registered: "
                  << extension->name();
     return false;
@@ -246,7 +246,7 @@ bool XWalkExtensionServer::ValidateExtensionEntryPoints(
     if (!ValidateExtensionIdentifier(entry_point))
       return false;
 
-    if (extension_symbols_.find(entry_point) != extension_symbols_.end()) {
+    if (ContainsKey(extension_symbols_, entry_point)) {
       LOG(WARNING) << "Entry point '" << entry_point
                    << "' clashes with another extension entry point.";
       return false;

--- a/extensions/common/xwalk_external_adapter.cc
+++ b/extensions/common/xwalk_external_adapter.cc
@@ -5,6 +5,7 @@
 #include "xwalk/extensions/common/xwalk_external_adapter.h"
 
 #include "base/logging.h"
+#include "base/stl_util.h"
 
 namespace xwalk {
 namespace extensions {
@@ -31,7 +32,7 @@ void XWalkExternalAdapter::RegisterExtension(
     XWalkExternalExtension* extension) {
   XW_Extension xw_extension = extension->xw_extension_;
   CHECK(IsValidXWExtension(xw_extension));
-  CHECK(extension_map_.find(xw_extension) == extension_map_.end());
+  CHECK(!ContainsKey(extension_map_, xw_extension));
   extension_map_[xw_extension] = extension;
 }
 
@@ -39,21 +40,21 @@ void XWalkExternalAdapter::UnregisterExtension(
     XWalkExternalExtension* extension) {
   XW_Extension xw_extension = extension->xw_extension_;
   CHECK(IsValidXWExtension(xw_extension));
-  CHECK(extension_map_.find(xw_extension) != extension_map_.end());
+  CHECK(ContainsKey(extension_map_, xw_extension));
   extension_map_.erase(xw_extension);
 }
 
 void XWalkExternalAdapter::RegisterInstance(XWalkExternalInstance* context) {
   XW_Instance xw_instance = context->xw_instance_;
   CHECK(IsValidXWInstance(xw_instance));
-  CHECK(instance_map_.find(xw_instance) == instance_map_.end());
+  CHECK(!ContainsKey(instance_map_, xw_instance));
   instance_map_[xw_instance] = context;
 }
 
 void XWalkExternalAdapter::UnregisterInstance(XWalkExternalInstance* context) {
   XW_Instance xw_instance = context->xw_instance_;
   CHECK(IsValidXWInstance(xw_instance));
-  CHECK(instance_map_.find(xw_instance) != instance_map_.end());
+  CHECK(ContainsKey(instance_map_, xw_instance));
   instance_map_.erase(xw_instance);
 }
 

--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -143,7 +143,7 @@ void XWalkModuleSystem::RegisterExtensionModule(
 
 void XWalkModuleSystem::RegisterNativeModule(
     const std::string& name, scoped_ptr<XWalkNativeModule> module) {
-  CHECK(native_modules_.find(name) == native_modules_.end());
+  CHECK(!ContainsKey(native_modules_, name));
   native_modules_[name] = module.release();
 }
 


### PR DESCRIPTION
Containskey() is exactly what this code needed. We keep using
find() (and the comparison to end()) when we will later make use of the
iterator.
