### PR TITLE
[Android] Enable the internal extension in the embedded mode.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -279,6 +279,12 @@ def Execution(options, sanitized_name):
     pak_des_path = os.path.join(sanitized_name, 'assets', 'xwalk.pak')
     shutil.copy(pak_src_path, pak_des_path)
 
+    js_src_dir = os.path.join('native_libs_res', 'jsapi')
+    js_des_dir = os.path.join(sanitized_name, 'assets', 'jsapi')
+    if os.path.exists(js_des_dir):
+      shutil.rmtree(js_des_dir)
+    shutil.copytree(js_src_dir, js_des_dir)
+
     res_ui_java = os.path.join('gen', 'ui_java')
     res_content_java = os.path.join('gen', 'content_java')
     res_xwalk_java = os.path.join('gen', 'xwalk_core_java')

--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -85,12 +85,12 @@ def PrepareFromXwalk(target_dir):
   for folder in app_src_folder_list:
     shutil.copytree(folder, os.path.join(app_src_dir, os.path.basename(folder)))
 
-  pak_file_src_path = os.path.join(os.path.dirname(target_dir),
-                                   'xwalk_runtime_lib', 'assets', 'xwalk.pak')
-  pak_file_des_dir = os.path.join(target_dir, 'native_libs_res')
-  if not os.path.exists(pak_file_des_dir):
-    os.makedirs(pak_file_des_dir)
-  shutil.copy(pak_file_src_path, os.path.join(pak_file_des_dir, 'xwalk.pak'))
+  native_res_file_src_dir = os.path.join(os.path.dirname(target_dir),
+                                         'xwalk_runtime_lib', 'assets')
+  native_res_file_des_dir = os.path.join(target_dir, 'native_libs_res')
+  if os.path.exists(native_res_file_des_dir):
+    shutil.rmtree(native_res_file_des_dir)
+  shutil.copytree(native_res_file_src_dir, native_res_file_des_dir)
 
   packaging_tool_list = ['./app/tools/android/customize.py',
                          './app/tools/android/make_apk.py',

--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -119,14 +119,14 @@
         {
           'action_name': 'prepare_xwalk_app_template',
           'inputs': [
-            'tools/prepare.py',
+            'build/android/generate_app_packaging_tool.py',
           ],
           'outputs': [
             # put an inexist file here to do this step every time.
             '<(PRODUCT_DIR)/xwalk_app_template_1'
           ],
           'action': [
-            'python', 'tools/prepare.py',
+            'python', 'build/android/generate_app_packaging_tool.py',
             '<(PRODUCT_DIR)/xwalk_app_template'
           ],
         },


### PR DESCRIPTION
Copy the js wrapper into the xwalk_app_template target, which
would be used by the web app when packaged in embedded mode.

BUG=https://crosswalk-project.org/jira/browse/XWALK-615
