### PR TITLE
[Android] Disable one test case about remote debug.

### DIFF
--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/EnableRemoteDebuggingTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/EnableRemoteDebuggingTest.java
@@ -7,6 +7,7 @@ package org.xwalk.runtime.client.test;
 
 import android.content.Context;
 import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
 
@@ -24,8 +25,11 @@ public class EnableRemoteDebuggingTest extends XWalkRuntimeClientTestBase {
         helper.testEnableRemoteDebugging(getActivity(), context);
     }
 
-    @SmallTest
-    @Feature({"DisableRemoteDebugging"})
+    // This test case failed on trybot, but passed on buildbot and local machine.
+    // Disabled it first, It will be enabled later.
+    // @SmallTest
+    // @Feature({"DisableRemoteDebugging"})
+    @DisabledTest
     public void testDisableRemoteDebugging() throws Throwable {
         Context context = getActivity();
         RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/EnableRemoteDebuggingTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/EnableRemoteDebuggingTest.java
@@ -7,6 +7,7 @@ package org.xwalk.runtime.client.embedded.test;
 
 import android.content.Context;
 import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
 
@@ -24,8 +25,11 @@ public class EnableRemoteDebuggingTest extends XWalkRuntimeClientTestBase {
         helper.testEnableRemoteDebugging(getActivity(), context);
     }
 
-    @SmallTest
-    @Feature({"DisableRemoteDebugging"})
+    // This test case failed on trybot, but passed on buildbot and local machine.
+    // Disabled it first, It will be enabled later.
+    // @SmallTest
+    // @Feature({"DisableRemoteDebugging"})
+    @DisabledTest
     public void testDisableRemoteDebugging() throws Throwable {
         Context context = getActivity();
         RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =


### PR DESCRIPTION
This patch disabled the test case "testDisableRemoteDebugging".
It is failed on trybot, but passed on buildbot. It can not be
reproduced on local machine.
It will be enabled later when we find the root cause.
