### PR TITLE
[Android] Fix XWalk crash issue when exiting if remote debugging is enab...

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -258,8 +258,8 @@ public class XWalkView extends FrameLayout {
     }
 
     public void destroy() {
-        disableRemoteDebugging();
         mContent.destroy();
+        disableRemoteDebugging();
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {


### PR DESCRIPTION
...led.

The root cause is that DevToolsHttpHandlerImpl::Stop has been called before
DevToolsClientHostImpl::InspectedContentsClosing. In that case, the thread
is released and message loop is set to null, so XWalk crashes.

The fix is to change the teardown sequence to destory view first, then shutdown
remote debugging server.

BUG=https://crosswalk-project.org/jira/browse/XWALK-312
