### PR TITLE
[Android][Extensions] Modify error message to comply with W3C spec

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilities.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilities.java
@@ -80,8 +80,10 @@ public class DeviceCapabilities extends XWalkExtension {
 
     protected JSONObject setErrorMessage(String error) {
         JSONObject out = new JSONObject();
+        JSONObject errorMessage = new JSONObject();
         try {
-            out.put("error", error);
+            errorMessage.put("message", error);
+            out.put("error", errorMessage);
         } catch (JSONException e) {
             Log.e(TAG, e.toString());
         }

--- a/test/android/data/device_capabilities.html
+++ b/test/android/data/device_capabilities.html
@@ -20,7 +20,7 @@
   <script>
     var Error = function(error) {
       document.title = "Fail";
-      console.log(error);
+      console.log(error.message);
     }
 
     function enumerateAllProps(obj) {


### PR DESCRIPTION
The spec ( http://www.w3.org/2012/sysapps/device-capabilities/ )  require an error message like:

``` javascript
function(error) { console.log("error occurred: " + error.message); });
```

while the current is:

``` javascript
function(error) { console.log("error occurred: " + error); });
```

The patch fix the little issue.
