### PR TITLE
[SysApps] Move RawSockets to the experimental namespace

### DIFF
--- a/sysapps/raw_socket/raw_socket_api_browsertest.html
+++ b/sysapps/raw_socket/raw_socket_api_browsertest.html
@@ -5,7 +5,7 @@
   <body>
     <script>
       var v8tools = sysapps_raw_socket_test.v8tools;
-      var api = xwalk.sysapps.raw_socket;
+      var api = xwalk.experimental.raw_socket;
 
       var current_test = 0;
       var test_list = [

--- a/sysapps/raw_socket/raw_socket_extension.cc
+++ b/sysapps/raw_socket/raw_socket_extension.cc
@@ -16,7 +16,7 @@ namespace xwalk {
 namespace sysapps {
 
 RawSocketExtension::RawSocketExtension() {
-  set_name("xwalk.sysapps.raw_socket");
+  set_name("xwalk.experimental.raw_socket");
   set_javascript_api(ResourceBundle::GetSharedInstance().GetRawDataResource(
       IDR_XWALK_SYSAPPS_RAW_SOCKET_API).as_string());
 }


### PR DESCRIPTION
It was agreed in some technical meeting that SysApps should be in the
experimental namespace for now.
