### PR TITLE
[Runtime] RuntimeRegistry should belong to XWalkContentBrowserClient

### DIFF
--- a/application/test/application_browsertest.cc
+++ b/application/test/application_browsertest.cc
@@ -47,5 +47,5 @@ void ApplicationBrowserTest::WaitForRuntimes(int runtime_count) {
 }
 
 int ApplicationBrowserTest::GetRuntimeNumber() {
-  return xwalk::RuntimeRegistry::Get()->runtimes().size();
+  return runtime_registry().runtimes().size();
 }

--- a/application/test/application_main_document_browsertest.cc
+++ b/application/test/application_main_document_browsertest.cc
@@ -34,7 +34,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationMainDocumentBrowserTest, MainDocument) {
   // At least the main document's runtime exist after launch.
   ASSERT_GE(GetRuntimeNumber(), 1);
 
-  xwalk::Runtime* main_runtime = xwalk::RuntimeRegistry::Get()->runtimes()[0];
+  xwalk::Runtime* main_runtime = runtime_registry().runtimes()[0];
   xwalk::RuntimeContext* runtime_context = main_runtime->runtime_context();
   xwalk::application::ApplicationService* service =
     runtime_context->GetApplicationSystem()->application_service();

--- a/extensions/test/external_extension_multi_process.cc
+++ b/extensions/test/external_extension_multi_process.cc
@@ -37,7 +37,7 @@ class ExternalExtensionMultiProcessTest : public XWalkExtensionsTestBase {
         new content::WindowedNotificationObserver(
           xwalk::NOTIFICATION_RUNTIME_OPENED,
           content::NotificationService::AllSources()));
-    const RuntimeList& runtimes = RuntimeRegistry::Get()->runtimes();
+    const RuntimeList& runtimes = runtime_registry().runtimes();
     for (RuntimeList::const_iterator it = runtimes.begin();
          it != runtimes.end(); ++it)
       original_runtimes_.push_back(*it);
@@ -46,7 +46,7 @@ class ExternalExtensionMultiProcessTest : public XWalkExtensionsTestBase {
   // Block UI thread until a new Runtime instance is created.
   Runtime* WaitForSingleNewRuntime() {
     notification_observer_->Wait();
-    const RuntimeList& runtimes = RuntimeRegistry::Get()->runtimes();
+    const RuntimeList& runtimes = runtime_registry().runtimes();
     for (RuntimeList::const_iterator it = runtimes.begin();
          it != runtimes.end(); ++it) {
       RuntimeList::iterator target =
@@ -78,7 +78,7 @@ class ExternalExtensionMultiProcessTest : public XWalkExtensionsTestBase {
 
 IN_PROC_BROWSER_TEST_F(ExternalExtensionMultiProcessTest,
     OpenLinkInNewRuntimeAndSameRP) {
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
 
   GURL url = GetExtensionsTestURL(base::FilePath(),
                                   base::FilePath().AppendASCII("same_rp.html"));
@@ -94,13 +94,13 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionMultiProcessTest,
   Runtime* second = WaitForSingleNewRuntime();
   EXPECT_TRUE(NULL != second);
   EXPECT_NE(runtime(), second);
-  EXPECT_EQ(len + 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len + 1, runtime_registry().runtimes().size());
   EXPECT_EQ(1, CountRegisterExtensions());
 }
 
 IN_PROC_BROWSER_TEST_F(ExternalExtensionMultiProcessTest,
     OpenLinkInNewRuntimeAndNewRP) {
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
 
   GURL url = GetExtensionsTestURL(base::FilePath(),
                                   base::FilePath().AppendASCII("new_rp.html"));
@@ -116,13 +116,13 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionMultiProcessTest,
   Runtime* second = WaitForSingleNewRuntime();
   EXPECT_TRUE(NULL != second);
   EXPECT_NE(runtime(), second);
-  EXPECT_EQ(len + 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len + 1, runtime_registry().runtimes().size());
   EXPECT_EQ(2, CountRegisterExtensions());
 }
 
 IN_PROC_BROWSER_TEST_F(ExternalExtensionMultiProcessTest,
     CreateNewRuntimeAndNewRP) {
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
 
   GURL url = GetExtensionsTestURL(base::FilePath(),
                                   base::FilePath().AppendASCII("new_rp.html"));
@@ -136,6 +136,6 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionMultiProcessTest,
   EXPECT_EQ(new_runtime, WaitForSingleNewRuntime());
   EXPECT_NE(runtime(), new_runtime);
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len + 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len + 1, runtime_registry().runtimes().size());
   EXPECT_EQ(2, CountRegisterExtensions());
 }

--- a/runtime/browser/geolocation/xwalk_geolocation_browsertest.cc
+++ b/runtime/browser/geolocation/xwalk_geolocation_browsertest.cc
@@ -61,7 +61,7 @@ class XWalkRuntimeTest : public InProcessBrowserTest {
         new content::WindowedNotificationObserver(
           xwalk::NOTIFICATION_RUNTIME_OPENED,
           content::NotificationService::AllSources()));
-    const RuntimeList& runtimes = RuntimeRegistry::Get()->runtimes();
+    const RuntimeList& runtimes = runtime_registry().runtimes();
     for (RuntimeList::const_iterator it = runtimes.begin();
          it != runtimes.end(); ++it)
       original_runtimes_.push_back(*it);
@@ -76,7 +76,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LoadGeolocationPage) {
   GURL url = xwalk_test_utils::GetTestURL(
       base::FilePath(), base::FilePath().AppendASCII(
           "geolocation/simple.html"));
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
   xwalk_test_utils::NavigateToURL(runtime(), url);
   int error_code;
   ASSERT_TRUE(content::ExecuteScriptAndExtractInt(
@@ -85,8 +85,8 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LoadGeolocationPage) {
       &error_code));
   EXPECT_NE(error_code, -1);
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len, runtime_registry().runtimes().size());
   runtime()->Close();
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len - 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len - 1, runtime_registry().runtimes().size());
 }

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -15,6 +15,7 @@
 #include "xwalk/runtime/browser/runtime_file_select_helper.h"
 #include "xwalk/runtime/browser/runtime_registry.h"
 #include "xwalk/runtime/browser/ui/color_chooser.h"
+#include "xwalk/runtime/browser/xwalk_content_browser_client.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/notification_details.h"
@@ -67,14 +68,15 @@ Runtime::Runtime(content::WebContents* web_contents)
   web_contents_->SetDelegate(this);
   runtime_context_ =
       static_cast<RuntimeContext*>(web_contents->GetBrowserContext());
-  RuntimeRegistry::Get()->AddRuntime(this);
+  XWalkContentBrowserClient::Get()->runtime_registry().AddRuntime(this);
 }
 
 Runtime::~Runtime() {
-  RuntimeRegistry::Get()->RemoveRuntime(this);
-
+  RuntimeRegistry& registry =
+          XWalkContentBrowserClient::Get()->runtime_registry();
+  registry.RemoveRuntime(this);
   // Quit the app once the last Runtime instance is removed.
-  if (RuntimeRegistry::Get()->runtimes().empty()) {
+  if (registry.runtimes().empty()) {
     base::MessageLoop::current()->PostTask(
         FROM_HERE, base::MessageLoop::QuitClosure());
   }
@@ -289,7 +291,8 @@ void Runtime::DidDownloadFavicon(int id,
   app_icon_ = gfx::Image::CreateFrom1xBitmap(bitmaps[0]);
   window_->UpdateIcon(app_icon_);
 
-  RuntimeRegistry::Get()->RuntimeAppIconChanged(this);
+  XWalkContentBrowserClient::Get()->
+          runtime_registry().RuntimeAppIconChanged(this);
 }
 
 void Runtime::Observe(int type,

--- a/runtime/browser/runtime_registry.cc
+++ b/runtime/browser/runtime_registry.cc
@@ -14,24 +14,12 @@ using content::RenderViewHost;
 
 namespace xwalk {
 
-// An application-wide runtime registry.
-static RuntimeRegistry* g_runtime_registry = NULL;
-
 RuntimeRegistry::RuntimeRegistry() {
-  DCHECK(g_runtime_registry == NULL);
-  g_runtime_registry = this;
 }
 
 RuntimeRegistry::~RuntimeRegistry() {
-  DCHECK(g_runtime_registry);
   DCHECK(runtime_list_.empty()) <<
       "Runtime instances are not empty!";
-  g_runtime_registry = NULL;
-}
-
-// static
-RuntimeRegistry* RuntimeRegistry::Get() {
-  return g_runtime_registry;
 }
 
 void RuntimeRegistry::AddObserver(RuntimeRegistryObserver* obs) {

--- a/runtime/browser/runtime_registry.h
+++ b/runtime/browser/runtime_registry.h
@@ -6,7 +6,7 @@
 #define XWALK_RUNTIME_BROWSER_RUNTIME_REGISTRY_H_
 
 #include <vector>
-
+#include "base/basictypes.h"
 #include "base/observer_list.h"
 
 namespace content {
@@ -38,9 +38,6 @@ typedef std::vector<Runtime*> RuntimeList;
 // It allows to retrieve all Runtime instances via RuntimeRegistry.
 class RuntimeRegistry {
  public:
-  // Get the singleton instance of RuntimeRegistry.
-  static RuntimeRegistry* Get();
-
   RuntimeRegistry();
   ~RuntimeRegistry();
 
@@ -66,6 +63,8 @@ class RuntimeRegistry {
   RuntimeList runtime_list_;
 
   ObserverList<RuntimeRegistryObserver> observer_list_;
+
+  DISALLOW_COPY_AND_ASSIGN(RuntimeRegistry);
 };
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -152,8 +152,10 @@ void SetXWalkCommandLineFlags() {
 }
 
 XWalkBrowserMainParts::XWalkBrowserMainParts(
-    const content::MainFunctionParams& parameters)
+    const content::MainFunctionParams& parameters,
+    RuntimeRegistry& runtime_registry)
     : BrowserMainParts(),
+      runtime_registry_(&runtime_registry),
       startup_url_(content::kAboutBlankURL),
       parameters_(parameters),
       run_default_message_loop_(true) {
@@ -256,11 +258,9 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
 
   DCHECK(runtime_context_);
   runtime_context_->PreMainMessageLoopRun();
-  runtime_registry_.reset(new RuntimeRegistry);
   extension_service_.reset(new extensions::XWalkExtensionService(this));
 #else
   runtime_context_.reset(new RuntimeContext);
-  runtime_registry_.reset(new RuntimeRegistry);
 
   runtime_registry_->AddObserver(
       runtime_context_->GetApplicationSystem()->process_manager());
@@ -350,13 +350,13 @@ void XWalkBrowserMainParts::RegisterInternalExtensionsInServer(
     server->RegisterExtension(scoped_ptr<XWalkExtension>(*it));
 #elif defined(OS_TIZEN_MOBILE)
   server->RegisterExtension(scoped_ptr<XWalkExtension>(
-      new sysapps::DeviceCapabilitiesExtension(runtime_registry_.get())));
+      new sysapps::DeviceCapabilitiesExtension(runtime_registry_)));
 #else
   server->RegisterExtension(scoped_ptr<XWalkExtension>(new RuntimeExtension()));
   server->RegisterExtension(scoped_ptr<XWalkExtension>(
       new ApplicationExtension(runtime_context()->GetApplicationSystem())));
   server->RegisterExtension(scoped_ptr<XWalkExtension>(
-      new experimental::DialogExtension(runtime_registry_.get())));
+      new experimental::DialogExtension(runtime_registry_)));
 #endif
   server->RegisterExtension(scoped_ptr<XWalkExtension>(
       new sysapps::RawSocketExtension()));

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -31,7 +31,8 @@ class XWalkBrowserMainParts : public content::BrowserMainParts,
     public extensions::XWalkExtensionService::Delegate {
  public:
   explicit XWalkBrowserMainParts(
-      const content::MainFunctionParams& parameters);
+      const content::MainFunctionParams& parameters,
+      RuntimeRegistry& runtime_registry);
   virtual ~XWalkBrowserMainParts();
 
   // BrowserMainParts overrides.
@@ -81,7 +82,7 @@ class XWalkBrowserMainParts : public content::BrowserMainParts,
 #endif
 
   // An application wide instance to manage all Runtime instances.
-  scoped_ptr<RuntimeRegistry> runtime_registry_;
+  RuntimeRegistry* runtime_registry_;
 
   scoped_ptr<extensions::XWalkExtensionService> extension_service_;
 

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -74,7 +74,7 @@ XWalkContentBrowserClient::~XWalkContentBrowserClient() {
 
 content::BrowserMainParts* XWalkContentBrowserClient::CreateBrowserMainParts(
     const content::MainFunctionParams& parameters) {
-  main_parts_ = new XWalkBrowserMainParts(parameters);
+  main_parts_ = new XWalkBrowserMainParts(parameters, runtime_registry_);
 
 #if defined(OS_ANDROID)
   main_parts_->SetRuntimeContext(g_runtime_context);

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -10,6 +10,7 @@
 #include "base/compiler_specific.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/common/main_function_params.h"
+#include "xwalk/runtime/browser/runtime_registry.h"
 
 namespace content {
 class BrowserContext;
@@ -69,9 +70,12 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
   XWalkBrowserMainParts* main_parts() { return main_parts_; }
 #endif
 
+  RuntimeRegistry& runtime_registry() { return runtime_registry_; }
+
  private:
   net::URLRequestContextGetter* url_request_context_getter_;
   XWalkBrowserMainParts* main_parts_;
+  RuntimeRegistry runtime_registry_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkContentBrowserClient);
 };

--- a/runtime/browser/xwalk_runtime_browsertest.cc
+++ b/runtime/browser/xwalk_runtime_browsertest.cc
@@ -119,7 +119,7 @@ class XWalkRuntimeTest : public InProcessBrowserTest {
         new content::WindowedNotificationObserver(
           xwalk::NOTIFICATION_RUNTIME_OPENED,
           content::NotificationService::AllSources()));
-    const RuntimeList& runtimes = RuntimeRegistry::Get()->runtimes();
+    const RuntimeList& runtimes = runtime_registry().runtimes();
     for (RuntimeList::const_iterator it = runtimes.begin();
          it != runtimes.end(); ++it)
       original_runtimes_.push_back(*it);
@@ -128,7 +128,7 @@ class XWalkRuntimeTest : public InProcessBrowserTest {
   // Block UI thread until a new Runtime instance is created.
   Runtime* WaitForSingleNewRuntime() {
     notification_observer_->Wait();
-    const RuntimeList& runtimes = RuntimeRegistry::Get()->runtimes();
+    const RuntimeList& runtimes = runtime_registry().runtimes();
     for (RuntimeList::const_iterator it = runtimes.begin();
          it != runtimes.end(); ++it) {
       RuntimeList::iterator target =
@@ -151,22 +151,22 @@ class XWalkRuntimeTest : public InProcessBrowserTest {
 // app launch, this test is disabled to avoid floody launches.
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, DISABLED_SecondLaunch) {
   MockRuntimeRegistryObserver observer;
-  RuntimeRegistry::Get()->AddObserver(&observer);
+  runtime_registry().AddObserver(&observer);
   Relaunch(GetCommandLineForRelaunch());
 
   Runtime* second_runtime = NULL;
   EXPECT_TRUE(second_runtime == WaitForSingleNewRuntime());
   EXPECT_CALL(observer, OnRuntimeAdded(second_runtime)).Times(1);
-  ASSERT_EQ(2u, RuntimeRegistry::Get()->runtimes().size());
+  ASSERT_EQ(2u, runtime_registry().runtimes().size());
 
-  RuntimeRegistry::Get()->RemoveObserver(&observer);
+  runtime_registry().RemoveObserver(&observer);
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CreateAndCloseRuntime) {
   MockRuntimeRegistryObserver observer;
-  RuntimeRegistry::Get()->AddObserver(&observer);
+  runtime_registry().AddObserver(&observer);
   // At least one Runtime instance is created at startup.
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
   ASSERT_EQ(1, len);
 
   // Create a new Runtime instance.
@@ -177,44 +177,44 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CreateAndCloseRuntime) {
   EXPECT_TRUE(url == new_runtime->web_contents()->GetURL());
   EXPECT_EQ(new_runtime, WaitForSingleNewRuntime());
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len + 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len + 1, runtime_registry().runtimes().size());
 
   // Close the newly created Runtime instance.
   EXPECT_CALL(observer, OnRuntimeRemoved(new_runtime)).Times(1);
   new_runtime->Close();
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len, runtime_registry().runtimes().size());
 
-  RuntimeRegistry::Get()->RemoveObserver(&observer);
+  runtime_registry().RemoveObserver(&observer);
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LoadURLAndClose) {
   GURL url(test_server()->GetURL("test.html"));
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
   runtime()->LoadURL(url);
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len, runtime_registry().runtimes().size());
   runtime()->Close();
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len - 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len - 1, runtime_registry().runtimes().size());
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CloseNativeWindow) {
   GURL url(test_server()->GetURL("test.html"));
   Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
       runtime()->runtime_context(), url);
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
   new_runtime->window()->Close();
   content::RunAllPendingInMessageLoop();
   // Closing native window will lead to close Runtime instance.
-  EXPECT_EQ(len - 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len - 1, runtime_registry().runtimes().size());
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LaunchWithFullscreenWindow) {
   MockRuntimeRegistryObserver observer;
-  RuntimeRegistry::Get()->AddObserver(&observer);
+  runtime_registry().AddObserver(&observer);
   // At least one Runtime instance is created at startup.
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
   ASSERT_EQ(1, len);
   // Original Runtime should has non fullscreen window.
   EXPECT_TRUE(false == runtime()->window()->IsFullscreen());
@@ -230,7 +230,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LaunchWithFullscreenWindow) {
   Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
       runtime()->runtime_context(), url);
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len + 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len + 1, runtime_registry().runtimes().size());
   fullscreen_observer.Wait();
   EXPECT_TRUE(true == new_runtime->window()->IsFullscreen());
 
@@ -238,13 +238,13 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LaunchWithFullscreenWindow) {
   EXPECT_CALL(observer, OnRuntimeRemoved(new_runtime)).Times(1);
   new_runtime->Close();
   content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len, runtime_registry().runtimes().size());
 
-  RuntimeRegistry::Get()->RemoveObserver(&observer);
+  runtime_registry().RemoveObserver(&observer);
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, HTML5FullscreenAPI) {
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
   GURL url = xwalk_test_utils::GetTestURL(
       base::FilePath(), base::FilePath().AppendASCII("fullscreen.html"));
   xwalk_test_utils::NavigateToURL(runtime(), url);
@@ -285,7 +285,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, GetWindowTitle) {
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, OpenLinkInNewRuntime) {
-  size_t len = RuntimeRegistry::Get()->runtimes().size();
+  size_t len = runtime_registry().runtimes().size();
   GURL url = xwalk_test_utils::GetTestURL(
       base::FilePath(), base::FilePath().AppendASCII("new_target.html"));
   xwalk_test_utils::NavigateToURL(runtime(), url);
@@ -298,7 +298,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, OpenLinkInNewRuntime) {
   Runtime* second = WaitForSingleNewRuntime();
   EXPECT_TRUE(NULL != second);
   EXPECT_NE(runtime(), second);
-  EXPECT_EQ(len + 1, RuntimeRegistry::Get()->runtimes().size());
+  EXPECT_EQ(len + 1, runtime_registry().runtimes().size());
 }
 
 #if !defined(USE_AURA)
