### PR TITLE
[Tizen] Making tarball verbosely.

### DIFF
--- a/packaging/gbp-flat-tree.sh
+++ b/packaging/gbp-flat-tree.sh
@@ -56,4 +56,5 @@ tar --update --file "${TAR_FILE}" \
     --exclude-vcs --exclude=native_client --exclude=LayoutTests \
     --exclude=src/out --directory="${BASE_SRC_DIR}" \
     --transform="s:^:crosswalk/:S" \
+    --verbose \
     src


### PR DESCRIPTION
Buildbot/trybot take task as died if there is no output beyond timeout(40mins).
Make taring is time consuming especially on low power machines.

Adding --verbose when making tar will resolve it. The side effect is the
compile log became much longer.
