### PR TITLE
[Android] Add back key support

### DIFF
--- a/app/android/app_hello_world/src/org/xwalk/app/hello/world/HelloWorldActivity.java
+++ b/app/android/app_hello_world/src/org/xwalk/app/hello/world/HelloWorldActivity.java
@@ -6,6 +6,7 @@ package org.xwalk.app.hello.world;
 
 import android.graphics.Color;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.View;
 import android.widget.TextView;
 
@@ -15,6 +16,17 @@ public class HelloWorldActivity extends XWalkRuntimeActivityBase {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        // Passdown the key-up event to runtime view.
+        if (getRuntimeView() != null &&
+                getRuntimeView().onKeyUp(keyCode, event)) {
+            return true;
+        }
+
+        return super.onKeyUp(keyCode, event);
     }
 
     @Override

--- a/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
+++ b/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
@@ -6,6 +6,7 @@ package org.xwalk.app.template;
 
 import android.graphics.Color;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.View;
 import android.widget.TextView;
 
@@ -15,6 +16,17 @@ public class AppTemplateActivity extends XWalkRuntimeActivityBase {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        // Passdown the key-up event to runtime view.
+        if (getRuntimeView() != null &&
+                getRuntimeView().onKeyUp(keyCode, event)) {
+            return true;
+        }
+
+        return super.onKeyUp(keyCode, event);
     }
 
     @Override

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
@@ -8,6 +8,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.util.AttributeSet;
+import android.view.KeyEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 
@@ -35,6 +36,7 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
     private Method mOnActivityResult;
     private Method mEnableRemoteDebugging;
     private Method mDisableRemoteDebugging;
+    private Method mOnKeyUp;
 
     // For instrumentation test.
     private Method mGetTitleForTest;
@@ -62,6 +64,7 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
         mOnActivityResult = lookupMethod("onActivityResult", int.class, int.class, Intent.class);
         mEnableRemoteDebugging = lookupMethod("enableRemoteDebugging", String.class, String.class);
         mDisableRemoteDebugging = lookupMethod("disableRemoteDebugging");
+        mOnKeyUp = lookupMethod("onKeyUp", int.class, KeyEvent.class);
     }
 
     /**
@@ -215,6 +218,14 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
      */
     public void disableRemoteDebugging() {
         invokeMethod(mDisableRemoteDebugging, mInstance);
+    }
+
+    /**
+     * Passdown key-up event to the runtime view.
+     * Usually meet the case of clicking on the back key.
+     */
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        return (Boolean) invokeMethod(mOnKeyUp, mInstance, keyCode, event);
     }
 
     // The following functions just for instrumentation test.

--- a/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/shell/XWalkRuntimeClientEmbeddedShellActivity.java
+++ b/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/shell/XWalkRuntimeClientEmbeddedShellActivity.java
@@ -30,6 +30,17 @@ public class XWalkRuntimeClientEmbeddedShellActivity extends XWalkRuntimeActivit
         super.onCreate(savedInstanceState);
     }
 
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        // Passdown the key-up event to runtime view.
+        if (getRuntimeView() != null &&
+                getRuntimeView().onKeyUp(keyCode, event)) {
+            return true;
+        }
+
+        return super.onKeyUp(keyCode, event);
+    }
+
     private static String sanitizeUrl(String url) {
         if (url == null) return url;
         if (url.startsWith("www.") || url.indexOf(":") == -1) url = "http://" + url;

--- a/app/android/runtime_client_shell/src/org/xwalk/runtime/client/shell/XWalkRuntimeClientShellActivity.java
+++ b/app/android/runtime_client_shell/src/org/xwalk/runtime/client/shell/XWalkRuntimeClientShellActivity.java
@@ -30,6 +30,17 @@ public class XWalkRuntimeClientShellActivity extends XWalkRuntimeActivityBase {
         super.onCreate(savedInstanceState);
     }
 
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        // Passdown the key-up event to runtime view.
+        if (getRuntimeView() != null &&
+                getRuntimeView().onKeyUp(keyCode, event)) {
+            return true;
+        }
+
+        return super.onKeyUp(keyCode, event);
+    }
+
     private static String sanitizeUrl(String url) {
         if (url == null) return url;
         if (url.startsWith("www.") || url.indexOf(":") == -1) url = "http://" + url;

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -98,6 +98,16 @@ public class XWalkViewShellActivity extends Activity {
         mView.onActivityResult(requestCode, resultCode, data);
     }
 
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && mView.canGoBack()) {
+            mView.goBack();
+            return true;
+        }
+
+        return super.onKeyUp(keyCode, event);
+    }
+
     private void waitForDebuggerIfNeeded() {
         if (CommandLine.getInstance().hasSwitch(CommandLine.WAIT_FOR_JAVA_DEBUGGER)) {
             Log.e(TAG, "Waiting for Java debugger to connect...");

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -7,6 +7,7 @@ package org.xwalk.runtime;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.view.KeyEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 
@@ -129,5 +130,15 @@ class XWalkCoreProviderImpl extends XWalkRuntimeViewProviderBase {
         mXwalkView.getXWalkViewContentForTest().getContentViewCoreForTest(
                 ).loadUrl(LoadUrlParams.createLoadDataParams(
                         data, mimeType, isBase64Encoded));
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && mXwalkView.canGoBack()) {
+            mXwalkView.goBack();
+            return true;
+        }
+
+        return false;
     }
 }

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeView.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeView.java
@@ -8,6 +8,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.util.AttributeSet;
+import android.view.KeyEvent;
 import android.widget.FrameLayout;
 
 /**
@@ -159,6 +160,14 @@ public class XWalkRuntimeView extends FrameLayout {
      */
     public void disableRemoteDebugging() {
         mProvider.disableRemoteDebugging();
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        // Passdown the key-up event to runtime core.
+        if (mProvider.onKeyUp(keyCode, event)) return true;
+
+        return super.onKeyUp(keyCode, event);
     }
 
     // For instrumentation test.

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -7,6 +7,7 @@ package org.xwalk.runtime;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.view.KeyEvent;
 import android.view.View;
 
 /**
@@ -29,6 +30,7 @@ public interface XWalkRuntimeViewProvider {
     public void loadAppFromManifest(String manifestUrl);
     public String enableRemoteDebugging(String frontEndUrl, String socketName);
     public void disableRemoteDebugging();
+    public boolean onKeyUp(int KeyCode, KeyEvent event);
 
     // For instrumentation test.
     public String getTitleForTest();

--- a/runtime/android/runtime_shell/src/org/xwalk/runtime/shell/XWalkRuntimeShellActivity.java
+++ b/runtime/android/runtime_shell/src/org/xwalk/runtime/shell/XWalkRuntimeShellActivity.java
@@ -75,6 +75,12 @@ public class XWalkRuntimeShellActivity extends Activity {
         mRuntimeView.onActivityResult(requestCode, resultCode, data);
     }
 
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (mRuntimeView.onKeyUp(keyCode, event)) return true;
+
+        return super.onKeyUp(keyCode, event);
+    }
 
     private void waitForDebuggerIfNeeded() {
         if (CommandLine.getInstance().hasSwitch(CommandLine.WAIT_FOR_JAVA_DEBUGGER)) {


### PR DESCRIPTION
1 The patch is to add the back key support for the runtime. The
expected behavior when putting on the back button is to go back
to the previous page, but now it results to exit the app.
2 Add a new goBack() interface into XWalkRuntimeView to handle this.
3 Hook the onKeyUp() method in XWalkRuntimeActivityBase and
XWalkRuntimeShellActivity to handle this.

BUG=https://crosswalk-project.org/jira/browse/XWALK-83
