### PR TITLE
[Android]  Fix the http auth issue due to activity.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultClient.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultClient.java
@@ -116,11 +116,11 @@ public class XWalkDefaultClient extends XWalkClient {
 
     private void showHttpAuthDialog( final XWalkHttpAuthHandler handler,
             final String host, final String realm) {
-        LinearLayout layout = new LinearLayout((Activity)mContext);
-        final TextView userNameView = new TextView((Activity)mContext);
-        final EditText userNameEditText = new EditText((Activity)mContext);
-        final TextView passwordView = new TextView((Activity)mContext);
-        final EditText passwordEditText = new EditText((Activity)mContext);
+        LinearLayout layout = new LinearLayout(mContext);
+        final TextView userNameView = new TextView(mContext);
+        final EditText userNameEditText = new EditText(mContext);
+        final TextView passwordView = new TextView(mContext);
+        final EditText passwordEditText = new EditText(mContext);
         layout.setOrientation(LinearLayout.VERTICAL);
         userNameView.setText(R.string.http_auth_user_name);
         passwordView.setText(R.string.http_auth_password);
@@ -129,8 +129,9 @@ public class XWalkDefaultClient extends XWalkClient {
         layout.addView(passwordView);
         layout.addView(passwordEditText);
 
-        AlertDialog.Builder mHttpAuthDialog = new AlertDialog.Builder((Activity)mContext);
-        mHttpAuthDialog.setTitle(R.string.http_auth_title)
+        final Activity curActivity = mView.getActivity();
+        AlertDialog.Builder httpAuthDialog = new AlertDialog.Builder(curActivity);
+        httpAuthDialog.setTitle(R.string.http_auth_title)
                 .setView(layout)
                 .setCancelable(false)
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Currently, the http authentication dialog activity is
transforming the context to activity, which has side effect
on MixContext for the crosswalk package.  This fix is used to
correct the http authentication dialog activity.

BUG=https://crosswalk-project.org/jira/browse/XWALK-634
