### PR TITLE
Added permission group and policy manageemnt classes.

### DIFF
--- a/application/browser/security/permission_group.h
+++ b/application/browser/security/permission_group.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_H_
+
+#include <string>
+
+#include "xwalk/application/common/permission_constants.h"
+
+namespace xwalk {
+namespace application {
+
+class PermissionGroup {
+ public:
+  PermissionGroup() {}
+  virtual ~PermissionGroup() {}
+
+  // If returned true, the perm_name contains the permission name
+  // according to the provided method name, otherwise the perm_name
+  // is untouched.
+  virtual bool GetPermissionName(const std::string& method_name,
+                                 std::string& perm_name) = 0;
+
+  virtual bool IsValidPermissionName(const std::string& perm_name) = 0;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_H_

--- a/application/browser/security/permission_group_external.cc
+++ b/application/browser/security/permission_group_external.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/security/permission_group_external.h"
+
+namespace xwalk {
+namespace application {
+
+// TODO(Bai): Complete this class implementation.
+PermissionGroupExternal::PermissionGroupExternal() {
+}
+
+PermissionGroupExternal::~PermissionGroupExternal() {
+}
+
+bool PermissionGroupExternal::GetPermissionName(
+    const std::string& method_name,
+    std::string& perm_name) {
+  return false;
+}
+
+bool PermissionGroupExternal::IsValidPermissionName(
+    const std::string& perm_name) {
+  return false;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/security/permission_group_external.h
+++ b/application/browser/security/permission_group_external.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_EXTERNAL_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_EXTERNAL_H_
+
+#include <string>
+
+#include "base/compiler_specific.h"
+#include "xwalk/application/browser/security/permission_group.h"
+
+namespace xwalk {
+namespace application {
+
+class PermissionGroupExternal: public PermissionGroup {
+ public:
+  PermissionGroupExternal();
+  ~PermissionGroupExternal();
+
+  bool GetPermissionName(const std::string& method_name,
+                         std::string& perm_name) OVERRIDE;
+
+  bool IsValidPermissionName(const std::string& perm_name) OVERRIDE;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_EXTERNAL_H_

--- a/application/browser/security/permission_group_internal.cc
+++ b/application/browser/security/permission_group_internal.cc
@@ -1,0 +1,32 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/security/permission_group_internal.h"
+
+namespace xwalk {
+namespace application {
+
+// TODO(Bai): Complete this class implementation according to the
+// permission list:
+// https://docs.google.com/a/intel.com/spreadsheet/ccc?key=
+// 0AmfuGardsG7gdGg1a0YxVVVNbEtKLTEzck9XMGYyRWc#gid=0
+PermissionGroupInternal::PermissionGroupInternal() {
+}
+
+PermissionGroupInternal::~PermissionGroupInternal() {
+}
+
+bool PermissionGroupInternal::GetPermissionName(
+    const std::string& method_name,
+    std::string& perm_name) {
+  return false;
+}
+
+bool PermissionGroupInternal::IsValidPermissionName(
+    const std::string& perm_name) {
+  return false;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/security/permission_group_internal.h
+++ b/application/browser/security/permission_group_internal.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_INTERNAL_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_INTERNAL_H_
+
+#include <string>
+
+#include "base/compiler_specific.h"
+#include "xwalk/application/browser/security/permission_group.h"
+
+namespace xwalk {
+namespace application {
+
+class PermissionGroupInternal: public PermissionGroup {
+ public:
+  PermissionGroupInternal();
+  ~PermissionGroupInternal();
+
+  bool GetPermissionName(const std::string& method_name,
+                         std::string& perm_name) OVERRIDE;
+
+  bool IsValidPermissionName(const std::string& perm_name) OVERRIDE;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_INTERNAL_H_

--- a/application/browser/security/permission_group_manager.cc
+++ b/application/browser/security/permission_group_manager.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/security/permission_group_manager.h"
+
+#include "base/logging.h"
+#include "xwalk/application/browser/security/permission_group_external.h"
+#include "xwalk/application/browser/security/permission_group_internal.h"
+
+namespace xwalk {
+namespace application {
+
+PermissionGroupManager::PermissionGroupManager() {
+  group_register_.push_back(new PermissionGroupInternal());
+  group_register_.push_back(new PermissionGroupExternal());
+}
+
+PermissionGroupManager::~PermissionGroupManager() {
+  for (std::vector<PermissionGroup*>::const_iterator iter
+      = group_register_.begin(); iter != group_register_.end(); ++iter) {
+    delete *iter;
+  }
+}
+
+bool PermissionGroupManager::GetPermissionName(const std::string& method_name,
+                                               std::string& perm_name) {
+  for (std::vector<PermissionGroup*>::const_iterator iter
+      = group_register_.begin(); iter != group_register_.end(); ++iter) {
+    if ((*iter)->GetPermissionName(method_name, perm_name))
+      return true;
+  }
+  return false;
+}
+
+bool PermissionGroupManager::IsValidPermissionName(
+    const std::string& perm_name) {
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/security/permission_group_manager.h
+++ b/application/browser/security/permission_group_manager.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_MANAGER_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_MANAGER_H_
+
+#include <string>
+#include <vector>
+
+#include "xwalk/application/browser/security/permission_group.h"
+#include "xwalk/application/common/permission_constants.h"
+
+namespace xwalk {
+namespace application {
+
+class PermissionGroupManager {
+ public:
+  PermissionGroupManager();
+  ~PermissionGroupManager();
+
+  // If returned true, the perm_name contains the valid permission name
+  // according to the given method name. Otherwise the perm_name will remain
+  // untouched.
+  bool GetPermissionName(const std::string& method_name,
+                         std::string& perm_name);
+
+  // Returns true if the permission name exists, otherwise false.
+  bool IsValidPermissionName(const std::string& perm_name);
+
+ private:
+  std::vector<PermissionGroup*> group_register_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_GROUP_MANAGER_H_

--- a/application/browser/security/permission_policy_manager.cc
+++ b/application/browser/security/permission_policy_manager.cc
@@ -1,0 +1,105 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/security/permission_policy_manager.h"
+
+#include "base/bind.h"
+#include "base/logging.h"
+#include "base/message_loop/message_loop.h"
+#include "xwalk/application/common/permission_constants.h"
+
+namespace xwalk {
+namespace application {
+
+PermissionPolicyManager::PermissionPolicyManager() {
+  session_policy_.reset(new SessionPolicyStorage());
+  persistent_policy_.reset(new PersistentPolicyStorage());
+  system_policy_.reset(new SystemPolicyStorage());
+}
+
+PermissionPolicyManager::~PermissionPolicyManager() {
+}
+
+void PermissionPolicyManager::GetRuntimePerm(
+    const std::string& app_id,
+    const std::string& perm_name,
+    OnRuntimePermCallback callback) {
+  // Consult session policy first.
+  StoredPermission perm = session_policy_->GetPermission(app_id, perm_name);
+  if (perm != INVALID_STORED_PERM) {
+    // "ASK" should not be in the session storage.
+    DCHECK(perm != ASK);
+    if (perm == ALLOW) {
+      base::MessageLoop::current()->PostTask(
+          FROM_HERE, base::Bind(callback, DENY_SESSION));
+      return;
+    }
+    if (perm == DENY) {
+      base::MessageLoop::current()->PostTask(
+                FROM_HERE, base::Bind(callback, DENY_SESSION));
+      return;
+    }
+    NOTREACHED();
+  }
+  // Then, consult the persistent policy storage.
+  perm = persistent_policy_->GetPermission(app_id, perm_name);
+  // Permission not found in persistent permission table, normally this should
+  // not happen because all the permission needed by the application should be
+  // contained in its manifest, so it also means that the application is asking
+  // for something wasn't allowed.
+  if (perm == INVALID_STORED_PERM) {
+    base::MessageLoop::current()->PostTask(
+              FROM_HERE, base::Bind(callback, INVALID_RUNTIME_PERM));
+    return;
+  }
+  if (perm == ASK) {
+    // TODO(Bai): We needed to pop-up a dialog asking user to chose one from
+    // either allow/deny for session/one shot/forever. Then, we need to update
+    // the session policy table accordingly.
+  }
+  if (perm == ALLOW) {
+    base::MessageLoop::current()->PostTask(
+                  FROM_HERE, base::Bind(callback, ALLOW_FOREVER));
+    return;
+  }
+  if (perm == DENY) {
+    base::MessageLoop::current()->PostTask(
+                  FROM_HERE, base::Bind(callback, DENY_FOREVER));
+    return;
+  }
+  NOTREACHED();
+}
+
+bool PermissionPolicyManager::PermInstall(
+    const std::string& app_id,
+    const std::vector<std::string>& perm_name_list) {
+  StoredPermissionMap perm_map;
+  StoredPermission perm;
+  for (std::vector<std::string>::const_iterator it = perm_name_list.begin();
+      it != perm_name_list.end(); ++it) {
+    perm = system_policy_->GetPermission(app_id, *it);
+    if (perm == INVALID_STORED_PERM) {
+      return false;
+    }
+    // Could either be ASK, ALLOW or DENY
+    perm_map[*it] = perm;
+  }
+  // It's transaction-protected.
+  return persistent_policy_->SetPermission(app_id, perm_map);
+}
+
+bool PermissionPolicyManager::PermUninstall(const std::string& app_id) {
+  // First, remove the session policy.
+  if (!TerminateSession(app_id))
+    return false;
+  // Then, clean up the persistent storage.
+  return persistent_policy_->RemovePermissionByID(app_id);
+}
+
+bool PermissionPolicyManager::TerminateSession(const std::string& app_id) {
+  return session_policy_->RemovePermissionByID(app_id);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/security/permission_policy_manager.h
+++ b/application/browser/security/permission_policy_manager.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_POLICY_MANAGER_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_POLICY_MANAGER_H_
+
+#include <string>
+#include <vector>
+
+#include "base/callback.h"
+#include "base/memory/scoped_ptr.h"
+#include "xwalk/application/common/permission_constants.h"
+#include "xwalk/application/browser/security/persistent_policy_storage.h"
+#include "xwalk/application/browser/security/session_policy_storage.h"
+#include "xwalk/application/browser/security/system_policy_storage.h"
+
+
+namespace xwalk {
+namespace application {
+
+typedef base::Callback<void (const RuntimePermission&)> OnRuntimePermCallback;
+
+class PermissionPolicyManager {
+ public:
+  PermissionPolicyManager();
+  ~PermissionPolicyManager();
+
+  void GetRuntimePerm(const std::string& app_id,
+                      const std::string& perm_name,
+                      OnRuntimePermCallback callback);
+
+  // We take the permission list from installer, indicating the permissions
+  // needed by the application, i.e. written in its manifest. But we need
+  // verify it against the system policy first.
+  // Note that, the permission name should be verified before calling this
+  // function.
+  bool PermInstall(const std::string& app_id,
+                   const std::vector<std::string>& perm_name_list);
+
+  bool PermUninstall(const std::string& app_id);
+
+  bool TerminateSession(const std::string& app_id);
+ private:
+  scoped_ptr<SessionPolicyStorage> session_policy_;
+  scoped_ptr<PersistentPolicyStorage> persistent_policy_;
+  scoped_ptr<SystemPolicyStorage> system_policy_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_PERMISSION_POLICY_MANAGER_H_

--- a/application/browser/security/persistent_policy_storage.cc
+++ b/application/browser/security/persistent_policy_storage.cc
@@ -1,0 +1,32 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/security/persistent_policy_storage.h"
+
+namespace xwalk {
+namespace application {
+
+PersistentPolicyStorage::PersistentPolicyStorage() {
+}
+
+PersistentPolicyStorage::~PersistentPolicyStorage() {
+}
+
+StoredPermission PersistentPolicyStorage::GetPermission(
+    const std::string& app_id,
+    const std::string& perm_name) {
+  return INVALID_STORED_PERM;
+}
+
+bool PersistentPolicyStorage::SetPermission(const std::string& app_id,
+                                            StoredPermissionMap& perm_map) {
+  return false;
+}
+
+bool PersistentPolicyStorage::RemovePermissionByID(const std::string& app_id) {
+  return false;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/security/persistent_policy_storage.h
+++ b/application/browser/security/persistent_policy_storage.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_PERSISTENT_POLICY_STORAGE_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_PERSISTENT_POLICY_STORAGE_H_
+
+#include <string>
+
+#include "xwalk/application/browser/security/policy_storage.h"
+
+namespace xwalk {
+namespace application {
+
+class PersistentPolicyStorage: public PolicyStorage {
+ public:
+  PersistentPolicyStorage();
+  ~PersistentPolicyStorage() OVERRIDE;
+
+  StoredPermission GetPermission(const std::string& app_id,
+                                 const std::string& perm_name) OVERRIDE;
+
+  bool SetPermission(const std::string& app_id,
+                     StoredPermissionMap& perm_map) OVERRIDE;
+
+  bool RemovePermissionByID(const std::string& app_id);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_PERSISTENT_POLICY_STORAGE_H_

--- a/application/browser/security/policy_storage.h
+++ b/application/browser/security/policy_storage.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_POLICY_STORAGE_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_POLICY_STORAGE_H_
+
+#include <map>
+#include <string>
+
+#include "base/compiler_specific.h"
+#include "xwalk/application/common/permission_constants.h"
+
+namespace xwalk {
+namespace application {
+
+typedef std::map<std::string, StoredPermission> StoredPermissionMap;
+
+class PolicyStorage {
+ public:
+  PolicyStorage() {}
+  virtual ~PolicyStorage() {}
+
+  virtual StoredPermission GetPermission(const std::string& app_id,
+                                         const std::string& perm_name) = 0;
+
+  virtual bool SetPermission(const std::string& app_id,
+                             StoredPermissionMap& perm_map) = 0;
+
+  bool SetSinglePermission(const std::string& app_id,
+                           const std::string& perm_name,
+                           const StoredPermission perm) {
+    StoredPermissionMap perm_map;
+    perm_map[perm_name] = perm;
+    return SetPermission(app_id, perm_map);
+  }
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_POLICY_STORAGE_H_

--- a/application/browser/security/session_policy_storage.cc
+++ b/application/browser/security/session_policy_storage.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/security/session_policy_storage.h"
+
+#include "base/logging.h"
+
+namespace xwalk {
+namespace application {
+
+SessionPolicyStorage::SessionPolicyStorage() {
+}
+
+SessionPolicyStorage::~SessionPolicyStorage() {
+}
+
+StoredPermission SessionPolicyStorage::GetPermission(
+    const std::string& app_id,
+    const std::string& perm_name) {
+  if (permission_map_.find(app_id) == permission_map_.end()) {
+    return INVALID_STORED_PERM;
+  } else {
+    StoredPermissionMap& map = permission_map_[app_id];
+    if (map.find(perm_name) == map.end())
+      return INVALID_STORED_PERM;
+    return map[perm_name];
+  }
+}
+
+bool SessionPolicyStorage::SetPermission(const std::string& app_id,
+                                         StoredPermissionMap& perm_map) {
+  if (permission_map_.find(app_id) == permission_map_.end()) {
+    permission_map_[app_id] = perm_map;
+    return true;
+  }
+  StoredPermissionMap& map = permission_map_[app_id];
+  for (StoredPermissionMap::iterator iter = perm_map.begin();
+      iter != perm_map.end(); ++iter) {
+    // Overwrite any existing policy.
+    map[iter->first] = iter->second;
+  }
+  return true;
+}
+
+bool SessionPolicyStorage::RemovePermissionByID(const std::string& app_id) {
+  if (permission_map_.find(app_id) == permission_map_.end()) {
+    LOG(ERROR) << "Application ID does not exist.";
+    return false;
+  }
+  permission_map_.erase(app_id);
+  return true;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/security/session_policy_storage.h
+++ b/application/browser/security/session_policy_storage.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_SESSION_POLICY_STORAGE_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_SESSION_POLICY_STORAGE_H_
+
+#include <map>
+#include <string>
+
+#include "xwalk/application/browser/security/policy_storage.h"
+
+namespace xwalk {
+namespace application {
+// Session policies are stored in a map, something like
+// [ [APP1,[bluetooth,ALLOW]], [APP2,[contact,DENY]] ...]
+class SessionPolicyStorage: public PolicyStorage {
+ public:
+  SessionPolicyStorage();
+  ~SessionPolicyStorage() OVERRIDE;
+
+  StoredPermission GetPermission(const std::string& app_id,
+                                 const std::string& perm_name) OVERRIDE;
+
+  bool SetPermission(const std::string& app_id,
+                     StoredPermissionMap& perm_map) OVERRIDE;
+
+  bool RemovePermissionByID(const std::string& app_id);
+ private:
+  std::map<std::string, StoredPermissionMap> permission_map_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_SESSION_POLICY_STORAGE_H_

--- a/application/browser/security/system_policy_storage.cc
+++ b/application/browser/security/system_policy_storage.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/security/system_policy_storage.h"
+
+namespace xwalk {
+namespace application {
+
+SystemPolicyStorage::SystemPolicyStorage() {
+}
+
+SystemPolicyStorage::~SystemPolicyStorage() {
+}
+
+StoredPermission SystemPolicyStorage::GetPermission(
+    const std::string& app_id,
+    const std::string& perm_name) {
+  return ALLOW;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/security/system_policy_storage.h
+++ b/application/browser/security/system_policy_storage.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_SECURITY_SYSTEM_POLICY_STORAGE_H_
+#define XWALK_APPLICATION_BROWSER_SECURITY_SYSTEM_POLICY_STORAGE_H_
+
+#include <string>
+
+#include "xwalk/application/browser/security/policy_storage.h"
+
+namespace xwalk {
+namespace application {
+
+class SystemPolicyStorage: public PolicyStorage {
+ public:
+  SystemPolicyStorage();
+  ~SystemPolicyStorage() OVERRIDE;
+  StoredPermission GetPermission(const std::string& app_id,
+                                 const std::string& perm_name) OVERRIDE;
+  // System policy is read-only
+  bool SetPermission(const std::string& app_id,
+                     StoredPermissionMap& perm_map) {
+    return false;
+  }
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_SECURITY_SYSTEM_POLICY_STORAGE_H_

--- a/application/common/permission_constants.cc
+++ b/application/common/permission_constants.cc
@@ -1,0 +1,11 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/permission_constants.h"
+
+namespace xwalk {
+namespace application {
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/permission_constants.h
+++ b/application/common/permission_constants.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_PERMISSION_CONSTANTS_H_
+#define XWALK_APPLICATION_COMMON_PERMISSION_CONSTANTS_H_
+
+namespace xwalk {
+namespace application {
+
+typedef enum {
+  ALLOW_ONCE,
+  ALLOW_SESSION,
+  ALLOW_FOREVER,
+  DENY_ONCE,
+  DENY_SESSION,
+  DENY_FOREVER,
+  INVALID_RUNTIME_PERM
+} RuntimePermission;
+
+typedef enum {
+  ALLOW,
+  DENY,
+  ASK,
+  INVALID_STORED_PERM
+} StoredPermission;
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_PERMISSION_CONSTANTS_H_


### PR DESCRIPTION
Added two major components of crosswalk API permission:
The permission group management and the permission policy management.
The permission group management is responsible for the mapping between
permission name and corresponding function name. The permission policy
manager is used to calculate the permission for a request.
For more details please refer to the design doc:
https://docs.google.com/a/intel.com/document/d/1TfU_oZo6P2Ff24w5RjRhYfPTJae5EzRWiXtdtxz0yBo/edit#
