### PR TITLE
[Application][Linux] Expose interface for launch apps via D-Bus

### DIFF
--- a/application/browser/application_service_provider_linux.cc
+++ b/application/browser/application_service_provider_linux.cc
@@ -11,6 +11,7 @@
 #include "dbus/message.h"
 #include "xwalk/dbus/xwalk_service_name.h"
 #include "xwalk/application/browser/linux/installed_applications_root.h"
+#include "xwalk/application/browser/linux/running_applications_root.h"
 
 namespace xwalk {
 namespace application {
@@ -30,6 +31,8 @@ void ApplicationServiceProviderLinux::OnDBusInitialized() {
   VLOG(1) << "D-Bus initialized.";
 
   installed_apps_.reset(new InstalledApplicationsRoot(
+      dbus_manager_.session_bus(), app_service()));
+  running_apps_.reset(new RunningApplicationsRoot(
       dbus_manager_.session_bus(), app_service()));
 
   // TODO(cmarcelo): This is just a placeholder to test D-Bus is working, remove

--- a/application/browser/application_service_provider_linux.h
+++ b/application/browser/application_service_provider_linux.h
@@ -13,6 +13,7 @@ namespace xwalk {
 namespace application {
 
 class InstalledApplicationsRoot;
+class RunningApplicationsRoot;
 
 // Uses a D-Bus service named "org.crosswalkproject" to expose application
 // management and launch functionality from ApplicationService.
@@ -29,6 +30,7 @@ class ApplicationServiceProviderLinux : public ApplicationServiceProvider {
 
   DBusManager dbus_manager_;
   scoped_ptr<InstalledApplicationsRoot> installed_apps_;
+  scoped_ptr<RunningApplicationsRoot> running_apps_;
 };
 
 }  // namespace application

--- a/application/browser/linux/running_applications_root.cc
+++ b/application/browser/linux/running_applications_root.cc
@@ -1,0 +1,104 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/linux/running_applications_root.h"
+
+#include <string>
+#include "base/bind.h"
+#include "dbus/bus.h"
+#include "dbus/message.h"
+
+namespace {
+
+// D-Bus Interface implemented by the root object of running applications.
+//
+// Methods:
+//
+//   Launch(string app_id)
+//     Launches the application with 'app_id'.
+//
+// TODO(cmarcelo): This should return an object path pointing to the
+// object representing the running application.
+const char kRunningApplicationsRootDBusInterface[] =
+    "org.crosswalkproject.RunningApplicationsRoot";
+
+const char kRunningApplicationsRootDBusError[] =
+    "org.crosswalkproject.RunningApplicationsRoot.Error";
+
+const dbus::ObjectPath kRunningApplicationsRootPath("/running");
+
+}  // namespace
+
+namespace xwalk {
+namespace application {
+
+RunningApplicationsRoot::RunningApplicationsRoot(
+    scoped_refptr<dbus::Bus> bus, ApplicationService* service)
+    : weak_factory_(this),
+      application_service_(service),
+      bus_(bus) {
+  root_object_ = bus_->GetExportedObject(kRunningApplicationsRootPath);
+  root_object_->ExportMethod(
+      kRunningApplicationsRootDBusInterface, "Launch",
+      base::Bind(&RunningApplicationsRoot::OnLaunch,
+                 weak_factory_.GetWeakPtr()),
+      base::Bind(&RunningApplicationsRoot::OnExported,
+                 weak_factory_.GetWeakPtr()));
+}
+
+RunningApplicationsRoot::~RunningApplicationsRoot() {}
+
+namespace {
+
+scoped_ptr<dbus::Response> CreateError(dbus::MethodCall* method_call,
+                                       const std::string& message) {
+    scoped_ptr<dbus::ErrorResponse> error_response =
+        dbus::ErrorResponse::FromMethodCall(
+            method_call, kRunningApplicationsRootDBusError, message);
+    return error_response.PassAs<dbus::Response>();
+}
+
+}
+
+void RunningApplicationsRoot::OnLaunch(
+    dbus::MethodCall* method_call,
+    dbus::ExportedObject::ResponseSender response_sender) {
+
+  dbus::MessageReader reader(method_call);
+  std::string app_id;
+  if (!reader.PopString(&app_id)) {
+    scoped_ptr<dbus::Response> response =
+        CreateError(method_call,
+                    "Error parsing message. Missing app_id argument.");
+    response_sender.Run(response.Pass());
+    return;
+  }
+
+  if (!application_service_->Launch(app_id)) {
+    scoped_ptr<dbus::Response> response =
+        CreateError(method_call,
+                    "Error launching application with id " + app_id);
+    response_sender.Run(response.Pass());
+    return;
+  }
+
+  scoped_ptr<dbus::Response> response =
+      dbus::Response::FromMethodCall(method_call);
+  response_sender.Run(response.Pass());
+}
+
+void RunningApplicationsRoot::OnExported(
+    const std::string& interface_name,
+    const std::string& method_name,
+    bool success) {
+  if (!success) {
+    LOG(WARNING) << "Error exporting method '" << interface_name
+                 << "." << method_name << "' in '"
+                 << kRunningApplicationsRootPath.value() << "'.";
+  }
+}
+
+}  // namespace application
+}  // namespace xwalk
+

--- a/application/browser/linux/running_applications_root.h
+++ b/application/browser/linux/running_applications_root.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_LINUX_RUNNING_APPLICATIONS_ROOT_H_
+#define XWALK_APPLICATION_BROWSER_LINUX_RUNNING_APPLICATIONS_ROOT_H_
+
+#include <string>
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_vector.h"
+#include "base/memory/weak_ptr.h"
+#include "dbus/exported_object.h"
+#include "xwalk/application/browser/application_service.h"
+
+namespace xwalk {
+namespace application {
+
+// Holds the D-Bus representation of the set of installed applications. This is
+// the entry point for launching applications and listing currently running
+// applications.
+class RunningApplicationsRoot {
+ public:
+  RunningApplicationsRoot(scoped_refptr<dbus::Bus> bus,
+                          ApplicationService* service);
+  ~RunningApplicationsRoot();
+
+ private:
+  void OnLaunch(dbus::MethodCall* method_call,
+                dbus::ExportedObject::ResponseSender response_sender);
+  void OnExported(const std::string& interface_name,
+                  const std::string& method_name,
+                  bool success);
+
+  base::WeakPtrFactory<RunningApplicationsRoot> weak_factory_;
+
+  ApplicationService* application_service_;
+  dbus::Bus* bus_;
+  dbus::ExportedObject* root_object_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_LINUX_RUNNING_APPLICATIONS_ROOT_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -86,6 +86,8 @@
             'browser/linux/installed_application_object.h',
             'browser/linux/installed_applications_root.cc',
             'browser/linux/installed_applications_root.h',
+            'browser/linux/running_applications_root.cc',
+            'browser/linux/running_applications_root.h',
           ],
         }],
         [ 'tizen_mobile == 1', {


### PR DESCRIPTION
The exported object '/running/' supports only one method in its
interface, that is used to Launch applications. The ObjectManager based
interface will come in future patches, once the notion of "running
application" is added to Crosswalk (Mikhail / Alex work).

At the moment, Crosswalk quits after the application window is closed,
even running as a service. This behavior will change in future
patches.
