### PR TITLE
[Android] Prompt error message when there is filed error in manifest.json.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -635,8 +635,7 @@ def main(argv):
   else:
     try:
       ParseManifest(options)
-    except KeyError, ec:
-      print 'The manifest file contains syntax errors.'
+    except SystemExit, ec:
       return ec.code
 
   options.name = ReplaceInvalidChars(options.name, 'apkname')

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -397,6 +397,30 @@ class TestMakeApk(unittest.TestCase):
                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = proc.communicate()
     self.assertTrue(out.find('no app launch path') != -1)
+    manifest_path = os.path.join('test_data', 'manifest',
+                                 'manifest_no_name.json')
+    proc = subprocess.Popen(['python', 'make_apk.py',
+                             '--manifest=%s' % manifest_path,
+                             self._mode],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('no \'name\' field') != -1)
+    manifest_path = os.path.join('test_data', 'manifest',
+                                 'manifest_no_version.json')
+    proc = subprocess.Popen(['python', 'make_apk.py',
+                             '--manifest=%s' % manifest_path,
+                             self._mode],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('no \'version\' field') != -1)
+    manifest_path = os.path.join('test_data', 'manifest',
+                                 'manifest_permissions_error.json')
+    proc = subprocess.Popen(['python', 'make_apk.py',
+                             '--manifest=%s' % manifest_path,
+                             self._mode],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    self.assertTrue(out.find('\'Permissions\' field error') != -1)
 
   def testExtensionsWithOneExtension(self):
     # Test with an existed extension.

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -53,10 +53,12 @@ class ManifestJsonParser(object):
       input_src = input_file.read()
       self.data_src = json.JSONDecoder().decode(input_src)
       self.ret_dict = self._output_items()
-    except IOError:
-      raise Exception('Error in decoding json-format manifest file.')
+    except (TypeError, ValueError, IOError):
+      print 'There is a parser error in manifest.json file.'
+      sys.exit(1)
     except KeyError:
-      raise Exception('Wrong keyword in json-format manifest file.')
+      print 'There is a field error in manifest.json file.'
+      sys.exit(1)
     finally:
       input_file.close()
 
@@ -83,7 +85,13 @@ class ManifestJsonParser(object):
     fullscreen:       The fullscreen flag of the application.
     """
     ret_dict = {}
+    if not self.data_src.has_key('name'):
+      print 'Error: no \'name\' field in manifest.json file.'
+      sys.exit(1)
     ret_dict['app_name'] = self.data_src['name']
+    if not self.data_src.has_key('version'):
+      print 'Error: no \'version\' field in manifest.json file.'
+      sys.exit(1)
     ret_dict['version'] = self.data_src['version']
     if self.data_src.has_key('launch_path'):
       app_url = self.data_src['launch_path']
@@ -112,8 +120,12 @@ class ManifestJsonParser(object):
     ret_dict['app_local_path'] = app_local_path
     ret_dict['permissions'] = ''
     if self.data_src.has_key('permissions'):
-      permission_list = self.data_src['permissions']
-      ret_dict['permissions'] = HandlePermissionList(permission_list)
+      try:
+        permission_list = self.data_src['permissions']
+        ret_dict['permissions'] = HandlePermissionList(permission_list)
+      except (TypeError, ValueError, IOError):
+        print '\'Permissions\' field error in manifest.json file.'
+        sys.exit(1)
     ret_dict['required_version'] = ''
     if self.data_src.has_key('required_version'):
       ret_dict['required_version'] = self.data_src['required_version']

--- a/app/tools/android/test_data/manifest/manifest_no_name.json
+++ b/app/tools/android/test_data/manifest/manifest_no_name.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0.0",
+  "launch_path": "http://www.intel.com",
+  "app": {
+      "launch": {
+          "local_path": "http://www.intel.com"
+      }
+  },
+  "description": "a sample description",
+  "origin": "app://app.id",
+  "icons": {
+  },
+  "default_locale": "en",
+  "permissions": ["geolocation"],
+  "required_version": "1.28.1.0",
+  "plugin": [],
+  "fullscreen":"true"
+}

--- a/app/tools/android/test_data/manifest/manifest_no_version.json
+++ b/app/tools/android/test_data/manifest/manifest_no_version.json
@@ -1,0 +1,18 @@
+{
+  "name": "Example",
+  "launch_path": "http://www.intel.com",
+  "app": {
+      "launch": {
+          "local_path": "http://www.intel.com"
+      }
+  },
+  "description": "a sample description",
+  "origin": "app://app.id",
+  "icons": {
+  },
+  "default_locale": "en",
+  "permissions": ["geolocation"],
+  "required_version": "1.28.1.0",
+  "plugin": [],
+  "fullscreen":"true"
+}

--- a/app/tools/android/test_data/manifest/manifest_permissions_error.json
+++ b/app/tools/android/test_data/manifest/manifest_permissions_error.json
@@ -1,0 +1,19 @@
+{
+  "name": "Example",
+  "version": "1.0.0",
+  "launch_path": "http://www.intel.com",
+  "app": {
+      "launch": {
+          "local_path": "http://www.intel.com"
+      }
+  },
+  "description": "a sample description",
+  "origin": "app://app.id",
+  "icons": {
+  },
+  "default_locale": "en",
+  "permissions": [{"filesystem":["write"]},"experimental"],
+  "required_version": "1.28.1.0",
+  "plugin": [],
+  "fullscreen":"true"
+}


### PR DESCRIPTION
[Android] Prompt error message when there is filed error in maniest.j…
…son.

  When there is field error in the file of manifest.json, error message
should be prompted. This fix is to prompt the error message if there is
filed error in manifest.json. In addition, the corresponding test cases
are added.

BUG=https://crosswalk-project.org/jira/browse/XWALK-648
