### PR TITLE
[XWalk 2][Extensions] Disable the Extension Framework entirely for --install and --uninstall

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -253,9 +253,6 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
 #else
   runtime_context_.reset(new RuntimeContext);
   runtime_registry_.reset(new RuntimeRegistry);
-  extension_service_.reset(new extensions::XWalkExtensionService(this));
-
-  RegisterExternalExtensions();
 
   xwalk::application::ApplicationSystem* system =
       runtime_context_->GetApplicationSystem();
@@ -263,6 +260,13 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
       system->application_service();
 
   CommandLine* command_line = CommandLine::ForCurrentProcess();
+  if (!command_line->HasSwitch(switches::kInstall) &&
+      !command_line->HasSwitch(switches::kUninstall)) {
+    extension_service_.reset(new extensions::XWalkExtensionService(this));
+
+    RegisterExternalExtensions();
+  }
+
   if (command_line->HasSwitch(switches::kRemoteDebuggingPort)) {
     std::string port_str =
         command_line->GetSwitchValueASCII(switches::kRemoteDebuggingPort);

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -135,7 +135,10 @@ XWalkContentBrowserClient::GetWebContentsViewDelegate(
 
 void XWalkContentBrowserClient::RenderProcessHostCreated(
     content::RenderProcessHost* host) {
-  main_parts_->extension_service()->OnRenderProcessHostCreated(host);
+  xwalk::extensions::XWalkExtensionService* extension_service =
+      main_parts_->extension_service();
+  if (extension_service)
+    extension_service->OnRenderProcessHostCreated(host);
 }
 
 content::MediaObserver* XWalkContentBrowserClient::GetMediaObserver() {


### PR DESCRIPTION
(cherry-picking this from Crosswalk Master)

As mentioned in https://github.com/crosswalk-project/crosswalk/issues/839,
we shouldn't be bootstrapping the entire BrowserProcess workflow when using
xwalk --install or xwalk --uninstall.

This patch disables the ExtensionService creation, the Extensions
loading and the Extensions registering as a workaround for the
crash mentioned in https://crosswalk-project.org/jira/browse/XWALK-31 .
