### PR TITLE
[Runtime] Add supporting for persistent background page

### DIFF
--- a/application/browser/application_process_manager.cc
+++ b/application/browser/application_process_manager.cc
@@ -85,7 +85,16 @@ void ApplicationProcessManager::OnRuntimeRemoved(Runtime* runtime) {
     ApplicationSystem* system = runtime_context_->GetApplicationSystem();
     ApplicationEventManager* event_manager = system->event_manager();
     ApplicationService* service = system->application_service();
-    std::string app_id = service->GetRunningApplication()->ID();
+
+    scoped_refptr<const ApplicationData> app_data =
+        service->GetRunningApplication();
+    const MainDocumentInfo* main_info =
+        ToMainDocumentInfo(app_data->GetManifestData(keys::kAppMainKey));
+    DCHECK(main_info);
+    if (main_info->IsPersistent())
+      return;
+
+    std::string app_id = app_data->ID();
 
     // If onSuspend is not registered in main document,
     // we close the main document immediately.

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -9,6 +9,7 @@ namespace xwalk {
 namespace application_manifest_keys {
 const char kAppKey[] = "app";
 const char kAppMainKey[] = "app.main";
+const char kAppMainPersistentKey[] = "app.main.persistent";
 const char kAppMainScriptsKey[] = "app.main.scripts";
 const char kAppMainSourceKey[] = "app.main.source";
 const char kDescriptionKey[] = "description";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -10,6 +10,7 @@ namespace xwalk {
 namespace application_manifest_keys {
   extern const char kAppKey[];
   extern const char kAppMainKey[];
+  extern const char kAppMainPersistentKey[];
   extern const char kAppMainScriptsKey[];
   extern const char kAppMainSourceKey[];
   extern const char kDescriptionKey[];

--- a/application/common/manifest_handlers/main_document_handler.cc
+++ b/application/common/manifest_handlers/main_document_handler.cc
@@ -14,7 +14,7 @@ namespace keys = application_manifest_keys;
 
 namespace application {
 
-MainDocumentInfo::MainDocumentInfo() {
+MainDocumentInfo::MainDocumentInfo() : persistent_(false) {
 }
 
 MainDocumentInfo::~MainDocumentInfo() {
@@ -43,6 +43,14 @@ bool MainDocumentHandler::Parse(scoped_refptr<ApplicationData> application,
     *error = ASCIIToUTF16("app.main doesn't contain a valid main document.");
     return false;
   }
+
+  bool persistent = false;
+  if (manifest->HasPath(keys::kAppMainPersistentKey) &&
+      !manifest->GetBoolean(keys::kAppMainPersistentKey, &persistent)) {
+    *error = ASCIIToUTF16("Invalid value of app.main.persistent");
+    return false;
+  }
+  main_doc_info->SetPersistent(persistent);
 
   application->SetManifestData(keys::kAppMainKey, main_doc_info.release());
   return true;

--- a/application/common/manifest_handlers/main_document_handler.h
+++ b/application/common/manifest_handlers/main_document_handler.h
@@ -28,8 +28,12 @@ class MainDocumentInfo : public ApplicationData::ManifestData {
     main_scripts_ = scripts;
   }
 
+  bool IsPersistent() const { return persistent_; }
+  void SetPersistent(bool persistent) { persistent_ = persistent; }
+
  private:
   GURL main_url_;
+  bool persistent_;
   std::vector<std::string> main_scripts_;
 
   DISALLOW_COPY_AND_ASSIGN(MainDocumentInfo);

--- a/application/common/manifest_handlers/main_document_handler_unittest.cc
+++ b/application/common/manifest_handlers/main_document_handler_unittest.cc
@@ -73,6 +73,16 @@ TEST_F(MainDocumentHandlerTest, SourceAndScripts) {
   ASSERT_TRUE(application.get());
   EXPECT_EQ(GetMainDocInfo(application)->GetMainURL(),
             application->GetResourceURL("1.html"));
+  EXPECT_FALSE(GetMainDocInfo(application)->IsPersistent());
+}
+
+TEST_F(MainDocumentHandlerTest, MainPersistent) {
+  manifest.SetString(keys::kAppMainSourceKey, "1.html");
+  manifest.SetBoolean(keys::kAppMainPersistentKey, true);
+  scoped_refptr<ApplicationData> application = CreateApplication();
+
+  ASSERT_TRUE(application.get());
+  EXPECT_TRUE(GetMainDocInfo(application)->IsPersistent());
 }
 
 }  // namespace application

--- a/application/test/application_main_document_browsertest.cc
+++ b/application/test/application_main_document_browsertest.cc
@@ -51,3 +51,28 @@ IN_PROC_BROWSER_TEST_F(ApplicationMainDocumentBrowserTest, MainDocument) {
   // window created by main document).
   WaitForRuntimes(2);
 }
+
+IN_PROC_BROWSER_TEST_F(ApplicationMainDocumentBrowserTest,
+                       MainDocumentPersistent) {
+  content::RunAllPendingInMessageLoop();
+  // At least the main document's runtime exist after launch.
+  ASSERT_GE(GetRuntimeNumber(), 1);
+
+  xwalk::Runtime* main_runtime = xwalk::RuntimeRegistry::Get()->runtimes()[0];
+  xwalk::RuntimeContext* runtime_context = main_runtime->runtime_context();
+  xwalk::application::ApplicationService* service =
+    runtime_context->GetApplicationSystem()->application_service();
+  const ApplicationData* app = service->GetRunningApplication();
+  GURL generated_url =
+    app->GetResourceURL(xwalk::application::kGeneratedMainDocumentFilename);
+  // Check main document URL.
+  ASSERT_EQ(main_runtime->web_contents()->GetURL(), generated_url);
+  ASSERT_TRUE(!main_runtime->window());
+
+  // There should exist 2 runtimes(one for generated main document, one for the
+  // window created by main document).
+  WaitForRuntimes(2);
+
+  xwalk::RuntimeRegistry::Get()->runtimes()[1]->Close();
+  WaitForRuntimes(1);
+}

--- a/application/test/data/main_document/manifest.json
+++ b/application/test/data/main_document/manifest.json
@@ -4,7 +4,8 @@
   "version": "1.0",
   "app": {
     "main": {
-      "scripts": ["main.js"]
+      "scripts": ["main.js"],
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
Add a new boolean attribute named "app.main.persistent" in manifest.json
to enable the persistent background supporting. So that the application
event page will keep in background even there is not any visible window belongs
to the application.

Here is the similar spec in Chrome: http://developer.chrome.com/extensions/event_pages.html
