### PR TITLE
Add Halton as the owner of Android extension implementaion.

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/OWNERS
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/OWNERS
@@ -1,0 +1,1 @@
+halton.huo@intel.com


### PR DESCRIPTION
Halton now is succesfully nominated as the owner of
runtime/android/java/src/org/xwalk/runtime/extension/api.
