### PR TITLE
[Android] Fix the failed test case about testPauseAndResume.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -176,9 +176,11 @@ public class XWalkContent extends FrameLayout {
     }
 
     public void onPause() {
+        mContentView.onHide();
     }
 
     public void onResume() {
+        mContentView.onShow();
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -334,7 +336,7 @@ public class XWalkContent extends FrameLayout {
     public int getRoutingID() {
         return nativeGetRoutingID(mXWalkContent);
     }
- 
+
     private class XWalkGeolocationCallback implements XWalkGeolocationPermissions.Callback {
         @Override
         public void invoke(final String origin, final boolean allow, final boolean retain) {


### PR DESCRIPTION
Due to the rebase to v32, the function "onActivityPause" and
"onActivityResume" was deleted from ContentViewCore.java.

The fix is to implement the onPause and onResume by another
function interfaces.

BUG=https://crosswalk-project.org/jira/browse/XWALK-351
