### PR TITLE
[Android] Fix the leaked IntentReceiver error.

### DIFF
--- a/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestRunnerActivity.java
+++ b/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestRunnerActivity.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.LinearLayout;
@@ -20,8 +21,10 @@ import org.xwalk.app.runtime.XWalkRuntimeClient;
  * This is a lightweight activity for tests that only require XWalk functionality.
  */
 public class XWalkRuntimeClientTestRunnerActivity extends Activity {
+    private final String TAG = "XWalkRuntimeClientTestRunnerActivity";
     private LinearLayout mLinearLayout;
     private BroadcastReceiver mReceiver;
+    private IntentFilter mIntentFilter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,7 +55,7 @@ public class XWalkRuntimeClientTestRunnerActivity extends Activity {
     }
 
     public void registerBroadcastReceiver(final XWalkRuntimeClient runtimeView) {
-        IntentFilter intentFilter = new IntentFilter("org.xwalk.intent");
+        mIntentFilter = new IntentFilter("org.xwalk.intent");
         mReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
@@ -70,12 +73,36 @@ public class XWalkRuntimeClientTestRunnerActivity extends Activity {
                 }
             }
         };
-        registerReceiver(mReceiver, intentFilter);
+        registerReceiver(mReceiver, mIntentFilter);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mReceiver != null & mIntentFilter != null) {
+            registerReceiver(mReceiver, mIntentFilter);
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        try {
+            unregisterReceiver(mReceiver);
+        } catch (IllegalArgumentException e) {
+            // Do nothing.
+            Log.e(TAG, "Illegal Argunment error");
+        }
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        unregisterReceiver(mReceiver);
+        try {
+            unregisterReceiver(mReceiver);
+        } catch (IllegalArgumentException e) {
+            // Do nothing.
+            Log.e(TAG, "Illegal Argunment error");
+        }
     }
 }

--- a/app/android/runtime_client_shell/src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestRunnerActivity.java
+++ b/app/android/runtime_client_shell/src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestRunnerActivity.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.LinearLayout;
@@ -20,8 +21,10 @@ import org.xwalk.app.runtime.XWalkRuntimeClient;
  * This is a lightweight activity for tests that only require XWalk functionality.
  */
 public class XWalkRuntimeClientTestRunnerActivity extends Activity {
+    private final String TAG = "XWalkRuntimeClientTestRunnerActivity";
     private LinearLayout mLinearLayout;
     private BroadcastReceiver mReceiver;
+    private IntentFilter mIntentFilter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,7 +55,7 @@ public class XWalkRuntimeClientTestRunnerActivity extends Activity {
     }
 
     public void registerBroadcastReceiver(final XWalkRuntimeClient runtimeView) {
-        IntentFilter intentFilter = new IntentFilter("org.xwalk.intent");
+        mIntentFilter = new IntentFilter("org.xwalk.intent");
         mReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
@@ -70,12 +73,36 @@ public class XWalkRuntimeClientTestRunnerActivity extends Activity {
                 }
             }
         };
-        registerReceiver(mReceiver, intentFilter);
+        registerReceiver(mReceiver, mIntentFilter);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mReceiver != null & mIntentFilter != null) {
+            registerReceiver(mReceiver, mIntentFilter);
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        try {
+            unregisterReceiver(mReceiver);
+        } catch (IllegalArgumentException e) {
+            // Do nothing
+            Log.e(TAG, "Illegal Argunment error");
+        }
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        unregisterReceiver(mReceiver);
+        try {
+            unregisterReceiver(mReceiver);
+        } catch (IllegalArgumentException e) {
+            // Do nothing
+            Log.e(TAG, "Illegal Argunment error");
+        }
     }
 }

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientTestGeneric.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientTestGeneric.java
@@ -29,7 +29,6 @@ public class XWalkRuntimeClientTestGeneric<T extends Activity>
                     mRuntimeView = new XWalkRuntimeClient(activity, null, null);
                 }
                 mRuntimeView.onCreate();
-                mRuntimeView.onResume();
                 mTestUtil = new XWalkRuntimeClientTestUtilBase(mRuntimeView,
                         getInstrumentation());
                 PageStatusCallback callback = mTestUtil.new PageStatusCallback();


### PR DESCRIPTION
Open the file browser or Gallery to select file in crosswalk,
the current activity was paused, wait for a moment, there is
a leaked IntentReceiver error.

The fix is to remove the onresume action in setUp(), add the
onpause and onresume action.

BUG=https://crosswalk-project.org/jira/browse/XWALK-664
