### PR TITLE
Exclude gdbserver from xwalk_core_library

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -280,6 +280,17 @@ def PostCopyLibraryProject(out_directory):
     os.remove(common_aidl_file)
 
 
+def RemoveUnusedFiles(out_directory):
+  # Exclude gdbserver binary in release mode, as it's GPL license.
+  mode = os.path.basename(os.path.normpath(out_directory))
+  if mode == 'Release':
+    libs_directory = os.path.join(out_directory, LIBRARY_PROJECT_NAME, 'libs')
+    if os.path.exists(libs_directory):
+      for root, _, files in os.walk(libs_directory):
+        if 'gdbserver' in files:
+          os.remove(os.path.join(root, 'gdbserver'))
+
+
 def main(argv):
   print 'Generating XWalkCore Library Project...'
   option_parser = optparse.OptionParser()
@@ -310,6 +321,8 @@ def main(argv):
   CopyJSBindingFiles(options.source, out_directory)
   # Post copy library project.
   PostCopyLibraryProject(out_directory)
+  # Remove unused files.
+  RemoveUnusedFiles(out_directory)
   print 'Your Android library project has been created at %s' % (
       out_project_directory)
 


### PR DESCRIPTION
For the release version of cordova container, there is a license
issue to contain a gdbsever binary in the release binary. Because
the gdbserver is under GPL license.
So exclude gdbserver binary from release version and leave it
for debug version.

BUG=https://crosswalk-project.org/jira/browse/XWALK-635
