### PR TITLE
[Packaging] Change the way we pass BUILDDIR_NAME to gyp and make.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,6 +17,11 @@ deps_xwalk = {
   # grit-i18n to latest version"). This is used for incremental Tizen builds to
   # work.
   'src/tools/grit': 'http://grit-i18n.googlecode.com/svn/trunk@138',
+
+  # Required until chromium-crosswalk tracks gyp r1797 or later.
+  # Needed for incremental Tizen builds after M32. See XWALK-454.
+  'src/tools/gyp': 'http://gyp.googlecode.com/svn/trunk@1797',
+
   'src/third_party/openmax_dl': 'http://webrtc.googlecode.com/svn/deps/third_party/openmax@5124',
 }
 vars_xwalk = {


### PR DESCRIPTION
The M32 Chromium rebase ended up causing a regression in the incremental
Tizen builds: even with no changes, an incremental build would always
trigger a regeneration of most of the V8 bindings in Blink, which then
caused an almost full rebuild of Blink itself.

This was caused by changes in Blink's Source/bindings/derived_sources.gyp,
which were generating some file lists that were dependencies for some
targets in the source tree itself. Since the source tree is erased in every
build, the file lists are regenerated and trigger all those rebuilds.

Fix this by pulling some commits that had to be made in Chromium and gyp
itself to properly support passing an absolute directory to gyp's
--generator-output option and then using that to know where to store the
file lists generated by gyp:

  Chromium r236822: Pass the gold binary to the linker using only absolute
                    paths.
  gyp r1797:        make: Support the generator_filelist_paths input info.

Now, instead of passing "builddir_name" when calling make, we pass --depth
and --generator-output to gyp.

While we could backport this commit to the crosswalk-2 branch, there isn't
really a need for that, as the previous process was working fine with M31.

BUG=https://crosswalk-project.org/jira/browse/XWALK-454
