### PR TITLE
[Android] Add orientation support in the packaging tool.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -129,6 +129,9 @@ def CustomizeXML(options, sanitized_name):
   activity_name = options.package + '.' + sanitized_name + 'Activity'
   EditElementAttribute(xmldoc, 'activity', 'android:name', activity_name)
   EditElementAttribute(xmldoc, 'activity', 'android:label', options.name)
+  if options.orientation:
+    EditElementAttribute(xmldoc, 'activity', 'android:screenOrientation',
+                         options.orientation)
   if options.fullscreen:
     AddThemeStyle(xmldoc, 'activity', 'android:theme', 'Fullscreen')
   else:
@@ -341,6 +344,12 @@ def main():
           'On Linux and Mac, the separator is ":". On Windows, it is ";".'
           'Such as: --extensions="/path/to/extension1:/path/to/extension2"')
   parser.add_option('--extensions', help=info)
+  info = ('The orientation of the web app\'s display on the device. '
+          'Such as: --orientation=landscape. The default value is "unspecified"'
+          'The value options are the same as those on the Android: '
+          'http://developer.android.com/guide/topics/manifest/'
+          'activity-element.html#screen')
+  parser.add_option('--orientation', help=info)
   options, _ = parser.parse_args()
   sanitized_name = ReplaceInvalidChars(options.name)
   try:

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -189,10 +189,13 @@ def Customize(options):
   extensions_list = ''
   if options.extensions:
     extensions_list = '--extensions=%s' % options.extensions
+  orientation = '--orientation=unspecified'
+  if options.orientation:
+    orientation = '--orientation=%s' % options.orientation
   cmd = ['python', 'customize.py', package,
           name, app_version, description, icon, permissions, app_url,
           remote_debugging, app_root, app_local_path, fullscreen_flag,
-          extensions_list]
+          extensions_list, orientation]
   RunCommand(cmd)
 
 
@@ -495,6 +498,12 @@ def main(argv):
   parser.add_option('--mode', help=info)
   info = ('The path of the XPK file. Such as: --xpk=/path/to/xpk/file')
   parser.add_option('--xpk', help=info)
+  info = ('The orientation of the web app\'s display on the device. '
+          'Such as: --orientation=landscape. The default value is "unspecified"'
+          'The value options are the same as those on the Android: '
+          'http://developer.android.com/guide/topics/manifest/'
+          'activity-element.html#screen')
+  parser.add_option('--orientation', help=info)
   options, _ = parser.parse_args()
   if len(argv) == 1:
     parser.print_help()

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -340,6 +340,23 @@ class TestMakeApk(unittest.TestCase):
     self.assertFalse(os.path.exists('Example'))
     self.assertFalse(os.path.isfile('Example.apk'))
 
+  def testOrientation(self):
+    proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',
+                             '--app-version=1.0.0',
+                             '--package=org.xwalk.example',
+                             '--app-url=http://www.intel.com',
+                             '--orientation=landscape'],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    _, _ = proc.communicate()
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('landscape') != -1)
+    self.assertTrue(os.path.exists('Example'))
+    self.assertTrue(os.path.isfile('Example.apk'))
+    Clean('Example')
+
 
 if __name__ == '__main__':
   parser = optparse.OptionParser()


### PR DESCRIPTION
Support the developer to set the display of app on device through
the option of packing tool. Such as: --orientation=landscape.
The default value is "unspecified".
The value options are the same as those on the Android:
http://developer.android.com/guide/topics/manifest/activity-element.html#screen
