### PR TITLE
[SysApps] Move the Promise implementation to a module

### DIFF
--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -78,6 +78,9 @@ void XWalkContentRendererClient::DidCreateModuleSystem(
   module_system->RegisterNativeModule("application", app_module.Pass());
   module_system->RegisterNativeModule("sysapps_common",
       extensions::CreateJSModuleFromResource(IDR_XWALK_SYSAPPS_COMMON_API));
+  module_system->RegisterNativeModule("sysapps_promise",
+      extensions::CreateJSModuleFromResource(
+          IDR_XWALK_SYSAPPS_COMMON_PROMISE_API));
 }
 
 }  // namespace xwalk

--- a/sysapps/common/common_promise_api.js
+++ b/sysapps/common/common_promise_api.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2013 unscriptable.com / John Hann. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+Promise.prototype = {
+  then: function(onFulfilled, onRejected) {
+    this._thens.push({ fulfill: onFulfilled, reject: onRejected });
+    return this;
+  },
+  fulfill: function(value) {
+    this._done('fulfill', value);
+  },
+  reject: function(error) {
+    this._done('reject', error);
+  },
+  _done: function(which, arg) {
+    // Cover and sync func `then()`.
+    this.then = which === 'fulfill' ?
+      function(fulfill, reject) { fulfill && fulfill(arg); return this; } :
+      function(fulfill, reject) { reject && reject(arg); return this; };
+    // Disallow multiple calls.
+    this.fulfill = this.reject =
+      function() { throw new Error('Promise already completed.'); }
+    // Complete all async `then()`s.
+    var then, i = 0;
+    while (then = this._thens[i++]) {
+      then[which] && then[which](arg);
+    }
+    delete this._thens;
+  }
+};
+
+function Promise() {
+  this._thens = [];
+};
+
+exports.Promise = Promise;

--- a/sysapps/device_capabilities/device_capabilities_api.js
+++ b/sysapps/device_capabilities/device_capabilities_api.js
@@ -1,49 +1,13 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
-// The Promise code are modified from https://gist.github.com/unscriptable/814052
-// with original copyright and license as below.
-//
-// (c) copyright unscriptable.com / John Hann
-// License MIT
 
 var _promises = {};
 var _next_promise_id = 0;
 var _listeners = {};
 var _next_listener_id = 0;
 
-function Promise() {
-  this._thens = [];
-}
-
-Promise.prototype = {
-  then: function(onFulfilled, onRejected) {
-    this._thens.push({fulfill: onFulfilled, reject: onRejected});
-    return this;
-  },
-  fulfill: function(value) {
-    this._done('fulfill', value);
-  },
-  reject: function(error) {
-    this._done('reject', error);
-  },
-  _done: function(which, arg) {
-    // Cover and sync func `then()`.
-    this.then = which === 'fulfill' ?
-      function(fulfill, reject) {fulfill && fulfill(arg); return this;} :
-      function(fulfill, reject) {reject && reject(arg); return this;};
-    // Disallow multiple calls.
-    this.fulfill = this.reject =
-      function() {throw new Error('Promise already completed.');}
-    // Complete all async `then()`s.
-    var then, i = 0;
-    while (then = this._thens[i++]) {
-      then[which] && then[which](arg);
-    }
-    delete this._thens;
-  }
-};
+var Promise = requireNative('sysapps_promise').Promise;
 
 var postMessage = function(msg) {
   var p = new Promise();

--- a/sysapps/sysapps_resources.grd
+++ b/sysapps/sysapps_resources.grd
@@ -11,6 +11,7 @@
   <release seq="1">
     <includes>
       <include name="IDR_XWALK_SYSAPPS_COMMON_API" file="common/common_api.js" type="BINDATA" />
+      <include name="IDR_XWALK_SYSAPPS_COMMON_PROMISE_API" file="common/common_promise_api.js" type="BINDATA" />
       <include name="IDR_XWALK_SYSAPPS_DEVICE_CAPABILITIES_API" file="device_capabilities/device_capabilities_api.js" type="BINDATA" />
       <include name="IDR_XWALK_SYSAPPS_RAW_SOCKET_API" file="raw_socket/raw_socket_api.js" type="BINDATA" />
     </includes>


### PR DESCRIPTION
So it can be shared with other APIs. We still need to evaluate if
we can use the Chromium's implementation of Promise or if we need
to write a new one + native helpers.
