### PR TITLE
[Android][SysApps] Change the unit of storage capacity to byte.

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesStorage.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesStorage.java
@@ -87,8 +87,8 @@ class DeviceCapabilitiesStorage {
             // FIXME(halton): After API level 18, use getTotalBytes() and
             // getAvailableBytes() instead
             long blockSize = stat.getBlockSize();
-            mCapacity = blockSize * stat.getBlockCount() / 1024;
-            mAvailCapacity = blockSize * stat.getAvailableBlocks() / 1024;
+            mCapacity = blockSize * stat.getBlockCount();
+            mAvailCapacity = blockSize * stat.getAvailableBlocks();
         }
 
         public JSONObject convertToJSON() {


### PR DESCRIPTION
According to the spec
http://device-capabilities.sysapps.org/#systemstorage-interface ,
the `capacity` should be in bytes but the original implementation
is in kilobytes.
