### PR TITLE
[Application] Rename Application class to ApplicationData

### DIFF
--- a/application/browser/application_process_manager.cc
+++ b/application/browser/application_process_manager.cc
@@ -33,7 +33,7 @@ ApplicationProcessManager::~ApplicationProcessManager() {
 
 bool ApplicationProcessManager::LaunchApplication(
         RuntimeContext* runtime_context,
-        const Application* application) {
+        const ApplicationData* application) {
   if (RunMainDocument(application))
     return true;
   // NOTE: For now we allow launching a web app from a local path. This may go
@@ -57,7 +57,7 @@ void ApplicationProcessManager::OnRuntimeRemoved(Runtime* runtime) {
 }
 
 bool ApplicationProcessManager::RunMainDocument(
-    const Application* application) {
+    const ApplicationData* application) {
   const Manifest* manifest = application->GetManifest();
   const base::DictionaryValue* dict = NULL;
   if (!manifest->GetDictionary(application_manifest_keys::kAppMainKey, &dict))
@@ -100,7 +100,7 @@ void ApplicationProcessManager::CloseMainDocument() {
 }
 
 bool ApplicationProcessManager::RunFromLocalPath(
-    const Application* application) {
+    const ApplicationData* application) {
   const Manifest* manifest = application->GetManifest();
   std::string entry_page;
   if (manifest->GetString(application_manifest_keys::kLaunchLocalPathKey,

--- a/application/browser/application_process_manager.h
+++ b/application/browser/application_process_manager.h
@@ -14,7 +14,7 @@
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/time/time.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/runtime/browser/runtime_registry.h"
 
 class GURL;
@@ -38,7 +38,7 @@ class ApplicationProcessManager : public RuntimeRegistryObserver {
   virtual ~ApplicationProcessManager();
 
   bool LaunchApplication(xwalk::RuntimeContext* runtime_context,
-                         const Application* application);
+                         const ApplicationData* application);
 
   Runtime* GetMainDocumentRuntime() const { return main_runtime_; }
 
@@ -48,8 +48,8 @@ class ApplicationProcessManager : public RuntimeRegistryObserver {
   virtual void OnRuntimeAppIconChanged(Runtime* runtime) OVERRIDE {}
 
  private:
-  bool RunMainDocument(const Application* application);
-  bool RunFromLocalPath(const Application* application);
+  bool RunMainDocument(const ApplicationData* application);
+  bool RunFromLocalPath(const ApplicationData* application);
   void CloseMainDocument();
 
   xwalk::RuntimeContext* runtime_context_;

--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -22,14 +22,14 @@
 #include "net/url_request/url_request_error_job.h"
 #include "net/url_request/url_request_file_job.h"
 #include "net/url_request/url_request_simple_job.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/application_file_util.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/application_resource.h"
 #include "xwalk/application/common/constants.h"
 
 using content::ResourceRequestInfo;
-using xwalk::application::Application;
+using xwalk::application::ApplicationData;
 
 namespace {
 
@@ -69,7 +69,7 @@ class GeneratedMainDocumentJob: public net::URLRequestSimpleJob {
   GeneratedMainDocumentJob(net::URLRequest* request,
                            net::NetworkDelegate* network_delegate,
                            const base::FilePath& relative_path,
-                           const scoped_refptr<const Application> application)
+                           const scoped_refptr<const ApplicationData> application)
     : net::URLRequestSimpleJob(request, network_delegate),
       application_(application),
       mime_type_("text/html"),
@@ -109,7 +109,7 @@ class GeneratedMainDocumentJob: public net::URLRequestSimpleJob {
  private:
   virtual ~GeneratedMainDocumentJob() {}
 
-  scoped_refptr<const Application> application_;
+  scoped_refptr<const ApplicationData> application_;
   const std::string mime_type_;
   const base::FilePath relative_path_;
   net::HttpResponseInfo response_info_;
@@ -183,7 +183,7 @@ class URLRequestApplicationJob : public net::URLRequestFileJob {
 class ApplicationProtocolHandler
     : public net::URLRequestJobFactory::ProtocolHandler {
  public:
-  explicit ApplicationProtocolHandler(const Application* application)
+  explicit ApplicationProtocolHandler(const ApplicationData* application)
     : application_(application) {
     CHECK(application_);
   }
@@ -195,7 +195,7 @@ class ApplicationProtocolHandler
       net::NetworkDelegate* network_delegate) const OVERRIDE;
 
  private:
-  const Application* application_;
+  const ApplicationData* application_;
   DISALLOW_COPY_AND_ASSIGN(ApplicationProtocolHandler);
 };
 
@@ -234,7 +234,7 @@ ApplicationProtocolHandler::MaybeCreateJob(
 }  // namespace
 
 linked_ptr<net::URLRequestJobFactory::ProtocolHandler>
-CreateApplicationProtocolHandler(const Application* application) {
+CreateApplicationProtocolHandler(const ApplicationData* application) {
   return  linked_ptr<net::URLRequestJobFactory::ProtocolHandler>(
       new ApplicationProtocolHandler(application));
 }

--- a/application/browser/application_protocols.h
+++ b/application/browser/application_protocols.h
@@ -11,14 +11,14 @@
 
 namespace xwalk {
 namespace application {
-class Application;
+class ApplicationData;
 }
 }
 
 // Creates the handlers for the app:// scheme.
 linked_ptr<net::URLRequestJobFactory::ProtocolHandler>
 CreateApplicationProtocolHandler(
-    const xwalk::application::Application* application);
+    const xwalk::application::ApplicationData* application);
 
 
 #endif  // XWALK_APPLICATION_BROWSER_APPLICATION_PROTOCOLS_H_

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -110,7 +110,7 @@ bool ApplicationService::Install(const base::FilePath& path, std::string* id) {
   }
 
   std::string error;
-  scoped_refptr<Application> application =
+  scoped_refptr<ApplicationData> application =
       LoadApplication(unpacked_dir,
                       app_id,
                       Manifest::COMMAND_LINE,
@@ -169,7 +169,7 @@ bool ApplicationService::Uninstall(const std::string& id) {
 }
 
 bool ApplicationService::Launch(const std::string& id) {
-  scoped_refptr<const Application> application = GetApplicationByID(id);
+  scoped_refptr<const ApplicationData> application = GetApplicationByID(id);
   if (!application) {
     LOG(ERROR) << "Application with id " << id << " haven't installed.";
     return false;
@@ -186,7 +186,7 @@ bool ApplicationService::Launch(const base::FilePath& path) {
     return false;
 
   std::string error;
-  scoped_refptr<const Application> application =
+  scoped_refptr<const ApplicationData> application =
       LoadApplication(path, Manifest::COMMAND_LINE, &error);
 
   if (!application) {
@@ -208,12 +208,12 @@ ApplicationService::GetInstalledApplications() const {
   return app_store_->GetInstalledApplications();
 }
 
-scoped_refptr<const Application> ApplicationService::GetApplicationByID(
+scoped_refptr<const ApplicationData> ApplicationService::GetApplicationByID(
     const std::string& id) const {
   return app_store_->GetApplicationByID(id);
 }
 
-const Application* ApplicationService::GetRunningApplication() const {
+const ApplicationData* ApplicationService::GetRunningApplication() const {
   return application_.get();
 }
 

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -11,7 +11,7 @@
 #include "base/observer_list.h"
 #include "xwalk/application/browser/application_store.h"
 #include "xwalk/runtime/browser/runtime_context.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 
 namespace xwalk {
 class RuntimeContext;
@@ -32,11 +32,11 @@ class ApplicationService {
   bool Launch(const std::string& id);
   bool Launch(const base::FilePath& path);
 
-  scoped_refptr<const Application> GetApplicationByID(
+  scoped_refptr<const ApplicationData> GetApplicationByID(
        const std::string& id) const;
   ApplicationStore::ApplicationMap* GetInstalledApplications() const;
   // Currently there's only one running application at a time.
-  const Application* GetRunningApplication() const;
+  const ApplicationData* GetRunningApplication() const;
 
   // Client code may use this class (and register with AddObserver below) to
   // keep track of applications installed/uninstalled.
@@ -54,7 +54,7 @@ class ApplicationService {
  private:
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationStore> app_store_;
-  scoped_refptr<const Application> application_;
+  scoped_refptr<const ApplicationData> application_;
   ObserverList<Observer> observers_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationService);

--- a/application/browser/application_store.cc
+++ b/application/browser/application_store.cc
@@ -40,7 +40,7 @@ ApplicationStore::~ApplicationStore() {
 }
 
 bool ApplicationStore::AddApplication(
-    scoped_refptr<const Application> application) {
+    scoped_refptr<const ApplicationData> application) {
   if (Contains(application->ID()))
     return true;
 
@@ -70,7 +70,7 @@ bool ApplicationStore::Contains(const std::string& app_id) const {
   return applications_->find(app_id) != applications_->end();
 }
 
-scoped_refptr<const Application> ApplicationStore::GetApplicationByID(
+scoped_refptr<const ApplicationData> ApplicationStore::GetApplicationByID(
     const std::string& application_id) const {
   ApplicationMapIterator it = applications_->find(application_id);
   if (it != applications_->end()) {
@@ -130,8 +130,8 @@ void ApplicationStore::InitApplications(const base::DictionaryValue* db) {
       break;
 
     std::string error;
-    scoped_refptr<Application> application =
-        Application::Create(base::FilePath::FromUTF8Unsafe(app_path),
+    scoped_refptr<ApplicationData> application =
+        ApplicationData::Create(base::FilePath::FromUTF8Unsafe(app_path),
                             Manifest::INTERNAL,
                             *manifest,
                             id,
@@ -149,9 +149,9 @@ void ApplicationStore::InitApplications(const base::DictionaryValue* db) {
   }
 }
 
-bool ApplicationStore::Insert(scoped_refptr<const Application> application) {
+bool ApplicationStore::Insert(scoped_refptr<const ApplicationData> application) {
   return applications_->insert(
-      std::pair<std::string, scoped_refptr<const Application> >(
+      std::pair<std::string, scoped_refptr<const ApplicationData> >(
           application->ID(), application)).second;
 }
 

--- a/application/browser/application_store.h
+++ b/application/browser/application_store.h
@@ -9,7 +9,7 @@
 #include <string>
 
 #include "base/memory/ref_counted.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/db_store_sqlite_impl.h"
 
 namespace xwalk {
@@ -23,9 +23,9 @@ namespace application {
 class ApplicationStore: public DBStore::Observer {
  public:
   typedef DBStoreSqliteImpl DBStoreImpl;
-  typedef std::map<std::string, scoped_refptr<const Application> >
+  typedef std::map<std::string, scoped_refptr<const ApplicationData> >
       ApplicationMap;
-  typedef std::map<std::string, scoped_refptr<const Application> >::iterator
+  typedef std::map<std::string, scoped_refptr<const ApplicationData> >::iterator
       ApplicationMapIterator;
 
   // The constaints for application storage.
@@ -37,13 +37,13 @@ class ApplicationStore: public DBStore::Observer {
   explicit ApplicationStore(xwalk::RuntimeContext* runtime_context);
   virtual ~ApplicationStore();
 
-  bool AddApplication(scoped_refptr<const Application> application);
+  bool AddApplication(scoped_refptr<const ApplicationData> application);
 
   bool RemoveApplication(const std::string& id);
 
   bool Contains(const std::string& app_id) const;
 
-  scoped_refptr<const Application> GetApplicationByID(
+  scoped_refptr<const ApplicationData> GetApplicationByID(
       const std::string& application_id) const;
 
   ApplicationMap* GetInstalledApplications() const;
@@ -59,7 +59,7 @@ class ApplicationStore: public DBStore::Observer {
 
  private:
   void InitApplications(const base::DictionaryValue* value);
-  bool Insert(scoped_refptr<const Application> application);
+  bool Insert(scoped_refptr<const ApplicationData> application);
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<DBStoreImpl> db_store_;
   scoped_ptr<ApplicationMap> applications_;

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -55,7 +55,7 @@ bool ApplicationSystem::HandleApplicationManagementCommands(
       return false;
 
     std::string app_id = std::string(args[0].begin(), args[0].end());
-    if (!Application::IsIDValid(app_id))
+    if (!ApplicationData::IsIDValid(app_id))
       return false;
 
     if (application_service_->Uninstall(app_id)) {
@@ -94,7 +94,7 @@ bool ApplicationSystem::LaunchFromCommandLine(
   // FIXME(cmarcelo): Remove when we move to a separate launcher on Tizen.
 #if defined(OS_TIZEN_MOBILE)
   std::string command_name = cmd_line.GetProgram().BaseName().MaybeAsASCII();
-  if (Application::IsIDValid(command_name)) {
+  if (ApplicationData::IsIDValid(command_name)) {
     *run_default_message_loop = application_service_->Launch(command_name);
     return true;
   }
@@ -107,7 +107,7 @@ bool ApplicationSystem::LaunchFromCommandLine(
   const CommandLine::StringVector& args = cmd_line.GetArgs();
   if (!args.empty()) {
     std::string app_id = std::string(args[0].begin(), args[0].end());
-    if (Application::IsIDValid(app_id)) {
+    if (ApplicationData::IsIDValid(app_id)) {
         *run_default_message_loop = application_service_->Launch(app_id);
         return true;
     }

--- a/application/browser/linux/installed_application_object.cc
+++ b/application/browser/linux/installed_application_object.cc
@@ -6,7 +6,7 @@
 
 #include "dbus/bus.h"
 #include "dbus/message.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 
 namespace xwalk {
 namespace application {
@@ -32,7 +32,7 @@ const char kInstalledApplicationDBusError[] =
 
 InstalledApplicationObject::InstalledApplicationObject(
     scoped_refptr<dbus::Bus> bus, const dbus::ObjectPath& base_path,
-    const Application* app)
+    const ApplicationData* app)
     : app_id_(app->ID()),
       path_(dbus::ObjectPath(base_path.value() + "/" + app_id_)),
       dbus_object_(bus->GetExportedObject(path_)),

--- a/application/browser/linux/installed_application_object.h
+++ b/application/browser/linux/installed_application_object.h
@@ -12,7 +12,7 @@
 namespace xwalk {
 namespace application {
 
-class Application;
+class ApplicationData;
 
 extern const char kInstalledApplicationDBusInterface[];
 extern const char kInstalledApplicationDBusError[];
@@ -24,7 +24,7 @@ class InstalledApplicationObject {
  public:
   InstalledApplicationObject(
       scoped_refptr<dbus::Bus> bus, const dbus::ObjectPath& base_path,
-      const Application* app);
+      const ApplicationData* app);
 
   // Set the callback used when the Uninstall() method is called in an
   // ApplicationObject.

--- a/application/browser/linux/installed_applications_root.cc
+++ b/application/browser/linux/installed_applications_root.cc
@@ -73,7 +73,7 @@ InstalledApplicationsRoot::~InstalledApplicationsRoot() {
 
 void InstalledApplicationsRoot::OnApplicationInstalled(
     const std::string& app_id) {
-  scoped_refptr<const Application> app(
+  scoped_refptr<const ApplicationData> app(
       application_service_->GetApplicationByID(app_id));
   installed_apps_.push_back(CreateObject(app));
 
@@ -120,7 +120,7 @@ void InstalledApplicationsRoot::CreateInitialObjects() {
 }
 
 InstalledApplicationObject* InstalledApplicationsRoot::CreateObject(
-    scoped_refptr<const Application> app) {
+    scoped_refptr<const ApplicationData> app) {
   InstalledApplicationObject* object =
       new InstalledApplicationObject(bus_, kInstalledApplicationsRootPath, app);
   // See comment in InstalledApplicationsRoot::OnUninstall().

--- a/application/browser/linux/installed_applications_root.h
+++ b/application/browser/linux/installed_applications_root.h
@@ -38,7 +38,7 @@ class InstalledApplicationsRoot : public ApplicationService::Observer {
   void CreateInitialObjects();
 
   InstalledApplicationObject* CreateObject(
-      scoped_refptr<const Application> app);
+      scoped_refptr<const ApplicationData> app);
 
   void OnGetManagedObjects(
       dbus::MethodCall* method_call,

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef XWALK_APPLICATION_COMMON_APPLICATION_H_
-#define XWALK_APPLICATION_COMMON_APPLICATION_H_
+#ifndef XWALK_APPLICATION_COMMON_APPLICATION_DATA_H_
+#define XWALK_APPLICATION_COMMON_APPLICATION_DATA_H_
 
 #include <algorithm>
 #include <iosfwd>
@@ -42,7 +42,7 @@ namespace application {
 // Once created, an Application object is immutable, with the exception of its
 // RuntimeData. This makes it safe to use on any thread, since access to the
 // RuntimeData is protected by a lock.
-class Application : public base::RefCountedThreadSafe<Application> {
+class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
  public:
   struct ManifestData;
 
@@ -56,7 +56,7 @@ class Application : public base::RefCountedThreadSafe<Application> {
     virtual ~ManifestData() {}
   };
 
-  static scoped_refptr<Application> Create(const base::FilePath& path,
+  static scoped_refptr<ApplicationData> Create(const base::FilePath& path,
       Manifest::SourceType source_type,
       const base::DictionaryValue& manifest_data,
       const std::string& explicit_id,
@@ -112,7 +112,7 @@ class Application : public base::RefCountedThreadSafe<Application> {
   bool IsHostedApp() const;
 
  private:
-  friend class base::RefCountedThreadSafe<Application>;
+  friend class base::RefCountedThreadSafe<ApplicationData>;
 
   // Chooses the application ID for an application based on a variety of
   // criteria. The chosen ID will be set in |manifest|.
@@ -121,9 +121,9 @@ class Application : public base::RefCountedThreadSafe<Application> {
                               const std::string& explicit_id,
                               string16* error);
 
-  Application(const base::FilePath& path,
+  ApplicationData(const base::FilePath& path,
             scoped_ptr<Manifest> manifest);
-  virtual ~Application();
+  virtual ~ApplicationData();
 
   // Initialize the application from a parsed manifest.
   bool Init(string16* error);
@@ -186,10 +186,10 @@ class Application : public base::RefCountedThreadSafe<Application> {
   scoped_ptr<tizen::AppcoreContext> appcore_context_;
 #endif
 
-  DISALLOW_COPY_AND_ASSIGN(Application);
+  DISALLOW_COPY_AND_ASSIGN(ApplicationData);
 };
 
 }  // namespace application
 }  // namespace xwalk
 
-#endif  // XWALK_APPLICATION_COMMON_APPLICATION_H_
+#endif  // XWALK_APPLICATION_COMMON_APPLICATION_DATA_H_

--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -17,7 +17,7 @@
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_restrictions.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/constants.h"
 #include "xwalk/application/common/manifest.h"
 #include "xwalk/application/common/application_manifest_constants.h"
@@ -32,7 +32,7 @@ namespace errors = xwalk::application_manifest_errors;
 namespace xwalk {
 namespace application {
 
-scoped_refptr<Application> LoadApplication(
+scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_path,
     Manifest::SourceType source_type,
     std::string* error) {
@@ -40,7 +40,7 @@ scoped_refptr<Application> LoadApplication(
                          source_type, error);
 }
 
-scoped_refptr<Application> LoadApplication(
+scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_path,
     const std::string& application_id,
     Manifest::SourceType source_type,
@@ -49,7 +49,8 @@ scoped_refptr<Application> LoadApplication(
   if (!manifest.get())
     return NULL;
 
-  scoped_refptr<Application> application = Application::Create(application_path,
+  scoped_refptr<ApplicationData> application = ApplicationData::Create(
+                                                             application_path,
                                                              source_type,
                                                              *manifest,
                                                              application_id,

--- a/application/common/application_file_util.h
+++ b/application/common/application_file_util.h
@@ -23,17 +23,17 @@ class FilePath;
 namespace xwalk {
 namespace application {
 
-class Application;
+class ApplicationData;
 
 // Loads and validates an application from the specified directory. Returns NULL
 // on failure, with a description of the error in |error|.
-scoped_refptr<Application> LoadApplication(
+scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_root,
     Manifest::SourceType source_type,
     std::string* error);
 
 // The same as LoadApplication except use the provided |application_id|.
-scoped_refptr<Application> LoadApplication(
+scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_root,
     const std::string& application_id,
     Manifest::SourceType source_type,

--- a/application/common/application_file_util_unittest.cc
+++ b/application/common/application_file_util_unittest.cc
@@ -10,14 +10,14 @@
 #include "base/path_service.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/manifest.h"
 #include "xwalk/application/common/constants.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/l10n/l10n_util.h"
 
-using xwalk::application::Application;
+using xwalk::application::ApplicationData;
 using xwalk::application::Manifest;
 
 namespace keys = xwalk::application_manifest_keys;
@@ -40,7 +40,7 @@ TEST_F(ApplicationFileUtilTest, LoadApplicationWithValidPath) {
       .AppendASCII("aaa");
 
   std::string error;
-  scoped_refptr<Application> application(LoadApplication(
+  scoped_refptr<ApplicationData> application(LoadApplication(
           install_dir, Manifest::COMMAND_LINE, &error));
   ASSERT_TRUE(application != NULL);
   EXPECT_EQ("The first application that I made.", application->Description());
@@ -59,7 +59,7 @@ TEST_F(ApplicationFileUtilTest,
       .AppendASCII("aaa");
 
   std::string error;
-  scoped_refptr<Application> application(LoadApplication(
+  scoped_refptr<ApplicationData> application(LoadApplication(
           install_dir, Manifest::COMMAND_LINE, &error));
   ASSERT_TRUE(application == NULL);
   ASSERT_FALSE(error.empty());
@@ -79,7 +79,7 @@ TEST_F(ApplicationFileUtilTest,
       .AppendASCII("bbb");
 
   std::string error;
-  scoped_refptr<Application> application(LoadApplication(
+  scoped_refptr<ApplicationData> application(LoadApplication(
           install_dir, Manifest::COMMAND_LINE, &error));
   ASSERT_TRUE(application == NULL);
   ASSERT_FALSE(error.empty());
@@ -88,18 +88,18 @@ TEST_F(ApplicationFileUtilTest,
                error.c_str());
 }
 
-static scoped_refptr<Application> LoadApplicationManifest(
+static scoped_refptr<ApplicationData> LoadApplicationManifest(
     base::DictionaryValue* manifest,
     const base::FilePath& manifest_dir,
     Manifest::SourceType location,
     int extra_flags,
     std::string* error) {
-  scoped_refptr<Application> application = Application::Create(
+  scoped_refptr<ApplicationData> application = ApplicationData::Create(
       manifest_dir, location, *manifest, std::string(), error);
   return application;
 }
 
-static scoped_refptr<Application> LoadApplicationManifest(
+static scoped_refptr<ApplicationData> LoadApplicationManifest(
     const std::string& manifest_value,
     const base::FilePath& manifest_dir,
     Manifest::SourceType location,
@@ -134,7 +134,7 @@ TEST_F(ApplicationFileUtilTest, ValidateThemeUTF8) {
           "  \"theme\": { \"images\": { \"theme_frame\": \"%s\" } }"
           "}", non_ascii_file.c_str());
   std::string error;
-  scoped_refptr<Application> application = LoadApplicationManifest(
+  scoped_refptr<ApplicationData> application = LoadApplicationManifest(
       kManifest, temp.path(), Manifest::COMMAND_LINE, 0, &error);
   ASSERT_TRUE(application.get()) << error;
 }

--- a/application/common/application_unittest.cc
+++ b/application/common/application_unittest.cc
@@ -4,7 +4,7 @@
 
 #include "base/file_util.h"
 #include "base/path_service.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/application_file_util.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/manifest.h"
@@ -23,15 +23,15 @@ TEST(ApplicationTest, LocationValuesTest) {
 }
 
 TEST(ApplicationTest, IsIDValid) {
-  EXPECT_TRUE(Application::IsIDValid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-  EXPECT_TRUE(Application::IsIDValid("pppppppppppppppppppppppppppppppp"));
-  EXPECT_TRUE(Application::IsIDValid("abcdefghijklmnopabcdefghijklmnop"));
-  EXPECT_TRUE(Application::IsIDValid("ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP"));
-  EXPECT_FALSE(Application::IsIDValid("abcdefghijklmnopabcdefghijklmno"));
-  EXPECT_FALSE(Application::IsIDValid("abcdefghijklmnopabcdefghijklmnopa"));
-  EXPECT_FALSE(Application::IsIDValid("0123456789abcdef0123456789abcdef"));
-  EXPECT_FALSE(Application::IsIDValid("abcdefghijklmnopabcdefghijklmnoq"));
-  EXPECT_FALSE(Application::IsIDValid("abcdefghijklmnopabcdefghijklmno0"));
+  EXPECT_TRUE(ApplicationData::IsIDValid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+  EXPECT_TRUE(ApplicationData::IsIDValid("pppppppppppppppppppppppppppppppp"));
+  EXPECT_TRUE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmnop"));
+  EXPECT_TRUE(ApplicationData::IsIDValid("ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP"));
+  EXPECT_FALSE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmno"));
+  EXPECT_FALSE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmnopa"));
+  EXPECT_FALSE(ApplicationData::IsIDValid("0123456789abcdef0123456789abcdef"));
+  EXPECT_FALSE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmnoq"));
+  EXPECT_FALSE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmno0"));
 }
 
 }  // namespace application

--- a/application/common/db_store.h
+++ b/application/common/db_store.h
@@ -10,7 +10,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/observer_list.h"
 #include "base/time/time.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 
 namespace xwalk {
 namespace application {
@@ -31,7 +31,7 @@ class DBStore {
   };
   explicit DBStore(base::FilePath path);
   virtual ~DBStore();
-  virtual bool Insert(const Application* application,
+  virtual bool Insert(const ApplicationData* application,
                       const base::Time install_time) = 0;
   virtual bool Remove(const std::string& key) = 0;
   base::DictionaryValue* GetApplications() const { return db_.get(); }

--- a/application/common/db_store_sqlite_impl.cc
+++ b/application/common/db_store_sqlite_impl.cc
@@ -213,7 +213,7 @@ bool DBStoreSqliteImpl::UpdateDBCache() {
   return true;
 }
 
-bool DBStoreSqliteImpl::Insert(const Application* application,
+bool DBStoreSqliteImpl::Insert(const ApplicationData* application,
                                const base::Time install_time) {
   if (!db_initialized_)
     return false;

--- a/application/common/db_store_sqlite_impl.h
+++ b/application/common/db_store_sqlite_impl.h
@@ -23,7 +23,7 @@ class DBStoreSqliteImpl: public DBStore {
   virtual ~DBStoreSqliteImpl();
 
   // Implement the DBStore inferface.
-  virtual bool Insert(const Application* application,
+  virtual bool Insert(const ApplicationData* application,
                       const base::Time install_time) OVERRIDE;
   virtual bool Remove(const std::string& key) OVERRIDE;
   virtual bool InitDB() OVERRIDE;

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -15,7 +15,7 @@ namespace application {
 ManifestHandler::~ManifestHandler() {
 }
 
-bool ManifestHandler::Validate(scoped_refptr<const Application> application,
+bool ManifestHandler::Validate(scoped_refptr<const ApplicationData> application,
                                std::string* error,
                                std::vector<InstallWarning>* warnings) const {
   return true;
@@ -69,7 +69,7 @@ void ManifestHandlerRegistry::Register(ManifestHandler* handler) {
 }
 
 bool ManifestHandlerRegistry::ParseAppManifest(
-    scoped_refptr<Application> application, string16* error) {
+    scoped_refptr<ApplicationData> application, string16* error) {
   std::map<int, ManifestHandler*> handlers_by_order;
   for (ManifestHandlerMap::iterator iter = handlers_.begin();
        iter != handlers_.end(); ++iter) {
@@ -89,7 +89,7 @@ bool ManifestHandlerRegistry::ParseAppManifest(
 }
 
 bool ManifestHandlerRegistry::ValidateAppManifest(
-    scoped_refptr<const Application> application,
+    scoped_refptr<const ApplicationData> application,
     std::string* error,
     std::vector<InstallWarning>* warnings) {
   for (ManifestHandlerMap::iterator iter = handlers_.begin();

--- a/application/common/manifest_handler.h
+++ b/application/common/manifest_handler.h
@@ -11,7 +11,7 @@
 
 #include "base/memory/linked_ptr.h"
 #include "base/strings/string16.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 
 namespace xwalk {
 namespace application {
@@ -22,12 +22,12 @@ class ManifestHandler {
 
   // Returns false in case of failure and sets writes error message
   // in |error| if present.
-  virtual bool Parse(scoped_refptr<Application> application,
+  virtual bool Parse(scoped_refptr<ApplicationData> application,
                      string16* error) = 0;
 
   // Returns false in case of failure and sets writes error message
   // in |error| if present.
-  virtual bool Validate(scoped_refptr<const Application> application,
+  virtual bool Validate(scoped_refptr<const ApplicationData> application,
                         std::string* error,
                         std::vector<InstallWarning>* warnings) const;
 
@@ -57,8 +57,8 @@ class ManifestHandlerRegistry {
   static ManifestHandlerRegistry* GetInstance();
 
   bool ParseAppManifest(
-       scoped_refptr<Application> application, string16* error);
-  bool ValidateAppManifest(scoped_refptr<const Application> application,
+       scoped_refptr<ApplicationData> application, string16* error);
+  bool ValidateAppManifest(scoped_refptr<const ApplicationData> application,
                            std::string* error,
                            std::vector<InstallWarning>* warnings);
 

--- a/application/common/manifest_handler_unittest.cc
+++ b/application/common/manifest_handler_unittest.cc
@@ -9,7 +9,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/manifest_handler.h"
 #include "xwalk/application/common/install_warning.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -91,7 +91,7 @@ class ManifestHandlerTest : public testing::Test {
     virtual ~TestManifestHandler() {}
 
     virtual bool Parse(
-        scoped_refptr<Application> application, string16* error) OVERRIDE {
+        scoped_refptr<ApplicationData> application, string16* error) OVERRIDE {
       watcher_->Record(name_);
       return true;
     }
@@ -120,7 +120,7 @@ class ManifestHandlerTest : public testing::Test {
         : TestManifestHandler(name, keys, prereqs, watcher) {
     }
     virtual bool Parse(
-        scoped_refptr<Application> application, string16* error) OVERRIDE {
+        scoped_refptr<ApplicationData> application, string16* error) OVERRIDE {
       *error = ASCIIToUTF16(name_);
       return false;
     }
@@ -151,12 +151,12 @@ class ManifestHandlerTest : public testing::Test {
     }
 
     virtual bool Parse(
-        scoped_refptr<Application> application, string16* error) OVERRIDE {
+        scoped_refptr<ApplicationData> application, string16* error) OVERRIDE {
       return true;
     }
 
     virtual bool Validate(
-        scoped_refptr<const Application> application,
+        scoped_refptr<const ApplicationData> application,
         std::string* error,
         std::vector<InstallWarning>* warnings) const OVERRIDE {
       return return_value_;
@@ -214,7 +214,7 @@ TEST_F(ManifestHandlerTest, DependentHandlers) {
   manifest.SetInteger("c.f", 5);
   manifest.SetInteger("g", 6);
   std::string error;
-  scoped_refptr<Application> application = Application::Create(
+  scoped_refptr<ApplicationData> application = ApplicationData::Create(
       base::FilePath(),
       Manifest::INVALID_TYPE,
       manifest,
@@ -242,7 +242,7 @@ TEST_F(ManifestHandlerTest, FailingHandlers) {
 
   // Succeeds when "a" is not recognized.
   std::string error;
-  scoped_refptr<Application> application = Application::Create(
+  scoped_refptr<ApplicationData> application = ApplicationData::Create(
       base::FilePath(),
       Manifest::INVALID_TYPE,
       manifest_a,
@@ -259,7 +259,7 @@ TEST_F(ManifestHandlerTest, FailingHandlers) {
   registry.reset();
   registry.reset(new ScopedTestingManifestHandlerRegistry(handlers));
 
-  application = Application::Create(
+  application = ApplicationData::Create(
       base::FilePath(),
       Manifest::INVALID_TYPE,
       manifest_a,
@@ -280,7 +280,7 @@ TEST_F(ManifestHandlerTest, Validate) {
   manifest.SetInteger("a", 1);
   manifest.SetInteger("b", 2);
   std::string error;
-  scoped_refptr<Application> application = Application::Create(
+  scoped_refptr<ApplicationData> application = ApplicationData::Create(
       base::FilePath(),
       Manifest::COMMAND_LINE,
       manifest,

--- a/application/common/manifest_handlers/permissions_handler.cc
+++ b/application/common/manifest_handlers/permissions_handler.cc
@@ -32,7 +32,7 @@ PermissionsHandler::PermissionsHandler() {
 PermissionsHandler::~PermissionsHandler() {
 }
 
-bool PermissionsHandler::Parse(scoped_refptr<Application> application,
+bool PermissionsHandler::Parse(scoped_refptr<ApplicationData> application,
                                string16* error) {
   if (!application->GetManifest()->HasKey(keys::kPermissionsKey)) {
     application->SetManifestData(keys::kPermissionsKey, new PermissionsInfo);

--- a/application/common/manifest_handlers/permissions_handler.h
+++ b/application/common/manifest_handlers/permissions_handler.h
@@ -13,7 +13,7 @@
 namespace xwalk {
 namespace application {
 
-class PermissionsInfo: public Application::ManifestData {
+class PermissionsInfo: public ApplicationData::ManifestData {
  public:
   PermissionsInfo();
   virtual ~PermissionsInfo();
@@ -34,7 +34,7 @@ class PermissionsHandler: public ManifestHandler {
   PermissionsHandler();
   virtual ~PermissionsHandler();
 
-  virtual bool Parse(scoped_refptr<Application> application,
+  virtual bool Parse(scoped_refptr<ApplicationData> application,
                      string16* error) OVERRIDE;
   virtual bool AlwaysParseForType(Manifest::Type type) const OVERRIDE;
   virtual std::vector<std::string> Keys() const OVERRIDE;

--- a/application/common/manifest_handlers/permissions_handler_unittest.cc
+++ b/application/common/manifest_handlers/permissions_handler_unittest.cc
@@ -16,7 +16,7 @@ namespace application {
 namespace {
 
 const std::vector<std::string>& GetAPIPermissionsInfo(
-    scoped_refptr<const Application> application) {
+    scoped_refptr<const ApplicationData> application) {
   PermissionsInfo* info = static_cast<PermissionsInfo*>(
       application->GetManifestData(keys::kPermissionsKey));
   DCHECK(info);
@@ -33,7 +33,7 @@ TEST_F(PermissionsHandlerTest, NonePermission) {
   manifest.SetString(keys::kNameKey, "no name");
   manifest.SetString(keys::kVersionKey, "0");
   std::string error;
-  scoped_refptr<Application> application = Application::Create(
+  scoped_refptr<ApplicationData> application = ApplicationData::Create(
       base::FilePath(),
       Manifest::INVALID_TYPE,
       manifest,
@@ -50,7 +50,7 @@ TEST_F(PermissionsHandlerTest, EmptyPermission) {
   base::ListValue* permissions = new base::ListValue;
   manifest.Set(keys::kPermissionsKey, permissions);
   std::string error;
-  scoped_refptr<Application> application = Application::Create(
+  scoped_refptr<ApplicationData> application = ApplicationData::Create(
       base::FilePath(),
       Manifest::INVALID_TYPE,
       manifest,
@@ -68,7 +68,7 @@ TEST_F(PermissionsHandlerTest, DeviceAPIPermission) {
   permissions->AppendString("geolocation");
   manifest.Set(keys::kPermissionsKey, permissions);
   std::string error;
-  scoped_refptr<Application> application = Application::Create(
+  scoped_refptr<ApplicationData> application = ApplicationData::Create(
       base::FilePath(),
       Manifest::INVALID_TYPE,
       manifest,

--- a/application/common/manifest_unittest.cc
+++ b/application/common/manifest_unittest.cc
@@ -54,7 +54,7 @@ class ManifestTest : public testing::Test {
 };
 
 // Verifies that application can access the correct keys.
-TEST_F(ManifestTest, Application) {
+TEST_F(ManifestTest, ApplicationData) {
   scoped_ptr<base::DictionaryValue> manifest_value(new base::DictionaryValue());
   manifest_value->SetString(keys::kNameKey, "extension");
   manifest_value->SetString(keys::kVersionKey, "1");

--- a/application/extension/application_event_extension.cc
+++ b/application/extension/application_event_extension.cc
@@ -9,7 +9,7 @@
 #include "xwalk/application/browser/application_event_manager.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/event_names.h"
 
 namespace xwalk {
@@ -29,7 +29,7 @@ XWalkExtensionInstance* ApplicationEventExtension::CreateInstance() {
     application_system_->application_service();
   // FIXME: return corresponding application info after shared runtime process
   // model is enabled.
-  const application::Application* app = service->GetRunningApplication();
+  const application::ApplicationData* app = service->GetRunningApplication();
   CHECK(app);
   return new AppEventExtensionInstance(
       application_system_->event_manager(), app->ID());

--- a/application/extension/application_runtime_extension.cc
+++ b/application/extension/application_runtime_extension.cc
@@ -13,7 +13,7 @@
 #include "xwalk/application/browser/application_process_manager.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/runtime/browser/runtime.h"
 
 using content::BrowserThread;
@@ -56,7 +56,7 @@ void AppRuntimeExtensionInstance::OnGetManifest(
   base::DictionaryValue* manifest_data = NULL;
   const application::ApplicationService* service =
     application_system_->application_service();
-  const application::Application* app = service->GetRunningApplication();
+  const application::ApplicationData* app = service->GetRunningApplication();
   if (app)
     manifest_data = app->GetManifest()->value()->DeepCopy();
 

--- a/application/test/application_main_document_browsertest.cc
+++ b/application/test/application_main_document_browsertest.cc
@@ -8,14 +8,14 @@
 #include "net/base/net_util.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
-#include "xwalk/application/common/application.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/constants.h"
 #include "xwalk/application/test/application_browsertest.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_registry.h"
 
-using xwalk::application::Application;
+using xwalk::application::ApplicationData;
 
 class ApplicationMainDocumentBrowserTest: public ApplicationBrowserTest {
  public:
@@ -40,7 +40,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationMainDocumentBrowserTest, MainDocument) {
   xwalk::RuntimeContext* runtime_context = main_runtime->runtime_context();
   xwalk::application::ApplicationService* service =
     runtime_context->GetApplicationSystem()->application_service();
-  const Application* app = service->GetRunningApplication();
+  const ApplicationData* app = service->GetRunningApplication();
   GURL generated_url =
     app->GetResourceURL(xwalk::application::kGeneratedMainDocumentFilename);
   // Check main document URL.

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -40,8 +40,8 @@
         'browser/installer/xpk_package.cc',
         'browser/installer/xpk_package.h',
 
-        'common/application.cc',
-        'common/application.h',
+        'common/application_data.cc',
+        'common/application_data.h',
         'common/application_file_util.cc',
         'common/application_file_util.h',
         'common/application_manifest_constants.cc',

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -170,7 +170,7 @@ net::URLRequestContextGetter* RuntimeContext::CreateRequestContext(
 
   xwalk::application::ApplicationService* service =
     application_system_.get()->application_service();
-  const xwalk::application::Application* running_app =
+  const xwalk::application::ApplicationData* running_app =
     service->GetRunningApplication();
   if (running_app) {
     protocol_handlers->insert(std::pair<std::string,


### PR DESCRIPTION
Rename Application class to ApplicationData as a first implementation step of https://docs.google.com/a/intel.com/document/d/1N0VVlut7JCWFbAEwTQc0loN9_D2JlOXRJprQeCbXY2U/edit#heading=h.23lva9lja986

That will allow us to introduce a real Application class.
