### PR TITLE
Query the number of presentation displays when extension is created.

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/presentation/PresentationExtension.java
@@ -115,6 +115,8 @@ public class PresentationExtension extends XWalkExtension {
         super(name, jsApi, context);
 
         mDisplayManager = XWalkDisplayManager.getInstance(context.getContext());
+        Display[] displays = mDisplayManager.getPresentationDisplays();
+        mAvailableDisplayCount = displays.length;
     }
 
     private Display getPreferredDisplay() {


### PR DESCRIPTION
In some case, e.g. in cordova container, onResume method won't get
called at startup, it is called only when resuming from background
status.

This fix can make sure that presentation.displayavailable flag won't
depend on the fact if PresentationExtension::onResume gets executed.
