### PR TITLE
[SysApps][Tizen] Fixed the incorrect event type and rename the event type

### DIFF
--- a/sysapps/device_capabilities/device_capabilities_instance.cc
+++ b/sysapps/device_capabilities/device_capabilities_instance.cc
@@ -98,12 +98,13 @@ void
 DeviceCapabilitiesInstance::HandleAddEventListener(const Json::Value& msg) {
   std::string event_name = msg["eventName"].asString();
   DeviceMap::iterator it;
-  if (event_name == "onattach" || event_name == "ondetach") {
+  if (event_name == "storageattach" || event_name == "storagedetach") {
     it = device_map_.find("Storage");
     if (it != device_map_.end()) {
       (it->second).AddEventListener(event_name, this);
     }
-  } else if (event_name == "onconnect" || event_name == "ondisconnect") {
+  } else if (event_name == "displayconnect" ||
+             event_name == "displaydisconnect") {
     it = device_map_.find("Display");
     if (it != device_map_.end()) {
       (it->second).AddEventListener(event_name, this);

--- a/sysapps/device_capabilities/device_capabilities_storage_tizen.cc
+++ b/sysapps/device_capabilities/device_capabilities_storage_tizen.cc
@@ -40,7 +40,7 @@ Json::Value* DeviceCapabilitiesStorage::Get() {
 
 void DeviceCapabilitiesStorage::AddEventListener(const std::string& event_name,
     DeviceCapabilitiesInstance* instance) {
-  if (event_name == "onattach")
+  if (event_name == "storageattach")
     attach_listeners_.push_back(instance);
   else
     detach_listeners_.push_back(instance);
@@ -113,7 +113,7 @@ void DeviceCapabilitiesStorage::UpdateStorageUnits(std::string command) {
   output["reply"] = Json::Value(command);
   DeviceStorageUnit mmcUnit;
   if (command == "attachStorage" && QueryStorage("MMC", mmcUnit)) {
-    output["eventName"] = Json::Value("onattach");
+    output["eventName"] = Json::Value("storageattach");
     SetJsonValue(&data, mmcUnit);
     storages_[mmcUnit.id] = mmcUnit;
     output["data"] = data;
@@ -126,7 +126,7 @@ void DeviceCapabilitiesStorage::UpdateStorageUnits(std::string command) {
        it != storages_.end(); it++) {
     DeviceStorageUnit unit = it->second;
     if (unit.type == "removable") {
-      output["eventName"] = Json::Value("ondetach");
+      output["eventName"] = Json::Value("storagedetach");
       SetJsonValue(&data, unit);
       storages_.erase(it);
       output["data"] = data;


### PR DESCRIPTION
1. remove 'on' before the event type
    such as: onattach -> attach
2. rename event type to keep consistent with spec
    such as: rename 'attach' -> 'storageattach'

spec: http://device-capabilities.sysapps.org/
