### PR TITLE
[Tools] Convert lint.py to Unix line endings

### DIFF
--- a/tools/lint.py
+++ b/tools/lint.py
@@ -178,7 +178,7 @@ def do_py_lint(changeset):
     os.chdir(previous_cwd)
   if _has_import_error:
     print 'You have error for python importing, please check your PYTHONPATH'
- 
+
 def do_lint(repo, base, args):
   # dir structure should be src/xwalk for xwalk
   #                         src/third_party/WebKit for blink
@@ -233,7 +233,7 @@ def main():
            '  3. HEAD~ elsewise')
 
   options, args = option_parser.parse_args()
-  
+
   sys.exit(do_lint(options.repo, options.base, args))
 
 if __name__ == '__main__':


### PR DESCRIPTION
Python on Windows should be able to recognize Unix line ending, but it
makes a difference for Unix-based, because we set it as a script and the
DOS line ending messes up the interpretation of "#!/usr/bin/env python"
line.

This means that we should be able to call on Unix-based systems:

  $ tools/lint.py

instead of having to call python with the script as argument.
