### PR TITLE
[Extensions] Disable the Extension Framework entirely for --install and --uninstall

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -238,13 +238,16 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
 #else
   runtime_context_.reset(new RuntimeContext);
   runtime_registry_.reset(new RuntimeRegistry);
-  extension_service_.reset(
-      new extensions::XWalkExtensionService());
-
-  RegisterInternalExtensions();
-  RegisterExternalExtensions();
 
   CommandLine* command_line = CommandLine::ForCurrentProcess();
+  if (!command_line->HasSwitch(switches::kInstall) &&
+      !command_line->HasSwitch(switches::kUninstall)) {
+    extension_service_.reset(new extensions::XWalkExtensionService());
+
+    RegisterInternalExtensions();
+    RegisterExternalExtensions();
+  }
+
   if (command_line->HasSwitch(switches::kRemoteDebuggingPort)) {
     std::string port_str =
         command_line->GetSwitchValueASCII(switches::kRemoteDebuggingPort);

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -117,7 +117,10 @@ XWalkContentBrowserClient::GetWebContentsViewDelegate(
 
 void XWalkContentBrowserClient::RenderProcessHostCreated(
     content::RenderProcessHost* host) {
-  main_parts_->extension_service()->OnRenderProcessHostCreated(host);
+  xwalk::extensions::XWalkExtensionService* extension_service =
+      main_parts_->extension_service();
+  if (extension_service)
+    extension_service->OnRenderProcessHostCreated(host);
 }
 
 content::MediaObserver* XWalkContentBrowserClient::GetMediaObserver() {


### PR DESCRIPTION
As mentioned in https://github.com/crosswalk-project/crosswalk/issues/839,
we shouldn't be bootstrapping the entire BrowserProcess workflow when using
xwalk --install or xwalk --uninstall.

This patch disables the ExtensionService creation and the Extensions
loading and registering as a workaround.

(In fact, XWalkBrowserMainParts::PreMainMessageLoopRun() is begging for a refactor already.)
