### PR TITLE
Permit the inclusion of Tizen Web UI Framework

### DIFF
--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -19,6 +19,10 @@
 #include "xwalk/runtime/common/xwalk_paths.h"
 #include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
 
+#if defined(OS_TIZEN_MOBILE)
+#include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
+#endif
+
 namespace xwalk {
 
 XWalkMainDelegate::XWalkMainDelegate()
@@ -87,7 +91,12 @@ content::ContentBrowserClient* XWalkMainDelegate::CreateContentBrowserClient() {
 
 content::ContentRendererClient*
     XWalkMainDelegate::CreateContentRendererClient() {
-  renderer_client_.reset(new XWalkContentRendererClient);
+#if defined(OS_TIZEN_MOBILE)
+  renderer_client_.reset(new XWalkContentRendererClientTizen());
+#else
+  renderer_client_.reset(new XWalkContentRendererClient());
+#endif
   return renderer_client_.get();
 }
+
 }  // namespace xwalk

--- a/runtime/browser/xwalk_runtime_browsertest.cc
+++ b/runtime/browser/xwalk_runtime_browsertest.cc
@@ -342,3 +342,14 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, DISABLED_FaviconTest_PNG) {
   content::RunMessageLoop();
   RuntimeRegistry::Get()->RemoveObserver(&observer);
 }
