### PR TITLE
[Extensions] Check if reply is valid after a SendSyncMessageToNative

### DIFF
--- a/extensions/renderer/xwalk_extension_module.cc
+++ b/extensions/renderer/xwalk_extension_module.cc
@@ -235,7 +235,11 @@ void XWalkExtensionModule::SendSyncMessageCallback(
   scoped_ptr<base::Value> reply(
       module->client_->SendSyncMessageToNative(module->instance_id_,
                                                value.Pass()));
-  result.Set(module->converter_->ToV8Value(reply.get(), context));
+
+  // If we tried to send a message to an instance that became invalid,
+  // then reply will be NULL.
+  if (reply)
+    result.Set(module->converter_->ToV8Value(reply.get(), context));
 }
 
 // static


### PR DESCRIPTION
When we try to send a sync message to an extension instance that
became invalid (i.e.: the extension process died) then we might
end up with a NULL reply. We should then check before converting
to a V8Value, thus avoiding the RenderProcess to crash.

That is the same behavior PostMessageCallback has nowadays.
