### PR TITLE
Dump runtime features with --list-runtime-features

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -152,10 +152,16 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
   runtime_context_.reset(new RuntimeContext);
   runtime_registry_.reset(new RuntimeRegistry);
 
+  CommandLine* command_line = CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kXWalkListRuntimeFeatures)) {
+    XWalkRuntimeFeatures::GetInstance()->DumpFeatures();
+    run_default_message_loop_ = false;
+    return;
+  }
+
   runtime_registry_->AddObserver(
       runtime_context_->GetApplicationSystem()->process_manager());
 
-  CommandLine* command_line = CommandLine::ForCurrentProcess();
   if (!command_line->HasSwitch(switches::kInstall) &&
       !command_line->HasSwitch(switches::kUninstall)) {
     extension_service_.reset(new extensions::XWalkExtensionService(this));

--- a/runtime/common/xwalk_runtime_features.cc
+++ b/runtime/common/xwalk_runtime_features.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <iostream>
 
 #include "base/message_loop/message_loop.h"
 
@@ -56,12 +57,26 @@ XWalkRuntimeFeatures::XWalkRuntimeFeatures(const CommandLine* cmd)
 
 XWalkRuntimeFeatures::~XWalkRuntimeFeatures() {}
 
+void XWalkRuntimeFeatures::DumpFeatures() const {
+  std::cout << "Runtime features:" << std::endl;
+  for (RuntimeFeaturesList::const_iterator it = runtime_features_.begin();
+       it != runtime_features_.end(); ++it) {
+    std::cout
+        << (it->enabled ? "  --disable-" : "  --enable-")
+        << it->command_line_switch
+        << (it->enabled ? " (disable " : " (enable ") << it->description << ")"
+        << std::endl;
+  }
+}
+
 void XWalkRuntimeFeatures::AddFeature(const char* name,
                                  const char* command_line_switch,
                                  const char* description,
                                  RuntimeFeatureStatus status) {
   RuntimeFeature feature;
   feature.name = name;
+  feature.command_line_switch = command_line_switch;
+  feature.description = description;
 
   if (experimental_features_enabled_) {
     feature.enabled = true;

--- a/runtime/common/xwalk_runtime_features.h
+++ b/runtime/common/xwalk_runtime_features.h
@@ -25,8 +25,12 @@ class XWalkRuntimeFeatures {
   static void Initialize(const CommandLine* cmd);
   static XWalkRuntimeFeatures* GetInstance();
 
+  void DumpFeatures() const;
+
   struct RuntimeFeature {
     std::string name;
+    std::string command_line_switch;
+    std::string description;
     bool enabled;
   };
 

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -36,4 +36,8 @@ const char kXWalkAllowExternalExtensionsForRemoteSources[] =
 // issue these requests is platform-specific.
 const char kXWalkRunAsService[] = "run-as-service";
 
+// Dump into the standard output the list of runtime features that can be passed
+// as command line switch.
+const char kXWalkListRuntimeFeatures[] = "list-runtime-features";
+
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -26,6 +26,8 @@ extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
 
 extern const char kXWalkRunAsService[];
 
+extern const char kXWalkListRuntimeFeatures[];
+
 }  // namespace switches
 
 #endif  // XWALK_RUNTIME_COMMON_XWALK_SWITCHES_H_


### PR DESCRIPTION
This is how the output looks like currently:

```
$ ./xwalk --list-runtime-features
Runtime features:
  --disable-raw-sockets (disable JavaScript support for using TCP and UDP sockets)
  --disable-device-capabilities (disable JavaScript support for peeking at device capabilities)
  --enable-dialog (enable JavaScript support to create open/save native dialogs)
```

Note that the code takes into account what is the default state of the feature and prints only the command line switch that can actually change this state.

For example Dialog is disabled by dafault, so we have the "enable" switch in the list.
