### PR TITLE
[UI] Clean NativeAppWindowViews

### DIFF
--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -4,31 +4,18 @@
 
 #include "xwalk/runtime/browser/ui/native_app_window_views.h"
 
-#include "xwalk/runtime/common/xwalk_notification_types.h"
 #include "content/public/browser/notification_service.h"
-#include "content/public/browser/render_view_host.h"
-#include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/web_contents.h"
-#include "content/public/browser/web_contents_view.h"
-#include "third_party/skia/include/core/SkPaint.h"
-#include "ui/views/controls/webview/webview.h"
-#include "ui/views/view.h"
-#include "ui/views/views_delegate.h"
-#include "ui/views/widget/widget.h"
-#include "ui/views/window/native_frame_view.h"
-#include "xwalk/runtime/browser/ui/top_view_layout_views.h"
-
-#if defined(USE_AURA)
-#include "ui/aura/env.h"
-#include "ui/aura/root_window.h"
-#include "ui/aura/window.h"
 #include "ui/gfx/screen.h"
+#include "ui/views/controls/webview/webview.h"
 #include "ui/views/widget/desktop_aura/desktop_screen.h"
+#include "ui/views/widget/widget.h"
+#include "xwalk/runtime/browser/ui/top_view_layout_views.h"
 #include "xwalk/runtime/browser/ui/xwalk_views_delegate.h"
-#endif
+#include "xwalk/runtime/common/xwalk_notification_types.h"
 
-#if defined(OS_WIN) && !defined(USE_AURA)
-#include "ui/gfx/icon_util.h"
+#if defined(OS_WIN)
+#include "ui/views/window/native_frame_view.h"
 #endif
 
 #if defined(OS_TIZEN_MOBILE)
@@ -305,12 +292,10 @@ NativeAppWindow* NativeAppWindow::Create(
 
 // static
 void NativeAppWindow::Initialize() {
-#if defined(USE_AURA)
   CHECK(!views::ViewsDelegate::views_delegate);
   gfx::Screen::SetScreenInstance(
       gfx::SCREEN_TYPE_NATIVE, views::CreateDesktopScreen());
   views::ViewsDelegate::views_delegate = new XWalkViewsDelegate();
-#endif
 }
 
 }  // namespace xwalk

--- a/runtime/browser/ui/native_app_window_views.h
+++ b/runtime/browser/ui/native_app_window_views.h
@@ -19,7 +19,6 @@
 
 namespace views {
 class WebView;
-class Widget;
 }
 
 namespace xwalk {


### PR DESCRIPTION
Remove unnecessary forward declarations, includes and ifdefs. Now that
Windows is using Aura, all the platforms using Views system (Win, Linux
and Tizen) are using Aura, so no more ifdef guards for USE_AURA.
