### PR TITLE
[DBus] Add PropertyExporter and DBusManager classes

### DIFF
--- a/dbus/DEPS
+++ b/dbus/DEPS
@@ -1,0 +1,6 @@
+include_rules = [
+  "-xwalk",
+  "+xwalk/dbus",
+  "+dbus",
+  "+base",
+]

--- a/dbus/dbus_manager.cc
+++ b/dbus/dbus_manager.cc
@@ -1,0 +1,52 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/dbus/dbus_manager.h"
+
+#include <string>
+#include "base/bind.h"
+#include "base/threading/thread.h"
+#include "dbus/bus.h"
+
+namespace xwalk {
+
+DBusManager::DBusManager(const std::string& service_name)
+    : weak_factory_(this),
+      service_name_(service_name) {}
+
+DBusManager::~DBusManager() {
+  session_bus_->ShutdownOnDBusThreadAndBlock();
+}
+
+void DBusManager::Initialize(const base::Closure& on_success_callback) {
+  on_success_callback_ = on_success_callback;
+
+  base::Thread::Options thread_options;
+  thread_options.message_loop_type = base::MessageLoop::TYPE_IO;
+  std::string thread_name = "Crosswalk D-Bus thread (" + service_name_ + ")";
+  dbus_thread_.reset(new base::Thread(thread_name.c_str()));
+  dbus_thread_->StartWithOptions(thread_options);
+
+  dbus::Bus::Options options;
+  options.dbus_task_runner = dbus_thread_->message_loop_proxy();
+  session_bus_ = new dbus::Bus(options);
+
+  session_bus_->RequestOwnership(
+      service_name_, dbus::Bus::REQUIRE_PRIMARY,
+      base::Bind(&DBusManager::OnNameOwned, weak_factory_.GetWeakPtr()));
+}
+
+scoped_refptr<dbus::Bus> DBusManager::session_bus() {
+  return session_bus_;
+}
+
+void DBusManager::OnNameOwned(const std::string& service_name, bool success) {
+  if (!success) {
+    LOG(ERROR) << "Could not own DBus service name '" << service_name << "'.";
+    return;
+  }
+  on_success_callback_.Run();
+}
+
+}  // namespace xwalk

