### PR TITLE
RuntimeContext must be destructed explicitly

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -216,6 +216,7 @@ bool XWalkBrowserMainParts::MainMessageLoopRun(int* result_code) {
 void XWalkBrowserMainParts::PostMainMessageLoopRun() {
   runtime_registry_->RemoveObserver(
       runtime_context_->GetApplicationSystem()->process_manager());
+  runtime_context_.reset();
 }
 
 void XWalkBrowserMainParts::RegisterInternalExtensionsInExtensionThreadServer(


### PR DESCRIPTION
When MessageLoop is stopped, runtime_context_ must be set to null.
It will call RuntimeContext destruction method, which happened on
MainThread. It blocked download_browsertest.

BUG=https://crosswalk-project.org/jira/browse/XWALK-408
