### PR TITLE
[Android][SysApps] Implement W3C Audio/Video codecs API for Android 4.1 and above

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/XWalkDisplayManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/XWalkDisplayManager.java
@@ -34,10 +34,11 @@ public abstract class XWalkDisplayManager {
         }
 
         if (mInstance == null) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 mInstance = new DisplayManagerJBMR1(mContext);
-            else
+            } else {
                 mInstance = new DisplayManagerNull();
+            }
         }
         return mInstance;
     }

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilities.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilities.java
@@ -19,6 +19,7 @@ public class DeviceCapabilities extends XWalkExtension {
     private static final String TAG = "DeviceCapabilities";
 
     private DeviceCapabilitiesCPU mCPU;
+    private DeviceCapabilitiesCodecs mCodecs;
     private DeviceCapabilitiesDisplay mDisplay;
     private DeviceCapabilitiesMemory mMemory;
     private DeviceCapabilitiesStorage mStorage;
@@ -27,6 +28,7 @@ public class DeviceCapabilities extends XWalkExtension {
         super(NAME, jsApiContent, context);
 
         mCPU = new DeviceCapabilitiesCPU(this, context);
+        mCodecs = new DeviceCapabilitiesCodecs(this, context);
         mDisplay = new DeviceCapabilitiesDisplay(this, context);
         mMemory = new DeviceCapabilitiesMemory(this, context);
         mStorage = new DeviceCapabilitiesStorage(this, context);
@@ -54,6 +56,8 @@ public class DeviceCapabilities extends XWalkExtension {
             JSONObject jsonOutput = new JSONObject();
             if (cmd.equals("getCPUInfo")) {
                 jsonOutput.put("data", mCPU.getInfo());
+            } else if (cmd.equals("getCodecsInfo")) {
+                jsonOutput.put("data", mCodecs.getInfo());
             } else if (cmd.equals("getDisplayInfo")) {
                 jsonOutput.put("data", mDisplay.getInfo());
             } else if (cmd.equals("getMemoryInfo")) {

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesCPU.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesCPU.java
@@ -13,7 +13,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.xwalk.runtime.extension.XWalkExtensionContext;
 
-public class DeviceCapabilitiesCPU {
+class DeviceCapabilitiesCPU {
     private static final String SYSTEM_INFO_STAT_FILE = "/proc/stat";
     private static final String TAG = "DeviceCapabilitiesCPU";
 

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesCodecs.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesCodecs.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.device_capabilities;
+
+import org.json.JSONObject;
+import org.xwalk.runtime.extension.XWalkExtensionContext;
+
+class DeviceCapabilitiesCodecs {
+    private static XWalkMediaCodec sMediaCodec;
+
+    public DeviceCapabilitiesCodecs(DeviceCapabilities instance,
+                                    XWalkExtensionContext context) {
+        sMediaCodec = XWalkMediaCodec.getInstance(instance);
+    }
+
+    public JSONObject getInfo() {
+        return sMediaCodec.getCodecsInfo();
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesDisplay.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesDisplay.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
 import org.xwalk.runtime.extension.api.XWalkDisplayManager;
 import org.xwalk.runtime.extension.XWalkExtensionContext;
 
-public class DeviceCapabilitiesDisplay {
+class DeviceCapabilitiesDisplay {
     private static final String TAG = "DeviceCapabilitiesDisplay";
 
     private DeviceCapabilities mDeviceCapabilities;

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesMemory.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesMemory.java
@@ -13,7 +13,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.xwalk.runtime.extension.XWalkExtensionContext;
 
-public class DeviceCapabilitiesMemory {
+class DeviceCapabilitiesMemory {
     private static final String TAG = "DeviceCapabilitiesMemory";
 
     private DeviceCapabilities mDeviceCapabilities;

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesStorage.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesStorage.java
@@ -20,7 +20,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.xwalk.runtime.extension.XWalkExtensionContext;
 
-public class DeviceCapabilitiesStorage {
+class DeviceCapabilitiesStorage {
     private static final String TAG = "DeviceCapabilitiesStorage";
 
     private DeviceCapabilities mDeviceCapabilities;

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/MediaCodec.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/MediaCodec.java
@@ -1,0 +1,85 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.device_capabilities;
+
+import java.util.HashSet;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+class MediaCodec extends XWalkMediaCodec {
+    public MediaCodec(DeviceCapabilities instance) {
+        mDeviceCapabilities = instance;
+
+        mAudioCodecsSet = new HashSet<AudioCodecElement>();
+        mVideoCodecsSet = new HashSet<VideoCodecElement>();
+
+        // Suppose the codecs that MediaCodec reports won't change during runtime,
+        // so initialize in constructor.
+        getCodecsList();
+    }
+
+    @Override
+    public JSONObject getCodecsInfo() {
+        JSONObject outputObject = new JSONObject();
+        JSONArray audioCodecsArray = new JSONArray();
+        JSONArray videoCodecsArray = new JSONArray();
+
+        try {
+            for (AudioCodecElement codecToAdd : mAudioCodecsSet) {
+                JSONObject codecsObject = new JSONObject();
+                codecsObject.put("format", codecToAdd.codecName);
+                audioCodecsArray.put(codecsObject);
+            }
+            for (VideoCodecElement codecToAdd : mVideoCodecsSet) {
+                JSONObject codecsObject = new JSONObject();
+                codecsObject.put("format", codecToAdd.codecName);
+                codecsObject.put("encode", codecToAdd.isEncoder);
+                codecsObject.put("hwAccel", codecToAdd.hwAccel);
+                videoCodecsArray.put(codecsObject);
+            }
+
+            outputObject.put("audioCodecs", audioCodecsArray);
+            outputObject.put("videoCodecs", videoCodecsArray);
+        } catch (JSONException e) {
+            return mDeviceCapabilities.setErrorMessage(e.toString());
+        }
+
+        return outputObject;
+    }
+
+    public void getCodecsList() {
+        int numCodecs = android.media.MediaCodecList.getCodecCount();
+        for (int i = 0; i < numCodecs; i++) {
+            android.media.MediaCodecInfo codecInfo =
+                    android.media.MediaCodecList.getCodecInfoAt(i);
+            String name = codecInfo.getName().toUpperCase();
+            boolean hasAdded = false;
+
+            for (String nameListElement : AUDIO_CODEC_NAMES) {
+                if (name.contains(nameListElement)) {
+                    mAudioCodecsSet.add(new AudioCodecElement(nameListElement));
+                    hasAdded = true;
+                    break;
+                }
+            }
+
+            if (hasAdded) {
+                continue;
+            }
+
+            for (String nameListElement : VIDEO_CODEC_NAMES) {
+                if (name.contains(nameListElement)) {
+                    boolean isEncoder = codecInfo.isEncoder();
+                    // FIXME(fyraimar): Get the right hwAccel value.
+                    mVideoCodecsSet.add(new VideoCodecElement(
+                            nameListElement, isEncoder, false));
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/MediaCodecNull.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/MediaCodecNull.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.device_capabilities;
+
+import org.json.JSONObject;
+
+class MediaCodecNull extends XWalkMediaCodec {
+    public MediaCodecNull(DeviceCapabilities instance) {
+    }
+
+    @Override
+    public JSONObject getCodecsInfo() {
+        return new JSONObject();
+    }
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/XWalkMediaCodec.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/XWalkMediaCodec.java
@@ -1,0 +1,90 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.extension.api.device_capabilities;
+
+import java.util.Set;
+
+import org.json.JSONObject;
+
+import android.os.Build;
+
+abstract class XWalkMediaCodec {
+    private static final String TAG = "XWalkMediaCodec";
+
+    /** Android MediaCodec API reports codec with namespace instead of common codec name.
+     *  For example: "OMX.google.h263.decoder", what this API want to report is "h263".
+     *
+     *  The below static lists are used to parse out the common codec name. The codec names
+     *  are referenced by below links, it maybe adjusted on demand.
+     *
+     *  http://www.chromium.org/audio-video
+     *  https://developer.mozilla.org/en-US/docs/HTML/Supported_media_formats
+     */
+    protected static final String[] AUDIO_CODEC_NAMES =
+            {"ALAC", "MP3", "AMRNB", "AMRWB", "AAC", "G711", "VORBIS", "WMA", "FLAC", "OPUS"};
+    protected static final String[] VIDEO_CODEC_NAMES =
+            {"H263", "H264", "MPEG4", "AVC", "WMV", "VP8", "Theora"};
+
+    protected Set<AudioCodecElement> mAudioCodecsSet;
+    protected Set<VideoCodecElement> mVideoCodecsSet;
+
+    protected DeviceCapabilities mDeviceCapabilities;
+    private static XWalkMediaCodec sInstance;
+
+    protected class AudioCodecElement {
+        public String codecName;
+
+        public AudioCodecElement(String name) {
+            codecName = name;
+        }
+
+        // Objects of this class need to be added to a HashSet, so we implement equals()
+        // and hashCode() to support comparison operation.
+        public boolean equals(Object obj) {
+            return this.codecName.equals(((AudioCodecElement)obj).codecName);
+        }
+
+        public int hashCode() {
+            return codecName.hashCode();
+        }
+    }
+
+    protected class VideoCodecElement {
+        public String codecName;
+        public boolean isEncoder;
+        public boolean hwAccel;
+
+        public VideoCodecElement(String name, boolean encoder, boolean hardware) {
+            codecName = name;
+            isEncoder = encoder;
+            hwAccel = hardware;
+        }
+
+        // Objects of this class need to be added to a HashSet, so we implement equals()
+        // and hashCode() to support comparison operation.
+        public boolean equals(Object obj) {
+            return this.codecName.equals(((VideoCodecElement)obj).codecName)
+                    && this.isEncoder == ((VideoCodecElement)obj).isEncoder
+                            && this.hwAccel == ((VideoCodecElement)obj).hwAccel;
+        }
+
+        public int hashCode() {
+            return codecName.hashCode();
+        }
+    }
+
+    public static XWalkMediaCodec getInstance(DeviceCapabilities instance) {
+        if (sInstance == null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                sInstance = new MediaCodec(instance);
+            } else {
+                sInstance = new MediaCodecNull(instance);
+            }
+        }
+        return sInstance;
+    }
+
+    public abstract JSONObject getCodecsInfo();
+}

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/device_capabilities_api.js
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/device_capabilities_api.js
@@ -27,6 +27,13 @@ exports.getCPUInfo = function() {
   return postMessage(msg);
 };
 
+exports.getAVCodecs = function() {
+  var msg = {
+    'cmd': 'getCodecsInfo'
+  };
+  return postMessage(msg);
+};
+
 exports.getDisplayInfo = function() {
   var msg = {
     'cmd': 'getDisplayInfo'


### PR DESCRIPTION
The current implementation relies on the MediaCodec class introduced
since Android 4.1 (API Level 16), as a result, an abstract class XWalkMediaCodec
is added to allow this API run on the older Android but will empty list.

The support for 4.0 (API level == 15) will be added in another PR.

SPEC=http://www.w3.org/2012/sysapps/device-capabilities/
BUG=https://crosswalk-project.org/jira/browse/XWALK-48
