### PR TITLE
[Android][Extension] Fixed getMemoryInfo to support Android 4.0 and belo...

### DIFF
--- a/test/android/data/device_capabilities.html
+++ b/test/android/data/device_capabilities.html
@@ -62,8 +62,8 @@
 
         system.getMemoryInfo()
             .then(function(memory) {
-              document.getElementById('memory').innerHTML = 'Total capacity: ' + memory.capacity / 1024 + '(MB)<br>' +
-                                                            'Avail capacity: ' + memory.availCapacity / 1024 + '(MB)';
+              document.getElementById('memory').innerHTML = 'Total capacity: ' + memory.capacity / (1024 * 1024) + '(MB)<br>' +
+                                                            'Avail capacity: ' + memory.availCapacity / (1024 * 1024) + '(MB)';
               onSuccess();
             }, Error);
 


### PR DESCRIPTION
...w.
1. The original implementation uses an API avaible since API level 16. Change
   the implementation to reading file "/proc/meminfo" when the target system
   is Android 4.0 and below.
2. The spec http://device-capabilities.sysapps.org/#memory requires to return
   byte instead of KB. So change the unit to byte.
