### PR TITLE
Prepare ApplicationService for managing multiple apps.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -52,12 +52,14 @@ class FinishEventObserver : public EventObserver {
 
 Application::Application(
     scoped_refptr<const ApplicationData> data,
-    RuntimeContext* runtime_context)
+    RuntimeContext* runtime_context, Observer* observer)
     : runtime_context_(runtime_context),
       application_data_(data),
       main_runtime_(NULL),
-      weak_ptr_factory_(this) {
+      observer_(observer) {
+  DCHECK(runtime_context_);
   DCHECK(application_data_);
+  DCHECK(observer_);
 }
 
 Application::~Application() {
@@ -90,8 +92,11 @@ void Application::OnRuntimeAdded(Runtime* runtime) {
 void Application::OnRuntimeRemoved(Runtime* runtime) {
   DCHECK(runtime);
   runtimes_.erase(runtime);
-  // FIXME: main_runtime_ should always be the last one to close
-  // in RuntimeRegistry. Need to fix the issue from browser tests.
+
+  if (runtimes_.empty())
+    observer_->OnApplicationTerminated(this);
+
+  // FIXME: main_runtime_ should always be closed as the last one.
   if (runtimes_.size() == 1 &&
       ContainsKey(runtimes_, main_runtime_)) {
     ApplicationSystem* system = runtime_context_->GetApplicationSystem();

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -18,13 +18,11 @@
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/runtime/browser/runtime.h"
 
-class GURL;
 
 namespace xwalk {
+
 class RuntimeContext;
-}
 
-namespace xwalk {
 namespace application {
 
 class ApplicationHost;
@@ -32,13 +30,23 @@ class Manifest;
 
 class Application : public Runtime::Observer {
  public:
+  class Observer {
+   public:
+    virtual void OnApplicationTerminated(Application*) {}
+
+   protected:
+    ~Observer() {}
+  };
+
   Application(scoped_refptr<const ApplicationData> data,
-              xwalk::RuntimeContext* context);
+              xwalk::RuntimeContext* context, Observer* observer);
   virtual ~Application();
 
   bool Launch();
   bool is_active() const { return !runtimes_.empty(); }
   void Close();
+
+  std::string id() const { return application_data_->ID(); }
 
   Runtime* GetMainDocumentRuntime() const { return main_runtime_; }
 
@@ -59,9 +67,9 @@ class Application : public Runtime::Observer {
   xwalk::RuntimeContext* runtime_context_;
   scoped_refptr<const ApplicationData> application_data_;
   xwalk::Runtime* main_runtime_;
-  base::WeakPtrFactory<Application> weak_ptr_factory_;
   std::set<Runtime*> runtimes_;
   scoped_ptr<EventObserver> finish_observer_;
+  Observer* observer_;
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -22,7 +22,7 @@
 #include "net/url_request/url_request_error_job.h"
 #include "net/url_request/url_request_file_job.h"
 #include "net/url_request/url_request_simple_job.h"
-#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/browser/application.h"
 #include "xwalk/application/common/application_file_util.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/application_resource.h"
@@ -234,7 +234,9 @@ ApplicationProtocolHandler::MaybeCreateJob(
 }  // namespace
 
 linked_ptr<net::URLRequestJobFactory::ProtocolHandler>
-CreateApplicationProtocolHandler(const ApplicationData* application) {
+CreateApplicationProtocolHandler(const xwalk::application::Application*
+                                 application) {
+  DCHECK(application);
   return  linked_ptr<net::URLRequestJobFactory::ProtocolHandler>(
-      new ApplicationProtocolHandler(application));
+              new ApplicationProtocolHandler(application->data()));
 }

--- a/application/browser/application_protocols.h
+++ b/application/browser/application_protocols.h
@@ -11,14 +11,14 @@
 
 namespace xwalk {
 namespace application {
-class ApplicationData;
+class Application;
 }
 }
 
 // Creates the handlers for the app:// scheme.
 linked_ptr<net::URLRequestJobFactory::ProtocolHandler>
 CreateApplicationProtocolHandler(
-    const xwalk::application::ApplicationData* application);
+    const xwalk::application::Application* application);
 
 
 #endif  // XWALK_APPLICATION_BROWSER_APPLICATION_PROTOCOLS_H_

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -9,7 +9,6 @@
 #include "base/file_util.h"
 #include "base/memory/scoped_ptr.h"
 #include "xwalk/application/browser/application_event_manager.h"
-#include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/application/browser/installer/package.h"
 #include "xwalk/application/common/application_file_util.h"
@@ -168,9 +167,9 @@ bool ApplicationService::Uninstall(const std::string& id) {
   return true;
 }
 
-bool ApplicationService::Launch(const std::string& id) {
+Application* ApplicationService::Launch(const std::string& id) {
   scoped_refptr<const ApplicationData> application_data =
-          GetApplicationByID(id);
+          app_store_->GetApplicationByID(id);
   if (!application_data) {
     LOG(ERROR) << "Application with id " << id << " haven't installed.";
     return false;
@@ -179,7 +178,7 @@ bool ApplicationService::Launch(const std::string& id) {
   return Launch(application_data);
 }
 
-bool ApplicationService::Launch(const base::FilePath& path) {
+Application* ApplicationService::Launch(const base::FilePath& path) {
   if (!base::DirectoryExists(path))
     return false;
 
@@ -195,16 +194,6 @@ bool ApplicationService::Launch(const base::FilePath& path) {
   return Launch(application_data);
 }
 
-ApplicationStore::ApplicationMap*
-ApplicationService::GetInstalledApplications() const {
-  return app_store_->GetInstalledApplications();
-}
-
-scoped_refptr<const ApplicationData> ApplicationService::GetApplicationByID(
-    const std::string& id) const {
-  return app_store_->GetApplicationByID(id);
-}
-
 void ApplicationService::AddObserver(Observer* observer) {
   observers_.AddObserver(observer);
 }
@@ -213,14 +202,28 @@ void ApplicationService::RemoveObserver(Observer* observer) {
   observers_.RemoveObserver(observer);
 }
 
-bool ApplicationService::Launch(
+void ApplicationService::OnApplicationTerminated(
+                                      Application* application) OVERRIDE {
+  ScopedVector<Application>::iterator found = std::find(
+            applications_.begin(), applications_.end(), application);
+  CHECK(found != applications_.end());
+  applications_.erase(found);
+}
+
+Application* ApplicationService::Launch(
     scoped_refptr<const ApplicationData> application_data) {
   ApplicationSystem* system = runtime_context_->GetApplicationSystem();
   ApplicationEventManager* event_manager = system->event_manager();
   event_manager->OnAppLoaded(application_data->ID());
 
-  application_.reset(new Application(application_data, runtime_context_));
-  return application_->Launch();
+  scoped_ptr<Application> application(new Application(application_data,
+                                                      runtime_context_, this));
+
+  if (!application->Launch())
+    return NULL;
+
+  applications_.push_back(application.release());
+  return applications_.back();
 }
 
 ApplicationStore* ApplicationService::application_store() {

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -8,7 +8,9 @@
 #include <string>
 #include "base/files/file_path.h"
 #include "base/memory/scoped_ptr.h"
+#include "base/memory/scoped_vector.h"
 #include "base/observer_list.h"
+#include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_store.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/application/common/application_data.h"
@@ -20,29 +22,12 @@ class RuntimeContext;
 namespace xwalk {
 namespace application {
 
-class Application;
-
-// This will manages applications install, uninstall, update and so on. It'll
-// also maintain all installed applications' info.
-class ApplicationService {
+// This will manage application install, uninstall, update and so on.
+class ApplicationService : public Application::Observer {
  public:
-  explicit ApplicationService(xwalk::RuntimeContext* runtime_context);
-  virtual ~ApplicationService();
-
-  bool Install(const base::FilePath& path, std::string* id);
-  bool Uninstall(const std::string& id);
-  bool Launch(const std::string& id);
-  bool Launch(const base::FilePath& path);
-
-  scoped_refptr<const ApplicationData> GetApplicationByID(
-       const std::string& id) const;
-  ApplicationStore::ApplicationMap* GetInstalledApplications() const;
-  // Currently there's only one running application at a time.
-  const Application* GetActiveApplication() const { return application_.get(); }
-
   // Client code may use this class (and register with AddObserver below) to
   // keep track of applications installed/uninstalled.
-  struct Observer {
+  class Observer {
    public:
     virtual void OnApplicationInstalled(const std::string& app_id) {}
     virtual void OnApplicationUninstalled(const std::string& app_id) {}
@@ -50,16 +35,31 @@ class ApplicationService {
     ~Observer() {}
   };
 
+  explicit ApplicationService(xwalk::RuntimeContext* runtime_context);
+  virtual ~ApplicationService();
+
+  bool Install(const base::FilePath& path, std::string* id);
+  bool Uninstall(const std::string& id);
+  Application* Launch(const std::string& id);
+  Application* Launch(const base::FilePath& path);
+
+  const ScopedVector<Application>& active_applications() const {
+      return applications_; }
+
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
+
   ApplicationStore* application_store();
 
  private:
-  bool Launch(scoped_refptr<const ApplicationData> application_data);
+  // Implementation of Application::Observer
+  virtual void OnApplicationTerminated(Application*) OVERRIDE;
+
+  Application* Launch(scoped_refptr<const ApplicationData> application_data);
 
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationStore> app_store_;
-  scoped_ptr<Application> application_;
+  ScopedVector<Application> applications_;
   ObserverList<Observer> observers_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationService);

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -46,7 +46,7 @@ bool ApplicationSystem::HandleApplicationManagementCommands(
     const CommandLine& cmd_line, const GURL& url) {
   if (cmd_line.HasSwitch(switches::kListApplications)) {
     ApplicationStore::ApplicationMap* apps =
-        application_service_->GetInstalledApplications();
+        application_service_->application_store()->GetInstalledApplications();
     LOG(INFO) << "Application ID                       Application Name";
     LOG(INFO) << "-----------------------------------------------------";
     ApplicationStore::ApplicationMapIterator it;
@@ -93,17 +93,28 @@ bool ApplicationSystem::HandleApplicationManagementCommands(
   return false;
 }
 
+template <typename T>
+bool ApplicationSystem::LaunchFromCommandLineParam(const T& param) {
+  scoped_refptr<Event> event = Event::CreateEvent(
+        kOnLaunched, scoped_ptr<base::ListValue>(new base::ListValue));
+  if (Application* application = application_service_->Launch(param)) {
+    event_manager_->SendEvent(application->id(), event);
+    return true;
+  }
+  return false;
+}
+
 bool ApplicationSystem::LaunchFromCommandLine(
     const CommandLine& cmd_line, const GURL& url,
     bool* run_default_message_loop) {
+
   // On Tizen, applications are launched by a symbolic link named like the
   // application ID.
   // FIXME(cmarcelo): Remove when we move to a separate launcher on Tizen.
 #if defined(OS_TIZEN_MOBILE)
   std::string command_name = cmd_line.GetProgram().BaseName().MaybeAsASCII();
   if (ApplicationData::IsIDValid(command_name)) {
-    *run_default_message_loop = application_service_->Launch(command_name);
-    SendOnLaunchedEvent();
+    *run_default_message_loop = LaunchFromCommandLineParam(command_name);
     return true;
   }
 #endif
@@ -116,29 +127,19 @@ bool ApplicationSystem::LaunchFromCommandLine(
   if (!args.empty()) {
     std::string app_id = std::string(args[0].begin(), args[0].end());
     if (ApplicationData::IsIDValid(app_id)) {
-        *run_default_message_loop = application_service_->Launch(app_id);
-        SendOnLaunchedEvent();
-        return true;
+      *run_default_message_loop = LaunchFromCommandLineParam(app_id);
+      return true;
     }
   }
 
   // Handles local directory.
   base::FilePath path;
-  if (net::FileURLToFilePath(url, &path) && base::DirectoryExists(path)) {
-    *run_default_message_loop = application_service_->Launch(path);
-    SendOnLaunchedEvent();
+  if (net::FileURLToFilePath(url, &path)) {
+    *run_default_message_loop = LaunchFromCommandLineParam(path);
     return true;
   }
 
   return false;
-}
-
-void ApplicationSystem::SendOnLaunchedEvent() {
-  scoped_refptr<Event> event = Event::CreateEvent(
-      kOnLaunched, scoped_ptr<base::ListValue>(new base::ListValue));
-  DCHECK(application_service_->GetActiveApplication());
-  event_manager_->SendEvent(
-      application_service_->GetActiveApplication()->data()->ID(), event);
 }
 
 bool ApplicationSystem::IsRunningAsService() const {

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -77,8 +77,8 @@ class ApplicationSystem {
   explicit ApplicationSystem(RuntimeContext* runtime_context);
 
  private:
-  // Dispatch the onLaunched event to current running application.
-  void SendOnLaunchedEvent();
+  template <typename T>
+  bool LaunchFromCommandLineParam(const T& param);
 
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationService> application_service_;

--- a/application/browser/linux/installed_applications_manager.cc
+++ b/application/browser/linux/installed_applications_manager.cc
@@ -62,7 +62,8 @@ InstalledApplicationsManager::~InstalledApplicationsManager() {
 
 void InstalledApplicationsManager::OnApplicationInstalled(
     const std::string& app_id) {
-  AddObject(application_service_->GetApplicationByID(app_id));
+  AddObject(application_service_->application_store()
+                                ->GetApplicationByID(app_id));
 }
 
 void InstalledApplicationsManager::OnApplicationUninstalled(
@@ -72,7 +73,7 @@ void InstalledApplicationsManager::OnApplicationUninstalled(
 
 void InstalledApplicationsManager::AddInitialObjects() {
   ApplicationStore::ApplicationMap* apps =
-      application_service_->GetInstalledApplications();
+      application_service_->application_store()->GetInstalledApplications();
   ApplicationStore::ApplicationMap::iterator it;
   for (it = apps->begin(); it != apps->end(); ++it)
     AddObject(it->second);

--- a/application/extension/application_event_extension.cc
+++ b/application/extension/application_event_extension.cc
@@ -28,12 +28,13 @@ ApplicationEventExtension::ApplicationEventExtension(
 XWalkExtensionInstance* ApplicationEventExtension::CreateInstance() {
   const application::ApplicationService* service =
     application_system_->application_service();
-  // FIXME: return corresponding application info after shared runtime process
+  // FIXME: return corresponding application after shared runtime process
   // model is enabled.
-  const application::Application* app = service->GetActiveApplication();
-  CHECK(app);
+  CHECK(!service->active_applications().empty());
+  const application::Application* app = service->active_applications()[0];
+
   return new AppEventExtensionInstance(
-      application_system_->event_manager(), app->data()->ID());
+              application_system_->event_manager(), app->id());
 }
 
 AppEventExtensionInstance::AppEventExtensionInstance(

--- a/application/extension/application_runtime_extension.cc
+++ b/application/extension/application_runtime_extension.cc
@@ -56,9 +56,12 @@ void AppRuntimeExtensionInstance::OnGetManifest(
   base::DictionaryValue* manifest_data = NULL;
   const application::ApplicationService* service =
     application_system_->application_service();
-  const application::Application* app = service->GetActiveApplication();
-  if (app)
+  // FIXME: return corresponding application after shared runtime process
+  // model is enabled.
+  if (!service->active_applications().empty()) {
+    const application::Application* app = service->active_applications()[0];
     manifest_data = app->data()->GetManifest()->value()->DeepCopy();
+  }
 
   scoped_ptr<base::ListValue> results(new base::ListValue());
   if (manifest_data)
@@ -73,8 +76,14 @@ void AppRuntimeExtensionInstance::OnGetMainDocumentID(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
   int main_routing_id = MSG_ROUTING_NONE;
-  const application::Application* application =
-          application_system_->application_service()->GetActiveApplication();
+
+  const application::ApplicationService* service =
+    application_system_->application_service();
+  if (service->active_applications().empty())
+    return;
+  // FIXME: return corresponding application info after shared runtime process
+  // model is enabled.
+  const application::Application* application = service->active_applications()[0];
   const Runtime* runtime = application->GetMainDocumentRuntime();
   if (runtime)
     main_routing_id = runtime->web_contents()->GetRoutingID();

--- a/application/test/application_eventapi_test.cc
+++ b/application/test/application_eventapi_test.cc
@@ -42,9 +42,11 @@ class ApplicationEventApiTest : public ApplicationApiTest {
     xwalk::RuntimeContext* runtime_context = main_runtime->runtime_context();
     xwalk::application::ApplicationSystem* system =
       runtime_context->GetApplicationSystem();
-    DCHECK(system->application_service()->GetActiveApplication());
+    xwalk::application::ApplicationService* service =
+      system->application_service();
+    DCHECK(service->active_applications().size() == 1);
 
-    app_id_ = system->application_service()->GetActiveApplication()->data()->ID();
+    app_id_ = service->active_applications()[0]->id();
     event_manager_ = system->event_manager();
     event_finish_observer_.reset(
         new MockFinishObserver(event_manager_, app_id_));

--- a/application/test/application_main_document_browsertest.cc
+++ b/application/test/application_main_document_browsertest.cc
@@ -39,9 +39,10 @@ IN_PROC_BROWSER_TEST_F(ApplicationMainDocumentBrowserTest, MainDocument) {
   xwalk::RuntimeContext* runtime_context = main_runtime->runtime_context();
   xwalk::application::ApplicationService* service =
     runtime_context->GetApplicationSystem()->application_service();
-  const ApplicationData* app = service->GetActiveApplication()->data();
+  DCHECK(service->active_applications().size() == 1);
+  const ApplicationData* app_data = service->active_applications()[0]->data();
   GURL generated_url =
-    app->GetResourceURL(xwalk::application::kGeneratedMainDocumentFilename);
+    app_data->GetResourceURL(xwalk::application::kGeneratedMainDocumentFilename);
   // Check main document URL.
   ASSERT_EQ(main_runtime->web_contents()->GetURL(), generated_url);
   ASSERT_TRUE(!main_runtime->window());

--- a/experimental/dialog/dialog_extension.cc
+++ b/experimental/dialog/dialog_extension.cc
@@ -129,12 +129,17 @@ void DialogInstance::OnShowSaveDialog(
 gfx::NativeWindow DialogInstance::GetOwningWindow() const {
   // FIXME(cmarcelo): We only support one runtime! (like MenuExtension)
   using namespace application;
-  const Application* running_app =
-        extension_->system_->application_service()->GetActiveApplication();
-  if (!running_app)
+  // FIXME(Mikhail): Should be able to obtain the corresponding app instance.
+  const ScopedVector<Application>& apps =
+        extension_->system_->application_service()->active_applications();
+
+  if (apps.empty())
     return NULL;
 
-  Runtime* runtime = running_app->GetMainDocumentRuntime();
+  Runtime* runtime = apps[0]->GetMainDocumentRuntime();
+  if (!runtime)
+    return NULL;
+
   return runtime->window()->GetNativeWindow();
 }
 


### PR DESCRIPTION
Prepare ApplicationService for managing multiple apps: it stores now scoped_vector of applications.
The ApplicationService interaface was cleaned.
Applcation Observer API was introduced to notify ApplicationService that the app has been closed.
