### PR TITLE
[Android] Fix app will crash at exit if runtime lib not found

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
@@ -225,7 +225,12 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
      * Usually meet the case of clicking on the back key.
      */
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        return (Boolean) invokeMethod(mOnKeyUp, mInstance, keyCode, event);
+        // Normally, java can handle the convertion of boolean and Boolean well,
+        // But here invokeMethod is possible to return null if runtime lib not found,
+        // Convert null to boolean will cause NullPointerException.
+        Boolean handled = (Boolean) invokeMethod(mOnKeyUp, mInstance, keyCode, event);
+        if (handled != null) return handled;
+        return false;
     }
 
     // The following functions just for instrumentation test.


### PR DESCRIPTION
It's because, the code is trying to get a boolean value from
method onKepUp in runtime. It will return null if runtime lib
not found.
For other class like String, return null is OK. But for boolean,
java will try to turn Boolean object null into boolean, which
causes NullPointerException.

BUG=https://crosswalk-project.org/jira/browse/XWALK-627
