### PR TITLE
[Android] Only allow to intercept navigation for main frame and subframe

### DIFF
--- a/runtime/browser/runtime_resource_dispatcher_host_delegate.cc
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -24,6 +25,7 @@
 #endif
 
 using content::BrowserThread;
+using navigation_interception::InterceptNavigationDelegate;
 
 namespace {
 base::LazyInstance<xwalk::RuntimeResourceDispatcherHostDelegate>
@@ -55,9 +57,23 @@ void RuntimeResourceDispatcherHostDelegate::RequestBeginning(
     bool is_continuation_of_transferred_request,
     ScopedVector<content::ResourceThrottle>* throttles) {
 #if defined(OS_ANDROID)
-  throttles->push_back(
-      navigation_interception::InterceptNavigationDelegate::
-          CreateThrottleFor(request));
+  bool allow_intercepting =
+      // We allow intercepting navigations within subframes, but only if the
+      // scheme other than http or https. This is because the embedder
+      // can't distinguish main frame and subframe callbacks (which could lead
+      // to broken content if the embedder decides to not ignore the main frame
+      // navigation, but ignores the subframe navigation).
+      // The reason this is supported at all is that certain JavaScript-based
+      // frameworks use iframe navigation as a form of communication with the
+      // embedder.
+      (resource_type == ResourceType::MAIN_FRAME ||
+       (resource_type == ResourceType::SUB_FRAME &&
+        !request->url().SchemeIs(content::kHttpScheme) &&
+        !request->url().SchemeIs(content::kHttpsScheme)));
+  if (allow_intercepting) {
+    throttles->push_back(InterceptNavigationDelegate::CreateThrottleFor(
+        request));
+  }
 #endif
 }
 


### PR DESCRIPTION
The interception for resource request should be restricted to main frame
and sub frames, so that the page loading state change events, e.g.
onPageStarted and onPageFinished, are triggered only for main frame and sub
frame instead of each kind of resources.

BUG=https://crosswalk-project.org/jira/browse/XWALK-306
