### PR TITLE
[Tizen] Load audio-session-manager library dynamically in the Browser process

### DIFF
--- a/packaging/crosswalk-tizen-audio-session-manager.patch
+++ b/packaging/crosswalk-tizen-audio-session-manager.patch
@@ -3,16 +3,28 @@ Author: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
 This patch includes Chromium side changes needed for integrating
 WebMediaPlayer with the Tizen Audio Session Manager.
 
+Also, it has changes that are needed for generating audio-session-manager
+stubs and load the library dynamically in the Browser process.
+
+audio-session-manager is using an _attribute_((constructor)) to initialize
+code and setup signal handlers at startup. So, linking with this library
+is causing a sandbox violation by executing the code in Renderer Process,
+since the Renderer Process and the Browser Process are linked with the
+same libraries.
+
+To prevent the problem, we load the audio-session-manager dynamically in
+the Browser process.
+
 diff --git src/build/linux/system.gyp src/build/linux/system.gyp
 index 68e4d36..3ae6ab3 100644
 --- src/build/linux/system.gyp
 +++ src/build/linux/system.gyp
-@@ -892,5 +892,27 @@
+@@ -892,5 +892,19 @@
          }],
        ],
      },
 +    {
-+      'target_name': 'resource_manager',
++      'target_name': 'audio_session_manager',
 +      'type': 'none',
 +      'toolsets': ['host', 'target'],
 +      'conditions': [
@@ -20,14 +32,6 @@ index 68e4d36..3ae6ab3 100644
 +          'direct_dependent_settings': {
 +            'cflags': [
 +              '<!@(<(pkg-config) --cflags audio-session-mgr)',
-+            ],
-+          },
-+          'link_settings': {
-+            'ldflags': [
-+              '<!@(<(pkg-config) --libs-only-L --libs-only-other audio-session-mgr)',
-+            ],
-+            'libraries': [
-+              '<!@(<(pkg-config) --libs-only-l audio-session-mgr)',
 +            ],
 +          },
 +        }],
@@ -98,7 +102,7 @@ diff --git src/content/content_browser.gypi src/content/content_browser.gypi
 index 1e3485c..6336e49 100644
 --- src/content/content_browser.gypi
 +++ src/content/content_browser.gypi
-@@ -1558,5 +1558,19 @@
+@@ -1558,5 +1558,69 @@
          '../third_party/speex/speex.gyp:libspeex',
        ],
      }],
@@ -106,14 +110,64 @@ index 1e3485c..6336e49 100644
 +      'sources': [
 +        '<(DEPTH)/xwalk/tizen/browser/audio_session_manager.cc',
 +        '<(DEPTH)/xwalk/tizen/browser/audio_session_manager.h',
++        '<(DEPTH)/xwalk/tizen/browser/audio_session_manager_init.cc',
++        '<(DEPTH)/xwalk/tizen/browser/audio_session_manager_init.h',
 +        '<(DEPTH)/xwalk/tizen/browser/browser_mediaplayer_manager.cc',
 +        '<(DEPTH)/xwalk/tizen/browser/browser_mediaplayer_manager.h',
 +      ],
++      'variables': {
++        'generate_stubs_script': '../tools/generate_stubs/generate_stubs.py',
++        'extra_header': '../xwalk/tizen/browser/audio_session_manager_stub_headers.fragment',
++        'sig_files': ['../xwalk/tizen/browser/audio_session_manager.sigs'],
++        'outfile_type': 'posix_stubs',
++        'stubs_filename_root': 'audio_session_manager_stubs',
++        'project_path': 'xwalk/tizen/browser',
++        'intermediate_dir': '<(INTERMEDIATE_DIR)',
++        'output_root': '<(SHARED_INTERMEDIATE_DIR)/audio_session_manager',
++      },
++      'include_dirs': [
++        '<(output_root)',
++      ],
++      'actions': [
++        {
++          'action_name': 'generate_stubs',
++          'inputs': [
++          '<(generate_stubs_script)',
++          '<(extra_header)',
++          '<@(sig_files)',
++          ],
++          'outputs': [
++            '<(intermediate_dir)/<(stubs_filename_root).cc',
++            '<(output_root)/<(project_path)/<(stubs_filename_root).h',
++          ],
++          'action': ['python',
++            '<(generate_stubs_script)',
++            '-i', '<(intermediate_dir)',
++            '-o', '<(output_root)/<(project_path)',
++            '-t', '<(outfile_type)',
++            '-e', '<(extra_header)',
++            '-s', '<(stubs_filename_root)',
++            '-p', '<(project_path)',
++            '<@(_inputs)',
++          ],
++          'process_outputs_as_sources': 1,
++          'message': 'Generating audio session manager stubs for dynamic loading',
++        },
++      ],
++      'conditions': [
++        ['OS=="linux" or OS=="solaris"', {
++          'link_settings': {
++            'libraries': [
++            '-ldl',
++            ],
++          },
++        }],
++      ],
 +      'dependencies': [
-+        '../build/linux/system.gyp:resource_manager',
++        '../build/linux/system.gyp:audio_session_manager',
 +      ],
 +      'export_dependent_settings': [
-+        '../build/linux/system.gyp:resource_manager',
++        '../build/linux/system.gyp:audio_session_manager',
 +      ],
 +    }],
    ],

