### PR TITLE
[Tizen][Runtime Model] Using the xwalk logo image when icons are not given in manifest.json

### DIFF
--- a/application/browser/installer/tizen/package_installer.cc
+++ b/application/browser/installer/tizen/package_installer.cc
@@ -101,7 +101,10 @@ bool PackageInstaller::GeneratePkgInfoXml() {
     xml_writer.AddAttribute("type", "c++app");
     xml_writer.AddAttribute("taskmanage", "true");
     xml_writer.WriteElement("label", application_->Name());
-    xml_writer.WriteElement("icon", icon_path_.BaseName().MaybeAsASCII());
+    if (icon_name_.empty())
+      xml_writer.WriteElement("icon", info::kDefaultIconName);
+    else
+      xml_writer.WriteElement("icon", icon_path_.BaseName().MaybeAsASCII());
     xml_writer.EndElement();  // Ends "ui-application"
   }
 

--- a/application/browser/installer/tizen/packageinfo_constants.cc
+++ b/application/browser/installer/tizen/packageinfo_constants.cc
@@ -22,6 +22,7 @@ const base::FilePath::CharType kXwalkPath[] =
 const base::FilePath::CharType kExecDir[] =
     FILE_PATH_LITERAL("bin");
 
+const char kDefaultIconName[] = "crosswalk.png";
 const char kIconKey[] = "icons.128";
 const char kOwner[] = "app";
 

--- a/application/browser/installer/tizen/packageinfo_constants.h
+++ b/application/browser/installer/tizen/packageinfo_constants.h
@@ -18,6 +18,7 @@ namespace application_packageinfo_constants {
   extern const base::FilePath::CharType kXwalkPath[];
   extern const base::FilePath::CharType kExecDir[];
 
+  extern const char kDefaultIconName[];
   extern const char kIconKey[];
   extern const char kOwner[];
 


### PR DESCRIPTION
The application button with default xwalk logo image will be placed on
home screen in Tizen if the icons field is not given in manifest.json.

BUG=https://crosswalk-project.org/jira/browse/XWALK-124
