### PR TITLE
[SysApps][Tizen] Add AVCodecs support in device capabilities

### DIFF
--- a/sysapps/device_capabilities/device_capabilities.gypi
+++ b/sysapps/device_capabilities/device_capabilities.gypi
@@ -1,9 +1,12 @@
 {
   'dependencies': [
     '../third_party/jsoncpp/jsoncpp.gyp:jsoncpp',
+    '../third_party/ffmpeg/ffmpeg.gyp:ffmpeg',
     'build/system.gyp:tizen_sysapps',
   ],
   'sources': [
+    'device_capabilities_avcodecs.cc',
+    'device_capabilities_avcodecs.h',
     'device_capabilities_cpu.h',
     'device_capabilities_cpu_tizen.cc',
     'device_capabilities_display.h',

--- a/sysapps/device_capabilities/device_capabilities_api.js
+++ b/sysapps/device_capabilities/device_capabilities_api.js
@@ -48,6 +48,13 @@ exports.getStorageInfo = function() {
   return postMessage(msg);
 };
 
+exports.getAVCodecs = function() {
+  var msg = {
+    'cmd': 'getAVCodecs'
+  };
+  return postMessage(msg);
+};
+
 function _addConstProperty(obj, propertyKey, propertyValue) {
   Object.defineProperty(obj, propertyKey, {
     configurable: false,

--- a/sysapps/device_capabilities/device_capabilities_avcodecs.cc
+++ b/sysapps/device_capabilities/device_capabilities_avcodecs.cc
@@ -1,0 +1,160 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/sysapps/device_capabilities/device_capabilities_avcodecs.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}  // extern "C"
+
+#include "base/files/file_path.h"
+#include "base/strings/string_split.h"
+#include "base/path_service.h"
+#include "content/public/common/content_paths.h"
+#include "media/filters/ffmpeg_glue.h"
+#include "media/base/media.h"
+#include "net/base/mime_util.h"
+
+namespace xwalk {
+namespace sysapps {
+
+DeviceCapabilitiesAVCodecs::DeviceCapabilitiesAVCodecs() {
+  InitializeAVCodecs();
+}
+
+Json::Value* DeviceCapabilitiesAVCodecs::Get() {
+  Json::Value* obj = new Json::Value();
+  (*obj)["audioCodecs"] = audioCodecs;
+  (*obj)["videoCodecs"] = videoCodecs;
+  return obj;
+}
+
+void DeviceCapabilitiesAVCodecs::InitializeAVCodecs() {
+  std::set<std::string> supportedAudioCodecs;
+  VideoCodecMap supportedVideoCodecs;
+  GetSupportedAVCodecs(&supportedAudioCodecs, &supportedVideoCodecs);
+
+  for (std::set<std::string>::const_iterator it = supportedAudioCodecs.begin();
+       it != supportedAudioCodecs.end(); ++it) {
+    Json::Value audioCodec;
+    audioCodec["format"] = Json::Value(*it);
+    audioCodecs.append(audioCodec);
+  }
+
+  for (VideoCodecMap::const_iterator it = supportedVideoCodecs.begin();
+       it != supportedVideoCodecs.end(); ++it) {
+    VideoCodec codec = it->second;
+    Json::Value videoCodec;
+    videoCodec["format"] = Json::Value(codec.format);
+    videoCodec["hwAccel"] = Json::Value(codec.hwAccel);
+    videoCodec["encode"] = Json::Value(codec.encode);
+    videoCodecs.append(videoCodec);
+  }
+}
+
+void DeviceCapabilitiesAVCodecs::GetAllCodecsAndFormatsFromFFmpeg(
+    std::vector<std::string>* audio_codecs,
+    std::vector<VideoCodec>* video_codecs,
+    std::vector<std::string>* formats) {
+  base::FilePath media_path;
+  PathService::Get(content::DIR_MEDIA_LIBS, &media_path);
+  media::InitializeMediaLibrary(media_path);
+  media::FFmpegGlue::InitializeFFmpeg();
+
+  AVCodec* codec = NULL;
+  while ((codec = av_codec_next(codec))) {
+    if (codec->type == AVMEDIA_TYPE_AUDIO)
+      audio_codecs->push_back(std::string(codec->name));
+    else if (codec->type == AVMEDIA_TYPE_VIDEO) {
+      VideoCodec v_codec;
+      v_codec.encode = false;
+      v_codec.format = std::string(codec->name);
+      // FIXME(qjia7): find how to get hwAccel value
+      v_codec.hwAccel = false;
+      if (av_codec_is_encoder(codec) != 0)
+        v_codec.encode = true;
+      video_codecs->push_back(v_codec);
+    }
+  }
+
+  AVInputFormat* iformat = NULL;
+  while ((iformat = av_iformat_next(iformat))) {
+    std::vector<std::string> formats_out;
+    base::SplitString(iformat->name, ',', &formats_out);
+    for (std::vector<std::string>::iterator it = formats_out.begin();
+         it != formats_out.end();
+         ++it) {
+      formats->push_back(*it);
+    }
+  }
+}
+
+void DeviceCapabilitiesAVCodecs::GetSupportedAudioCodecForMimeType(
+    const std::vector<std::string>& codecs,
+    std::set<std::string>* codecs_out,
+    const std::string& mimetype) {
+  if (!net::IsSupportedMediaMimeType(mimetype))
+    return;
+  for (std::vector<std::string>::const_iterator it = codecs.begin();
+       it != codecs.end(); ++it) {
+    std::string it_codec = *it;
+    if (net::IsStrictMediaMimeType(mimetype)) {
+      std::vector<std::string> strict_codecs;
+      net::ParseCodecString(it_codec, &strict_codecs, false);
+      if (net::IsSupportedStrictMediaMimeType(mimetype,
+                                              strict_codecs)) {
+        codecs_out->insert(it_codec);
+      }
+    } else {
+      codecs_out->insert(it_codec);
+    }
+  }
+}
+
+void DeviceCapabilitiesAVCodecs::GetSupportedVideoCodecForMimeType(
+    const std::vector<VideoCodec>& codecs,
+    VideoCodecMap* codecs_out,
+    const std::string& mimetype) {
+  if (!net::IsSupportedMediaMimeType(mimetype))
+    return;
+  for (std::vector<VideoCodec>::const_iterator it = codecs.begin();
+       it != codecs.end(); ++it) {
+    VideoCodec it_codec = *it;
+    if (net::IsStrictMediaMimeType(mimetype)) {
+      std::vector<std::string> strict_codecs;
+      net::ParseCodecString(it_codec.format, &strict_codecs, false);
+      if (net::IsSupportedStrictMediaMimeType(mimetype,
+                                              strict_codecs)) {
+        (*codecs_out)[it_codec.format] = it_codec;
+      }
+    } else {
+      (*codecs_out)[it_codec.format] = it_codec;
+    }
+  }
+}
+
+void DeviceCapabilitiesAVCodecs::GetSupportedAVCodecs(
+    std::set<std::string>* supportedAudioCodecs,
+    VideoCodecMap* supportedVideoCodecs) {
+  std::vector<std::string> audioCodecsSet;
+  std::vector<VideoCodec> videoCodecsSet;
+  std::vector<std::string> formats;
+  GetAllCodecsAndFormatsFromFFmpeg(&audioCodecsSet, &videoCodecsSet, &formats);
+
+  for (std::vector<std::string>::const_iterator it_format = formats.begin();
+       it_format != formats.end(); ++it_format) {
+    std::string audio_mime_type = std::string("audio/" + *it_format);
+    std::string video_mime_type = std::string("video/" + *it_format);
+    GetSupportedAudioCodecForMimeType(audioCodecsSet,
+                                      supportedAudioCodecs,
+                                      audio_mime_type);
+    GetSupportedVideoCodecForMimeType(videoCodecsSet,
+                                      supportedVideoCodecs,
+                                      video_mime_type);
+  }
+}
+
+}  // namespace sysapps
+}  // namespace xwalk

--- a/sysapps/device_capabilities/device_capabilities_avcodecs.h
+++ b/sysapps/device_capabilities/device_capabilities_avcodecs.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_SYSAPPS_DEVICE_CAPABILITIES_DEVICE_CAPABILITIES_AVCODECS_H_
+#define XWALK_SYSAPPS_DEVICE_CAPABILITIES_DEVICE_CAPABILITIES_AVCODECS_H_
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "third_party/jsoncpp/source/include/json/json.h"
+#include "xwalk/sysapps/device_capabilities/device_capabilities_utils.h"
+
+namespace xwalk {
+namespace sysapps {
+
+class DeviceCapabilitiesAVCodecs : public DeviceCapabilitiesObject {
+ public:
+  static DeviceCapabilitiesObject& GetDeviceInstance() {
+    static DeviceCapabilitiesAVCodecs instance;
+    return instance;
+  }
+  Json::Value* Get();
+  void AddEventListener(const std::string& event_name,
+      DeviceCapabilitiesInstance* instance) {}
+  void RemoveEventListener(DeviceCapabilitiesInstance* instance) {}
+
+ private:
+  struct VideoCodec {
+    bool encode;
+    bool hwAccel;
+    std::string format;
+  };
+  typedef std::map<std::string, VideoCodec> VideoCodecMap;
+
+  explicit DeviceCapabilitiesAVCodecs();
+  void InitializeAVCodecs();
+  void GetAllCodecsAndFormatsFromFFmpeg(std::vector<std::string>* audio_codecs,
+                                        std::vector<VideoCodec>* video_codecs,
+                                        std::vector<std::string>* formats);
+  void GetSupportedAVCodecs(
+      std::set<std::string>* supportedAudioCodecs,
+      VideoCodecMap* supportedVideoCodecs);
+  void GetSupportedAudioCodecForMimeType(
+      const std::vector<std::string>& codecs,
+      std::set<std::string>* out_codecs,
+      const std::string& mimetype);
+  void GetSupportedVideoCodecForMimeType(
+      const std::vector<VideoCodec>& codecs,
+      VideoCodecMap* out_codecs,
+      const std::string& mimetype);
+
+  Json::Value audioCodecs;
+  Json::Value videoCodecs;
+};
+
+}  // namespace sysapps
+}  // namespace xwalk
+
+#endif  // XWALK_SYSAPPS_DEVICE_CAPABILITIES_DEVICE_CAPABILITIES_AVCODECS_H_

--- a/sysapps/device_capabilities/device_capabilities_instance.cc
+++ b/sysapps/device_capabilities/device_capabilities_instance.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/logging.h"
+#include "xwalk/sysapps/device_capabilities/device_capabilities_avcodecs.h"
 #include "xwalk/sysapps/device_capabilities/device_capabilities_cpu.h"
 #include "xwalk/sysapps/device_capabilities/device_capabilities_display.h"
 #include "xwalk/sysapps/device_capabilities/device_capabilities_memory.h"
@@ -34,6 +35,8 @@ DeviceCapabilitiesInstance::~DeviceCapabilitiesInstance() {
 
 void DeviceCapabilitiesInstance::DeviceMapInitialize() {
   device_map_.insert(DeviceMapPair(
+      "AVCodec", DeviceCapabilitiesAVCodecs::GetDeviceInstance()));
+  device_map_.insert(DeviceMapPair(
       "CPU", DeviceCapabilitiesCpu::GetDeviceInstance()));
   device_map_.insert(DeviceMapPair(
       "Display", DeviceCapabilitiesDisplay::GetDeviceInstance()));
@@ -58,7 +61,9 @@ void DeviceCapabilitiesInstance::HandleMessage(scoped_ptr<base::Value> msg) {
   }
   std::string cmd = input["cmd"].asString();
 
-  if (cmd == "getCPUInfo") {
+  if (cmd == "getAVCodecs") {
+    HandleGetDeviceInfo("AVCodec", input);
+  } else if (cmd == "getCPUInfo") {
     HandleGetDeviceInfo("CPU", input);
   } else if (cmd == "getMemoryInfo") {
     HandleGetDeviceInfo("Memory", input);

--- a/test/android/data/device_capabilities.html
+++ b/test/android/data/device_capabilities.html
@@ -67,6 +67,23 @@
               onSuccess();
             }, Error);
 
+        system.getAVCodecs()
+            .then(function(avcodecs) {
+              var msg = "";
+              for (var i = 0; i < avcodecs.audioCodecs.length; ++i) {
+                  msg += enumerateAllProps(avcodecs.audioCodecs[i]);
+                  msg += '---------\n';
+              }
+              for (var i = 0; i < avcodecs.videoCodecs.length; ++i) {
+                  msg += enumerateAllProps(avcodecs.videoCodecs[i]);
+                  msg += '---------\n';
+              }
+              var output = document.getElementById("avcodecs");
+              output.value += msg;
+              output.scrollTop = output.scrollHeight;
+              onSuccess();
+            }, Error);
+
         system.getDisplayInfo()
             .then(function(display) {
               var msg = ''; 
@@ -135,6 +152,10 @@
   <div class="memory">
     <p class="subtitle center">MemoryInfo</p>
     <p class="text" id="memory"></p>
+  </div>
+  <div class="avcodecs">
+    <p class="subtitle center">avcodecs</p>
+    <textarea id="avcodecs" readonly=true></textarea>
   </div>
   <div class="display">
     <p class="subtitle center">DisplayInfo</p>


### PR DESCRIPTION
The main idea is as below:
1. Get supported codec and mime format list from <code>libffmpegsumo.so</code>
2. Use APIs in <code>net/base/mime_util.h</code> to verify whether a format/codec supported.
   If true, the codec will be added in the supported media codecs list.

The step 2 logic refers to implementation of
<code>WebKit::WebMimeRegistry::supportsMediaMIMEType()</code>

spec: http://device-capabilities.sysapps.org/
feature: https://crosswalk-project.org/jira/browse/XWALK-47
