### PR TITLE
[Android] Add owners for android related directories.

### DIFF
--- a/app/OWNERS
+++ b/app/OWNERS
@@ -1,0 +1,1 @@
+yongsheng.zhu@intel.com

--- a/test/android/OWNERS
+++ b/test/android/OWNERS
@@ -1,0 +1,1 @@
+yongsheng.zhu@intel.com


### PR DESCRIPTION
We've submitted many patches into these directories and they're only
used for Android port. But we forget to add owners.
