### PR TITLE
[Android] Fix the title comparison crashes with NullPointer

### DIFF
--- a/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
@@ -40,6 +40,8 @@ public class RuntimeClientApiTestBase<T extends Activity> {
     }
 
     public void compareTitle(String prevTitle, String title, String msg, Relation relation) {
+        if (prevTitle == null) prevTitle = "";
+        if (title == null) title = "";
         switch (relation) {
             case EQUAL:
                 mTestCase.assertTrue(msg, title.equals(prevTitle));


### PR DESCRIPTION
Assign empty string for null pointer before comparison.
