### PR TITLE
[Tizen][Performance] Enable Accelerated 2D Canvas.

### DIFF
--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -8,6 +8,7 @@
 #include "base/strings/string_piece.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/common/content_switches.h"
+#include "gpu/config/gpu_info.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "webkit/common/user_agent/user_agent_util.h"
@@ -19,6 +20,15 @@ XWalkContentClient::XWalkContentClient() {
 }
 
 XWalkContentClient::~XWalkContentClient() {
+}
+
+void XWalkContentClient::SetGpuInfo(const gpu::GPUInfo& gpu_info) {
+#if defined(OS_TIZEN_MOBILE)
+  gpu::GPUInfo& gpu_info_writable = const_cast<gpu::GPUInfo&>(gpu_info);
+  // Enable Accelerated 2D Canvas.
+  // See SupportsAccelerated2dCanvas() in compositor_util.cc
+  gpu_info_writable.can_lose_context = false;
+#endif
 }
 
 std::string XWalkContentClient::GetProduct() const {

--- a/runtime/common/xwalk_content_client.h
+++ b/runtime/common/xwalk_content_client.h
@@ -18,6 +18,7 @@ class XWalkContentClient : public content::ContentClient {
   XWalkContentClient();
   virtual ~XWalkContentClient();
 
+  virtual void SetGpuInfo(const gpu::GPUInfo& gpu_info) OVERRIDE;
   virtual std::string GetProduct() const OVERRIDE;
   virtual std::string GetUserAgent() const OVERRIDE;
   virtual string16 GetLocalizedString(int message_id) const OVERRIDE;


### PR DESCRIPTION
If GPU context can be lost, Accelerated 2D Canvas is disabled, because there is
no way to recover Accelerated 2D Canvas when GPU crashes. Currently, only EGL
backend marks GPUInfo::can_lose_context true (means Accelerated 2D Canvas cannot
be enabled). However, interestingly, Android and ChromeOS mark it false to take
advantage of Accelerated 2D Canvas without fallback solution. They just take a
risk.

So Tizen also takes a risk like Android and ChromeOS. It is worth to do it
because performance improvement is very significant (2~3 times).

HOW:
CollectContextGraphicsInfo(GPUInfo\* gpu_info) in gpu_info_collector_x11.cc is
the right place to mark GPUInfo::can_lose_context false as ChromeOS does.
However, this PR adds small hack into Crosswalk code because this hack can make
us not change chromium-crosswalk. XWalkContentClient::SetGpuInfo() is originally
intended to only read gpu info, not write.

Measurement data:
1. http://www.craftymind.com/factory/guimark3/vector/GM3_JS_Vector.html
Software Canvas : 14.91 FPS
Accelerated 2D Canvas : 44.82 FPS
2. http://www.craftymind.com/factory/guimark3/bitmap/GM3_JS_Bitmap.html
Software Canvas : 17.16 FPS
Accelerated 2D Canvas : 54.58 FPS
3. http://www.craftymind.com/factory/guimark3/compute/GM3_JS_Compute.html
Software Canvas : 19.36 FPS
Accelerated 2D Canvas : 39.18 FPS

BUG=https://crosswalk-project.org/jira/browse/XWALK-531,
https://crosswalk-project.org/jira/browse/XWALK-73
