### PR TITLE
REGRESSION(86246ac): Roll back chromium-crosswalk to 4b75b5f.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '31.0.1650.57'
-chromium_crosswalk_point = '9129c030a4bb018a1c2257ae9fc2534d5b5751b7'
+chromium_crosswalk_point = '4b75b5fa6af4cf8c601c748b75c0176ef7ec175c'
 blink_crosswalk_point = '690163cbfa45ca0a5237e79745f342034aabda70'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
Go 6 revisions back in chromium-crosswalk and point to the same commit we were
pointing to before rebasing Chromium from 31.0.1650.12 to 31.0.1650.57.

It is a bit weird that we have quite a few commits being unused in 
chromium-crosswalk, but the M31 rebase should not have changed that anyway
(plus it broke the build due to missing gstreamer dependencies in the spec 
file for Tizen).

BUG=https://crosswalk-project.org/jira/browse/XWALK-471