@@ -311,7 +311,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, DISABLED_FaviconTest_ICO) {
       base::FilePath(FILE_PATH_LITERAL("16x16.ico"))));
 
   FaviconChangedObserver observer(icon_file);
-  RuntimeRegistry::Get()->AddObserver(&observer);
+  runtime_registry().AddObserver(&observer);
 
   GURL url = xwalk_test_utils::GetTestURL(
       base::FilePath(FILE_PATH_LITERAL("favicon")),
@@ -319,7 +319,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, DISABLED_FaviconTest_ICO) {
 
   xwalk_test_utils::NavigateToURL(runtime(), url);
   content::RunMessageLoop();
-  RuntimeRegistry::Get()->RemoveObserver(&observer);
+  runtime_registry().RemoveObserver(&observer);
 }
 
 #if !defined(USE_AURA)
@@ -332,7 +332,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, DISABLED_FaviconTest_PNG) {
       base::FilePath(FILE_PATH_LITERAL("48x48.png"))));
 
   FaviconChangedObserver observer(icon_file);
-  RuntimeRegistry::Get()->AddObserver(&observer);
+  runtime_registry().AddObserver(&observer);
 
   GURL url = xwalk_test_utils::GetTestURL(
       base::FilePath(FILE_PATH_LITERAL("favicon")),
@@ -340,5 +340,5 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, DISABLED_FaviconTest_PNG) {
 
   xwalk_test_utils::NavigateToURL(runtime(), url);
   content::RunMessageLoop();
-  RuntimeRegistry::Get()->RemoveObserver(&observer);
+  runtime_registry().RemoveObserver(&observer);
 }

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -14,7 +14,7 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/test/test_file_util.h"
 #include "xwalk/runtime/browser/runtime.h"
