### PR TITLE
Implements runtime flags for Xwalk.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -23,6 +23,7 @@
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_registry.h"
+#include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 #include "xwalk/runtime/extension/runtime_extension.h"
 #include "xwalk/sysapps/raw_socket/raw_socket_extension.h"
@@ -226,8 +227,10 @@ void XWalkBrowserMainParts::RegisterInternalExtensionsInExtensionThreadServer(
   server->RegisterExtension(scoped_ptr<XWalkExtension>(new RuntimeExtension()));
   server->RegisterExtension(scoped_ptr<XWalkExtension>(
       new experimental::DialogExtension(runtime_registry_.get())));
-  server->RegisterExtension(scoped_ptr<XWalkExtension>(
-      new sysapps::RawSocketExtension()));
+  if (XWalkRuntimeFeatures::isRawSocketsAPIEnabled()) {
+    server->RegisterExtension(scoped_ptr<XWalkExtension>(
+        new sysapps::RawSocketExtension()));
+  }
 }
 
 void XWalkBrowserMainParts::RegisterInternalExtensionsInUIThreadServer(

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -32,6 +32,7 @@
 #include "xwalk/runtime/browser/android/cookie_manager.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_registry.h"
+#include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "xwalk/runtime/extension/runtime_extension.h"
 #include "xwalk/sysapps/raw_socket/raw_socket_extension.h"
 
@@ -150,8 +151,10 @@ XWalkBrowserMainPartsAndroid::RegisterInternalExtensionsInExtensionThreadServer(
   for (; it != extensions_.end(); ++it)
     server->RegisterExtension(scoped_ptr<XWalkExtension>(*it));
 
-  server->RegisterExtension(scoped_ptr<XWalkExtension>(
-      new sysapps::RawSocketExtension()));
+  if (XWalkRuntimeFeatures::isRawSocketsAPIEnabled()) {
+    server->RegisterExtension(scoped_ptr<XWalkExtension>(
+        new sysapps::RawSocketExtension()));
+  }
 }
 
 void XWalkBrowserMainPartsAndroid::RegisterExtension(

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -9,6 +9,7 @@
 #include "content/public/common/content_switches.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
 #include "xwalk/extensions/common/xwalk_extension_server.h"
+#include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "xwalk/runtime/extension/runtime_extension.h"
 #include "xwalk/sysapps/raw_socket/raw_socket_extension.h"
 #include "ui/gl/gl_switches.h"
@@ -57,10 +58,14 @@ void
 XWalkBrowserMainPartsTizen::RegisterInternalExtensionsInExtensionThreadServer(
     extensions::XWalkExtensionServer* server) {
   CHECK(server);
-  server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(
-      new sysapps::DeviceCapabilitiesExtension(runtime_registry_.get())));
-  server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(
-      new sysapps::RawSocketExtension()));
+  if (XWalkRuntimeFeatures::isDeviceCapabilitiesAPIEnabled()) {
+    server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(
+        new sysapps::DeviceCapabilitiesExtension(runtime_registry_.get())));
+  }
+  if (XWalkRuntimeFeatures::isRawSocketsAPIEnabled()) {
+    server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(
+        new sysapps::RawSocketExtension()));
+  }
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -17,6 +17,7 @@
 #include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_quota_permission_context.h"
