### PR TITLE
[Runtime] Make Runtimes know their application ID

### DIFF
--- a/application/browser/application_process_manager.cc
+++ b/application/browser/application_process_manager.cc
@@ -83,7 +83,7 @@ bool ApplicationProcessManager::RunMainDocument(
     return false;
   }
 
-  main_runtime_ = Runtime::Create(runtime_context_, url);
+  main_runtime_ = Runtime::Create(runtime_context_, url, application->ID());
   return true;
 }
 
@@ -105,7 +105,7 @@ bool ApplicationProcessManager::RunFromLocalPath(
       return false;
     }
 
-    Runtime::CreateWithDefaultWindow(runtime_context_, url);
+    Runtime::CreateWithDefaultWindow(runtime_context_, url, application->ID());
     return true;
   }
 

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -40,27 +40,30 @@ const int kDefaultHeight = 600;
 }  // namespace
 
 // static
-Runtime* Runtime::Create(RuntimeContext* runtime_context, const GURL& url) {
+Runtime* Runtime::Create(RuntimeContext* runtime_context, const GURL& url,
+                         const std::string& app_id) {
   WebContents::CreateParams params(runtime_context, NULL);
   params.routing_id = MSG_ROUTING_NONE;
   WebContents* web_contents = WebContents::Create(params);
 
-  Runtime* runtime = new Runtime(web_contents);
+  Runtime* runtime = new Runtime(web_contents, app_id);
   runtime->LoadURL(url);
   return runtime;
 }
 
 // static
 Runtime* Runtime::CreateWithDefaultWindow(
-    RuntimeContext* runtime_context, const GURL& url) {
-  Runtime* runtime = Runtime::Create(runtime_context, url);
+    RuntimeContext* runtime_context, const GURL& url,
+    const std::string& app_id) {
+  Runtime* runtime = Runtime::Create(runtime_context, url, app_id);
   runtime->AttachDefaultWindow();
   return runtime;
 }
 
-Runtime::Runtime(content::WebContents* web_contents)
+Runtime::Runtime(content::WebContents* web_contents, const std::string& app_id)
     : WebContentsObserver(web_contents),
       window_(NULL),
+      app_id_(app_id),
       weak_ptr_factory_(this),
       fullscreen_options_(NO_FULLSCREEN)  {
   web_contents_.reset(web_contents);
@@ -208,7 +211,7 @@ void Runtime::WebContentsCreated(
     const string16& frame_name,
     const GURL& target_url,
     content::WebContents* new_contents) {
-  Runtime* new_runtime = new Runtime(new_contents);
+  Runtime* new_runtime = new Runtime(new_contents, app_id_);
   new_runtime->AttachDefaultWindow();
 }
 

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -5,6 +5,7 @@
 #ifndef XWALK_RUNTIME_BROWSER_RUNTIME_H_
 #define XWALK_RUNTIME_BROWSER_RUNTIME_H_
 
+#include <string>
 #include <vector>
 
 #include "base/basictypes.h"
@@ -39,9 +40,11 @@ class Runtime : public content::WebContentsDelegate,
                 public NativeAppWindowDelegate {
  public:
   // Create a new Runtime instance with the given browsing context.
-  static Runtime* Create(RuntimeContext*, const GURL&);
+  static Runtime* Create(RuntimeContext*, const GURL&,
+                         const std::string& app_id = "");
   // Create a new Runtime instance which binds to a default app window.
-  static Runtime* CreateWithDefaultWindow(RuntimeContext*, const GURL&);
+  static Runtime* CreateWithDefaultWindow(RuntimeContext*, const GURL&,
+                                          const std::string& app_id = "");
 
   // Attach to a default app window.
   void AttachDefaultWindow();
@@ -56,9 +59,11 @@ class Runtime : public content::WebContentsDelegate,
   RuntimeContext* runtime_context() const { return runtime_context_; }
   gfx::Image app_icon() const { return app_icon_; }
 
+  const std::string& app_id() const { return app_id_; }
+
  protected:
-  explicit Runtime(RuntimeContext* runtime_context);
-  explicit Runtime(content::WebContents* web_contents);
+  explicit Runtime(content::WebContents* web_contents,
+                   const std::string& app_id);
   virtual ~Runtime();
 
     // Overridden from content::WebContentsDelegate:
@@ -138,6 +143,7 @@ class Runtime : public content::WebContentsDelegate,
   NativeAppWindow* window_;
 
   gfx::Image app_icon_;
+  std::string app_id_;
 
   base::WeakPtrFactory<Runtime> weak_ptr_factory_;
 


### PR DESCRIPTION
Crosswalk is switching its process model to shared runtime process mode, meaning that we are going to have several applications sharing the same browser process.

This patch makes a runtime know which application it belongs to. This data further will be used in Runtime registry and other classes as they have to be modified in order to support shared runtime process mode.
