### PR TITLE
[Tizen] add the 'gst-plugins-atomisp-devel' buildrequires to spec

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -24,6 +24,7 @@ BuildRequires:  bzip2-devel
 BuildRequires:  expat-devel
 BuildRequires:  flex
 BuildRequires:  gperf
+BuildRequires:  gst-plugins-atomisp-devel
 BuildRequires:  libasound-devel
 BuildRequires:  libcap-devel
 BuildRequires:  pkgmgr-info-parser-devel


### PR DESCRIPTION
chromium needs the header and lib files exported from this package to drive the
camera device on Tizen 2.1 hardware platforms.

BUG=XWALK-176
