### PR TITLE
[UI] Make Crosswalk Aura use native window decoration.

### DIFF
--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -14,9 +14,7 @@
 #include "xwalk/runtime/browser/ui/xwalk_views_delegate.h"
 #include "xwalk/runtime/common/xwalk_notification_types.h"
 
-#if defined(OS_WIN)
 #include "ui/views/window/native_frame_view.h"
-#endif
 
 #if defined(OS_TIZEN_MOBILE)
 #include "xwalk/runtime/browser/ui/native_app_window_tizen.h"
@@ -228,12 +226,16 @@ bool NativeAppWindowViews::CanMaximize() const {
   return resizable_ && maximum_size_.IsEmpty();
 }
 
-#if defined(OS_WIN)
+// XWalk makes use of a plane view, in order to not draw any custom window
+// decoration and let that up to the native platform.
 views::NonClientFrameView* NativeAppWindowViews::CreateNonClientFrameView(
     views::Widget* widget) {
+#if defined(OS_TIZEN_MOBILE)
+  // Tizen must use a frameless window. See NativeAppWindowViews::Initialize().
+  NOTREACHED();
+#endif
   return new views::NativeFrameView(widget);
 }
-#endif
 
 ////////////////////////////////////////////////////////////
 // views::View implementation

--- a/runtime/browser/ui/native_app_window_views.h
+++ b/runtime/browser/ui/native_app_window_views.h
@@ -79,10 +79,8 @@ class NativeAppWindowViews : public NativeAppWindow,
       gfx::Rect* bounds, ui::WindowShowState* show_state) const OVERRIDE;
   virtual bool CanResize() const OVERRIDE;
   virtual bool CanMaximize() const OVERRIDE;
-#if defined(OS_WIN)
   virtual views::NonClientFrameView* CreateNonClientFrameView(
       views::Widget* widget) OVERRIDE;
-#endif
   // views::View implementation.
   virtual void ChildPreferredSizeChanged(views::View* child) OVERRIDE;
   virtual void OnFocus() OVERRIDE;


### PR DESCRIPTION
Current Crosswalk Aura port (linux and window) draws window decoration by
itself, so look-and-feel is very different to native ui.
We need to delegate window decoration to each platform.

Widget::CreateNonClientFrameView() gives a chance to an embedder to decorate window
frame. If an embedder does not do anything, Widget makes aura default window
decoration. XWalk makes use of a plane view, in order to not draw any custom
window decoration and let that up to the native platform.

This PR needs the counter part PR for chromium-crosswalk. The chromium PR
changes desktop_root_window_host to request each platform to draw window
decoration.

BUG=https://crosswalk-project.org/jira/browse/XWALK-629
