### PR TITLE
[Android] Handle external protocol correctly

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -54,6 +54,8 @@ public class XWalkContentsClientBridge extends XWalkContentsClient
             final String url = navigationParams.url;
             boolean ignoreNavigation = false;
 
+            if (shouldOverrideUrlLoading(url)) return true;
+
             if (mNavigationHandler != null) {
                 ignoreNavigation = mNavigationHandler.handleNavigation(navigationParams);
             }

--- a/runtime/browser/runtime_resource_dispatcher_host_delegate.cc
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate.cc
@@ -77,4 +77,19 @@ void RuntimeResourceDispatcherHostDelegate::DownloadStarting(
 #endif
 }
 
+bool RuntimeResourceDispatcherHostDelegate::HandleExternalProtocol(
+    const GURL& url,
+    int child_id,
+    int route_id) {
+#if defined(OS_ANDROID)
+  // On Android, there are many Uris need to be handled differently.
+  // e.g: sms:, tel:, mailto: and etc.
+  // So here return false to let embedders to decide which protocol
+  // to be handled.
+  return false;
+#else
+  return true;
+#endif
+}
+
 }  // namespace xwalk

--- a/runtime/browser/runtime_resource_dispatcher_host_delegate.h
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate.h
@@ -35,6 +35,10 @@ class RuntimeResourceDispatcherHostDelegate
       bool is_content_initiated,
       bool must_download,
       ScopedVector<content::ResourceThrottle>* throttles) OVERRIDE;
+  virtual bool HandleExternalProtocol(
+      const GURL& url,
+      int child_id,
+      int route_id) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RuntimeResourceDispatcherHostDelegate);


### PR DESCRIPTION
The external protocol is not handled well.
1. There is a new interface at content resource loader
   delegate, which is "HandleExternalProtocol", it must
   return false for the protocol we want to handle
   differently.
2. The method "shouldOverrideUrlLoading" in XWalkContentClient
   is not hooked into navigation interceptor, so the override
   in derived client is not invoked at all.

BUG=https://crosswalk-project.org/jira/browse/XWALK-150
