### PR TITLE
Implement the public user agent methods in runtime.

### DIFF
--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -26,8 +26,12 @@ std::string XWalkContentClient::GetProduct() const {
 }
 
 std::string XWalkContentClient::GetUserAgent() const {
-  // TODO(hmin): Define user agent for xwalk.
-  std::string product = "Chrome/" XWALK_VERSION;
+  std::string product = "Chrome/" CHROME_VERSION;
+#if (defined(OS_TIZEN_MOBILE) || defined(OS_ANDROID))
+  product += " Mobile Crosswalk/" XWALK_VERSION;
+#else
+  product += " Crosswalk/" XWALK_VERSION;
+#endif
   CommandLine* command_line = CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kUseMobileUserAgent))
     product += " Mobile";

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -2,6 +2,7 @@
   'variables': {
     'xwalk_product_name': 'XWalk',
     'xwalk_version': '<!(python ../chrome/tools/build/version.py -f VERSION -t "@MAJOR@.@MINOR@.@BUILD@.@PATCH@")',
+    'chrome_version': '<!(python ../chrome/tools/build/version.py -f ../chrome/VERSION -t "@MAJOR@.@MINOR@.@BUILD@.@PATCH@")',
     'conditions': [
       ['OS=="linux"', {
        'use_custom_freetype%': 1,
@@ -19,7 +20,7 @@
       'target_name': 'xwalk_runtime',
       'type': 'static_library',
       'defines!': ['CONTENT_IMPLEMENTATION'],
-      'defines': ['XWALK_VERSION="<(xwalk_version)"'],
+      'defines': ['XWALK_VERSION="<(xwalk_version)"','CHROME_VERSION="<(chrome_version)"'],
       'variables': {
         'chromium_code': 1,
       },


### PR DESCRIPTION
  The user agent is not supported in crosswalk runtime. This is
to implement the public user agent methods for crosswalk, it adds
the corresponding user agent description according to the specific
platform type.

 Based on ZTE975 Build/JDQ39, the user agent string is listed as follows:
 Mozilla/5.0 (Linux; Android 4.2.2; ZTE 975 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.14 Mobile Crosswalk/3.32.49.0 Mobile Safari/537.36

BUG=https://crosswalk-project.org/jira/browse/XWALK-595
