### PR TITLE
[Android] Fix crash issue caused by the download listener.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultDownloadListener.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultDownloadListener.java
@@ -9,18 +9,29 @@ import android.app.DownloadManager.Request;
 import android.content.pm.PackageManager;
 import android.content.Context;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Environment;
 import android.webkit.MimeTypeMap;
 import android.webkit.URLUtil;
 import android.widget.Toast;
 import android.Manifest;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.xwalk.core.AndroidProtocolHandler;
 import org.xwalk.core.DownloadListener;
 import org.xwalk.core.R;
 
 public class XWalkDefaultDownloadListener implements DownloadListener {
     private static String DOWNLOAD_START_TOAST;
     private static String DOWNLOAD_NO_PERMISSION_TOAST;
+    private static String DOWNLOAD_ALREADY_EXISTS_TOAST;
+    private static String DOWNLOAD_FAILED_TOAST;
+    private static String DOWNLOAD_FINISHED_TOAST;
 
     private Context mContext;
 
@@ -30,6 +41,12 @@ public class XWalkDefaultDownloadListener implements DownloadListener {
         DOWNLOAD_START_TOAST = mContext.getString(R.string.download_start_toast);
         DOWNLOAD_NO_PERMISSION_TOAST =
                 mContext.getString(R.string.download_no_permission_toast);
+        DOWNLOAD_ALREADY_EXISTS_TOAST =
+                mContext.getString(R.string.download_already_exists_toast);
+        DOWNLOAD_FAILED_TOAST =
+                mContext.getString(R.string.download_failed_toast);
+        DOWNLOAD_FINISHED_TOAST =
+                mContext.getString(R.string.download_finished_toast);
     }
 
     @Override
@@ -41,11 +58,16 @@ public class XWalkDefaultDownloadListener implements DownloadListener {
         // We only start download request if we have permission.
         if (!checkWriteExternalPermission()) return;
 
-        Request request = new Request(Uri.parse(url));
-        request.setDestinationInExternalPublicDir(
-                Environment.DIRECTORY_DOWNLOADS, fileName);
-        getDownloadManager().enqueue(request);
-        popupMessages(DOWNLOAD_START_TOAST + fileName);
+        Uri src = Uri.parse(url);
+        if (src.getScheme().equals("http") || src.getScheme().equals("https")) {
+            Request request = new Request(Uri.parse(url));
+            request.setDestinationInExternalPublicDir(
+                    Environment.DIRECTORY_DOWNLOADS, fileName);
+            getDownloadManager().enqueue(request);
+            popupMessages(DOWNLOAD_START_TOAST + fileName);
+        } else {
+            new FileTransfer(url, fileName).execute();
+        }
     }
 
     private String getFileName(String url, String contentDisposition, String mimetype) {
@@ -81,5 +103,65 @@ public class XWalkDefaultDownloadListener implements DownloadListener {
 
     private void popupMessages(String message) {
         Toast.makeText(mContext, message, Toast.LENGTH_SHORT).show();
+    }
+
+    private class FileTransfer extends AsyncTask<Void, Void, String> {
+        String url;
+        String fileName;
+
+        public FileTransfer(String url, String fileName) {
+            this.url = url;
+            this.fileName = fileName;
+        }
+
+        @Override
+        protected String doInBackground(Void... params) {
+            OutputStream dstStream = null;
+            InputStream srcStream = null;
+            File dir = Environment.getExternalStoragePublicDirectory(
+                    Environment.DIRECTORY_DOWNLOADS);
+            File dst = new File(dir, fileName);
+            if (dst.exists()) {
+                return "Existed";
+            }
+            try {
+                dstStream = new FileOutputStream(dst);
+                srcStream = AndroidProtocolHandler.open(mContext, url);
+                if (dstStream != null && srcStream != null) {
+                    streamTransfer(srcStream, dstStream);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally {
+                try {
+                    if (srcStream != null) srcStream.close();
+                    if (dstStream != null) dstStream.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    return "Failed";
+                }
+            }
+            return "Finished";
+        }
+
+        @Override
+        protected void onPostExecute(String result) {
+            if (result.equals("Failed")) {
+                popupMessages(DOWNLOAD_FAILED_TOAST);
+            } else if (result.equals("Existed")) {
+                popupMessages(DOWNLOAD_ALREADY_EXISTS_TOAST);
+            } else if (result.equals("Finished")) {
+                popupMessages(DOWNLOAD_FINISHED_TOAST);
+            }
+        }
+
+        private void streamTransfer(InputStream src, OutputStream dst) throws IOException {
+            // Transfer bytes from src to dst.
+            byte[] buf = new byte[1024];
+            int length = 0;
+            while ((length = src.read(buf)) > 0) {
+                dst.write(buf, 0, length);
+            }
+        }
     }
 }

--- a/runtime/android/java/strings/android_xwalk_strings.grd
+++ b/runtime/android/java/strings/android_xwalk_strings.grd
@@ -17,6 +17,15 @@
       <message desc="Prompt for Downloading no permission toast [CHAR-LIMIT=32]" name="IDS_DOWNLOAD_NO_PERMISSION_TOAST">
         No permission to write, abort.
       </message>
+      <message desc="Prompt for Downloading already exists toast [CHAR-LIMIT=32]" name="IDS_DOWNLOAD_ALREADY_EXISTS_TOAST">
+        Downloading file already exists, abort.
+      </message>
+      <message desc="Prompt for failed to download toast [CHAR-LIMIT=32]" name="IDS_DOWNLOAD_FAILED_TOAST">
+        Failed to download file.
+      </message>
+      <message desc="Prompt for finished to download toast [CHAR-LIMIT=32]" name="IDS_DOWNLOAD_FINISHED_TOAST">
+        Finished to download file.
+      </message>
       <message desc="Title for the Ssl Alert dialog [CHAR-LIMIT=32]" name="IDS_SSL_ALERT_TITLE">
         Ssl Alert
       </message>


### PR DESCRIPTION
This is because the XWalk core uses the request API to download
local file in the case, which would cause the crash.

So when downloading the local file, download listener would
only do the file transfer for this.

BUG=https://crosswalk-project.org/jira/browse/XWALK-338
