### PR TITLE
[Runtime Model] Introduce sqlite table to save system events. 

### DIFF
--- a/application/browser/application_store.h
+++ b/application/browser/application_store.h
@@ -32,6 +32,7 @@ class ApplicationStore: public DBStore::Observer {
   static const char kManifestPath[];
   static const char kApplicationPath[];
   static const char kInstallTime[];
+  static const char kRegisteredEvents[];
 
   explicit ApplicationStore(xwalk::RuntimeContext* runtime_context);
   virtual ~ApplicationStore();
@@ -46,6 +47,10 @@ class ApplicationStore: public DBStore::Observer {
       const std::string& application_id) const;
 
   ApplicationMap* GetInstalledApplications() const;
+
+  bool SetApplicationEvents(const std::string& id,
+                            base::ListValue* events);
+  base::ListValue* GetApplicationEvents(const std::string& id);
 
   // Implement the DBStore::Observer.
   virtual void OnDBValueChanged(const std::string& key,

--- a/application/common/db_store.h
+++ b/application/common/db_store.h
@@ -34,7 +34,7 @@ class DBStore {
   virtual bool Insert(const Application* application,
                       const base::Time install_time) = 0;
   virtual bool Remove(const std::string& key) = 0;
-  const base::DictionaryValue* GetApplications() const { return db_.get(); }
+  base::DictionaryValue* GetApplications() const { return db_.get(); }
 
   void AddObserver(DBStore::Observer* observer) {
     observers_.AddObserver(observer);

--- a/application/common/db_store_constants.cc
+++ b/application/common/db_store_constants.cc
@@ -1,0 +1,73 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/db_store_constants.h"
+#include "base/strings/stringprintf.h"
+
+namespace xwalk {
+namespace db_store_constants {
+
+const char kAppTableName[] = "applications";
+const char kAppID[] = "id";
+const char kAppManifest[] = "manifest";
+const char kAppPath[] = "path";
+const char kAppInstallTime[] = "install_time";
+
+const char kEventTableName[] = "registered_events";
+const char kEventAppID[] = "id";
+const char kEventsName[] = "event_names";
+
+const char kCreateAppTableOp[] =
+    "CREATE TABLE applications ("
+    "id TEXT NOT NULL UNIQUE PRIMARY KEY,"
+    "manifest TEXT NOT NULL,"
+    "path TEXT NOT NULL,"
+    "install_time REAL)";
+
+const char kCreateEventTableOp[] =
+    "CREATE TABLE registered_events ("
+    "id TEXT NOT NULL,"
+    "event_names TEXT NOT NULL,"
+    "PRIMARY KEY (id),"
+    "FOREIGN KEY (id) REFERENCES applications(id)"
+    "ON DELETE CASCADE)";
+
+const char kGetAllRowsFromAppEventTableOp[] =
+    "SELECT applications.id, manifest, path, install_time, event_names "
+    "FROM applications "
+    "LEFT JOIN registered_events "
+    "ON applications.id = registered_events.id";
+
+const char kSetApplicationWithBindOp[] =
+    "INSERT INTO applications (manifest, path, install_time, id) "
+    "VALUES (?,?,?,?)";
+
+const char kUpdateApplicationWithBindOp[] =
+    "UPDATE applications SET manifest = ?, path = ?,"
+    "install_time = ? WHERE id = ?";
+
+const char kDeleteApplicationWithBindOp[] =
+    "DELETE FROM applications WHERE id = ?";
+
+const char kSetManifestWithBindOp[] =
+    "UPDATE applications SET manifest = ? WHERE id = ?";
+
+const char kSetInstallTimeWithBindOp[] =
+    "UPDATE applications SET install_time = ? WHERE id = ?";
+
+const char kSetApplicationPathWithBindOp[] =
+    "UPDATE applications SET path = ? WHERE id = ?";
+
+const char kInsertEventsWithBindOp[] =
+    "INSERT INTO registered_events (event_names, id) "
+    "VALUES(?,?)";
+
+const char kUpdateEventsWithBindOp[] =
+    "UPDATE registered_events SET event_names = ? WHERE id = ?";
+
+const char kDeleteEventsWithBindOp[] =
+    "DELETE FROM registered_events WHERE id = ?";
+
+}  // namespace db_store_constants
+}  // namespace xwalk

--- a/application/common/db_store_constants.h
+++ b/application/common/db_store_constants.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_DB_STORE_CONSTANTS_H_
+#define XWALK_APPLICATION_COMMON_DB_STORE_CONSTANTS_H_
+
+#include "base/files/file_path.h"
+#include "base/basictypes.h"
+
+namespace xwalk {
+namespace db_store_constants {
+  extern const char kAppTableName[];
+  extern const char kAppID[];
+  extern const char kAppManifest[];
+  extern const char kAppPath[];
+  extern const char kAppInstallTime[];
+
+  extern const char kEventTableName[];
+  extern const char kEventAppID[];
+  extern const char kEventsName[];
+
+  extern const char kCreateAppTableOp[];
+  extern const char kCreateEventTableOp[];
+  extern const char kGetAllRowsFromAppEventTableOp[];
+  extern const char kSetApplicationWithBindOp[];
+  extern const char kUpdateApplicationWithBindOp[];
+  extern const char kDeleteApplicationWithBindOp[];
+  extern const char kSetManifestWithBindOp[];
+  extern const char kSetInstallTimeWithBindOp[];
+  extern const char kSetApplicationPathWithBindOp[];
+  extern const char kInsertEventsWithBindOp[];
+  extern const char kUpdateEventsWithBindOp[];
+  extern const char kDeleteEventsWithBindOp[];
+
+}  // namespace db_store_constants
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_DB_STORE_CONSTANTS_H_

--- a/application/common/db_store_sqlite_impl.h
+++ b/application/common/db_store_sqlite_impl.h
@@ -50,6 +50,12 @@ class DBStoreSqliteImpl: public DBStore {
   bool SetManifestValue(const std::string& id, base::Value* value);
   bool SetInstallTimeValue(const std::string& id, base::Value* value);
   bool SetApplicationPathValue(const std::string& id, base::Value* value);
+
+  bool SetEventsValue(const std::string& id,
+                      base::Value* events,
+                      const std::string& operation);
+  bool DeleteEventsValue(const std::string& id);
+
   scoped_ptr<sql::Connection> sqlite_db_;
   sql::MetaTable meta_table_;
   bool db_initialized_;

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -42,6 +42,8 @@
         'common/constants.h',
         'common/db_store.cc',
         'common/db_store.h',
+        'common/db_store_constants.cc',
+        'common/db_store_constants.h',
         'common/db_store_sqlite_impl.cc',
         'common/db_store_sqlite_impl.h',
         'common/id_util.cc',


### PR DESCRIPTION
From [1], System events are events sent by the system, a system event
can wake up a terminated application. If user want a system event has
the capability to wake up, then he/she should add listener to that event
in the main document, listener added in other document won’t have such
capability.

To implement this, system events information that registered in the main
document should be saved into system database during installation time.
Whenever a system event comes to event router, the router will check
whether the event is supported by the specified application. If yes,
router will dispatch the event to application, for example, launches a
terminated application and executing onLaunch callback.

This PR is the SQLite implementation to save system event information into
database. It creates a table named 'registered_events' in Crosswalk
application datbase file('applications.db'). The table contains two
columns for each item, (id, event_names). It also provides
some  Getter and Setter functions to read/write/remove item(s) from the
database.

In order to speed read/write from database, db_cache_ is introduced. It
is a Dictionary type, with key 'application_id' and value of event name
list.

Reference:
[1]
https://docs.google.com/document/d/1cDb54Cs1wjbNQPb7W44_4aj1bzPI9dqsb2aRDkZmDTE/edit?pli=1#heading=h.v1w5rrn37icm
