### PR TITLE
Roll chromium to aac7580

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '32.0.1700.14'
-chromium_crosswalk_point = '1acc1e54fdc8088db25f0951ec5ae3bf513bddf7'
+chromium_crosswalk_point = 'aac7580327a58fa48b59f4036d90b92cdb9a62c6'
 blink_crosswalk_point = '406ead10374ecc6a9271c5074f5861e17c43432f'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
Bring in 4 commits:
d51e985 [Tizen] Dynamically load the camera driver at runtime
c1b54ed [Tizen] Add the EGL backend in VAVDA for Tizen Mobile.
55288b3 Revert "x11: Fix a few touch-event related issues:"
1127c91 [Tizen][Performance] Enable Accelerated 2D Canvas.
