### PR TITLE
[Android] Add the check of application launch path in packaging tool.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -99,6 +99,11 @@ def ParseManifest(options):
     options.permissions = parser.GetPermissions()
   if parser.GetAppUrl():
     options.app_url = parser.GetAppUrl()
+  elif parser.GetAppLocalPath():
+    options.app_local_path = parser.GetAppLocalPath()
+  else:
+    print 'Error: there is no app launch path defined in manifest.json.'
+    sys.exit(9)
   if parser.GetAppRoot():
     options.app_root = parser.GetAppRoot()
     temp_dict = parser.GetIcons()
@@ -110,8 +115,6 @@ def ParseManifest(options):
     if icon_dict:
       icon_file = max(icon_dict.iteritems(), key=operator.itemgetter(0))[1]
       options.icon = os.path.join(options.app_root, icon_file)
-  if parser.GetAppLocalPath():
-    options.app_local_path = parser.GetAppLocalPath()
   options.enable_remote_debugging = False
   if parser.GetFullScreenFlag().lower() == 'true':
     options.fullscreen = True

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -340,6 +340,16 @@ class TestMakeApk(unittest.TestCase):
     self.checkApk('Example.apk')
     Clean('Example')
 
+  def testManifestWithError(self):
+    manifest_path = os.path.join('test_data', 'manifest',
+                                 'manifest_no_app_launch_path.json')
+    proc = subprocess.Popen(['python', 'make_apk.py',
+                             '--manifest=%s' % manifest_path,
+                             self._mode],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('no app launch path') != -1)
+
   def testExtensionsWithOneExtension(self):
     # Test with an existed extension.
     extension_path = 'test_data/extensions/myextension'

--- a/app/tools/android/test_data/manifest/manifest_no_app_launch_path.json
+++ b/app/tools/android/test_data/manifest/manifest_no_app_launch_path.json
@@ -1,0 +1,13 @@
+{
+  "name": "Example",
+  "version": "1.0.0",
+  "description": "a sample description",
+  "origin": "app://app.id",
+  "icons": {
+  },
+  "default_locale": "en",
+  "permissions": ["geolocation"],
+  "required_version": "1.28.1.0",
+  "plugin": [],
+  "fullscreen":"true"
+}


### PR DESCRIPTION
   Since there is no prompt when there is no application launch path
in the manifest.json file, to improve the user experience of crosswalk,
in the packaging tool, add the check of application launch path in packaging
tool.

BUG=https://crosswalk-project.org/jira/browse/XWALK-645
