### PR TITLE
[Android] Remove dependency between XWalkManifestReader and XWalkView.

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -96,8 +96,6 @@ def CopyJavaSources(project_source, out_directory):
       'xwalk/runtime/android/java/src/org/xwalk/core',
       'xwalk/extensions/android/java/src/org/xwalk/core/extensions',
       'xwalk/runtime/android/java/src/org/xwalk/runtime/extension',
-      'xwalk/runtime/android/java/'
-          'src/org/xwalk/runtime/XWalkManifestReader.java',
   ]
 
   for source in java_srcs_to_copy:

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -19,7 +19,6 @@ import org.xwalk.core.client.XWalkDefaultClient;
 import org.xwalk.core.client.XWalkDefaultDownloadListener;
 import org.xwalk.core.client.XWalkDefaultNavigationHandler;
 import org.xwalk.core.client.XWalkDefaultWebChromeClient;
-import org.xwalk.runtime.XWalkManifestReader;
 
 public class XWalkView extends FrameLayout {
 
@@ -94,15 +93,7 @@ public class XWalkView extends FrameLayout {
         mContent.loadUrl(url);
     }
 
-    public void loadAppFromManifest(String manifestUrl) {
-        XWalkManifestReader manifestReader = new XWalkManifestReader(mActivity);
-        String manifest = manifestReader.read(manifestUrl);
-        int position = manifestUrl.lastIndexOf("/");
-        if (position == -1) {
-            throw new RuntimeException("The URL of manifest file is invalid.");
-        }
-
-        String path = manifestUrl.substring(0, position + 1);
+    public void loadAppFromManifest(String path, String manifest) {
         mContent.loadAppFromManifest(path, manifest);
     }
 

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -20,11 +20,13 @@ import org.xwalk.runtime.extension.XWalkExtensionManager;
  */
 class XWalkCoreProviderImpl extends XWalkRuntimeViewProviderBase {
     private Context mContext;
+    private Activity mActivity;
     private XWalkView mXwalkView;
 
     public XWalkCoreProviderImpl(Context context, Activity activity) {
         super(context, activity);
         mContext = context;
+        mActivity = activity;
         mExtensionManager = new XWalkExtensionManager(context, activity);
         init(context, activity);
     }
@@ -43,7 +45,15 @@ class XWalkCoreProviderImpl extends XWalkRuntimeViewProviderBase {
 
     @Override
     public void loadAppFromManifest(String manifestUrl) {
-        mXwalkView.loadAppFromManifest(manifestUrl);
+        XWalkManifestReader manifestReader = new XWalkManifestReader(mActivity);
+        String manifest = manifestReader.read(manifestUrl);
+        int position = manifestUrl.lastIndexOf("/");
+        if (position == -1) {
+            throw new RuntimeException("The URL of manifest file is invalid.");
+        }
+
+        String path = manifestUrl.substring(0, position + 1);
+        mXwalkView.loadAppFromManifest(path, manifest);
     }
 
     @Override


### PR DESCRIPTION
XWalkManifestReader is in org.xwalk.runtime package, it's on higher
layer than XWalk core, and XWalkManifestReader should not be awared
by XWalk core. So remove the XWalkManifestReader reference from the
XWalkView class.

BUG=https://crosswalk-project.org/jira/browse/XWALK-149
