### PR TITLE
[Tizen][UI] Move TizenSystemIndicator to tizen/mobile/ui/

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -9,8 +9,8 @@
 #include "ui/gfx/transform.h"
 #include "ui/views/view.h"
 #include "ui/views/widget/widget.h"
-#include "xwalk/runtime/browser/ui/tizen_system_indicator.h"
 #include "xwalk/runtime/browser/ui/top_view_layout_views.h"
+#include "xwalk/tizen/mobile/ui/tizen_system_indicator.h"
 
 namespace xwalk {
 

--- a/tizen/mobile/ui/tizen_plug_message_writer.cc
+++ b/tizen/mobile/ui/tizen_plug_message_writer.cc
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "xwalk/runtime/browser/ui/tizen_plug_message_writer.h"
+#include "xwalk/tizen/mobile/ui/tizen_plug_message_writer.h"
 
 #include <arpa/inet.h>
 #include <unistd.h>

--- a/tizen/mobile/ui/tizen_plug_message_writer.h
+++ b/tizen/mobile/ui/tizen_plug_message_writer.h
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_MESSAGE_WRITER_H_
-#define XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_MESSAGE_WRITER_H_
+#ifndef XWALK_TIZEN_MOBILE_UI_TIZEN_PLUG_MESSAGE_WRITER_H_
+#define XWALK_TIZEN_MOBILE_UI_TIZEN_PLUG_MESSAGE_WRITER_H_
 
 #include "base/basictypes.h"
 
@@ -124,4 +124,4 @@ class TizenPlugMessageWriter {
 
 }  // namespace xwalk
 
-#endif  // XWALK_RUNTIME_BROWSER_UI_TIZEN_PLUG_MESSAGE_WRITER_H_
+#endif  // XWALK_TIZEN_MOBILE_UI_TIZEN_PLUG_MESSAGE_WRITER_H_

--- a/tizen/mobile/ui/tizen_system_indicator.cc
+++ b/tizen/mobile/ui/tizen_system_indicator.cc
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "xwalk/runtime/browser/ui/tizen_system_indicator.h"
+#include "xwalk/tizen/mobile/ui/tizen_system_indicator.h"
 
 #include "ui/gfx/canvas.h"
 #include "content/public/browser/browser_thread.h"
-#include "xwalk/runtime/browser/ui/tizen_system_indicator_watcher.h"
+#include "xwalk/tizen/mobile/ui/tizen_system_indicator_watcher.h"
 
 #include "ui/views/widget/native_widget.h"
 #include "ui/views/widget/root_view.h"

--- a/tizen/mobile/ui/tizen_system_indicator.h
+++ b/tizen/mobile/ui/tizen_system_indicator.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef XWALK_RUNTIME_BROWSER_UI_TIZEN_SYSTEM_INDICATOR_H_
-#define XWALK_RUNTIME_BROWSER_UI_TIZEN_SYSTEM_INDICATOR_H_
+#ifndef XWALK_TIZEN_MOBILE_UI_TIZEN_SYSTEM_INDICATOR_H_
+#define XWALK_TIZEN_MOBILE_UI_TIZEN_SYSTEM_INDICATOR_H_
 
 #include <string>
 #include "ui/gfx/image/image_skia.h"
@@ -42,4 +42,4 @@ class TizenSystemIndicator : public views::View {
 
 }  // namespace xwalk
 
-#endif  // XWALK_RUNTIME_BROWSER_UI_TIZEN_SYSTEM_INDICATOR_H_
+#endif  // XWALK_TIZEN_MOBILE_UI_TIZEN_SYSTEM_INDICATOR_H_

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.cc
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.cc
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "xwalk/runtime/browser/ui/tizen_system_indicator_watcher.h"
+#include "xwalk/tizen/mobile/ui/tizen_system_indicator_watcher.h"
 
 #include <arpa/inet.h>
 #include <fcntl.h>
@@ -15,7 +15,7 @@
 #include "ipc/unix_domain_socket_util.h"
 #include "base/strings/string_tokenizer.h"
 #include "base/environment.h"
-#include "xwalk/runtime/browser/ui/tizen_system_indicator.h"
+#include "xwalk/tizen/mobile/ui/tizen_system_indicator.h"
 
 using content::BrowserThread;
 

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.h
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.h
@@ -3,16 +3,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef XWALK_RUNTIME_BROWSER_UI_TIZEN_SYSTEM_INDICATOR_WATCHER_H_
-#define XWALK_RUNTIME_BROWSER_UI_TIZEN_SYSTEM_INDICATOR_WATCHER_H_
-
-#include "xwalk/runtime/browser/ui/tizen_plug_message_writer.h"
+#ifndef XWALK_TIZEN_MOBILE_UI_TIZEN_SYSTEM_INDICATOR_WATCHER_H_
+#define XWALK_TIZEN_MOBILE_UI_TIZEN_SYSTEM_INDICATOR_WATCHER_H_
 
 #include <string>
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/shared_memory.h"
 #include "base/message_loop/message_pump_libevent.h"
 #include "ui/gfx/size.h"
+#include "xwalk/tizen/mobile/ui/tizen_plug_message_writer.h"
 
 namespace xwalk {
 
@@ -73,4 +72,4 @@ class TizenSystemIndicatorWatcher : public base::MessagePumpLibevent::Watcher {
 
 }  // namespace xwalk
 
-#endif  // XWALK_RUNTIME_BROWSER_UI_TIZEN_SYSTEM_INDICATOR_WATCHER_H_
+#endif  // XWALK_TIZEN_MOBILE_UI_TIZEN_SYSTEM_INDICATOR_WATCHER_H_

--- a/tizen/xwalk_tizen.gypi
+++ b/tizen/xwalk_tizen.gypi
@@ -4,6 +4,8 @@
     'target_name': 'xwalk_tizen_lib',
     'type': 'static_library',
     'dependencies': [
+      '../../skia/skia.gyp:skia',
+      '../../ui/ui.gyp:ui',
       '../build/system.gyp:tizen_appcore',
     ],
     'include_dirs': [
@@ -12,6 +14,12 @@
     'sources': [
       'appcore_context.cc',
       'appcore_context.h',
+      'mobile/ui/tizen_plug_message_writer.cc',
+      'mobile/ui/tizen_plug_message_writer.h',
+      'mobile/ui/tizen_system_indicator.cc',
+      'mobile/ui/tizen_system_indicator.h',
+      'mobile/ui/tizen_system_indicator_watcher.cc',
+      'mobile/ui/tizen_system_indicator_watcher.h',
     ],
   }],
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -155,6 +155,7 @@
         [ 'tizen_mobile == 1', {
           'dependencies': [
             'sysapps/sysapps_resources.gyp:xwalk_sysapps_resources',
+            'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
           ],
           'includes': [
             'sysapps/device_capabilities/device_capabilities.gypi',
@@ -168,12 +169,6 @@
             'runtime/browser/tizen/tizen_platform_sensor.h',
             'runtime/browser/ui/native_app_window_tizen.cc',
             'runtime/browser/ui/native_app_window_tizen.h',
-            'runtime/browser/ui/tizen_plug_message_writer.cc',
-            'runtime/browser/ui/tizen_plug_message_writer.h',
-            'runtime/browser/ui/tizen_system_indicator.cc',
-            'runtime/browser/ui/tizen_system_indicator.h',
-            'runtime/browser/ui/tizen_system_indicator_watcher.cc',
-            'runtime/browser/ui/tizen_system_indicator_watcher.h',
             'runtime/browser/xwalk_browser_main_parts_tizen.cc',
             'runtime/browser/xwalk_browser_main_parts_tizen.h',
           ],


### PR DESCRIPTION
Move system indicator view and its helpers to tizen/mobile/ui/. The
rationale is that tizen/mobile/ directory stores components that are
self-contained and Tizen mobile specific.