+
+#if defined(OS_TIZEN_MOBILE)
+IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LoadTizenWebUiFwFile) {
+  GURL url = xwalk_test_utils::GetTestURL(
+      base::FilePath(), base::FilePath().AppendASCII("tizenwebuifw.html"));
+  string16 title = ASCIIToUTF16("Pass");
+  content::TitleWatcher title_watcher(runtime()->web_contents(), title);
+  xwalk_test_utils::NavigateToURL(runtime(), url);
+  EXPECT_EQ(title, title_watcher.WaitAndGetTitle());
+}
+#endif

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
@@ -1,0 +1,76 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
+
+#include <string>
+
+#include "base/files/file_path.h"
+#include "net/base/net_util.h"
+#include "url/gurl.h"
+
+namespace xwalk {
+
+namespace {
+
+const base::FilePath kTizenWebUiFwPath("/usr/share/tizen-web-ui-fw/");
+const std::string kTizenWebUiFw = "/tizen-web-ui-fw/";
+
+bool HasKnownExtension(const base::FilePath& path) {
+  if (path.MatchesExtension(".js"))
+    return true;
+  if (path.MatchesExtension(".css"))
+    return true;
+  if (path.MatchesExtension(".png"))
+    return true;
+  return false;
+}
+
+size_t GetRootPathLength(const GURL& first_party_for_cookies) {
+  const std::string& path = first_party_for_cookies.PathForRequest();
+  return path.rfind('/');
+}
+
+};  // namespace
+
+bool XWalkContentRendererClientTizen::WillSendRequest(
+    WebKit::WebFrame*, content::PageTransition, const GURL& url,
+    const GURL& first_party_for_cookies, GURL* new_url) {
+  DCHECK(new_url);
+
+  if (!first_party_for_cookies.SchemeIsFile())
+    return false;
+
+  const size_t root_path_length = GetRootPathLength(first_party_for_cookies);
+  if (root_path_length == std::string::npos)
+    return false;
+
+  const std::string& relative_path = url.path();
+  size_t tizen_web_ui_fw_pos = relative_path.find(kTizenWebUiFw,
+      root_path_length);
+  if (tizen_web_ui_fw_pos == std::string::npos)
+    return false;
+
+  tizen_web_ui_fw_pos += kTizenWebUiFw.length();
+  const base::FilePath& resource_path = kTizenWebUiFwPath.Append(
+      relative_path.substr(tizen_web_ui_fw_pos));
+
+  // FIXME(leandro): base::NormalizeFilePath(resource_path) should be called
+  // here to make sure files are really beneath kTizenWebUiFwPath, but the
+  // sandbox prevents the Render process from calling realpath().
+  if (!kTizenWebUiFwPath.IsParent(resource_path))
+    return false;
+
+  if (!HasKnownExtension(resource_path))
+    return false;
+
+  GURL replacement_url = net::FilePathToFileURL(resource_path);
+  if (!replacement_url.is_valid())
+    return false;
+
+  new_url->Swap(&replacement_url);
+  return true;
+}
+
+}  // namespace xwalk

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_RENDERER_TIZEN_XWALK_CONTENT_RENDERER_CLIENT_TIZEN_H_
+#define XWALK_RUNTIME_RENDERER_TIZEN_XWALK_CONTENT_RENDERER_CLIENT_TIZEN_H_
+
+#include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
+
+namespace xwalk {
+
+class XWalkContentRendererClientTizen : public XWalkContentRendererClient {
+ public:
+  virtual bool WillSendRequest(WebKit::WebFrame* frame,
+                               content::PageTransition transition_type,
+                               const GURL& url,
+                               const GURL& first_party_for_cookies,
+                               GURL* new_url) OVERRIDE;
+ private:
+  DISALLOW_COPY_AND_ASSIGN(XWalkContentRendererClientTizen);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_RENDERER_TIZEN_XWALK_CONTENT_RENDERER_CLIENT_TIZEN_H_

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -18,6 +18,10 @@
 #include "xwalk/runtime/renderer/android/xwalk_render_view_ext.h"
 #endif
 
+#if defined(OS_TIZEN_MOBILE)
+#include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
+#endif
+
 namespace xwalk {
 
 namespace {

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -15,6 +15,8 @@ namespace xwalk {
 
 class XWalkRenderProcessObserver;
 
+// When implementing a derived class, make sure to update
+// `in_process_browser_test.cc` and `xwalk_main_delegate.cc`.
 class XWalkContentRendererClient
     : public content::ContentRendererClient,
       public extensions::XWalkExtensionRendererController::Delegate {

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -7,19 +7,13 @@
 #include "base/auto_reset.h"
 #include "base/bind.h"
 #include "base/command_line.h"
-#include "base/file_util.h"
+#include "base/debug/leak_annotations.h"
 #include "base/files/file_path.h"
+#include "base/file_util.h"
 #include "base/lazy_instance.h"
 #include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/test/test_file_util.h"
-#include "xwalk/runtime/browser/runtime.h"
-#include "xwalk/runtime/browser/runtime_registry.h"
-#include "xwalk/runtime/common/xwalk_paths.h"
-#include "xwalk/runtime/common/xwalk_switches.h"
-#include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
-#include "xwalk/test/base/xwalk_test_suite.h"
-#include "xwalk/test/base/xwalk_test_utils.h"
 #include "content/public/browser/notification_service.h"
 #include "content/public/browser/notification_types.h"
 #include "content/public/common/content_switches.h"
@@ -29,15 +23,32 @@
 #include "content/public/test/test_navigation_observer.h"
 #include "content/public/test/test_utils.h"
 #include "net/test/spawned_test_server/spawned_test_server.h"
+#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/runtime/browser/runtime_registry.h"
+#include "xwalk/runtime/common/xwalk_paths.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
+#include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
+#include "xwalk/test/base/xwalk_test_suite.h"
+#include "xwalk/test/base/xwalk_test_utils.h"
+
+#if defined(OS_TIZEN_MOBILE)
+#include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
+#endif
 
 using xwalk::RuntimeList;
 using xwalk::RuntimeRegistry;
+using xwalk::XWalkContentRendererClient;
 
 namespace {
 
 // Used when running in single-process mode.
-base::LazyInstance<xwalk::XWalkContentRendererClient>::Leaky
-    g_xwalk_content_renderer_client = LAZY_INSTANCE_INITIALIZER;
+#if defined(OS_TIZEN_MOBILE)
+base::LazyInstance<XWalkContentRendererClientTizen>::Leaky
+        g_xwalk_content_renderer_client = LAZY_INSTANCE_INITIALIZER;
+#else
+base::LazyInstance<XWalkContentRendererClient>::Leaky
+        g_xwalk_content_renderer_client = LAZY_INSTANCE_INITIALIZER;
+#endif
 
 }  // namespace
 

--- a/test/data/tizenwebuifw.html
+++ b/test/data/tizenwebuifw.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+<title>Fail</title>
+<script src="tizen-web-ui-fw/latest/js/tizen-web-ui-fw.js"></script>
+<script>
+if (typeof($) === 'object' && typeof($.tizen) === 'object')
+	window.document.title = 'Pass';
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -176,6 +176,8 @@
             'runtime/browser/ui/tizen_system_indicator_watcher.h',
             'runtime/browser/xwalk_browser_main_parts_tizen.cc',
             'runtime/browser/xwalk_browser_main_parts_tizen.h',
+            'runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc',
+            'runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h',
           ],
         }],
         ['OS=="android"',{


### PR DESCRIPTION
This patch creates a Tizen-specific XWalkContentRendererClient that implements the WillSendRequest hook.  This hook, as the name implies, is called before every request is made from a particular WebKit::WebFrame.  By tapping into this hook, it is possible to rewrite requests so that they have the full file path.

Some measures are taken so that relative paths outside where the Tizen Web UI Framework can't be referenced; also, only known extensions are permitted.
