### PR TITLE
[Android] Fix debug mode crash issue

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -99,7 +99,6 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopRun() {
     run_default_message_loop_ = false;
   }
 
-  DCHECK(runtime_context_);
   runtime_context_.reset(new RuntimeContext);
   runtime_registry_.reset(new RuntimeRegistry);
   extension_service_.reset(new extensions::XWalkExtensionService(this));


### PR DESCRIPTION
runtime_context_ should be null in the function PreMainMessageLoopRun.
The DCHECK(runtime_context_) should be removed.