+#include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents.h"
@@ -68,6 +69,7 @@ XWalkContentBrowserClient::~XWalkContentBrowserClient() {
 
 content::BrowserMainParts* XWalkContentBrowserClient::CreateBrowserMainParts(
     const content::MainFunctionParams& parameters) {
+  XWalkRuntimeFeatures::Initialize(CommandLine::ForCurrentProcess());
 #if defined(OS_MACOSX)
   main_parts_ = new XWalkBrowserMainPartsMac(parameters);
 #elif defined(OS_ANDROID)

--- a/runtime/common/xwalk_runtime_features.cc
+++ b/runtime/common/xwalk_runtime_features.cc
@@ -1,0 +1,81 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/common/xwalk_runtime_features.h"
+
+#include <algorithm>
+#include <functional>
+
+#include "base/message_loop/message_loop.h"
+
+namespace xwalk {
+
+XWalkRuntimeFeatures* g_features = NULL;
+
+struct MatchRuntimeFeature
+  : std::unary_function<XWalkRuntimeFeatures::RuntimeFeature, bool> {
+  explicit MatchRuntimeFeature(const std::string& name) : name(name) {}
+  bool operator()(const XWalkRuntimeFeatures::RuntimeFeature& entry) const {
+    return entry.name == name;
+  }
+  const std::string name;
+};
+
+// static
+void XWalkRuntimeFeatures::Initialize(const CommandLine* cmd) {
+  g_features = new XWalkRuntimeFeatures(cmd);
+}
+
+// static
+XWalkRuntimeFeatures* XWalkRuntimeFeatures::GetInstance() {
+  return g_features;
+}
+
+XWalkRuntimeFeatures::XWalkRuntimeFeatures(const CommandLine* cmd)
+  : command_line_(cmd) {
+  // Add new features here with the following parameters :
+  // - Name of the feature
+  // - Name of the command line switch which will be used after the
+  // --enable/--disable
+  // - Description of the feature
+  // - Status of the feature : experimental which is turned off by default or
+  // stable which is turned on by default
+  AddFeature("RawSocketsAPI", "raw-sockets",
+             "JavaScript support for using TCP and UDP sockets", Stable);
+  AddFeature("DeviceCapabilitiesAPI", "device-capabilities",
+             "JavaScript support for peeking at device capabilities", Stable);
+}
+
+XWalkRuntimeFeatures::~XWalkRuntimeFeatures() {}
+
+void XWalkRuntimeFeatures::AddFeature(const char* name,
+                                 const char* command_line_switch,
+                                 const char* description,
+                                 RuntimeFeatureStatus status) {
+  RuntimeFeature feature;
+  feature.name = name;
+
+  if (command_line_->HasSwitch(
+              ("disable-" + std::string(command_line_switch)))) {
+    feature.enabled = false;
+  } else if (command_line_->HasSwitch(
+              ("enable-" + std::string(command_line_switch)))) {
+    feature.enabled = true;
+  } else {
+    feature.enabled = (status == Stable);
+  }
+
+  runtimeFeatures_.push_back(feature);
+}
+
+bool XWalkRuntimeFeatures::isFeatureEnabled(const char* name) const {
+  RuntimeFeaturesList::const_iterator it = std::find_if(
+    runtimeFeatures_.begin(), runtimeFeatures_.end(),
+      MatchRuntimeFeature(name));
+  if (it == runtimeFeatures_.end())
+    return false;
+  return (*it).enabled;
+}
+
+}  // namespace xwalk

--- a/runtime/common/xwalk_runtime_features.h
+++ b/runtime/common/xwalk_runtime_features.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_COMMON_XWALK_RUNTIME_FEATURES_H_
+#define XWALK_RUNTIME_COMMON_XWALK_RUNTIME_FEATURES_H_
+
+#include <string>
+#include <vector>
+
+#include "base/command_line.h"
+
+namespace xwalk {
+
+#define DECLARE_RUNTIME_FEATURE(NAME) static bool is ##NAME## Enabled() \
+  { return GetInstance()->isFeatureEnabled( #NAME ); }
+
+class XWalkRuntimeFeatures {
+ public:
+  // Declare new features here and and define them in xwalk_runtime_features.cc.
+  DECLARE_RUNTIME_FEATURE(RawSocketsAPI);
+  DECLARE_RUNTIME_FEATURE(DeviceCapabilitiesAPI);
+
+  static void Initialize(const CommandLine* cmd);
+  static XWalkRuntimeFeatures* GetInstance();
+
+  struct RuntimeFeature {
+    std::string name;
+    bool enabled;
+  };
+
+ private:
+  enum RuntimeFeatureStatus {
+    Stable,
+    Experimental
+  };
+
+  explicit XWalkRuntimeFeatures(const CommandLine* cmd);
+  ~XWalkRuntimeFeatures();
+  void AddFeature(const char* name, const char* command_line_switch,
+                  const char* description, RuntimeFeatureStatus status);
+  bool isFeatureEnabled(const char* name) const;
+  typedef std::vector<RuntimeFeature> RuntimeFeaturesList;
+  RuntimeFeaturesList runtimeFeatures_;
+  const CommandLine* command_line_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_COMMON_XWALK_RUNTIME_FEATURES_H_

--- a/runtime/common/xwalk_runtime_features_unittest.cc
+++ b/runtime/common/xwalk_runtime_features_unittest.cc
@@ -1,0 +1,32 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/command_line.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "xwalk/runtime/common/xwalk_runtime_features.h"
+#include "content/public/test/test_utils.h"
+
+TEST(XWalkRuntimeFeaturesTest, ValidateStableFeatures) {
+  CommandLine cmd(CommandLine::NO_PROGRAM);
+  xwalk::XWalkRuntimeFeatures::Initialize(&cmd);
+  EXPECT_TRUE(xwalk::XWalkRuntimeFeatures::isRawSocketsAPIEnabled());
+  EXPECT_TRUE(xwalk::XWalkRuntimeFeatures::isDeviceCapabilitiesAPIEnabled());
+}
+
+TEST(XWalkRuntimeFeaturesTest, ValidateExperimentalFeatures) {
+  CommandLine cmd(CommandLine::NO_PROGRAM);
+  xwalk::XWalkRuntimeFeatures::Initialize(&cmd);
+}
+
+TEST(XWalkRuntimeFeaturesTest, CommandLineOverrideDefaults) {
+  CommandLine cmd(CommandLine::NO_PROGRAM);
+  cmd.AppendSwitch("--enable-raw-sockets");
+  xwalk::XWalkRuntimeFeatures::Initialize(&cmd);
+  EXPECT_TRUE(xwalk::XWalkRuntimeFeatures::isRawSocketsAPIEnabled());
+
+  CommandLine cmd2 = CommandLine(CommandLine::NO_PROGRAM);
+  cmd2.AppendSwitch("--disable-raw-sockets");
+  xwalk::XWalkRuntimeFeatures::Initialize(&cmd2);
+  EXPECT_FALSE(xwalk::XWalkRuntimeFeatures::isRawSocketsAPIEnabled());
+}

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -139,6 +139,8 @@
         'runtime/common/xwalk_content_client.h',
         'runtime/common/xwalk_paths.cc',
         'runtime/common/xwalk_paths.h',
+        'runtime/common/xwalk_runtime_features.cc',
+        'runtime/common/xwalk_runtime_features.h',
         'runtime/common/xwalk_switches.cc',
         'runtime/common/xwalk_switches.h',
         'runtime/extension/runtime.idl',

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -84,6 +84,7 @@
       'application/common/manifest_unittest.cc',
       'application/common/db_store_sqlite_impl_unittest.cc',
       'runtime/common/xwalk_content_client_unittest.cc',
+      'runtime/common/xwalk_runtime_features_unittest.cc',
       'test/base/run_all_unittests.cc',
     ],
     'conditions': [


### PR DESCRIPTION
A new class is added to handle the runtime flags where each feature is
declared as "stable" or "experimental".

This class contains the getters XWalkRuntimeFeatures::isMyFeatureEnabled()
used to know if a feature is on or off from the C++ code.

Note that this class also handles whether a feature has been overriden
by the command line (--enable/--disable-myfeature) by querying the
CommandLine object.