-#include "xwalk/runtime/browser/runtime_registry.h"
+#include "xwalk/runtime/browser/xwalk_content_browser_client.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 #include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
@@ -88,11 +88,15 @@ void InProcessBrowserTest::TearDown() {
   BrowserTestBase::TearDown();
 }
 
+xwalk::RuntimeRegistry& InProcessBrowserTest::runtime_registry() const {
+    return xwalk::XWalkContentBrowserClient::Get()->runtime_registry();
+}
+
 void InProcessBrowserTest::RunTestOnMainThreadLoop() {
   // Pump startup related events.
   content::RunAllPendingInMessageLoop();
 
-  const RuntimeList& runtimes = RuntimeRegistry::Get()->runtimes();
+  const RuntimeList& runtimes = runtime_registry().runtimes();
   if (!runtimes.empty()) {
     runtime_ = runtimes.at(0);
       content::WaitForLoadStop(runtime_->web_contents());
@@ -133,5 +137,5 @@ bool InProcessBrowserTest::CreateDataPathDir() {
 }
 
 void InProcessBrowserTest::QuitAllRuntimes() {
-  RuntimeRegistry::Get()->CloseAll();
+  runtime_registry().CloseAll();
 }

--- a/test/base/in_process_browser_test.h
+++ b/test/base/in_process_browser_test.h
@@ -16,6 +16,7 @@
 
 namespace xwalk {
 class Runtime;
+class RuntimeRegistry;
 }
 
 class CommandLine;
@@ -49,6 +50,7 @@ class InProcessBrowserTest : public content::BrowserTestBase {
  protected:
   // Returns the runtime instance created by CreateRuntime.
   xwalk::Runtime* runtime() const { return runtime_; }
+  xwalk::RuntimeRegistry& runtime_registry() const;
 
   // Override this to add any custom cleanup code that needs to be done on the
   // main thread before the browser is torn down.


### PR DESCRIPTION
RuntimeRegistry should stop being a singleton itself but rather should belong to XWalkContentBrowserClient which is supposed to be a "main" object holding the rest.
