### PR TITLE
[Android] Fix the test case about testExtensionBroadcast.

### DIFF
--- a/test/android/data/broadcast.html
+++ b/test/android/data/broadcast.html
@@ -14,7 +14,7 @@
         + "   var messageReceivedInIframe = null;\n"
         + "    function messageHandler (msg) {\n"
         + "      messageReceivedInIframe = msg;\n"
-        + "      if (messageReceivedInIframe != null)\n"
+        + "      if (top.window.messageReceivedInTop != null)\n"
         + "      top.window.verifyResult();\n"
         + "    }\n"
         + "   broadcast.setHandler(messageHandler);\n"


### PR DESCRIPTION
verifyResult() will be called from sub and top frame. When it was
called from sub frame, the value of messageReceivedInTop was null,
then set the title to "Fail". In java code, the value of title was
"Fail", so this test case failed.

The fix is to add a variable to check the function "verifyResult()"
was called from top or sub frame.

BUG=https://crosswalk-project.org/jira/browse/XWALK-530
