### PR TITLE
Enable overlay scrollbars for all platforms

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -122,6 +122,8 @@ void SetXWalkCommandLineFlags() {
   command_line->AppendSwitch(switches::kEnableFixedLayout);
   command_line->AppendSwitch(xswitches::kEnableViewport);
 
+  command_line->AppendSwitch(switches::kEnableOverlayScrollbars);
+
   // Enable multithreaded GPU compositing of web content.
   // This also enables pinch on Tizen.
   command_line->AppendSwitch(switches::kEnableThreadedCompositing);


### PR DESCRIPTION
We need overlay scrollbars for Tizen and any platform supporting
viewport changes (@viewport or meta tag). Chromium is going in the
same direction.

To get the right size, offset from viewport edge and fade out,
additional changes are needed to Chromium.
