### PR TITLE
[Android] Enable the io thread client in xwalk content.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -14,6 +14,7 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.ViewGroup;
+import android.webkit.WebResourceResponse;
 import android.widget.FrameLayout;
 
 import org.chromium.base.CalledByNative;
@@ -41,6 +42,7 @@ public class XWalkContent extends FrameLayout {
     private WindowAndroid mWindow;
     private XWalkView mXWalkView;
     private XWalkContentsClientBridge mContentsClientBridge;
+    private XWalkContentsIoThreadClient mIoThreadClient;
     private XWalkWebContentsDelegateAdapter mXWalkContentsDelegateAdapter;
     private XWalkSettings mSettings;
     private XWalkGeolocationPermissions mGeolocationPermissions;
@@ -58,6 +60,7 @@ public class XWalkContent extends FrameLayout {
         mContentsClientBridge = new XWalkContentsClientBridge(mXWalkView);
         mXWalkContentsDelegateAdapter = new XWalkWebContentsDelegateAdapter(
             mContentsClientBridge);
+        mIoThreadClient = new XWalkIoThreadClientImpl();
 
         // Initialize ContentViewRenderView
         mContentViewRenderView = new ContentViewRenderView(context) {
@@ -76,7 +79,7 @@ public class XWalkContent extends FrameLayout {
                         FrameLayout.LayoutParams.MATCH_PARENT));
 
         mXWalkContent = nativeInit(mXWalkContentsDelegateAdapter, mContentsClientBridge);
-        mWebContents = nativeGetWebContents(mXWalkContent,
+        mWebContents = nativeGetWebContents(mXWalkContent, mIoThreadClient,
                 mContentsClientBridge.getInterceptNavigationDelegate());
 
         // Initialize mWindow which is needed by content
@@ -337,6 +340,66 @@ public class XWalkContent extends FrameLayout {
         return nativeGetRoutingID(mXWalkContent);
     }
 
+    //--------------------------------------------------------------------------------------------
+    private class XWalkIoThreadClientImpl implements XWalkContentsIoThreadClient {
+        // All methods are called on the IO thread.
+
+        @Override
+        public int getCacheMode() {
+            return mSettings.getCacheMode();
+        }
+
+        @Override
+        public InterceptedRequestData shouldInterceptRequest(final String url,
+                boolean isMainFrame) {
+
+            WebResourceResponse webResourceResponse = mContentsClientBridge.shouldInterceptRequest(url);
+            InterceptedRequestData interceptedRequestData = null;
+
+            if (webResourceResponse == null) {
+                mContentsClientBridge.getCallbackHelper().postOnLoadResource(url);
+            } else {
+                if (isMainFrame && webResourceResponse.getData() == null) {
+                    mContentsClientBridge.getCallbackHelper().postOnReceivedError(-1, null, url);
+                }
+                interceptedRequestData = new InterceptedRequestData(webResourceResponse.getMimeType(),
+                                                                    webResourceResponse.getEncoding(),
+                                                                    webResourceResponse.getData());
+            }
+            return interceptedRequestData;
+        }
+
+        @Override
+        public boolean shouldBlockContentUrls() {
+            return !mSettings.getAllowContentAccess();
+        }
+
+        @Override
+        public boolean shouldBlockFileUrls() {
+            return !mSettings.getAllowFileAccess();
+        }
+
+        @Override
+        public boolean shouldBlockNetworkLoads() {
+            return mSettings.getBlockNetworkLoads();
+        }
+
+        @Override
+        public void onDownloadStart(String url,
+                                    String userAgent,
+                                    String contentDisposition,
+                                    String mimeType,
+                                    long contentLength) {
+            mContentsClientBridge.getCallbackHelper().postOnDownloadStart(url, userAgent,
+                    contentDisposition, mimeType, contentLength);
+        }
+
+        @Override
+        public void newLoginRequest(String realm, String account, String args) {
+            mContentsClientBridge.getCallbackHelper().postOnReceivedLoginRequest(realm, account, args);
+        }
+    }
+
     private class XWalkGeolocationCallback implements XWalkGeolocationPermissions.Callback {
         @Override
         public void invoke(final String origin, final boolean allow, final boolean retain) {
@@ -383,6 +446,7 @@ public class XWalkContent extends FrameLayout {
             XWalkContentsClientBridge bridge);
     private static native void nativeDestroy(int nativeXWalkContent);
     private native int nativeGetWebContents(int nativeXWalkContent,
+            XWalkContentsIoThreadClient ioThreadClient,
             InterceptNavigationDelegate delegate);
     private native void nativeClearCache(int nativeXWalkContent, boolean includeDiskFiles);
     private native String nativeDevToolsAgentId(int nativeXWalkContent);

--- a/runtime/android/java/src/org/xwalk/core/XWalkSettings.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkSettings.java
@@ -10,6 +10,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.os.Process;
+import android.webkit.WebSettings;
 
 import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
@@ -35,6 +36,7 @@ public class XWalkSettings {
     private boolean mAllowUniversalAccessFromFileURLs = false;
     private boolean mAllowFileAccessFromFileURLs = false;
     private boolean mJavaScriptCanOpenWindowsAutomatically = true;
+    private int mCacheMode = WebSettings.LOAD_DEFAULT;
     private boolean mSupportMultipleWindows = false;
     private boolean mAppCacheEnabled = true;
     private boolean mDomStorageEnabled = true;
@@ -143,6 +145,26 @@ public class XWalkSettings {
     public void setWebContents(int nativeWebContents) {
         synchronized (mXWalkSettingsLock) {
             nativeSetWebContents(mNativeXWalkSettings, nativeWebContents);
+        }
+    }
+
+    /**
+     * See {@link android.webkit.WebSettings#setCacheMode}.
+     */
+    public void setCacheMode(int mode) {
+        synchronized (mXWalkSettingsLock) {
+            if (mCacheMode != mode) {
+                mCacheMode = mode;
+            }
+        }
+    }
+
+    /**
+     * See {@link android.webkit.WebSettings#getCacheMode}.
+     */
+    public int getCacheMode() {
+        synchronized (mXWalkSettingsLock) {
+            return mCacheMode;
         }
     }
 

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -35,7 +35,8 @@ class XWalkContent {
   static XWalkContent* FromID(int render_process_id, int render_view_id);
   static XWalkContent* FromWebContents(content::WebContents* web_contents);
 
-  jint GetWebContents(JNIEnv* env, jobject obj, jobject delegate);
+  jint GetWebContents(JNIEnv* env, jobject obj, jobject io_thread_client,
+                      jobject delegate);
   void ClearCache(JNIEnv* env, jobject obj, jboolean include_disk_files);
   ScopedJavaLocalRef<jstring> DevToolsAgentId(JNIEnv* env, jobject obj);
   void Destroy(JNIEnv* env, jobject obj);
@@ -69,7 +70,8 @@ class XWalkContent {
                                  jstring origin);
 
  private:
-  content::WebContents* CreateWebContents(JNIEnv* env, jobject delegate);
+  content::WebContents* CreateWebContents(JNIEnv* env, jobject io_thread_client,
+                                          jobject delegate);
 
   JavaObjectWeakGlobalRef java_ref_;
   scoped_ptr<content::WebContents> web_contents_;


### PR DESCRIPTION
  The io thread client is implemented while not enabled in xwalk content,
this fix is to enable the io thread client in xwalk content and adding the
related handler into the xwalk content native layer and java layer.

BUG=https://crosswalk-project.org/jira/browse/XWALK-653
