### PR TITLE
[Runtime] Implement onSuspend event support.

### DIFF
--- a/application/browser/application_process_manager.h
+++ b/application/browser/application_process_manager.h
@@ -14,6 +14,7 @@
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/time/time.h"
+#include "xwalk/application/browser/event_observer.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/runtime/browser/runtime_registry.h"
 
@@ -48,14 +49,17 @@ class ApplicationProcessManager : public RuntimeRegistryObserver {
   virtual void OnRuntimeAppIconChanged(Runtime* runtime) OVERRIDE {}
 
  private:
+  friend class FinishEventObserver;
   bool RunMainDocument(const ApplicationData* application);
   bool RunFromLocalPath(const ApplicationData* application);
   void CloseMainDocument();
+  bool IsOnSuspendHandlerRegistered(const std::string& app_id) const;
 
   xwalk::RuntimeContext* runtime_context_;
   xwalk::Runtime* main_runtime_;
   base::WeakPtrFactory<ApplicationProcessManager> weak_ptr_factory_;
   std::set<Runtime*> runtimes_;
+  scoped_ptr<EventObserver> finish_observer_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationProcessManager);
 };

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -228,5 +228,9 @@ bool ApplicationService::Launch(
       application);
 }
 
+ApplicationStore* ApplicationService::application_store() {
+  return app_store_.get();
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -50,6 +50,7 @@ class ApplicationService {
 
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
+  ApplicationStore* application_store();
 
  private:
   bool Launch(scoped_refptr<const ApplicationData> application);

--- a/application/browser/event_observer.h
+++ b/application/browser/event_observer.h
@@ -24,8 +24,9 @@ class EventObserver {
   virtual void Observe(const std::string& app_id,
                        scoped_refptr<Event> event) = 0;
 
- protected:
   virtual ~EventObserver();
+
+ protected:
   ApplicationEventManager* event_manager_;
 };
 

--- a/application/common/event_names.cc
+++ b/application/common/event_names.cc
@@ -9,6 +9,8 @@ namespace application {
 
 const char kOnLaunched[] = "onLaunched";
 
+const char kOnSuspend[] = "onSuspend";
+
 const char kOnJavaScriptEventAck[] = "onJavaScriptEventAck";
 
 }  // namespace application

--- a/application/common/event_names.h
+++ b/application/common/event_names.h
@@ -9,6 +9,7 @@ namespace xwalk {
 namespace application {
 
 extern const char kOnLaunched[];
+extern const char kOnSuspend[];
 extern const char kOnJavaScriptEventAck[];
 
 }  // namespace application

--- a/application/extension/application_runtime_api.js
+++ b/application/extension/application_runtime_api.js
@@ -22,3 +22,4 @@ exports.getMainDocument = function(callback) {
 };
 
 exports.onLaunched = new xwalk.app.events.Event("onLaunched");
+exports.onSuspend = new xwalk.app.events.Event("onSuspend");


### PR DESCRIPTION
"onSuspend" event is sent to the main page just before it is closed.
This gives the application an opportunity to do some clean up.

When application process manager finds the last open window is closed,
it sends 'onSuspend' event to main page.
The application process manager is also an observer of 'finish onSuspend'
event so that it will close the main page after the 'onSuspend' event is
executed.