--- a/tizen/browser/audio_session_manager.sigs
+++ b/tizen/browser/audio_session_manager.sigs
@@ -1,0 +1,10 @@
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+#------------------------------------------------
+# Functions from audio-session-manager used in Crosswalk code.
+#------------------------------------------------
+bool ASM_register_sound(const int application_pid, int *asm_handle, ASM_sound_events_t sound_event, ASM_sound_states_t sound_state, ASM_sound_cb_t callback, void* cb_data, ASM_resource_t mm_resource, int *error_code);
+bool ASM_unregister_sound(const int asm_handle, ASM_sound_events_t sound_event, int *error_code);
+bool ASM_set_sound_state(const int asm_handle, ASM_sound_events_t sound_event, ASM_sound_states_t sound_state, ASM_resource_t mm_resource, int *error_code);

--- a/tizen/browser/audio_session_manager_init.cc
+++ b/tizen/browser/audio_session_manager_init.cc
@@ -1,0 +1,57 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/tizen/browser/audio_session_manager_init.h"
+
+#include "base/files/file_path.h"
+#include "base/lazy_instance.h"
+#include "xwalk/tizen/browser/audio_session_manager_stubs.h"
+
+using xwalk_tizen_browser::kModuleAudio_session_manager;
+using xwalk_tizen_browser::InitializeStubs;
+using xwalk_tizen_browser::StubPathMap;
+
+namespace tizen {
+
+static const base::FilePath::CharType kAsmModuleLib[] =
+    FILE_PATH_LITERAL("libaudio-session-mgr.so.0");
+
+// Audio session manager must only be initialized once, so use a
+// LazyInstance to ensure this.
+class AudioSessionManagerInitializer {
+ public:
+  bool Initialize() {
+    if (!tried_initialize_) {
+      tried_initialize_ = true;
+      StubPathMap paths;
+
+      paths[kModuleAudio_session_manager].push_back(kAsmModuleLib);
+      initialized_ = InitializeStubs(paths);
+    }
+    return initialized_;
+  }
+
+ private:
+  friend struct base::DefaultLazyInstanceTraits<AudioSessionManagerInitializer>;
+
+  AudioSessionManagerInitializer()
+      : initialized_(false),
+        tried_initialize_(false) {
+  }
+
+  bool initialized_;
+  bool tried_initialize_;
+
+  DISALLOW_COPY_AND_ASSIGN(AudioSessionManagerInitializer);
+};
+
+static base::LazyInstance<AudioSessionManagerInitializer>::Leaky g_asm_library =
+    LAZY_INSTANCE_INITIALIZER;
+
+bool InitializeAudioSessionManager() {
+  return g_asm_library.Get().Initialize();
+}
+
+}  // namespace tizen

--- a/tizen/browser/audio_session_manager_init.h
+++ b/tizen/browser/audio_session_manager_init.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Contains code that should be used for initializing the
+// audio session manager library as a whole.
+
+#ifndef XWALK_TIZEN_BROWSER_AUDIO_SESSION_MANAGER_INIT_H_
+#define XWALK_TIZEN_BROWSER_AUDIO_SESSION_MANAGER_INIT_H_
+
+#include "content/common/content_export.h"
+
+namespace tizen {
+
+// Attempts to initialize the audio session manager library.
+// Returns true if everything was successfully initialized, false otherwise.
+CONTENT_EXPORT bool InitializeAudioSessionManager();
+
+}  // namespace tizen
+
+#endif  // XWALK_TIZEN_BROWSER_AUDIO_SESSION_MANAGER_INIT_H_

--- a/tizen/browser/audio_session_manager_stub_headers.fragment
+++ b/tizen/browser/audio_session_manager_stub_headers.fragment
@@ -1,0 +1,8 @@
+// The extra include header needed in the generated stub file for defining
+// various audio session manager types.
+
+extern "C" {
+
+#include <audio-session-manager.h>
+
+}

--- a/tizen/browser/browser_mediaplayer_manager.cc
+++ b/tizen/browser/browser_mediaplayer_manager.cc
@@ -7,6 +7,7 @@
 
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_contents.h"
+#include "xwalk/tizen/browser/audio_session_manager_init.h"
 #include "xwalk/tizen/common/media_player_messages.h"
 
 namespace tizen {
@@ -102,6 +103,13 @@ void BrowserMediaPlayerManager::OnInitialize(
     MediaPlayerID player_id,
     int process_id,
     const GURL& url) {
+
+  // Initialize the audio session manager library.
+  if (!InitializeAudioSessionManager()) {
+    DLOG(WARNING) << "Failed on loading the audio session manager library";
+    return;
+  }
+
   RemoveAudioSessionManager(player_id);
   AudioSessionManager* session_manager =
       new AudioSessionManager(this, player_id, process_id);


### PR DESCRIPTION
This PR includes changes that are needed for generating audio-session-manager
stubs and load the library dynamically in the Browser process.

audio-session-manager is using an _attribute_((constructor)) to initialize code and
setup signal handlers at startup. So, linking with this library is causing a sandbox
violation by executing the code in Renderer Process, since the Renderer Process
and the Browser Process are linked with the same libraries.

To prevent this issue, we load the audio-session-manager library dynamically in
the Browser process.

BUG=https://crosswalk-project.org/jira/browse/XWALK-517
