### PR TITLE
[Runtime Model] Add permissions handler for manifest.json

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -16,6 +16,7 @@ const char kLaunchLocalPathKey[] = "app.launch.local_path";
 const char kLaunchWebURLKey[] = "app.launch.web_url";
 const char kManifestVersionKey[] = "manifest_version";
 const char kNameKey[] = "name";
+const char kPermissionsKey[] = "permissions";
 const char kVersionKey[] = "version";
 const char kWebURLsKey[] = "app.urls";
 }  // namespace application_manifest_keys

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -17,6 +17,7 @@ namespace application_manifest_keys {
   extern const char kLaunchWebURLKey[];
   extern const char kManifestVersionKey[];
   extern const char kNameKey[];
+  extern const char kPermissionsKey[];
   extern const char kVersionKey[];
   extern const char kWebURLsKey[];
 }  // namespace application_manifest_keys

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -7,6 +7,7 @@
 #include <set>
 
 #include "base/stl_util.h"
+#include "xwalk/application/common/manifest_handlers/permissions_handler.h"
 
 namespace xwalk {
 namespace application {
@@ -53,6 +54,7 @@ ManifestHandlerRegistry* ManifestHandlerRegistry::GetInstance() {
     std::vector<ManifestHandler*> handlers;
     // FIXME: Add manifest handlers here like this:
     // handlers.push_back(new xxxHandler);
+    handlers.push_back(new PermissionsHandler);
 
     registry_ = new ManifestHandlerRegistry(handlers);
   }

--- a/application/common/manifest_handlers/permissions_handler.cc
+++ b/application/common/manifest_handlers/permissions_handler.cc
@@ -1,0 +1,72 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/permissions_handler.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_manifest_keys;
+
+namespace application {
+
+namespace {
+inline bool IsAPIPermission(const std::string& permission) {
+  // FIXME: Need to check from global API permissions set.
+  return true;
+}
+}  // namespace
+
+PermissionsInfo::PermissionsInfo() {
+}
+
+PermissionsHandler::PermissionsHandler() {
+}
+
+bool PermissionsHandler::Parse(scoped_refptr<Application> application,
+                               string16* error) {
+  if (!application->GetManifest()->HasKey(keys::kPermissionsKey)) {
+    application->SetManifestData(keys::kPermissionsKey, new PermissionsInfo);
+    return true;
+  }
+
+  const base::ListValue* permissions = NULL;
+  if (!application->GetManifest()->GetList(
+          keys::kPermissionsKey, &permissions) || !permissions) {
+    *error = ASCIIToUTF16("Invalid value of permissions.");
+    return false;
+  }
+
+  scoped_ptr<PermissionsInfo> permissions_info(new PermissionsInfo);
+  std::vector<std::string> api_permissions;
+  for (size_t i = 0; i < permissions->GetSize(); ++i) {
+    std::string permission;
+    if (!permissions->GetString(i, &permission)) {
+      *error = ASCIIToUTF16(
+          "An error occurred when parsing permission string.");
+      return false;
+    }
+
+    if (IsAPIPermission(permission))
+      api_permissions.push_back(permission);
+  }
+  permissions_info->SetAPIPermissions(api_permissions);
+  application->SetManifestData(keys::kPermissionsKey,
+                               permissions_info.release());
+
+  return true;
+}
+
+bool PermissionsHandler::AlwaysParseForType(Manifest::Type type) const {
+  return true;
+}
+
+std::vector<std::string> PermissionsHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kPermissionsKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/permissions_handler.h
+++ b/application/common/manifest_handlers/permissions_handler.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_PERMISSIONS_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_PERMISSIONS_HANDLER_H_
+
+#include <string>
+#include <vector>
+
+#include "xwalk/application/common/manifest_handler.h"
+
+namespace xwalk {
+namespace application {
+
+class PermissionsInfo: public Application::ManifestData {
+ public:
+  PermissionsInfo();
+
+  const std::vector<std::string>& GetAPIPermissions() const {
+    return api_permissions_;}
+  void SetAPIPermissions(const std::vector<std::string>& api_permissions) {
+    api_permissions_ = api_permissions;
+  }
+
+ private:
+  std::vector<std::string> api_permissions_;
+  DISALLOW_COPY_AND_ASSIGN(PermissionsInfo);
+};
+
+class PermissionsHandler: public ManifestHandler {
+ public:
+  PermissionsHandler();
+
+  virtual bool Parse(scoped_refptr<Application> application,
+                     string16* error) OVERRIDE;
+  virtual bool AlwaysParseForType(Manifest::Type type) const OVERRIDE;
+  virtual std::vector<std::string> Keys() const OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(PermissionsHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_PERMISSIONS_HANDLER_H_

--- a/application/common/manifest_handlers/permissions_handler_unittest.cc
+++ b/application/common/manifest_handlers/permissions_handler_unittest.cc
@@ -1,0 +1,85 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/permissions_handler.h"
+
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace xwalk {
+
+namespace keys = application_manifest_keys;
+
+namespace application {
+
+namespace {
+
+const std::vector<std::string>& GetAPIPermissionsInfo(
+    scoped_refptr<const Application> application) {
+  PermissionsInfo* info = static_cast<PermissionsInfo*>(
+      application->GetManifestData(keys::kPermissionsKey));
+  DCHECK(info);
+  return info->GetAPIPermissions();
+}
+
+}  // namespace
+
+class PermissionsHandlerTest: public testing::Test {
+};
+
+TEST_F(PermissionsHandlerTest, NonePermission) {
+  base::DictionaryValue manifest;
+  manifest.SetString(keys::kNameKey, "no name");
+  manifest.SetString(keys::kVersionKey, "0");
+  std::string error;
+  scoped_refptr<Application> application = Application::Create(
+      base::FilePath(),
+      Manifest::INVALID_TYPE,
+      manifest,
+      "",
+      &error);
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0);
+}
+
+TEST_F(PermissionsHandlerTest, EmptyPermission) {
+  base::DictionaryValue manifest;
+  manifest.SetString(keys::kNameKey, "no name");
+  manifest.SetString(keys::kVersionKey, "0");
+  base::ListValue* permissions = new base::ListValue;
+  manifest.Set(keys::kPermissionsKey, permissions);
+  std::string error;
+  scoped_refptr<Application> application = Application::Create(
+      base::FilePath(),
+      Manifest::INVALID_TYPE,
+      manifest,
+      "",
+      &error);
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0);
+}
+
+TEST_F(PermissionsHandlerTest, DeviceAPIPermission) {
+  base::DictionaryValue manifest;
+  manifest.SetString(keys::kNameKey, "no name");
+  manifest.SetString(keys::kVersionKey, "0");
+  base::ListValue* permissions = new base::ListValue;
+  permissions->AppendString("geolocation");
+  manifest.Set(keys::kPermissionsKey, permissions);
+  std::string error;
+  scoped_refptr<Application> application = Application::Create(
+      base::FilePath(),
+      Manifest::INVALID_TYPE,
+      manifest,
+      "",
+      &error);
+  EXPECT_TRUE(application.get());
+  const std::vector<std::string>& permission_list =
+      GetAPIPermissionsInfo(application);
+  EXPECT_EQ(permission_list.size(), 1);
+  EXPECT_STREQ(permission_list[0].c_str(), "geolocation");
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -51,6 +51,8 @@
         'common/manifest.h',
         'common/manifest_handler.cc',
         'common/manifest_handler.h',
+        'common/manifest_handlers/permissions_handler.cc',
+        'common/manifest_handlers/permissions_handler.h',
 
         'extension/application_extension.cc',
         'extension/application_extension.h',

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -77,6 +77,7 @@
       'application/common/application_unittest.cc',
       'application/common/application_file_util_unittest.cc',
       'application/common/id_util_unittest.cc',
+      'application/common/manifest_handlers/permissions_handler_unittest.cc',
       'application/common/manifest_handler_unittest.cc',
       'application/common/manifest_unittest.cc',
       'application/common/db_store_sqlite_impl_unittest.cc',


### PR DESCRIPTION
Permissions handler can parse the permissions field in manifest.json,
and save the permissions information into Application object as
ManifestData struct.
