### PR TITLE
[Android] Fix ActionUri test failure after rebase to M32

### DIFF
--- a/runtime/browser/runtime_resource_dispatcher_host_delegate.cc
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate.cc
@@ -52,7 +52,6 @@ void RuntimeResourceDispatcherHostDelegate::RequestBeginning(
     ResourceType::Type resource_type,
     int child_id,
     int route_id,
-    bool is_continuation_of_transferred_request,
     ScopedVector<content::ResourceThrottle>* throttles) {
 #if defined(OS_ANDROID)
   throttles->push_back(

--- a/runtime/browser/runtime_resource_dispatcher_host_delegate.h
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate.h
@@ -24,7 +24,6 @@ class RuntimeResourceDispatcherHostDelegate
       ResourceType::Type resource_type,
       int child_id,
       int route_id,
-      bool is_continuation_of_transferred_request,
       ScopedVector<content::ResourceThrottle>* throttles) OVERRIDE;
   virtual void DownloadStarting(
       net::URLRequest* request,


### PR DESCRIPTION
It's caused by the changing of RequestBeginning api in
content::ResourceDispatcherHostDelegate.

Fix by adjusting the api in xwalk's delegate accordingly.
