### PR TITLE
Add a generic --enable-xwalk-experimental-features to turn on all the experimental features.

### DIFF
--- a/runtime/common/xwalk_runtime_features.cc
+++ b/runtime/common/xwalk_runtime_features.cc
@@ -34,6 +34,10 @@ XWalkRuntimeFeatures* XWalkRuntimeFeatures::GetInstance() {
 
 XWalkRuntimeFeatures::XWalkRuntimeFeatures(const CommandLine* cmd)
   : command_line_(cmd) {
+  if (cmd->HasSwitch("enable-xwalk-experimental-features"))
+    experimental_features_enabled_ = true;
+  else
+    experimental_features_enabled_ = false;
   // Add new features here with the following parameters :
   // - Name of the feature
   // - Name of the command line switch which will be used after the
@@ -56,7 +60,9 @@ void XWalkRuntimeFeatures::AddFeature(const char* name,
   RuntimeFeature feature;
   feature.name = name;
 
-  if (command_line_->HasSwitch(
+  if (experimental_features_enabled_) {
+    feature.enabled = true;
+  } else if (command_line_->HasSwitch(
               ("disable-" + std::string(command_line_switch)))) {
     feature.enabled = false;
   } else if (command_line_->HasSwitch(
@@ -70,6 +76,9 @@ void XWalkRuntimeFeatures::AddFeature(const char* name,
 }
 
 bool XWalkRuntimeFeatures::isFeatureEnabled(const char* name) const {
+  if (experimental_features_enabled_)
+    return true;
+
   RuntimeFeaturesList::const_iterator it = std::find_if(
     runtimeFeatures_.begin(), runtimeFeatures_.end(),
       MatchRuntimeFeature(name));

--- a/runtime/common/xwalk_runtime_features.h
+++ b/runtime/common/xwalk_runtime_features.h
@@ -43,6 +43,7 @@ class XWalkRuntimeFeatures {
   typedef std::vector<RuntimeFeature> RuntimeFeaturesList;
   RuntimeFeaturesList runtimeFeatures_;
   const CommandLine* command_line_;
+  bool experimental_features_enabled_;
 };
 
 }  // namespace xwalk

--- a/runtime/common/xwalk_runtime_features_unittest.cc
+++ b/runtime/common/xwalk_runtime_features_unittest.cc
@@ -30,3 +30,18 @@ TEST(XWalkRuntimeFeaturesTest, CommandLineOverrideDefaults) {
   xwalk::XWalkRuntimeFeatures::Initialize(&cmd2);
   EXPECT_FALSE(xwalk::XWalkRuntimeFeatures::isRawSocketsAPIEnabled());
 }
+
+TEST(XWalkRuntimeFeaturesTest, CommandLineEnableExperimentalFeatures) {
+  CommandLine cmd(CommandLine::NO_PROGRAM);
+  cmd.AppendSwitch("--enable-xwalk-experimental-features");
+  xwalk::XWalkRuntimeFeatures::Initialize(&cmd);
+  EXPECT_TRUE(xwalk::XWalkRuntimeFeatures::isRawSocketsAPIEnabled());
+  EXPECT_TRUE(xwalk::XWalkRuntimeFeatures::isDeviceCapabilitiesAPIEnabled());
+
+  CommandLine cmd2 = CommandLine(CommandLine::NO_PROGRAM);
+  cmd2.AppendSwitch("--disable-raw-sockets");
+  cmd2.AppendSwitch("--enable-xwalk-experimental-features");
+  xwalk::XWalkRuntimeFeatures::Initialize(&cmd2);
+  EXPECT_TRUE(xwalk::XWalkRuntimeFeatures::isRawSocketsAPIEnabled());
+  EXPECT_TRUE(xwalk::XWalkRuntimeFeatures::isDeviceCapabilitiesAPIEnabled());
+}


### PR DESCRIPTION
This will allow our brave users to test the greatest and the latest.
Ideally we need to find a mechanism to trigger this on our Canary
builds (just like Chromium) so the testing can happen early in the
release process.
