### PR TITLE
[Application][D-Bus] Request service name after object tree is built

### DIFF
--- a/application/browser/application_service_provider_linux.h
+++ b/application/browser/application_service_provider_linux.h
@@ -7,6 +7,7 @@
 
 #include "xwalk/application/browser/application_service_provider.h"
 
+#include <string>
 #include "xwalk/dbus/dbus_manager.h"
 
 namespace xwalk {
@@ -23,7 +24,7 @@ class ApplicationServiceProviderLinux : public ApplicationServiceProvider {
   virtual ~ApplicationServiceProviderLinux();
 
  private:
-  void OnDBusInitialized();
+  void OnServiceNameExported(const std::string& service_name, bool success);
 
   // TODO(cmarcelo): Remove this once we expose real objects.
   void ExportTestObject();

--- a/dbus/dbus_manager.h
+++ b/dbus/dbus_manager.h
@@ -9,7 +9,6 @@
 #include "base/callback.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_ptr.h"
-#include "base/memory/weak_ptr.h"
 
 namespace base {
 class Thread;
@@ -25,23 +24,16 @@ namespace xwalk {
 // all users of DBus inside Crosswalk.
 class DBusManager {
  public:
-  explicit DBusManager(const std::string& service_name);
+  DBusManager();
   ~DBusManager();
-
-  // FIXME(cmarcelo): Notify about failure. We probably want to move
-  // to a delegate/observer interface in the future.
-  void Initialize(const base::Closure& on_success_callback);
 
   scoped_refptr<dbus::Bus> session_bus();
 
  private:
   void OnNameOwned(const std::string& service_name, bool success);
 
-  base::WeakPtrFactory<DBusManager> weak_factory_;
-  std::string service_name_;
   scoped_ptr<base::Thread> dbus_thread_;
   scoped_refptr<dbus::Bus> session_bus_;
-  base::Closure on_success_callback_;
 };
 
 }  // namespace xwalk


### PR DESCRIPTION
The code was wrongly setting up the object tree (and it's interfaces)
only after the name was registered. This caused a race condition when
testing D-Bus auto activation: the client would wait for service name to
get up and try to call it, and in some cases the objects or interfaces
were not ready yet.

The code now will request the service name only after everything is
setup.

As part of this change, DBusManager interface changed a bit: it doesn't
try to handle service ownership anymore and just sticks to setting up
the bus. It also initializes the Bus connection (and the thread) lazily,
so we can move it to a more general Crosswalk object but ensuring that
connection won't be created if not used.
