### PR TITLE
[Android] Exclude the gdbserver from release mode of packaging tool.

### DIFF
--- a/build/android/common_function.py
+++ b/build/android/common_function.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+
+def RemoveUnusedFilesInReleaseMode(mode, target_directory):
+  # Exclude gdbserver binary in release mode, as it's GPL license.
+  if mode == 'Release':
+    if os.path.exists(target_directory):
+      for root, _, files in os.walk(target_directory):
+        if 'gdbserver' in files:
+          os.remove(os.path.join(root, 'gdbserver'))

--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -3,10 +3,12 @@
 # Copyright (c) 2013 Intel Corporation. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+# pylint: disable=F0401
 
 import os
 import shutil
 import sys
+from common_function import RemoveUnusedFilesInReleaseMode
 
 def Clean(dir_to_clean):
   if os.path.isdir(dir_to_clean):
@@ -135,6 +137,11 @@ def PrepareFromXwalk(src_dir, target_dir):
       shutil.copy(source_path, target_path)
     else:
       shutil.copytree(source_path, target_path)
+
+  # Remove unused files.
+  mode = os.path.basename(os.path.dirname(target_dir))
+  RemoveUnusedFilesInReleaseMode(mode, os.path.join(target_dir, 'native_libs'))
+
 
 def main(args):
   if len(args) != 1:

--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -3,12 +3,14 @@
 # Copyright (c) 2013 Intel Corporation. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+# pylint: disable=F0401
 
 import distutils.dir_util
 import optparse
 import os
 import shutil
 import sys
+from common_function import RemoveUnusedFilesInReleaseMode
 
 LIBRARY_PROJECT_NAME = 'xwalk_core_library'
 XWALK_CORE_SHELL_APK = 'xwalk_core_shell_apk'
@@ -280,17 +282,6 @@ def PostCopyLibraryProject(out_directory):
     os.remove(common_aidl_file)
 
 
-def RemoveUnusedFiles(out_directory):
-  # Exclude gdbserver binary in release mode, as it's GPL license.
-  mode = os.path.basename(os.path.normpath(out_directory))
-  if mode == 'Release':
-    libs_directory = os.path.join(out_directory, LIBRARY_PROJECT_NAME, 'libs')
-    if os.path.exists(libs_directory):
-      for root, _, files in os.walk(libs_directory):
-        if 'gdbserver' in files:
-          os.remove(os.path.join(root, 'gdbserver'))
-
-
 def main(argv):
   print 'Generating XWalkCore Library Project...'
   option_parser = optparse.OptionParser()
@@ -322,7 +313,9 @@ def main(argv):
   # Post copy library project.
   PostCopyLibraryProject(out_directory)
   # Remove unused files.
-  RemoveUnusedFiles(out_directory)
+  mode = os.path.basename(os.path.normpath(out_directory))
+  RemoveUnusedFilesInReleaseMode(mode,
+        os.path.join(out_directory, LIBRARY_PROJECT_NAME, 'libs'))
   print 'Your Android library project has been created at %s' % (
       out_project_directory)
 

--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -136,6 +136,7 @@
         {
           'action_name': 'prepare_xwalk_app_template',
           'inputs': [
+            'build/android/common_function.py',
             'build/android/generate_app_packaging_tool.py',
           ],
           'outputs': [

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -39,6 +39,7 @@
           'action_name': 'generate_xwalk_core_library',
           'message': 'Generating XwalkCore Library Project.',
           'inputs': [
+            '<(DEPTH)/xwalk/build/android/common_function.py',
             '<(DEPTH)/xwalk/build/android/generate_xwalk_core_library.py',
           ],
           'outputs': [


### PR DESCRIPTION
The gdbserver is used for debugging XWalk, which should not be included
in the release binary of packaging tool. Because it would introduce additional size
of the binary. 

So exclude gdbserver binary from release version and leave it for debug version
the same as that for xwalk_core_library.
