### PR TITLE
[WiDi API] Destroy XWalkView instance when presentation content is closed

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
@@ -248,6 +248,7 @@ public class PresentationExtension extends XWalkExtension {
                     @Override
                     public void onContentClosed(XWalkPresentationContent content) {
                         if (content == mPresentationContent) {
+                            mPresentationContent.close();
                             mPresentationContent = null;
                             if (mPresentationView != null) mPresentationView.cancel();
                         }

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/XWalkPresentationContent.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/XWalkPresentationContent.java
@@ -63,8 +63,7 @@ public class XWalkPresentationContent {
     }
 
     public void close() {
-        // TODO(hmin): Add code to destroy XWalkView instance.
-        // mContentView.destroy();
+        mContentView.destroy();
         mPresentationId = INVALID_PRESENTATION_ID;
         mContentView = null;
     }


### PR DESCRIPTION
The XWalkView instance should be destroyed once the presentation content is closed.
Otherwise, the resources allocated would be leaked. For example, zombie pages would
be listed in chrome web inspector (chrome://inspect) after the presentation content gets
closed by calling window.close API.

BUG=https://crosswalk-project.org/jira/browse/XWALK-336
