### PR TITLE
[Runtime] Polish a Sqlite table selection statement.

### DIFF
--- a/application/common/db_store_constants.cc
+++ b/application/common/db_store_constants.cc
@@ -34,10 +34,10 @@ const char kCreateEventTableOp[] =
     "ON DELETE CASCADE)";
 
 const char kGetAllRowsFromAppEventTableOp[] =
-    "SELECT applications.id, manifest, path, install_time, event_names "
-    "FROM applications "
-    "LEFT JOIN registered_events "
-    "ON applications.id = registered_events.id";
+    "SELECT A.id, A.manifest, A.path, A.install_time, B.event_names "
+    "FROM applications as A "
+    "LEFT JOIN registered_events as B "
+    "ON A.id = B.id";
 
 const char kSetApplicationWithBindOp[] =
     "INSERT INTO applications (manifest, path, install_time, id) "


### PR DESCRIPTION
The name 'registered_event' is not explicitly declared which table it
comes from in previous SQL statement.
This PR explicitly clarifies column of which table is selected.
