### PR TITLE
[Android] Popup correct message if runtime lib is for wrong arch

### DIFF
--- a/app/android/app_hello_world/res/values/strings.xml
+++ b/app/android/app_hello_world/res/values/strings.xml
@@ -15,4 +15,7 @@ found in the LICENSE file.
     <string name="dialog_message_update_runtime_lib_warning">An update is recommended for &quot;Crosswalk Runtime Library&quot;.</string>
     <string name="dialog_title_install_runtime_lib">Crosswalk Runtime Library not found</string>
     <string name="dialog_message_install_runtime_lib">Please install &quot;Crosswalk Runtime Library&quot; first.</string>
+    <string name="dialog_title_install_right_abi">Mismatch on process architecture between Crosswalk and your device</string>
+    <string name="dialog_message_install_right_abi_embedded">Please install %1$s packaged with Crosswalk for %2$s.</string>
+    <string name="dialog_message_install_right_abi_shared">Please install &quot;Crosswalk Runtime Library&quot; for %1$s.</string>
 </resources>

--- a/app/android/app_template/res/values/strings.xml
+++ b/app/android/app_template/res/values/strings.xml
@@ -15,4 +15,7 @@ found in the LICENSE file.
     <string name="dialog_message_update_runtime_lib_warning">An update is recommended for &quot;Crosswalk Runtime Library&quot;.</string>
     <string name="dialog_title_install_runtime_lib">Crosswalk Runtime Library not found</string>
     <string name="dialog_message_install_runtime_lib">Please install &quot;Crosswalk Runtime Library&quot; first.</string>
+    <string name="dialog_title_install_right_abi">Mismatch on process architecture between Crosswalk and your device</string>
+    <string name="dialog_message_install_right_abi_embedded">Please install %1$s packaged with Crosswalk for %2$s.</string>
+    <string name="dialog_message_install_right_abi_shared">Please install &quot;Crosswalk Runtime Library&quot; for %1$s.</string>
 </resources>

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/CrossPackageWrapper.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/CrossPackageWrapper.java
@@ -17,19 +17,19 @@ public abstract class CrossPackageWrapper {
     private Class<?> mTargetClass;
     private Constructor<?> mCreator;
     private CrossPackageWrapperExceptionHandler mExceptionHandler;
-    private boolean mLibraryEmbedded;
+    private static boolean sLibraryEmbedded = true;
 
     public CrossPackageWrapper(Context ctx, String className,
             CrossPackageWrapperExceptionHandler handler, Class<?>... parameters) {
         try {
             mTargetClass = ctx.getClassLoader().loadClass(className);
-            mLibraryEmbedded = true;
+            sLibraryEmbedded = true;
         } catch (ClassNotFoundException e) {
-            mLibraryEmbedded = false;
+            sLibraryEmbedded = false;
         }
         mExceptionHandler = handler;
         try {
-            if (mLibraryEmbedded) {
+            if (sLibraryEmbedded) {
                 mLibCtx = ctx;
             } else {
                 mLibCtx = ctx.createPackageContext(
@@ -67,14 +67,10 @@ public abstract class CrossPackageWrapper {
     }
 
     public void handleException(Exception e) {
-        // mExceptionHandler is for handling runtime library not found or
-        // not match, if library is embedded, should not invoke it.
-        if (mLibraryEmbedded) return;
         if (mExceptionHandler != null) mExceptionHandler.onException(e);
     }
 
     public void handleException(String e) {
-        if (mLibraryEmbedded) return;
         if (mExceptionHandler != null) mExceptionHandler.onException(e);
     }
 
@@ -112,5 +108,9 @@ public abstract class CrossPackageWrapper {
             }
         }
         return ret;
+    }
+
+    public static boolean libraryIsEmbedded() {
+        return sLibraryEmbedded;
     }
 }

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeLibraryException.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeLibraryException.java
@@ -19,14 +19,14 @@ public class XWalkRuntimeLibraryException extends Exception {
     public final static int XWALK_RUNTIME_LIBRARY_NOT_INSTALLED = 1;
     public final static int XWALK_RUNTIME_LIBRARY_NOT_UP_TO_DATE_CRITICAL = 2;
     public final static int XWALK_RUNTIME_LIBRARY_NOT_UP_TO_DATE_WARNING = 3;
-    public final static int XWALK_RUNTIME_LIBRARY_LOAD_FAILED = 4;
+    public final static int XWALK_CORE_LIBRARY_SO_NOT_EXIST = 4;
     public final static int XWALK_RUNTIME_LIBRARY_INVOKE_FAILED = 5;
     
     private int mType;
     private Exception mOriginException;
     
     XWalkRuntimeLibraryException(int type, Exception originException) {
-        mType = XWALK_RUNTIME_LIBRARY_NOT_INSTALLED;
+        mType = type;
         mOriginException = originException;
     }
     


### PR DESCRIPTION
For android, if the native library does not match the
cpu arch of the target device, the library file won't be
installed to the device.
So if we found that the runtime lib package exist without
libxwalkcore.so, it can be considered the runtime lib is
for another cpu architecture.

BUG=https://crosswalk-project.org/jira/browse/XWALK-606
