### PR TITLE
[Android] Enable test case for presentation API in embedded mode

### DIFF
--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PresentationTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PresentationTest.java
@@ -16,10 +16,8 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class PresentationTest extends XWalkRuntimeClientTestBase {
 
-    // @SmallTest
-    // @Feature({"PresentationTest"})
-    // TODO: Since the embedded extension issue, disable this temporarily.
-    @DisabledTest
+    @SmallTest
+    @Feature({"PresentationTest"})
     public void testPresentationDisplayAvailable() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientTestRunnerActivity>(


### PR DESCRIPTION
Extension in embedded mode is now avaialble, reopen the test case for
presentation API
