### PR TITLE
[Android] Refine the test case about onPause and onResume.

### DIFF
--- a/test/android/util/src/org/xwalk/test/util/XWalkTestUtilBase.java
+++ b/test/android/util/src/org/xwalk/test/util/XWalkTestUtilBase.java
@@ -89,12 +89,6 @@ public class XWalkTestUtilBase<T> {
         return helper.getTitle();
     }
 
-    public void waitForTitleUpdated(int seconds) throws Exception {
-        CallbackHelper helper = mCallbackHelpers.getOnTitleUpdatedHelper();
-        int currentCallCount = helper.getCallCount();
-        helper.waitForCallback(currentCallCount, 1, seconds, TimeUnit.SECONDS);
-    }
-
     public XWalkTestUtilCallbacks getCallbackHelpers() {
         return mCallbackHelpers;
     }


### PR DESCRIPTION
This patch refined the test case about onPause and onResume on
embedded and shared mode. It's for the runtime client.
Invoke onPause or onResume on main thread, wait for some seconds
to ensure that action is done, get the first title. Then wait for
some milliseconds, get the title again. Compare the two titles.

We can not use the TimerTask directly, because it creates a external
thread which was not executed when the main thread exit.

For embedded client test:
1. install XWalkRuntimeClientEmbeddedShell.apk
2. python build/android/test_runner.py instrumentation \
--test-apk=XWalkRuntimeClientEmbeddedTest -v -f testPauseResume

For shared client test:
1. install XWalkRuntimeLib.apk
2. install XWalkRuntimeClientShell.apk
3. python build/android/test_runner.py instrumentation \
--test-apk=XWalkRuntimeClientTest -v -f testPauseResume
