### PR TITLE
Launch xwalk with the current orientation (not portrait)

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -32,8 +32,10 @@ void NativeAppWindowTizen::Initialize() {
   DCHECK(root_window);
   root_window->AddObserver(this);
 
-  if (SensorProvider::GetInstance())
-    SensorProvider::GetInstance()->AddObserver(this);
+  if (SensorProvider* sensor = SensorProvider::GetInstance()) {
+    OnRotationChanged(sensor->GetCurrentRotation());
+    sensor->AddObserver(this);
+  }
 }
 
 NativeAppWindowTizen::~NativeAppWindowTizen() {


### PR DESCRIPTION
Without this bug fix, xwalk will always launch in portrait-primary
and never rotate to the correct orientation, as it internally
doesn't consider to be in portrait-primary.
