### PR TITLE
[Tizen] add the 'gst-plugins-atomisp-devel' buildrequires to spec.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -22,6 +22,7 @@ BuildRequires:  bzip2-devel
 BuildRequires:  expat-devel
 BuildRequires:  flex
 BuildRequires:  gperf
+BuildRequires:  gst-plugins-atomisp-devel
 BuildRequires:  libasound-devel
 BuildRequires:  pkgmgr-info-parser-devel
 BuildRequires:  python


### PR DESCRIPTION
chromium needs the header and lib files exported from this package to drive the
camera device on Tizen 2.1 hardware platforms.

BUG=https://crosswalk-project.org/jira/browse/XWALK-50
