### PR TITLE
[application] Remove "application launch from local path" support

### DIFF
--- a/application/browser/application_process_manager.cc
+++ b/application/browser/application_process_manager.cc
@@ -32,13 +32,8 @@ ApplicationProcessManager::~ApplicationProcessManager() {
 }
 
 bool ApplicationProcessManager::LaunchApplication(
-        RuntimeContext* runtime_context,
         const ApplicationData* application) {
-  if (RunMainDocument(application))
-    return true;
-  // NOTE: For now we allow launching a web app from a local path. This may go
-  // away at some point.
-  return RunFromLocalPath(application);
+  return RunMainDocument(application);
 }
 
 void ApplicationProcessManager::OnRuntimeAdded(Runtime* runtime) {
@@ -97,25 +92,6 @@ void ApplicationProcessManager::CloseMainDocument() {
   DCHECK(main_runtime_);
   main_runtime_->Close();
   main_runtime_ = NULL;
-}
-
-bool ApplicationProcessManager::RunFromLocalPath(
-    const ApplicationData* application) {
-  const Manifest* manifest = application->GetManifest();
-  std::string entry_page;
-  if (manifest->GetString(application_manifest_keys::kLaunchLocalPathKey,
-        &entry_page) && !entry_page.empty()) {
-    GURL url = application->GetResourceURL(entry_page);
-    if (url.is_empty()) {
-      LOG(WARNING) << "Can't find a valid local path URL for app.";
-      return false;
-    }
-
-    Runtime::CreateWithDefaultWindow(runtime_context_, url);
-    return true;
-  }
-
-  return false;
 }
 
 }  // namespace application

--- a/application/browser/application_process_manager.h
+++ b/application/browser/application_process_manager.h
@@ -37,8 +37,7 @@ class ApplicationProcessManager : public RuntimeRegistryObserver {
   explicit ApplicationProcessManager(xwalk::RuntimeContext* runtime_context);
   virtual ~ApplicationProcessManager();
 
-  bool LaunchApplication(xwalk::RuntimeContext* runtime_context,
-                         const ApplicationData* application);
+  bool LaunchApplication(const ApplicationData* application);
 
   Runtime* GetMainDocumentRuntime() const { return main_runtime_; }
 
@@ -49,7 +48,6 @@ class ApplicationProcessManager : public RuntimeRegistryObserver {
 
  private:
   bool RunMainDocument(const ApplicationData* application);
-  bool RunFromLocalPath(const ApplicationData* application);
   void CloseMainDocument();
 
   xwalk::RuntimeContext* runtime_context_;

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -223,9 +223,7 @@ bool ApplicationService::Launch(
   ApplicationEventManager* event_manager = system->event_manager();
   event_manager->OnAppLoaded(application->ID());
 
-  return system->process_manager()->LaunchApplication(
-      runtime_context_,
-      application);
+  return system->process_manager()->LaunchApplication(application);
 }
 
 }  // namespace application


### PR DESCRIPTION
We rely fully on main document as application entry point (see
http://anssiko.github.io/runtime/app-lifecycle.html).

The deprecated "application launch from local path" code path should be removed as
1) it is not used but brings extra complexity
2) it does not provide the logic which we rely on in many places within xwalk (for instance initialization of main_runtime_ or non-persistent main document implementation).
