### PR TITLE
[Android] Remove assertion for is_valid() check in XWalkExtensionAndroid

### DIFF
--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -52,7 +52,7 @@ bool XWalkExtensionAndroid::is_valid() {
 
 void XWalkExtensionAndroid::PostMessage(JNIEnv* env, jobject obj,
                                        jint instance, jstring msg) {
-  DCHECK(is_valid());
+  if (!is_valid()) return;
 
   InstanceMap::iterator it = instances_.find(instance);
   if (it == instances_.end()) {
@@ -67,7 +67,8 @@ void XWalkExtensionAndroid::PostMessage(JNIEnv* env, jobject obj,
 
 void XWalkExtensionAndroid::BroadcastMessage(JNIEnv* env, jobject obj,
                                              jstring msg) {
-  DCHECK(is_valid());
+  if (!is_valid()) return;
+
   const char* str = env->GetStringUTFChars(msg, 0);
   for (InstanceMap::iterator it = instances_.begin();
        it != instances_.end(); ++it) {


### PR DESCRIPTION
Application will be crashed at start time when secondary display opened in debug version.
Root cause:
At start time, PresentationExtension will be created and send broadcastMessage,
but the presentation XWalkExtensionInstance has not been created at this time.
There will be an assertion before sending messages which will check whether any instance created.
Solution:
Remove the assertion, only check is_valid(), if it's not valid, just return.
I think it's acceptable for extensions to send message even no instance created,
we can just ignore the message.

BUG=https://crosswalk-project.org/jira/browse/XWALK-398
