### PR TITLE
Add MODIFY_AUDIO_SETTINGS permission in Android manifest

### DIFF
--- a/app/android/app_hello_world/AndroidManifest.xml
+++ b/app/android/app_hello_world/AndroidManifest.xml
@@ -27,6 +27,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/android/app_template/AndroidManifest.xml
+++ b/app/android/app_template/AndroidManifest.xml
@@ -28,6 +28,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/android/runtime_client_embedded_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_embedded_shell/AndroidManifest.xml
@@ -34,6 +34,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>

--- a/app/android/runtime_client_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_shell/AndroidManifest.xml
@@ -34,6 +34,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>

--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -34,6 +34,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/runtime/android/runtime_shell/AndroidManifest.xml
+++ b/runtime/android/runtime_shell/AndroidManifest.xml
@@ -34,6 +34,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>


### PR DESCRIPTION
The volume hardware button can't control music volume when using webaudio
playing music. This is because app has no pemission to set audio volume.

MODIFY_AUDIO_SETTINGS allows application to be able to configure audio settings.
In android audio manager, a function SetAudioMode is added to set audio mode.

BUG=https://crosswalk-project.org/jira/browse/XWALK-622
