### PR TITLE
[Application] Add Application Management tool

### DIFF
--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -1,0 +1,38 @@
+{
+  'targets': [
+    {
+      'target_name': 'gio',
+      'type': 'none',
+      'variables': {
+        'glib_packages': 'glib-2.0 gio-2.0',
+      },
+      'direct_dependent_settings': {
+        'cflags': [
+          '<!@(pkg-config --cflags <(glib_packages))',
+        ],
+      },
+      'link_settings': {
+        'ldflags': [
+          '<!@(pkg-config --libs-only-L --libs-only-other <(glib_packages))',
+        ],
+        'libraries': [
+          '<!@(pkg-config --libs-only-l <(glib_packages))',
+        ],
+      },
+    },
+    {
+      'target_name': 'xwalkctl',
+      'type': 'executable',
+      'product_name': 'xwalkctl',
+      'dependencies': [
+        'gio',
+      ],
+      'include_dirs': [
+        '..',
+      ],
+      'sources': [
+        'xwalkctl_main.c',
+      ],
+    },
+  ],
+}

--- a/application/tools/linux/xwalkctl_main.c
+++ b/application/tools/linux/xwalkctl_main.c
@@ -1,0 +1,211 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <glib.h>
+#include <gio/gio.h>
+
+static const char* xwalk_service_name = "org.crosswalkproject";
+static const char* xwalk_installed_path = "/installed";
+static const char* xwalk_installed_iface =
+    "org.crosswalkproject.InstalledApplicationsRoot";
+static const char* xwalk_installed_app_iface =
+    "org.crosswalkproject.InstalledApplication";
+
+static char* install_path;
+static char* uninstall_appid;
+
+static GOptionEntry entries[] =
+{
+  { "install", 'i', 0, G_OPTION_ARG_STRING, &install_path,
+    "Path of the application to be installed", "PATH" },
+  { "uninstall", 'u', 0, G_OPTION_ARG_STRING, &uninstall_appid,
+    "Uninstall the application with this appid", "APPID" },
+  { NULL }
+};
+
+static bool install_application(const char* path)
+{
+  GError* error = NULL;
+  GDBusProxy* proxy;
+  bool ret;
+
+  proxy = g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+		  G_DBUS_PROXY_FLAGS_NONE, NULL, xwalk_service_name,
+		  xwalk_installed_path, xwalk_installed_iface, NULL, &error);
+  if (!proxy) {
+    g_print("Couldn't create proxy for '%s': %s\n", xwalk_installed_iface,
+            error->message);
+    g_error_free(error);
+    ret = false;
+    goto done;
+  }
+
+  GVariant* result = g_dbus_proxy_call_sync(proxy, "Install",
+                                            g_variant_new("(s)", path),
+                                            G_DBUS_CALL_FLAGS_NONE,
+                                            -1, NULL, &error);
+  if (!result) {
+    g_print("Installing application failed: %s\n", error->message);
+    g_error_free(error);
+    ret = false;
+    goto done;
+  }
+
+  const char* object_path;
+
+  g_variant_get(result, "(o)", &object_path);
+  g_print("Application installed with path '%s'\n", object_path);
+  g_variant_unref(result);
+
+  ret = true;
+
+done:
+  if (proxy)
+    g_object_unref(proxy);
+
+  return ret;
+}
+
+static bool uninstall_application(GDBusObjectManager* installed,
+                                  const char* appid)
+{
+  GList* objects = g_dbus_object_manager_get_objects(installed);
+  GList* l;
+  bool ret = false;
+
+  for (l = objects; l; l = l->next) {
+    GDBusObject* object = l->data;
+    GDBusInterface* iface = g_dbus_object_get_interface(
+        object,
+        xwalk_installed_app_iface);
+    if (!iface)
+      continue;
+
+    GDBusProxy* proxy = G_DBUS_PROXY(iface);
+
+    GVariant* value = g_dbus_proxy_get_cached_property(proxy, "AppID");
+    if (!value) {
+      g_object_unref(iface);
+      continue;
+    }
+
+    const char* id;
+    g_variant_get(value, "s", &id);
+
+    if (g_strcmp0(appid, id)) {
+      g_object_unref(iface);
+      continue;
+    }
+
+    GError* error = NULL;
+    GVariant* result = g_dbus_proxy_call_sync(proxy, "Uninstall", NULL,
+                                              G_DBUS_CALL_FLAGS_NONE,
+                                              -1, NULL, &error);
+    if (!result) {
+      g_print("Uninstalling application failed: %s\n", error->message);
+      g_error_free(error);
+      g_object_unref(iface);
+      ret = false;
+      goto done;
+    }
+
+    g_object_unref(iface);
+    ret = true;
+    goto done;
+  }
+
+  g_print("Application ID '%s' could not be found\n", appid);
+
+done:
+  g_list_free_full(objects, g_object_unref);
+
+  return ret;
+}
+
+static void list_applications(GDBusObjectManager* installed) {
+  GList* objects = g_dbus_object_manager_get_objects(installed);
+  GList* l;
+
+  for (l = objects; l; l = l->next) {
+    GDBusObject* object = l->data;
+    GDBusInterface* iface = g_dbus_object_get_interface(
+        object,
+        xwalk_installed_app_iface);
+    if (!iface)
+      continue;
+
+    GDBusProxy* proxy = G_DBUS_PROXY(iface);
+    GVariant* id_variant;
+    id_variant = g_dbus_proxy_get_cached_property(proxy, "AppID");
+    if (!id_variant) {
+      g_object_unref(iface);
+      continue;
+    }
+
+    const char* id;
+    g_variant_get(id_variant, "s", &id);
+
+    GVariant* name_variant;
+    name_variant = g_dbus_proxy_get_cached_property(proxy, "Name");
+    if (!name_variant) {
+      g_object_unref(iface);
+      continue;
+    }
+
+    const char* name;
+    g_variant_get(name_variant, "s", &name);
+
+    g_print("%s\t%s\n", id, name);
+
+    g_object_unref(iface);
+  }
+
+  g_list_free_full(objects, g_object_unref);
+}
+
+int main(int argc, char* argv[]) {
+  GError* error = NULL;
+  GOptionContext* context;
+  GMainLoop* mainloop;
+  int err = 0;
+  bool success;
+
+#if !GLIB_CHECK_VERSION(2, 36, 0)
+  // g_type_init() is deprecated on GLib since 2.36, Tizen has 2.32.
+  g_type_init();
+#endif
+
+  context = g_option_context_new("- Crosswalk Application Management");
+  g_option_context_add_main_entries(context, entries, NULL);
+  if (!g_option_context_parse(context, &argc, &argv, &error)) {
+    g_print("option parsing failed: %s\n", error->message);
+    exit(1);
+  }
+
+  GDBusObjectManager* installed_om = g_dbus_object_manager_client_new_for_bus_sync(
+      G_BUS_TYPE_SESSION, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
+      xwalk_service_name, xwalk_installed_path,
+      NULL, NULL, NULL, NULL, NULL);
+  if (!installed_om) {
+    g_print("Service '%s' could not be reached\n", xwalk_service_name);
+    exit(1);
+  }
+
+  if (install_path) {
+    success = install_application(install_path);
+  } else if (uninstall_appid) {
+    success = uninstall_application(installed_om, uninstall_appid);
+  } else {
+    g_print("Application ID                       Application Name\n");
+    g_print("-----------------------------------------------------\n");
+    list_applications(installed_om);
+    g_print("-----------------------------------------------------\n");
+    success = true;
+  }
+
+  return success ? 0 : 1;
+}

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -138,5 +138,17 @@
         },
       ],
     },
