### PR TITLE
[Mac] Fix the build

### DIFF
--- a/application/browser/application_event_manager.cc
+++ b/application/browser/application_event_manager.cc
@@ -27,6 +27,9 @@ Event::Event(const std::string& event_name,
   DCHECK(args_);
 }
 
+Event::~Event() {
+}
+
 ApplicationEventManager::ApplicationEventManager(ApplicationSystem* system)
   : system_(system) {
 }

--- a/application/browser/application_event_manager.h
+++ b/application/browser/application_event_manager.h
@@ -35,7 +35,9 @@ class Event : public base::RefCounted<Event> {
   base::ListValue* args() const { return args_.get(); }
 
  private:
+  friend class base::RefCounted<Event>;
   Event(const std::string& event_name, scoped_ptr<base::ListValue> event_args);
+  ~Event();
 
   // The event to dispatch.
   std::string name_;

--- a/application/browser/application_event_router.h
+++ b/application/browser/application_event_router.h
@@ -34,7 +34,7 @@ class ApplicationSystem;
 class ApplicationEventRouter : public content::WebContentsObserver {
  public:
   ApplicationEventRouter(ApplicationSystem* system, const std::string& app_id);
-  ~ApplicationEventRouter();
+  virtual ~ApplicationEventRouter();
 
   // Implement content::WebContentsObserver.
   virtual void DidStopLoading(

--- a/application/common/manifest_handlers/permissions_handler.cc
+++ b/application/common/manifest_handlers/permissions_handler.cc
@@ -23,7 +23,13 @@ inline bool IsAPIPermission(const std::string& permission) {
 PermissionsInfo::PermissionsInfo() {
 }
 
+PermissionsInfo::~PermissionsInfo() {
+}
+
 PermissionsHandler::PermissionsHandler() {
+}
+
+PermissionsHandler::~PermissionsHandler() {
 }
 
 bool PermissionsHandler::Parse(scoped_refptr<Application> application,

--- a/application/common/manifest_handlers/permissions_handler.h
+++ b/application/common/manifest_handlers/permissions_handler.h
@@ -16,6 +16,7 @@ namespace application {
 class PermissionsInfo: public Application::ManifestData {
  public:
   PermissionsInfo();
+  virtual ~PermissionsInfo();
 
   const std::vector<std::string>& GetAPIPermissions() const {
     return api_permissions_;}
@@ -31,6 +32,7 @@ class PermissionsInfo: public Application::ManifestData {
 class PermissionsHandler: public ManifestHandler {
  public:
   PermissionsHandler();
+  virtual ~PermissionsHandler();
 
   virtual bool Parse(scoped_refptr<Application> application,
                      string16* error) OVERRIDE;

--- a/extensions/browser/xwalk_extension_service.h
+++ b/extensions/browser/xwalk_extension_service.h
@@ -78,7 +78,7 @@ class XWalkExtensionService : public content::NotificationObserver,
 
   // XWalkExtensionProcessHost::Delegate implementation.
   virtual void OnExtensionProcessDied(XWalkExtensionProcessHost* eph,
-      int render_process_id);
+      int render_process_id) OVERRIDE;
 
   // NotificationObserver implementation.
   virtual void Observe(int type, const content::NotificationSource& source,


### PR DESCRIPTION
[chromium-style] Complex class/struct needs an explicit out-of-line destructor.
[chromium-style] Classes that are ref-counted should have explicit destructors that are declared protected or private.
[chromium-style] Overriding method must have "virtual" keyword.