--- a/dbus/dbus_manager.h
+++ b/dbus/dbus_manager.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_DBUS_DBUS_MANAGER_H_
+#define XWALK_DBUS_DBUS_MANAGER_H_
+
+#include <string>
+#include "base/callback.h"
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_ptr.h"
+#include "base/memory/weak_ptr.h"
+
+namespace base {
+class Thread;
+}
+
+namespace dbus {
+class Bus;
+}
+
+namespace xwalk {
+
+// Holds a DBus thread and a session bus connection, that should be shared by
+// all users of DBus inside Crosswalk.
+class DBusManager {
+ public:
+  explicit DBusManager(const std::string& service_name);
+  ~DBusManager();
+
+  // FIXME(cmarcelo): Notify about failure. We probably want to move
+  // to a delegate/observer interface in the future.
+  void Initialize(const base::Closure& on_success_callback);
+
+  scoped_refptr<dbus::Bus> session_bus();
+
+ private:
+  void OnNameOwned(const std::string& service_name, bool success);
+
+  base::WeakPtrFactory<DBusManager> weak_factory_;
+  std::string service_name_;
+  scoped_ptr<base::Thread> dbus_thread_;
+  scoped_refptr<dbus::Bus> session_bus_;
+  base::Closure on_success_callback_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_DBUS_DBUS_MANAGER_H_

--- a/dbus/dbus_manager_unittest.cc
+++ b/dbus/dbus_manager_unittest.cc
@@ -1,0 +1,123 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <string>
+#include "base/bind.h"
+#include "base/message_loop/message_loop.h"
+#include "base/run_loop.h"
+#include "base/threading/thread.h"
+#include "dbus/bus.h"
+#include "dbus/exported_object.h"
+#include "dbus/message.h"
+#include "dbus/object_proxy.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "xwalk/dbus/dbus_manager.h"
+#include "xwalk/dbus/test_client.h"
+
+using xwalk::DBusManager;
+
+const char kTestServiceName[] = "org.crosswalkproject.test_service";
+const char kTestInterface[] = "org.crosswalkproject.test_service.Interface";
+const char kTestMethod[] = "Method";
+const dbus::ObjectPath kTestObjectPath("/test/path");
+
+// Test whether initialization of a DBusManager succeeds.
+TEST(DBusManagerTest, Initialize) {
+  base::MessageLoop message_loop;
+  DBusManager manager(kTestServiceName);
+
+  base::RunLoop run_loop;
+  manager.Initialize(run_loop.QuitClosure());
+  run_loop.Run();
+
+  ASSERT_TRUE(manager.session_bus());
+  ASSERT_TRUE(manager.session_bus()->is_connected());
+}
+
+void EmptyCallback() {}
+
+// Uses a DBusManager to expose an object with a method. Provide hooks (on_*
+// callbacks), so that calling code can track whether the object was exposed and
+// the method was called.
+class ExportObjectService {
+ public:
+  ExportObjectService()
+      : on_exported(base::Bind(EmptyCallback)),
+        on_method_called(base::Bind(EmptyCallback)),
+        manager_(kTestServiceName),
+        dbus_object_(NULL) {}
+
+  void Initialize() {
+    manager_.Initialize(
+        base::Bind(&ExportObjectService::OnInitialized,
+                   base::Unretained(this)));
+  }
+
+  base::Closure on_exported;
+  base::Closure on_method_called;
+
+ private:
+  void OnInitialized() {
+    dbus_object_ = manager_.session_bus()->GetExportedObject(kTestObjectPath);
+    dbus_object_->ExportMethod(
+        kTestInterface, kTestMethod,
+        base::Bind(&ExportObjectService::OnMethodCalled,
+                   base::Unretained(this)),
+        base::Bind(&ExportObjectService::OnExported,
+                   base::Unretained(this)));
+  }
+
+  void OnExported(const std::string& interface_name,
+                  const std::string& method_name,
+                  bool success) {
+    on_exported.Run();
+  }
+
+  void OnMethodCalled(dbus::MethodCall* method_call,
+                      dbus::ExportedObject::ResponseSender response_sender) {
+    on_method_called.Run();
+  }
+
+  DBusManager manager_;
+  dbus::ExportedObject* dbus_object_;
+};
+
+// Test whether we can expose an object using DBusManager.
+TEST(DBusManagerTest, ExportObject) {
+  base::MessageLoop message_loop;
+  base::RunLoop run_loop;
+  ExportObjectService test_service;
+  test_service.on_exported = base::Bind(run_loop.QuitClosure());
+  test_service.Initialize();
+  run_loop.Run();
+}
+
+// Call the method exposed by ExportObjectService.
+class CallMethodClient : public dbus::TestClient {
+ public:
+  void CallTestMethod() {
+    dbus::ObjectProxy* object_proxy =
+        bus_->GetObjectProxy(kTestServiceName, kTestObjectPath);
+
+    dbus::MethodCall method_call(kTestInterface, kTestMethod);
+    object_proxy->CallMethod(&method_call,
+                             dbus::ObjectProxy::TIMEOUT_USE_DEFAULT,
+                             dbus::ObjectProxy::EmptyResponseCallback());
+  }
+};
+
+// Tests whether we can call a method exported by a bus created in DBusManager.
+TEST(DBusManagerTest, CallMethod) {
+  base::MessageLoop message_loop;
+  base::RunLoop run_loop;
+
+  CallMethodClient test_client;
+  ExportObjectService test_service;
+  test_service.on_method_called = base::Bind(run_loop.QuitClosure());
+  test_service.on_exported = base::Bind(&CallMethodClient::CallTestMethod,
+                                        base::Unretained(&test_client));
+  test_service.Initialize();
+
+  run_loop.Run();
+}

--- a/dbus/property_exporter.cc
+++ b/dbus/property_exporter.cc
@@ -1,0 +1,134 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/dbus/property_exporter.h"
+
+#include <string>
+#include "base/bind.h"
+#include "base/stl_util.h"
+#include "base/values.h"
+#include "dbus/message.h"
+#include "dbus/property.h"
+
+namespace {
+
+const char kErrorName[] = "org.freedesktop.DBus.Properties.Error";
+
+}  // namespace
+
+namespace dbus {
+
+PropertyExporter::PropertyExporter(ExportedObject* object,
+                                   const ObjectPath& path)
+    : path_(path),
+      weak_factory_(this) {
+  CHECK(object);
+  object->ExportMethod(
+      kPropertiesInterface, kPropertiesGet,
+      base::Bind(&PropertyExporter::OnGet, weak_factory_.GetWeakPtr()),
+      base::Bind(&PropertyExporter::OnExported, weak_factory_.GetWeakPtr()));
+}
+
+PropertyExporter::~PropertyExporter() {
+  STLDeleteValues(&interfaces_);
+}
+
+void PropertyExporter::Set(const std::string& interface,
+                           const std::string& property,
+                           scoped_ptr<base::Value> value) {
+  // TODO(cmarcelo): Support more types as we need to use them.
+  if (!value->IsType(base::Value::TYPE_STRING)
+      && !value->IsType(base::Value::TYPE_INTEGER)) {
+    LOG(ERROR) << "PropertyExporter can only can "
+               << "export String and Integer properties";
+    return;
+  }
+
+  InterfacesMap::iterator it = interfaces_.find(interface);
+  base::DictionaryValue* dict;
+  if (it != interfaces_.end()) {
+    dict = it->second;
+  } else {
+    dict = new DictionaryValue;
+    interfaces_[interface] = dict;
+  }
+
+  dict->Set(property, value.release());
+
+  // TODO(cmarcelo): Emit PropertyChanged signal.
+}
+
+namespace {
+
+void AppendVariantOfValue(MessageWriter* writer, const base::Value* value) {
+  switch (value->GetType()) {
+    case base::Value::TYPE_STRING: {
+      std::string s;
+      value->GetAsString(&s);
+      writer->AppendVariantOfString(s);
+      break;
+    }
+    case base::Value::TYPE_INTEGER: {
+      int n;
+      value->GetAsInteger(&n);
+      writer->AppendVariantOfInt32(n);
+      break;
+    }
+    default:
+      LOG(ERROR) << "Unsupported base::Value when converting to DBus VARIANT.";
+  }
+}
+
+}  // namespace
+
+void PropertyExporter::OnGet(
+    MethodCall* method_call, ExportedObject::ResponseSender response_sender) {
+  MessageReader reader(method_call);
+  std::string interface;
+  std::string property;
+  if (!reader.PopString(&interface) || !reader.PopString(&property)) {
+    scoped_ptr<ErrorResponse> error_response = ErrorResponse::FromMethodCall(
+        method_call, kErrorName, "Error parsing arguments.");
+    response_sender.Run(error_response.PassAs<Response>());
+    return;
+  }
+
+  InterfacesMap::const_iterator it = interfaces_.find(interface);
+  if (it == interfaces_.end()) {
+    scoped_ptr<ErrorResponse> error_response = ErrorResponse::FromMethodCall(
+        method_call, kErrorName,
+        "Interface '" + interface + "' not found for object '"
+        + path_.value() + "'.");
+    response_sender.Run(error_response.PassAs<Response>());
+    return;
+  }
+
+  const DictionaryValue* dict = it->second;
+  const base::Value* value = NULL;
+  if (!dict->Get(property, &value)) {
+    scoped_ptr<ErrorResponse> error_response = ErrorResponse::FromMethodCall(
+        method_call, kErrorName,
+        "Property '" + property + "' of interface '" + interface
+        + "' not found for object '" + path_.value() + "'.");
+    response_sender.Run(error_response.PassAs<Response>());
+    return;
+  }
+
+  scoped_ptr<Response> response = Response::FromMethodCall(method_call);
+  MessageWriter writer(response.get());
+  AppendVariantOfValue(&writer, value);
+  response_sender.Run(response.Pass());
+}
+
+void PropertyExporter::OnExported(const std::string& interface_name,
+                                  const std::string& method_name,
+                                  bool success) {
+  if (!success) {
+    LOG(WARNING) << "Error exporting method '" << interface_name
+                 << "." << method_name << "' in object '"
+                 << path_.value() << "'.";
+  }
+}
+
+}  // namespace dbus

--- a/dbus/property_exporter.h
+++ b/dbus/property_exporter.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_DBUS_PROPERTY_EXPORTER_H_
+#define XWALK_DBUS_PROPERTY_EXPORTER_H_
+
+#include <map>
+#include <string>
+#include "base/memory/scoped_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "dbus/exported_object.h"
+#include "dbus/object_path.h"
+
+namespace base {
+class DictionaryValue;
+class Value;
+}
+
+namespace dbus {
+
+// Exports org.freedesktop.DBus.Properties interface for the given
+// ExportedObject. Properties should be set directly into the exporter object
+// using the function Set().
+class PropertyExporter {
+ public:
+  PropertyExporter(dbus::ExportedObject* object, const dbus::ObjectPath& path);
+  ~PropertyExporter();
+
+  void Set(const std::string& interface,
+           const std::string& property,
+           scoped_ptr<base::Value>);
+
+  // TODO(cmarcelo): We need some callback to indicate when all the methods
+  // were exported.
+
+ private:
+  void OnGet(dbus::MethodCall* method_call,
+             dbus::ExportedObject::ResponseSender response_sender);
+  void OnExported(const std::string& interface_name,
+                  const std::string& method_name,
+                  bool success);
+
+  typedef std::map<std::string, base::DictionaryValue*> InterfacesMap;
+  InterfacesMap interfaces_;
+
+  dbus::ObjectPath path_;
+  base::WeakPtrFactory<PropertyExporter> weak_factory_;
+};
+
+}  // namespace dbus
+
+#endif  // XWALK_DBUS_PROPERTY_EXPORTER_H_

--- a/dbus/property_exporter_unittest.cc
+++ b/dbus/property_exporter_unittest.cc
@@ -1,0 +1,109 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/dbus/property_exporter.h"
+
+#include "base/bind.h"
+#include "base/run_loop.h"
+#include "base/values.h"
+#include "dbus/bus.h"
+#include "dbus/property.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "xwalk/dbus/dbus_manager.h"
+#include "xwalk/dbus/test_client.h"
+
+const char kTestServiceName[] = "org.crosswalkproject.test_properties";
+const char kTestInterface[] = "org.crosswalkproject.test_properties.Interface";
+const char kTestProperty[] = "Property";
+const dbus::ObjectPath kTestObjectPath("/object_with_properties");
+
+class ExportObjectWithPropertiesService {
+ public:
+  ExportObjectWithPropertiesService()
+      : manager_(kTestServiceName),
+        dbus_object_(NULL) {}
+
+  void Initialize(const base::Closure& on_initialized_callback) {
+    on_initialized_callback_ = on_initialized_callback;
+    manager_.Initialize(
+        base::Bind(&ExportObjectWithPropertiesService::OnInitialized,
+                   base::Unretained(this)));
+  }
+
+ private:
+  void OnInitialized() {
+    dbus_object_ =
+        manager_.session_bus()->GetExportedObject(kTestObjectPath);
+    properties_.reset(
+        new dbus::PropertyExporter(dbus_object_, kTestObjectPath));
+    scoped_ptr<base::Value> value(base::Value::CreateStringValue("Pass"));
+    properties_->Set(kTestInterface, kTestProperty, value.Pass());
+    on_initialized_callback_.Run();
+  }
+
+  xwalk::DBusManager manager_;
+  dbus::ExportedObject* dbus_object_;
+  scoped_ptr<dbus::PropertyExporter> properties_;
+  base::Closure on_initialized_callback_;
+};
+
+// Use dbus/property.h to access the property exposed above.
+class GetPropertyClient : public dbus::TestClient {
+ public:
+  struct Properties : public dbus::PropertySet {
+    dbus::Property<std::string> property;
+    Properties(dbus::ObjectProxy* object_proxy,
+               const PropertyChangedCallback callback)
+        : dbus::PropertySet(object_proxy, kTestInterface, callback) {
+      RegisterProperty(kTestProperty, &property);
+    }
+  };
+
+  explicit GetPropertyClient(const base::Closure& on_get_property_callback)
+      : on_get_property_callback_(on_get_property_callback) {
+    object_proxy_ = bus_->GetObjectProxy(kTestServiceName, kTestObjectPath);
+    properties_.reset(
+        new Properties(object_proxy_,
+                       base::Bind(&GetPropertyClient::OnPropertyChanged,
+                                  base::Unretained(this))));
+    properties_->ConnectSignals();
+  }
+
+  void GetProperty() {
+    properties_->property.Get(
+        base::Bind(&GetPropertyClient::GetCallback, base::Unretained(this)));
+  }
+
+  std::string result() const { return result_; }
+
+ private:
+  void OnPropertyChanged(const std::string& property_name) {}
+  void GetCallback(bool success) {
+    if (success)
+      result_ = properties_->property.value();
+    on_get_property_callback_.Run();
+  }
+
+  dbus::ObjectProxy* object_proxy_;
+  scoped_ptr<Properties> properties_;
+  base::Closure on_get_property_callback_;
+  std::string result_;
+};
+
+// Get a property exported using PropertyExporter helper class.
+TEST(PropertyExporterTest, Simple) {
+  base::MessageLoop message_loop;
+  ExportObjectWithPropertiesService test_service;
+
+  base::RunLoop run_loop;
+  GetPropertyClient test_client(run_loop.QuitClosure());
+
+  // After initialize we call GetProperty in the client that will try to get a
+  // property and then run the QuitClosure() passed above, exiting the run loop.
+  test_service.Initialize(base::Bind(&GetPropertyClient::GetProperty,
+                                     base::Unretained(&test_client)));
+  run_loop.Run();
+
+  ASSERT_EQ(test_client.result(), "Pass");
+}

--- a/dbus/test_client.cc
+++ b/dbus/test_client.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/dbus/test_client.h"
+
+#include "dbus/bus.h"
+
+namespace dbus {
+
+TestClient::TestClient()
+    : dbus_thread_("TestClient D-Bus Thread") {
+  // Note that we need to create a thread here so that
+  // dbus::Bus have a MessageLoop with type IO, that is necessary for its
+  // operation.
+  base::Thread::Options thread_options;
+  thread_options.message_loop_type = base::MessageLoop::TYPE_IO;
+  dbus_thread_.StartWithOptions(thread_options);
+
+  dbus::Bus::Options options;
+  options.dbus_task_runner = dbus_thread_.message_loop_proxy();
+  bus_ = new dbus::Bus(options);
+}
+
+TestClient::~TestClient() {
+  bus_->ShutdownOnDBusThreadAndBlock();
+}
+
+}  // namespace dbus

--- a/dbus/test_client.h
+++ b/dbus/test_client.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_DBUS_TEST_CLIENT_H_
+#define XWALK_DBUS_TEST_CLIENT_H_
+
+#include "base/memory/ref_counted.h"
+#include "base/threading/thread.h"
+
+namespace dbus {
+
+class Bus;
+
+// Helper class that provide code to create separated DBus thread and bus
+// connection.
+class TestClient {
+ public:
+  TestClient();
+  ~TestClient();
+
+ protected:
+  scoped_refptr<Bus> bus_;
+
+ private:
+  base::Thread dbus_thread_;
+};
+
+}  // namespace dbus
+
+#endif  // XWALK_DBUS_TEST_CLIENT_H_

--- a/dbus/xwalk_dbus.gyp
+++ b/dbus/xwalk_dbus.gyp
@@ -1,0 +1,40 @@
+{
+  'targets': [
+    {
+      'target_name': 'xwalk_dbus',
+      'type': 'static_library',
+      'dependencies': [
+        '../../base/base.gyp:base',
+        '../../build/linux/system.gyp:dbus',
+        '../../dbus/dbus.gyp:dbus',
+      ],
+      'sources': [
+        'dbus_manager.cc',
+        'dbus_manager.h',
+        'property_exporter.cc',
+        'property_exporter.h',
+        'xwalk_service_name.cc',
+        'xwalk_service_name.h',
+      ],
+    },
+    {
+      'target_name': 'xwalk_dbus_unittests',
+      'type': 'executable',
+      'dependencies': [
+        '../../base/base.gyp:base',
+        '../../base/base.gyp:run_all_unittests',
+        '../../base/base.gyp:test_support_base',
+        '../../build/linux/system.gyp:dbus',
+        '../../dbus/dbus.gyp:dbus',
+        '../../testing/gtest.gyp:gtest',
+        'xwalk_dbus',
+      ],
+      'sources': [
+        'test_client.cc',
+        'test_client.h',
+        'dbus_manager_unittest.cc',
+        'property_exporter_unittest.cc',
+      ],
+    },
+  ],
+}

--- a/dbus/xwalk_service_name.cc
+++ b/dbus/xwalk_service_name.cc
@@ -1,0 +1,11 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/dbus/xwalk_service_name.h"
+
+namespace xwalk {
+
+const char kXWalkDBusServiceName[] = "org.crosswalkproject";
+
+}  // namespace xwalk

--- a/dbus/xwalk_service_name.h
+++ b/dbus/xwalk_service_name.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_DBUS_XWALK_SERVICE_NAME_H_
+#define XWALK_DBUS_XWALK_SERVICE_NAME_H_
+
+#include <string>
+
+namespace xwalk {
+
+extern const char kXWalkDBusServiceName[];
+
+}  // namespace xwalk
+
+#endif  // XWALK_DBUS_XWALK_SERVICE_NAME_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -582,8 +582,7 @@
         ['OS!="android"', {
           'dependencies': [
             'xwalk',
-            'xwalk_browsertest',
-            'xwalk_unittest',
+            'xwalk_all_tests',
           ],
         },
         {

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -1,6 +1,21 @@
 {
   'targets': [
   {
+    'target_name': 'xwalk_all_tests',
+    'type': 'none',
+    'dependencies': [
+      'xwalk_unittest',
+      'xwalk_browsertest',
+    ],
+    'conditions': [
+      ['OS=="linux"', {
+        'dependencies': [
+          'dbus/xwalk_dbus.gyp:xwalk_dbus_unittests',
+        ],
+      }],
+    ],
+  },
+  {
     'target_name': 'xwalk_test_common',
     'type': 'static_library',
     'dependencies': [
@@ -43,7 +58,6 @@
       }],
     ],
   },  # xwalk_test_common target
-
   {
     'target_name': 'xwalk_unittest',
     'type': 'executable',


### PR DESCRIPTION
This commit bootstraps the xwalk/dbus directory with two classes we
intend to use when implementing the '--run-as-service' mode in Linux.

The 'DBusManager' is a convenience class that packages the creation of
the DBus thread and the bus connection. There need to be only one of
those for the whole Crosswalk, so it should be passed around for the
subsystems that need it.

The 'PropertyExporter' class is a partial implementation of a helper
class that exports the 'org.freedesktop.DBus.Properties' interface for a
certain 'dbus::ExportedObject'. It's interface is still incomplete, and
at the moment it will be focused on covering our use cases for
'--run-as-service'. Chromium have a infrastructure for dealing with
properties but only on the client-side, this class adds the server side.

Unit testing infrastructure, as well as basic sanity tests were
added. With these bootstrapped is easy to add new tests later. The new
target 'xwalk_all_tests' was added to include this module in the build
system.
