### PR TITLE
[Applications][D-Bus] Emit InterfacesAdded and InterfacesRemoved signal

### DIFF
--- a/application/browser/linux/installed_application_object.h
+++ b/application/browser/linux/installed_application_object.h
@@ -6,6 +6,7 @@
 #define XWALK_APPLICATION_BROWSER_LINUX_INSTALLED_APPLICATION_OBJECT_H_
 
 #include <string>
+#include <vector>
 #include "base/memory/ref_counted.h"
 #include "xwalk/dbus/property_exporter.h"
 
@@ -36,6 +37,10 @@ class InstalledApplicationObject {
 
   dbus::ObjectPath path() const { return path_; }
   std::string app_id() const { return app_id_; }
+
+  std::vector<std::string> interfaces() const {
+    return properties_.interfaces();
+  }
 
  private:
   std::string app_id_;

--- a/application/browser/linux/installed_applications_root.cc
+++ b/application/browser/linux/installed_applications_root.cc
@@ -112,13 +112,20 @@ void InstalledApplicationsRoot::OnApplicationUninstalled(
     return;
   }
 
+  dbus::Signal interfaces_removed(kDBusObjectManagerInterface,
+                                "InterfacesRemoved");
+  dbus::MessageWriter writer(&interfaces_removed);
+
+  writer.AppendObjectPath((*it)->path());
+  writer.AppendArrayOfStrings((*it)->interfaces());
+
+  root_object_->SendSignal(&interfaces_removed);
+
   // We need to explicitly unregister the exported object.
   bus_->UnregisterExportedObject((*it)->path());
 
   // Since this is a ScopedVector, erasing will actually destroy the value.
   installed_apps_.erase(it);
-
-  // TODO(cmarcelo): Emit InterfacesRemoved() signal.
 }
 
 void InstalledApplicationsRoot::CreateInitialObjects() {

--- a/dbus/property_exporter.cc
+++ b/dbus/property_exporter.cc
@@ -124,6 +124,17 @@ void PropertyExporter::AppendPropertiesToWriter(const std::string& interface,
   writer->CloseContainer(&dict_writer);
 }
 
+std::vector<std::string> PropertyExporter::interfaces() const {
+  std::vector<std::string> interfaces;
+
+  InterfacesMap::const_iterator it = interfaces_.begin();
+  for (; it != interfaces_.end(); ++it) {
+    interfaces.push_back(it->first);
+  }
+
+  return interfaces;
+}
+
 void PropertyExporter::OnGet(
     MethodCall* method_call, ExportedObject::ResponseSender response_sender) {
   MessageReader reader(method_call);

--- a/dbus/property_exporter.h
+++ b/dbus/property_exporter.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "dbus/exported_object.h"
@@ -38,6 +39,8 @@ class PropertyExporter {
 
   void AppendPropertiesToWriter(const std::string& interface,
                                 MessageWriter* writer);
+
+  std::vector<std::string> interfaces() const;
 
  private:
   void OnGet(dbus::MethodCall* method_call,


### PR DESCRIPTION
These two signals are defined in the ObjectManager part of the D-Bus specification, so clients interested in some parts of our object tree are notified when the tree is modified either by adding new interfaces, in our case this would happen when a new application is installed, or interfaces are removed, when an application is removed.
