### PR TITLE
[Android] Improve the illegal character handler in packaging tool.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -21,8 +21,10 @@ def ReplaceInvalidChars(value, mode='default'):
   if mode == 'default':
     invalid_chars = '\/:*?"<>|- '
   elif mode == 'apkname':
-    invalid_chars = '\/:*?"<>|-'
+    invalid_chars = '\/:.*?"<>|- '
   for c in invalid_chars:
+    if mode == 'apkname' and c in value:
+      print "Illegal character: '%s' is replaced with '_'" % c
     value = value.replace(c,'_')
   return value
 
@@ -374,7 +376,7 @@ def main():
           'activity-element.html#screen')
   parser.add_option('--orientation', help=info)
   options, _ = parser.parse_args()
-  sanitized_name = ReplaceInvalidChars(options.name)
+  sanitized_name = ReplaceInvalidChars(options.name, 'apkname')
   try:
     Prepare(options, sanitized_name)
     CustomizeXML(options, sanitized_name)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -58,6 +58,17 @@ class TestMakeApk(unittest.TestCase):
     out, _ = proc.communicate()
     self.assertTrue(out.find('The APK name is required!') == -1)
     Clean('Example')
+    invalid_chars = '\/:.*?"<>|- '
+    for c in invalid_chars:
+      invalid_name = '--name=Example' + c
+      proc = subprocess.Popen(['python', 'make_apk.py', invalid_name,
+                               '--app-version=1.0.0',
+                               '--package=org.xwalk.example',
+                               '--app-url=http://www.intel.com'],
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+      out, _ = proc.communicate()
+      self.assertTrue(out.find('Illegal character') != -1)
+      Clean('Example_')
 
   def testAppVersion(self):
     proc = subprocess.Popen(['python', 'make_apk.py', '--name=Example',


### PR DESCRIPTION
When the application name includes the illegal character '.', the
packaging tool doesn't handle it and other illegal characters are
handled but no prompt. This fix is to improve the illegal character
handler in the packaging tool and the test case related to illegal
application name is added.

BUG=https://crosswalk-project.org/jira/browse/XWALK-139
