### PR TITLE
[Android] packaging tool fails to run on Windows host.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -399,7 +399,7 @@ def Execution(options, sanitized_name):
 
   src_dir = '-DSOURCE_DIR=' + os.path.join(sanitized_name, 'src')
   apk_path = '-DUNSIGNED_APK_PATH=' + os.path.join('out', 'app-unsigned.apk')
-  native_lib_path = '-DNATIVE_LIBS_DIR='
+  native_lib_path = '-DNATIVE_LIBS_DIR= '
   if options.mode == 'embedded':
     native_lib_path += os.path.join('native_libs', 'libs')
   cmd = ['python', 'scripts/gyp/ant.py',


### PR DESCRIPTION
It's because the ant on Windows would crunch the following flags
when the current flag is set with null, which would cause the
packaging stage failed. This is only a issue on Windows host.
Fix it with setting the flag with white space.
