### PR TITLE
[Runtime] Fix RuntimeContext ownership and unify its creation

### DIFF
--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -32,6 +32,7 @@
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge_base.h"
 #include "xwalk/runtime/browser/android/xwalk_web_contents_delegate.h"
 #include "xwalk/runtime/browser/runtime_context.h"
+#include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
 #include "xwalk/runtime/browser/xwalk_content_browser_client.h"
 #include "jni/XWalkContent_jni.h"
 
@@ -111,8 +112,14 @@ jint XWalkContent::GetWebContents(
 
 content::WebContents* XWalkContent::CreateWebContents(
     JNIEnv* env, jobject intercept_navigation_delegate) {
-  RuntimeContext* runtime_context =
-      XWalkContentBrowserClient::GetRuntimeContext();
+
+  XWalkBrowserMainParts* main_parts =
+          XWalkContentBrowserClient::Get()->main_parts();
+  CHECK(main_parts);
+  // FIXME : need a better way to get context.
+  RuntimeContext* runtime_context = main_parts->runtime_context();
+  CHECK(runtime_context);
+
   content::WebContents* web_contents = content::WebContents::Create(
       content::WebContents::CreateParams(runtime_context));
 

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -65,8 +65,7 @@ Runtime::Runtime(content::WebContents* web_contents)
       fullscreen_options_(NO_FULLSCREEN)  {
   web_contents_.reset(web_contents);
   web_contents_->SetDelegate(this);
-  runtime_context_ =
-      static_cast<RuntimeContext*>(web_contents->GetBrowserContext());
+  runtime_context_ = RuntimeContext::FromWebContents(web_contents);
   RuntimeRegistry::Get()->AddRuntime(this);
 }
 

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -57,12 +57,8 @@ class RuntimeContext::RuntimeResourceContext : public content::ResourceContext {
   DISALLOW_COPY_AND_ASSIGN(RuntimeResourceContext);
 };
 
-#if !defined(OS_ANDROID)
 RuntimeContext::RuntimeContext()
   : resource_context_(new RuntimeResourceContext) {
-#else
-RuntimeContext::RuntimeContext() {
-#endif
   InitWhileIOAllowed();
   application_system_.reset(new xwalk::application::ApplicationSystem(this));
 }
@@ -74,14 +70,12 @@ RuntimeContext::~RuntimeContext() {
   }
 }
 
-#if defined(OS_ANDROID)
 // static
 RuntimeContext* RuntimeContext::FromWebContents(
     content::WebContents* web_contents) {
   // This is safe; this is the only implementation of the browser context.
   return static_cast<RuntimeContext*>(web_contents->GetBrowserContext());
 }
-#endif
 
 void RuntimeContext::InitWhileIOAllowed() {
   CommandLine* cmd_line = CommandLine::ForCurrentProcess();
@@ -101,14 +95,6 @@ base::FilePath RuntimeContext::GetPath() const {
 #endif
   return result;
 }
-
-#if defined(OS_ANDROID)
-void RuntimeContext::InitializeBeforeThreadCreation() {
-}
-
-void RuntimeContext::PreMainMessageLoopRun() {
-}
-#endif
 
 bool RuntimeContext::IsOffTheRecord() const {
   // We don't consider off the record scenario.
@@ -154,10 +140,6 @@ net::URLRequestContextGetter*
 }
 
 content::ResourceContext* RuntimeContext::GetResourceContext()  {
-#if defined(OS_ANDROID)
-  if (!resource_context_.get())
-    resource_context_.reset(new RuntimeResourceContext);
-#endif
   return resource_context_.get();
 }
 

--- a/runtime/browser/runtime_context.h
+++ b/runtime/browser/runtime_context.h
@@ -37,17 +37,9 @@ class RuntimeContext : public content::BrowserContext {
   RuntimeContext();
   virtual ~RuntimeContext();
 
-#if defined(OS_ANDROID)
   // Convenience method to returns the RuntimeContext corresponding to the
   // given WebContents.
   static RuntimeContext* FromWebContents(content::WebContents* web_contents);
-
-  // Called before BrowserThreads are created.
-  void InitializeBeforeThreadCreation();
-
-  // Maps to BrowserMainParts::PreMainMessageLoopRun.
-  void PreMainMessageLoopRun();
-#endif
 
   // BrowserContext implementation.
   virtual base::FilePath GetPath() const OVERRIDE;

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -162,12 +162,6 @@ XWalkBrowserMainParts::XWalkBrowserMainParts(
 XWalkBrowserMainParts::~XWalkBrowserMainParts() {
 }
 
-#if defined(OS_ANDROID)
-void XWalkBrowserMainParts::SetRuntimeContext(RuntimeContext* context) {
-  runtime_context_ = context;
-}
-#endif
-
 void XWalkBrowserMainParts::PreMainMessageLoopStart() {
   SetXWalkCommandLineFlags();
 
@@ -214,10 +208,6 @@ void XWalkBrowserMainParts::PreEarlyInitialization() {
 }
 
 int XWalkBrowserMainParts::PreCreateThreads() {
-#if defined(OS_ANDROID)
-  DCHECK(runtime_context_);
-  runtime_context_->InitializeBeforeThreadCreation();
-#endif
   return content::RESULT_CODE_NORMAL_EXIT;
 }
 
@@ -254,9 +244,6 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     run_default_message_loop_ = false;
   }
 
-  DCHECK(runtime_context_);
-  runtime_context_->PreMainMessageLoopRun();
-  runtime_registry_.reset(new RuntimeRegistry);
   extension_service_.reset(new extensions::XWalkExtensionService(this));
 #else
   runtime_context_.reset(new RuntimeContext);
@@ -354,7 +341,7 @@ void XWalkBrowserMainParts::RegisterInternalExtensionsInServer(
 #else
   server->RegisterExtension(scoped_ptr<XWalkExtension>(new RuntimeExtension()));
   server->RegisterExtension(scoped_ptr<XWalkExtension>(
-      new ApplicationExtension(runtime_context()->GetApplicationSystem())));
+      new ApplicationExtension(runtime_context_->GetApplicationSystem())));
   server->RegisterExtension(scoped_ptr<XWalkExtension>(
       new experimental::DialogExtension(runtime_registry_.get())));
 #endif

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -48,16 +48,13 @@ class XWalkBrowserMainParts : public content::BrowserMainParts,
       extensions::XWalkExtensionServer* server) OVERRIDE;
 
 #if defined(OS_ANDROID)
-  void SetRuntimeContext(RuntimeContext* context);
-  RuntimeContext* runtime_context() { return runtime_context_; }
+  RuntimeContext* runtime_context() { return runtime_context_.get(); }
 
   // XWalkExtensionAndroid needs to register its extensions on
   // XWalkBrowserMainParts so they get correctly registered on-demand
   // by XWalkExtensionService each time a in_process Server is created.
   void RegisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
   void UnregisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
-#else
-  RuntimeContext* runtime_context() { return runtime_context_.get(); }
 #endif
   extensions::XWalkExtensionService* extension_service() {
     return extension_service_.get();
@@ -74,11 +71,9 @@ class XWalkBrowserMainParts : public content::BrowserMainParts,
 #endif
 
 #if defined(OS_ANDROID)
-  RuntimeContext* runtime_context_;
   ScopedVector<extensions::XWalkExtension> extensions_;
-#else
-  scoped_ptr<RuntimeContext> runtime_context_;
 #endif
+  scoped_ptr<RuntimeContext> runtime_context_;
 
   // An application wide instance to manage all Runtime instances.
   scoped_ptr<RuntimeRegistry> runtime_registry_;

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -36,11 +36,6 @@ namespace {
 // The application-wide singleton of ContentBrowserClient impl.
 XWalkContentBrowserClient* g_browser_client = NULL;
 
-#if defined(OS_ANDROID)
-// Android creates and holds its browser context by browser client.
-RuntimeContext* g_runtime_context;
-#endif
-
 }  // namespace
 
 // static
@@ -48,37 +43,22 @@ XWalkContentBrowserClient* XWalkContentBrowserClient::Get() {
   return g_browser_client;
 }
 
-#if defined(OS_ANDROID)
-// static
-RuntimeContext* XWalkContentBrowserClient::GetRuntimeContext() {
-  return g_runtime_context;
-}
-#endif
 
 XWalkContentBrowserClient::XWalkContentBrowserClient()
     : main_parts_(NULL) {
   DCHECK(!g_browser_client);
   g_browser_client = this;
-#if defined(OS_ANDROID)
-  g_runtime_context = new RuntimeContext();
-#endif
 }
 
 XWalkContentBrowserClient::~XWalkContentBrowserClient() {
   DCHECK(g_browser_client);
   g_browser_client = NULL;
-#if defined(OS_ANDROID)
-  g_runtime_context = NULL;
-#endif
 }
 
 content::BrowserMainParts* XWalkContentBrowserClient::CreateBrowserMainParts(
     const content::MainFunctionParams& parameters) {
   main_parts_ = new XWalkBrowserMainParts(parameters);
 
-#if defined(OS_ANDROID)
-  main_parts_->SetRuntimeContext(g_runtime_context);
-#endif
   return main_parts_;
 }
 

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -30,9 +30,6 @@ class RuntimeContext;
 class XWalkContentBrowserClient : public content::ContentBrowserClient {
  public:
   static XWalkContentBrowserClient* Get();
-#if defined(OS_ANDROID)
-  static RuntimeContext* GetRuntimeContext();
-#endif
 
   XWalkContentBrowserClient();
   virtual ~XWalkContentBrowserClient();


### PR DESCRIPTION
On Android RuntimeContext used to be a singleton which is wrong as content::ContentBrowserClient lifetime should be equal to the duration of the browser session, meaning its creation&deletion should be controlled by BrowserMainLoop.

This patch unifies the creation of RuntimeContext between android and others removing ugly '#ifdefs' and unneeded difference in the code path.
