### PR TITLE
[Extensions] Invalidate exposed functions when the extension module is destroyed

### DIFF
--- a/extensions/renderer/xwalk_extension_module.cc
+++ b/extensions/renderer/xwalk_extension_module.cc
@@ -64,13 +64,11 @@ XWalkExtensionModule::~XWalkExtensionModule() {
 
   // Deleting the data will disable the functions, they'll return early. We do
   // this because it might be the case that the JS objects we created outlive
-  // this object, even if we destroy the references we have.
-  // TODO(cmarcelo): Add a test for this case.
-  // FIXME(cmarcelo): These calls are causing crashes on shutdown with Chromium
-  //                  29.0.1547.57 and had to be commented out.
-  // v8::Handle<v8::Object> function_data =
-  //     v8::Handle<v8::Object>::New(isolate, function_data_);
-  // function_data->Delete(v8::String::New(kXWalkExtensionModule));
+  // this object (getting references from inside an iframe and then destroying
+  // the iframe), even if we destroy the references we have.
+  v8::Handle<v8::Object> function_data =
+      v8::Handle<v8::Object>::New(isolate, function_data_);
+  function_data->Delete(v8::String::New(kXWalkExtensionModule));
 
   object_template_.Reset();
   function_data_.Reset();

--- a/extensions/test/data/do_count_function.html
+++ b/extensions/test/data/do_count_function.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+<script>
+  function do_count() { counter.count(); }
+</script>
+<body>
+</body>
+</html>

--- a/extensions/test/data/iframe_keep_reference.html
+++ b/extensions/test/data/iframe_keep_reference.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>This should not crash the Render Process!</h1>
+<script>
+// Create an iframe that will load a page that contains only a do_count()
+// function that calls the counter extension.
+var c = document.createElement("iframe");
+c.src = 'do_count_function.html';
+
+// When the page load, we keep a reference to the function inside the iframe,
+// destroy the iframe, and try to
+c.onload = function() {
+  var do_count = c.contentWindow.do_count;
+
+  // We use setTimeout here to escape from the onload callback of iframe, since
+  // during callback execution the iframe wouldn't be garbage collected, because
+  // it would still be on the stack.
+  setTimeout(function() {
+    try {
+      // This will be correctly called, and increase the counter.
+      do_count();
+      document.body.removeChild(c);
+      c = null;
+      gc();
+
+      // This won't affect the counter, since by now the instance will be destroyed.
+      // It should also not crash the Render Process.
+      do_count();
+      document.title = 'Pass';
+    } catch(e) {
+      console
+      document.title = 'Fail';
+    }
+  }, 0);
+};
+
+// Makes sure the iframe will get loaded by adding to the page.
+document.body.appendChild(c);
+</script>
+</body>
+</html>

--- a/extensions/test/extension_in_iframe.cc
+++ b/extensions/test/extension_in_iframe.cc
@@ -109,3 +109,19 @@ IN_PROC_BROWSER_TEST_F(XWalkExtensionsIFrameTest,
   }
 }
 
+// We can keep references to a function that uses one of our APIs from inside an
+// iframe. After the iframe is destroyed, we don't expect these functions to
+// work, but they also should not crash the Render Process. See
+// iframe_keep_reference.html for more details.
+IN_PROC_BROWSER_TEST_F(XWalkExtensionsIFrameTest,
+                       KeepingReferenceToFunctionFromDestroyedIFrame) {
+  content::RunAllPendingInMessageLoop();
+  GURL url = GetExtensionsTestURL(
+      base::FilePath(),
+      base::FilePath().AppendASCII("iframe_keep_reference.html"));
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+  xwalk_test_utils::NavigateToURL(runtime(), url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+  ASSERT_EQ(g_count, 1);
+}


### PR DESCRIPTION
The crash identified back when doing our Chromium update could not be
reproduced. This commit also adds a test. Without the change, RP would
crash in the test. With the change, RP doesn't crash anymore.

TEST=XWalkExtensionsIFrameTest.KeepingReferenceToFunctionFromDestroyedIFrame
BUG=https://crosswalk-project.org/jira/browse/XWALK-184
