### PR TITLE
[Extensions] Remove --disable-loading-extensions-on-demand switch

### DIFF
--- a/extensions/common/xwalk_extension_switches.cc
+++ b/extensions/common/xwalk_extension_switches.cc
@@ -6,13 +6,6 @@
 
 namespace switches {
 
-// TODO(cmarcelo): We are developing this feature behind a flag. The
-// plan is to switch the flag meaning when the full feature is
-// implemented. One release later, after stabilization, we completely
-// remove this flag since we expect this feature not to be optional.
-const char kXWalkDisableLoadingExtensionsOnDemand[] =
-    "disable-loading-extensions-on-demand";
-
 // TODO(cmarcelo): Currently we are disabling it by default, once Extension
 // Process patches land, we'll change this to be "disable-extension-process"
 // so that it will be enabled by default. Remember to forcely disable it for

--- a/extensions/common/xwalk_extension_switches.h
+++ b/extensions/common/xwalk_extension_switches.h
@@ -8,7 +8,6 @@
 // This file contains switches that are used inside extensions/ code.
 namespace switches {
 
-extern const char kXWalkDisableLoadingExtensionsOnDemand[];
 extern const char kXWalkDisableExtensionProcess[];
 extern const char kXWalkExtensionProcess[];
 

--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -44,10 +44,6 @@ XWalkExtensionRendererController::XWalkExtensionRendererController(
     LOG(INFO) << "EXTENSION PROCESS DISABLED.";
   else
     SetupExtensionProcessClient(browser_channel);
-
-  if (cmd_line->HasSwitch(switches::kXWalkDisableLoadingExtensionsOnDemand)) {
-    LOG(INFO) << "LOADING EXTENSIONS ON DEMAND DISABLED.";
-  }
 }
 
 XWalkExtensionRendererController::~XWalkExtensionRendererController() {

--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -291,10 +291,6 @@ v8::Handle<v8::Object> XWalkModuleSystem::RequireNative(
 }
 
 void XWalkModuleSystem::Initialize() {
-  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
-  const bool on_demand_enabled =
-      !cmd_line->HasSwitch(switches::kXWalkDisableLoadingExtensionsOnDemand);
-
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope handle_scope(isolate);
 
@@ -308,10 +304,8 @@ void XWalkModuleSystem::Initialize() {
 
   ExtensionModules::iterator it = extension_modules_.begin();
   for (; it != extension_modules_.end(); ++it) {
-    if (on_demand_enabled && it->use_trampoline) {
-      if (InstallTrampoline(context, &*it))
-        continue;
-    }
+    if (it->use_trampoline && InstallTrampoline(context, &*it))
+      continue;
     it->module->LoadExtensionCode(context, require_native);
   }
 }

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -103,9 +103,8 @@ XWalkContentBrowserClient::CreateRequestContextForStoragePartition(
 void XWalkContentBrowserClient::AppendExtraCommandLineSwitches(
     CommandLine* command_line, int child_process_id) {
   CommandLine* browser_process_cmd_line = CommandLine::ForCurrentProcess();
-  const int extra_switches_count = 2;
+  const int extra_switches_count = 1;
   const char* extra_switches[extra_switches_count] = {
-    switches::kXWalkDisableLoadingExtensionsOnDemand,
     switches::kXWalkDisableExtensionProcess
   };
 


### PR DESCRIPTION
The feature was added for Crosswalk 2. We kept the switch to easily
remove it in Crosswalk 2 in case of regressions, with the plan to remove
it from the next release.

Since the feature has been stable and no regressions related to it were
found in the Crosswalk 2 beta branch so far, we are removing the
switch now.
