### PR TITLE
[D-Bus] Add support for GetAll() in PropertyExporter 

### DIFF
--- a/dbus/property_exporter.h
+++ b/dbus/property_exporter.h
@@ -19,6 +19,8 @@ class Value;
 
 namespace dbus {
 
+class MessageWriter;
+
 // Exports org.freedesktop.DBus.Properties interface for the given
 // ExportedObject. Properties should be set directly into the exporter object
 // using the function Set().
@@ -34,9 +36,14 @@ class PropertyExporter {
   // TODO(cmarcelo): We need some callback to indicate when all the methods
   // were exported.
 
+  void AppendPropertiesToWriter(const std::string& interface,
+                                MessageWriter* writer);
+
  private:
   void OnGet(dbus::MethodCall* method_call,
              dbus::ExportedObject::ResponseSender response_sender);
+  void OnGetAll(dbus::MethodCall* method_call,
+                dbus::ExportedObject::ResponseSender response_sender);
   void OnExported(const std::string& interface_name,
                   const std::string& method_name,
                   bool success);

--- a/dbus/property_exporter_unittest.cc
+++ b/dbus/property_exporter_unittest.cc
@@ -178,3 +178,27 @@ TEST(PropertyExporterTest, GetChangeGet) {
   test_client.WaitForUpdates(1);
   ASSERT_EQ(test_client.properties()->property.value(), "Pass 2");
 }
+
+// Test GetAll interface with multiple properties.
+TEST(PropertyExporterTest, GetAll) {
+  base::MessageLoop message_loop;
+  ExportObjectWithPropertiesService test_service;
+  GetPropertyClient test_client(&message_loop);
+
+  // Will run message loop until service is initialized.
+  test_service.Initialize(base::Bind(&base::MessageLoop::Quit,
+                                     base::Unretained(&message_loop)));
+  message_loop.Run();
+
+  test_service.SetStringProperty("Property", "Pass");
+  test_service.SetStringProperty("OtherProperty", "Pass");
+
+  ASSERT_NE(test_client.properties()->property.value(), "Pass");
+  ASSERT_NE(test_client.properties()->other_property.value(), "Pass");
+
+  test_client.properties()->GetAll();
+  test_client.WaitForUpdates(2);
+
+  ASSERT_EQ(test_client.properties()->property.value(), "Pass");
+  ASSERT_EQ(test_client.properties()->other_property.value(), "Pass");
+}


### PR DESCRIPTION
See commit message for details. The patch that implements GetAll() is implemented on top of another PR

https://github.com/crosswalk-project/crosswalk/pull/1183

that improves the unittest file, so that we can easily test GetAll as well. Please use this PR to review only the GetAll() patch.
