### PR TITLE
[Tizen] Revert "[Tizen] Enforce device scale factor value to '2.0' on Tizen"

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -50,7 +50,6 @@
 
 #if defined(OS_TIZEN_MOBILE)
 #include "content/browser/device_orientation/device_inertial_sensor_service.h"
-#include "ui/gfx/switches.h"
 #include "xwalk/application/browser/installer/tizen/package_installer.h"
 #include "xwalk/runtime/browser/tizen/tizen_data_fetcher_shared_memory.h"
 #include "xwalk/sysapps/device_capabilities/device_capabilities_extension.h"
@@ -117,9 +116,6 @@ void SetXWalkCommandLineFlags() {
   else
     gl_name = gfx::kGLImplementationEGLName;
   command_line->AppendSwitchASCII(switches::kUseGL, gl_name);
-  // Workaround to provide viewport meta tag proper behavior on Tizen.
-  // FIXME: Must be removed when https://codereview.chromium.org/27156003/ is landed.
-  command_line->AppendSwitchASCII(switches::kForceDeviceScaleFactor, "2.0");
 #endif
 
   // Always use fixed layout and viewport tag.


### PR DESCRIPTION
This reverts commit c79b41fde47fe0a6da116c9d4f0c2e9ad5410e15.

As Aura scales all the contents including UI elements, this change affected status bar appearance. The status bar should handle HIDPI properly before we can enable it again on Tizen.
