### PR TITLE
[Android] Check webview legacy api for external protocol handling first

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -51,12 +51,9 @@ public class XWalkContentsClientBridge extends XWalkContentsClient
 
         public boolean shouldIgnoreNavigation(NavigationParams navigationParams) {
             final String url = navigationParams.url;
-            boolean ignoreNavigation = false;
-
-            if (mNavigationHandler != null) {
-                ignoreNavigation = mNavigationHandler.handleNavigation(navigationParams);
-            }
-            if (!ignoreNavigation) ignoreNavigation = shouldOverrideUrlLoading(url);
+            boolean ignoreNavigation = shouldOverrideUrlLoading(url) ||
+                     (mNavigationHandler != null &&
+                      mNavigationHandler.handleNavigation(navigationParams));
 
             if (!ignoreNavigation) {
                 // Post a message to UI thread to notify the page is starting to load.


### PR DESCRIPTION
Crosswalk provides two ways for embedders to extend protocol handling.
1. The same api as legacy webview api in XWalkContentsClient,
   shouldOverrideUrlLoading().
2. Extends XWalkNavigationHandler.

By default, xwalk doesn't do anything in shouldOverrideUrlLoading, but
handles action uri in XWalkNavigationHandler.
To avoid the case that some embedder override shouldOverrideUrlLoading
in the way conflicts with what xwalk already did in XWalkNavigationHandler,
calling shouldOverrideUrlLoading prior to invoke XWalkNavigationHandler
so that embedders won't get confused.

BUG=https://crosswalk-project.org/jira/browse/XWALK-654
