### PR TITLE
[Tizen] Fix build regression cause by PR #1249

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -93,7 +93,6 @@ This package contains additional support files that are needed for running Cross
 cp %{SOURCE1001} .
 cp %{SOURCE1002} .
 cp %{SOURCE1003} .
-cp %{SOURCE1004} .
 sed "s/@VERSION@/%{version}/g" %{name}.xml.in > %{name}.xml
 
 cp -a src/AUTHORS AUTHORS.chromium


### PR DESCRIPTION
Legacy install_into_pkginfo_db.py related is not get removed clean, this
cause rpmbuild failure.