+    {
+      'target_name': 'xwalk_application_tools',
+      'type': 'none',
+      'defines': ['XWALK_VERSION="<(xwalk_version)"'],
+      'conditions': [
+        ['OS=="linux"', {
+          'dependencies': [
+            'application/tools/linux/xwalk_application_tools.gyp:xwalkctl',
+          ],
+        }],
+      ],
+    },
   ],
 }

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -162,7 +162,7 @@ export GYP_GENERATORS='make'
 -Dtizen_mobile=1 \
 -Duse_openssl=1
 
-make %{?_smp_mflags} -C "${BUILDDIR_NAME}" BUILDTYPE=Release xwalk
+make %{?_smp_mflags} -C "${BUILDDIR_NAME}" BUILDTYPE=Release xwalk xwalkctl
 
 %install
 # Support building in a non-standard directory, possibly outside %{_builddir}.
@@ -187,6 +187,7 @@ cd src
 # Binaries.
 install -p -D %{SOURCE1} %{buildroot}%{_bindir}/xwalk
 install -p -D ${BUILDDIR_NAME}/out/Release/xwalk %{buildroot}%{_libdir}/xwalk/xwalk
+install -p -D ${BUILDDIR_NAME}/out/Release/xwalkctl %{buildroot}%{_bindir}/xwalkctl
 install -p -D %{SOURCE1004} %{buildroot}%{_bindir}/install_into_pkginfo_db.py
 
 # Supporting libraries and resources.
@@ -202,6 +203,7 @@ install -p -D ../%{name}.png %{buildroot}%{_desktop_icondir}/%{name}.png
 %manifest %{name}.manifest
 # %license AUTHORS.chromium AUTHORS.xwalk LICENSE.chromium LICENSE.xwalk
 %{_bindir}/xwalk
+%{_bindir}/xwalkctl
 %{_bindir}/install_into_pkginfo_db.py
 %{_libdir}/xwalk/libffmpegsumo.so
 %{_libdir}/xwalk/xwalk


### PR DESCRIPTION
This tool provides a way to list, install and uninstall Applications
using the D-Bus API that will be provided by Crosswalk when it is run
using the run-as-service switch.

Fow now, only listing installed applications is tested. When Crosswalk
implements the install/uninstall functionality, there should be little
to no changes to this tool. But the code is included so the aim of
this tool is made clear.

This tool is implemented using only glib instead of the Chromium D-Bus bindings
to keep this code simpler, the Chromium D-Bus bindings require a separated
thread for handling D-Bus messages.
