### PR TITLE
Support the 2x resolution of the Tizen System Indicator

### DIFF
--- a/tizen/mobile/ui/tizen_system_indicator.cc
+++ b/tizen/mobile/ui/tizen_system_indicator.cc
@@ -43,25 +43,9 @@ bool TizenSystemIndicator::IsConnected() const {
   return watcher_;
 }
 
-void TizenSystemIndicator::OnPaint(gfx::Canvas* canvas) {
-  View::OnPaint(canvas);
-
-  if (image_.isNull())
-    return;
-  canvas->DrawImageInt(image_, 0, 0);
-}
-
 gfx::Size TizenSystemIndicator::GetPreferredSize() {
-  if (IsConnected())
-    return watcher_->GetSize();
-  return gfx::Size(0, 0);
-}
-
-void TizenSystemIndicator::SetImage(const gfx::ImageSkia& img) {
-  if (!IsConnected() || img.isNull())
-    return;
-  image_ = img;
-  SchedulePaint();
+  // The size must be in DIPs. SkiaImage handles that and null images.
+  return GetImage().size();
 }
 
 bool TizenSystemIndicator::OnMousePressed(const ui::MouseEvent& event) {
@@ -144,7 +128,7 @@ void TizenSystemIndicator::OnMouseMoved(const ui::MouseEvent& event) {
 
 void TizenSystemIndicator::SetOrientation(Orientation orientation) {
   orientation_ = orientation;
-  image_ = gfx::ImageSkia();
+  SetImage(0);
 
   // TODO(ricardotk): Implement landscape mode, for now we simply do not show
   // the indicator in landscape mode.

--- a/tizen/mobile/ui/tizen_system_indicator.h
+++ b/tizen/mobile/ui/tizen_system_indicator.h
@@ -7,7 +7,7 @@
 
 #include <string>
 #include "ui/gfx/image/image_skia.h"
-#include "ui/views/view.h"
+#include "ui/views/controls/image_view.h"
 
 namespace xwalk {
 
@@ -16,7 +16,7 @@ class TizenSystemIndicatorWatcher;
 // This view paints the Tizen Mobile system indicator provided by the system.
 // We get to it by using the Elementary "Plug" system from EFL, reading the
 // image from a shared memory area.
-class TizenSystemIndicator : public views::View {
+class TizenSystemIndicator : public views::ImageView {
  public:
   TizenSystemIndicator();
   virtual ~TizenSystemIndicator();
@@ -28,18 +28,14 @@ class TizenSystemIndicator : public views::View {
   Orientation GetOrientation() const;
 
   // views::View implementation.
-  virtual void OnPaint(gfx::Canvas* canvas) OVERRIDE;
   gfx::Size GetPreferredSize() OVERRIDE;
 
  private:
-  // Will be called immediately after the image was updated
-  void SetImage(const gfx::ImageSkia& img);
   virtual bool OnMousePressed(const ui::MouseEvent& event) OVERRIDE;
   virtual void OnMouseReleased(const ui::MouseEvent& event) OVERRIDE;
   virtual void OnMouseMoved(const ui::MouseEvent& event) OVERRIDE;
   virtual void OnTouchEvent(ui::TouchEvent* event) OVERRIDE;
 
-  gfx::ImageSkia image_;
   Orientation orientation_;
   scoped_ptr<TizenSystemIndicatorWatcher> watcher_;
   friend class TizenSystemIndicatorWatcher;

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.cc
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.cc
@@ -15,6 +15,8 @@
 #include "ipc/unix_domain_socket_util.h"
 #include "base/strings/string_tokenizer.h"
 #include "base/environment.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/gfx/screen.h"
 
 using content::BrowserThread;
 
@@ -480,7 +482,10 @@ void TizenSystemIndicatorWatcher::UpdateIndicatorImage() {
   bitmap.setConfig(SkBitmap::kARGB_8888_Config, width_, height_);
   bitmap.setPixels(shared_memory_->memory());
 
-  const gfx::ImageSkia img_skia = gfx::ImageSkia::CreateFrom1xBitmap(bitmap);
+  gfx::ImageSkia img_skia;
+  gfx::Display display = gfx::Screen::GetNativeScreen()->GetPrimaryDisplay();
+  img_skia.AddRepresentation(gfx::ImageSkiaRep(bitmap,
+      display.device_scale_factor()));
   indicator_->SetImage(img_skia);
 }
 


### PR DESCRIPTION
Change to inherit from ImageView instead of View as it fits our
use-case. Insert the system indicator image as a 2.0 image
representation in the ImageSkia, and use its size as the preferred
size.

Thanks for Dongseong Hwang for his help with testing!
