### PR TITLE
[Extensions] Fix regression, extensions not being registered on Tizen and Android

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -110,7 +110,8 @@ void XWalkBrowserMainPartsAndroid::PostMainMessageLoopRun() {
   base::MessageLoopForUI::current()->Start();
 }
 
-void XWalkBrowserMainPartsAndroid::RegisterInternalExtensionsInServer(
+void
+XWalkBrowserMainPartsAndroid::RegisterInternalExtensionsInExtensionThreadServer(
     extensions::XWalkExtensionServer* server) {
   CHECK(server);
   ScopedVector<XWalkExtension>::const_iterator it = extensions_.begin();

--- a/runtime/browser/xwalk_browser_main_parts_android.h
+++ b/runtime/browser/xwalk_browser_main_parts_android.h
@@ -21,7 +21,7 @@ class XWalkBrowserMainPartsAndroid : public XWalkBrowserMainParts {
   virtual void PreMainMessageLoopRun() OVERRIDE;
   virtual void PostMainMessageLoopRun() OVERRIDE;
 
-  virtual void RegisterInternalExtensionsInServer(
+  virtual void RegisterInternalExtensionsInExtensionThreadServer(
       extensions::XWalkExtensionServer* server) OVERRIDE;
 
   // XWalkExtensionAndroid needs to register its extensions on

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -53,7 +53,8 @@ void XWalkBrowserMainPartsTizen::PreMainMessageLoopRun() {
   XWalkBrowserMainParts::PreMainMessageLoopRun();
 }
 
-void XWalkBrowserMainPartsTizen::RegisterInternalExtensionsInServer(
+void
+XWalkBrowserMainPartsTizen::RegisterInternalExtensionsInExtensionThreadServer(
     extensions::XWalkExtensionServer* server) {
   CHECK(server);
   server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(

--- a/runtime/browser/xwalk_browser_main_parts_tizen.h
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.h
@@ -19,7 +19,7 @@ class XWalkBrowserMainPartsTizen : public XWalkBrowserMainParts {
   virtual void PreMainMessageLoopStart() OVERRIDE;
   virtual void PreMainMessageLoopRun() OVERRIDE;
 
-  virtual void RegisterInternalExtensionsInServer(
+  virtual void RegisterInternalExtensionsInExtensionThreadServer(
       extensions::XWalkExtensionServer* server) OVERRIDE;
 
  private:


### PR DESCRIPTION
RegisterInternalExtensionsInServer should have been renamed for Tizen and
Android and not only for desktop. The extensions were not being registered
because of that for these platforms.

Thanks to Jesus Sanchez-Palencia for pointing the directions.
