### PR TITLE
[XESh] Print both Crosswalk and v8 version

### DIFF
--- a/extensions/xesh/xesh_main.cc
+++ b/extensions/xesh/xesh_main.cc
@@ -47,6 +47,12 @@ const char kInputFilePath[] = "input-file";
 
 namespace {
 
+inline void PrintInitialInfo() {
+  fprintf(stderr, "\n---- XESh: XWalk Extensions Shell ----");
+  fprintf(stderr, "\nCrosswalk Version: %s\nv8 Version: %s\n", XWALK_VERSION,
+      v8::V8::GetVersion());
+}
+
 inline void PrintPromptLine() {
   fprintf(stderr, "xesh> ");
 }
@@ -163,7 +169,6 @@ class ExtensionManager {
     std::vector<std::string> extensions =
         RegisterExternalExtensionsInDirectory(&server_, extensions_dir);
 
-    fprintf(stderr, "\n---- XESh: XWalk Extensions Shell ----");
     fprintf(stderr, "\nExtensions Loaded:\n");
     std::vector<std::string>::const_iterator it = extensions.begin();
     for (; it != extensions.end(); ++it)
@@ -230,6 +235,8 @@ class ExtensionManager {
 int main(int argc, char* argv[]) {
   base::AtExitManager exit_manager;
   CommandLine::Init(argc, argv);
+
+  PrintInitialInfo();
 
   base::MessageLoop main_message_loop(base::MessageLoop::TYPE_UI);
   main_message_loop.set_thread_name("XESh_Main");

--- a/extensions/xesh/xesh_v8_runner.cc
+++ b/extensions/xesh/xesh_v8_runner.cc
@@ -97,9 +97,6 @@ void XEShV8Runner::RegisterAccessors(v8::Handle<v8::Context> context) {
       v8::FunctionTemplate::New(PrintCallback)->GetFunction());
 
   context->Global()->SetAccessor(v8::String::New("quit"), QuitCallback);
-
-  context->Global()->Set(v8::String::New("version"),
-      v8::FunctionTemplate::New(VersionCallback)->GetFunction());
 }
 
 // static
@@ -128,14 +125,5 @@ void XEShV8Runner::QuitCallback(v8::Local<v8::String> property,
   fflush(stdout);
   fflush(stderr);
   exit(0);
-}
-
-// static
-void XEShV8Runner::VersionCallback(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  // FIXME(jeez): add XWalk version here.
-  std::string v8_version("V8 Version: ");
-  v8_version.append(v8::V8::GetVersion());
-  args.GetReturnValue().Set(v8::String::New(v8_version.c_str()));
 }
 

--- a/extensions/xesh/xesh_v8_runner.h
+++ b/extensions/xesh/xesh_v8_runner.h
@@ -26,7 +26,6 @@ class XEShV8Runner {
   static void PrintCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void QuitCallback(v8::Local<v8::String> property,
       const v8::PropertyCallbackInfo<v8::Value>& info);
-  static void VersionCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
 #endif  // XWALK_EXTENSIONS_XESH_XESH_V8_RUNNER_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -605,6 +605,7 @@
     {
       'target_name': 'xwalk_extension_shell',
       'type': 'executable',
+      'defines': ['XWALK_VERSION="<(xwalk_version)"'],
       'product_name': 'xesh',
       'conditions': [
         ['OS=="linux"', {


### PR DESCRIPTION
This patch adds a PrintInitialInfo() function that
prints Crosswalk and v8 versions, in addition to the
XESh "banner".

After that there is no need to keep the JS version();
callback implemented, so it was removed from V8Runner.
