### PR TITLE
Fix build on Mac by handling the return value of SQLite calls.

### DIFF
--- a/application/common/db_store_sqlite_impl.cc
+++ b/application/common/db_store_sqlite_impl.cc
@@ -122,7 +122,11 @@ DBStoreSqliteImpl::DBStoreSqliteImpl(const base::FilePath& path)
     }
   }
 
-  sqlite_db_->Execute("PRAGMA foreign_keys=ON");
+  int ret = sqlite_db_->Execute("PRAGMA foreign_keys=ON");
+  if (!ret) {
+    LOG(ERROR) << "Unable to enforce foreign key contraints.";
+    return;
+  }
   sqlite_db_->Preload();
 }
 


### PR DESCRIPTION
Handle the return value and print a message error if the request failed.
