### PR TITLE
[Android][Extensions] Rename event handler's event type to comply with W...

### DIFF
--- a/sysapps/device_capabilities/device_capabilities_api.js
+++ b/sysapps/device_capabilities/device_capabilities_api.js
@@ -161,13 +161,13 @@ exports.addEventListener = function(eventName, callback) {
   if (!_hasListener(eventName)) {
     var msg = {
       'cmd': 'addEventListener',
-      'eventName': eventName
+      'eventName': 'on' + eventName
     };
     extension.postMessage(JSON.stringify(msg));
   }
 
   var listener = {
-    'eventName': eventName,
+    'eventName': 'on' + eventName,
     'callback': callback
   };
 

--- a/test/android/data/device_capabilities.html
+++ b/test/android/data/device_capabilities.html
@@ -92,28 +92,28 @@
               onSuccess();
             }, Error);
 
-        navigator.system.addEventListener('onattach', function(storage) {
+        navigator.system.addEventListener('attach', function(storage) {
             var output = document.getElementById('event');
             var msg = enumerateAllProps(storage);
             output.value += 'Storage attached with below properties:\n' + msg + '--------\n';
             output.scrollTop = output.scrollHeight;
           });
 
-        navigator.system.addEventListener('ondetach', function(storage) {
+        navigator.system.addEventListener('detach', function(storage) {
             var output = document.getElementById('event');
             var msg = enumerateAllProps(storage);
             output.value += 'Storage detached with below properties:\n' + msg + '--------\n';
             output.scrollTop = output.scrollHeight;
           });
 
-        navigator.system.addEventListener('onconnect', function(display) {
+        navigator.system.addEventListener('connect', function(display) {
             var output = document.getElementById('event');
             var msg = enumerateAllProps(display);
             output.value += 'Display connected with below properties:\n' + msg + '--------\n';
             output.scrollTop = output.scrollHeight;
           });
 
-        navigator.system.addEventListener('ondisconnect', function(display) {
+        navigator.system.addEventListener('disconnect', function(display) {
             var output = document.getElementById('event');
             var msg = enumerateAllProps(display);
             output.value += 'Display disconnected with below properties:\n' + msg + '--------\n';


### PR DESCRIPTION
...3C spec

The type name in the addEventListener() should be 'attach' instead of 'onattach' according to the W3C spec.

The spec file : 
http://www.w3.org/TR/2011/WD-html5-20110525/webappapis.html#event-handler-attributes
