### PR TITLE
[Extensions] Change when we create the extensions

### DIFF
--- a/application/test/application_apitest.cc
+++ b/application/test/application_apitest.cc
@@ -4,15 +4,14 @@
 
 #include "xwalk/application/test/application_apitest.h"
 
+#include <vector>
 #include "content/public/test/browser_test_utils.h"
 #include "net/base/net_util.h"
 #include "xwalk/application/test/application_browsertest.h"
 #include "xwalk/application/test/application_testapi.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 
-using xwalk::extensions::XWalkExtensionService;
-using xwalk::extensions::XWalkExtensionServer;
+using namespace xwalk::extensions;  // NOLINT
 
 ApplicationApiTest::ApplicationApiTest()
   : test_runner_(new ApiTestRunner()) {
@@ -22,8 +21,8 @@ ApplicationApiTest::~ApplicationApiTest() {
 }
 
 void ApplicationApiTest::SetUp() {
-  XWalkExtensionService::SetRegisterUIThreadExtensionsCallbackForTesting(
-      base::Bind(&ApplicationApiTest::RegisterExtensions,
+  XWalkExtensionService::SetCreateUIThreadExtensionsCallbackForTesting(
+      base::Bind(&ApplicationApiTest::CreateExtensions,
                  base::Unretained(this)));
   ApplicationBrowserTest::SetUp();
 }
@@ -35,12 +34,10 @@ void ApplicationApiTest::SetUpCommandLine(CommandLine* command_line) {
   command_line->AppendArg(url.spec());
 }
 
-void ApplicationApiTest::RegisterExtensions(XWalkExtensionServer* server) {
-  scoped_ptr<ApiTestExtension> extension(new ApiTestExtension);
+void ApplicationApiTest::CreateExtensions(XWalkExtensionVector* extensions) {
+  ApiTestExtension* extension = new ApiTestExtension;
   extension->SetObserver(test_runner_.get());
-  bool registered = server->RegisterExtension(
-      extension.PassAs<XWalkExtension>());
-  ASSERT_TRUE(registered);
+  extensions->push_back(extension);
 }
 
 IN_PROC_BROWSER_TEST_F(ApplicationApiTest, ApiTest) {

--- a/application/test/application_apitest.h
+++ b/application/test/application_apitest.h
@@ -5,16 +5,11 @@
 #ifndef XWALK_APPLICATION_TEST_APPLICATION_APITEST_H_
 #define XWALK_APPLICATION_TEST_APPLICATION_APITEST_H_
 
+#include <vector>
 #include "xwalk/application/test/application_browsertest.h"
+#include "xwalk/extensions/common/xwalk_extension_vector.h"
 
 class ApiTestRunner;
-
-namespace xwalk {
-namespace extensions {
-class XWalkExtensionServer;
-class XWalkExtensionService;
-}
-}
 
 class ApplicationApiTest : public ApplicationBrowserTest {
  public:
@@ -28,7 +23,7 @@ class ApplicationApiTest : public ApplicationBrowserTest {
   scoped_ptr<ApiTestRunner> test_runner_;
 
  private:
-  void RegisterExtensions(xwalk::extensions::XWalkExtensionServer* server);
+  void CreateExtensions(xwalk::extensions::XWalkExtensionVector* extensions);
 };
 
 #endif  // XWALK_APPLICATION_TEST_APPLICATION_APITEST_H_

--- a/extensions/common/xwalk_extension_vector.h
+++ b/extensions/common/xwalk_extension_vector.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_VECTOR_H_
+#define XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_VECTOR_H_
+
+#include <vector>
+
+namespace xwalk {
+namespace extensions {
+
+class XWalkExtension;
+
+typedef std::vector<XWalkExtension*> XWalkExtensionVector;
+
+}  // namespace extensions
+}  // namespace xwalk
+
+#endif  // XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_VECTOR_H_

--- a/extensions/extensions.gypi
+++ b/extensions/extensions.gypi
@@ -16,6 +16,7 @@
     'common/xwalk_extension_server.h',
     'common/xwalk_extension_switches.cc',
     'common/xwalk_extension_switches.h',
+    'common/xwalk_extension_vector.h',
     'common/xwalk_external_adapter.cc',
     'common/xwalk_external_adapter.h',
     'common/xwalk_external_extension.cc',

--- a/extensions/test/conflicting_entry_points.cc
+++ b/extensions/test/conflicting_entry_points.cc
@@ -8,13 +8,10 @@
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionInstance;
-using xwalk::extensions::XWalkExtensionServer;
+using namespace xwalk::extensions;  // NOLINT
 
 namespace {
 
@@ -90,20 +87,20 @@ class ConflictsWithEntryPointExtension
 
 class XWalkExtensionsConflictsWithNameTest : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server, new CleanExtension));
-    ASSERT_FALSE(RegisterExtensionForTest(
-        server, new ConflictsWithNameExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new CleanExtension);
+    extensions->push_back(new ConflictsWithNameExtension);
   }
 };
 
 class XWalkExtensionsConflictsWithEntryPointTest
     : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server, new CleanExtension));
-    ASSERT_FALSE(RegisterExtensionForTest(
-        server, new ConflictsWithEntryPointExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new CleanExtension);
+    extensions->push_back(new ConflictsWithEntryPointExtension);
   }
 };
 

--- a/extensions/test/context_destruction.cc
+++ b/extensions/test/context_destruction.cc
@@ -10,14 +10,11 @@
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/in_process_browser_test.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionInstance;
-using xwalk::extensions::XWalkExtensionServer;
+using namespace xwalk::extensions;  // NOLINT
 
 namespace {
 
@@ -75,8 +72,9 @@ class OnceExtension : public XWalkExtension {
 
 class XWalkExtensionsContextDestructionTest : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server, new OnceExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new OnceExtension);
   }
 
   virtual void TearDown() OVERRIDE {

--- a/extensions/test/export_object.cc
+++ b/extensions/test/export_object.cc
@@ -7,14 +7,11 @@
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/in_process_browser_test.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionInstance;
-using xwalk::extensions::XWalkExtensionServer;
+using namespace xwalk::extensions;  // NOLINT
 
 class TestExportObjectExtensionInstance : public XWalkExtensionInstance {
  public:
@@ -56,11 +53,10 @@ class TestExportCustomObjectExtension : public XWalkExtension {
 
 class XWalkExtensionsExportObjectTest : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server,
-                                         new TestExportObjectExtension));
-    ASSERT_TRUE(RegisterExtensionForTest(server,
-                                         new TestExportCustomObjectExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new TestExportObjectExtension);
+    extensions->push_back(new TestExportCustomObjectExtension);
   }
 };
 

--- a/extensions/test/extension_in_iframe.cc
+++ b/extensions/test/extension_in_iframe.cc
@@ -10,14 +10,11 @@
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/in_process_browser_test.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionInstance;
-using xwalk::extensions::XWalkExtensionServer;
+using namespace xwalk::extensions;  // NOLINT
 
 namespace {
 
@@ -55,8 +52,9 @@ class CounterExtension : public XWalkExtension {
 
 class XWalkExtensionsIFrameTest : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server, new CounterExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new CounterExtension);
   }
 };
 

--- a/extensions/test/external_extension_multi_process.cc
+++ b/extensions/test/external_extension_multi_process.cc
@@ -14,10 +14,10 @@
 #include "content/public/test/test_utils.h"
 
 using xwalk::NativeAppWindow;
-using xwalk::extensions::XWalkExtensionServer;
 using xwalk::Runtime;
 using xwalk::RuntimeList;
 using xwalk::RuntimeRegistry;
+using xwalk::extensions::XWalkExtensionVector;
 
 
 class ExternalExtensionMultiProcessTest : public XWalkExtensionsTestBase {
@@ -61,7 +61,8 @@ class ExternalExtensionMultiProcessTest : public XWalkExtensionsTestBase {
   }
 
   // This will be called everytime a new RenderProcess has been created.
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
     register_extensions_count_++;
   }
 

--- a/extensions/test/in_process_threads_browsertest.cc
+++ b/extensions/test/in_process_threads_browsertest.cc
@@ -5,17 +5,12 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
-#include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/extensions/test/xwalk_extensions_test_base.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionInstance;
-using xwalk::extensions::XWalkExtensionServer;
-using xwalk::extensions::XWalkExtensionService;
+using namespace xwalk::extensions;  // NOLINT
 
 const char kInProcessExtensionThread[] = "in_process_extension_thread";
 const char kInProcessUIThread[] = "in_process_ui_thread";
@@ -70,19 +65,14 @@ class InProcessExtension : public XWalkExtension {
 
 class InProcessThreadsTest : public XWalkExtensionsTestBase {
  public:
-  virtual void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    bool registered = server->RegisterExtension(
-        scoped_ptr<XWalkExtension>(
-            new InProcessExtension(kInProcessUIThread)));
-    ASSERT_TRUE(registered);
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new InProcessExtension(kInProcessUIThread));
   }
 
-  virtual void RegisterExtensionsOnExtensionThread(
-      XWalkExtensionServer* server) OVERRIDE {
-    bool registered = server->RegisterExtension(
-        scoped_ptr<XWalkExtension>(
-            new InProcessExtension(kInProcessExtensionThread)));
-    ASSERT_TRUE(registered);
+  virtual void CreateExtensionsForExtensionThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new InProcessExtension(kInProcessExtensionThread));
   }
 };
 

--- a/extensions/test/internal_extension_browsertest.cc
+++ b/extensions/test/internal_extension_browsertest.cc
@@ -10,7 +10,6 @@
 #include "content/public/test/test_utils.h"
 #include "xwalk/grit/xwalk_extensions_resources.h"
 #include "ui/base/resource/resource_bundle.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/extensions/test/test.h"
 #include "xwalk/extensions/test/xwalk_extensions_test_base.h"
 #include "xwalk/runtime/browser/runtime.h"
@@ -154,8 +153,9 @@ void TestExtensionInstance::DispatchHeartbeat() {
 
 class InternalExtensionTest : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server, new TestExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new TestExtension);
   }
 };
 

--- a/extensions/test/nested_namespace.cc
+++ b/extensions/test/nested_namespace.cc
@@ -7,13 +7,10 @@
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionInstance;
-using xwalk::extensions::XWalkExtensionServer;
+using namespace xwalk::extensions;  // NOLINT
 
 namespace {
 
@@ -91,18 +88,20 @@ class AnotherExtension : public XWalkExtension {
 
 class XWalkExtensionsNestedNamespaceTest : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server, new OuterExtension));
-    ASSERT_TRUE(RegisterExtensionForTest(server, new InnerExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new OuterExtension);
+    extensions->push_back(new InnerExtension);
   }
 };
 
 class XWalkExtensionsTrampolinesForNested : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server, new OuterExtension));
-    ASSERT_TRUE(RegisterExtensionForTest(server, new InnerExtension));
-    ASSERT_TRUE(RegisterExtensionForTest(server, new AnotherExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new OuterExtension);
+    extensions->push_back(new InnerExtension);
+    extensions->push_back(new AnotherExtension);
   }
 };
 

--- a/extensions/test/v8tools_module.cc
+++ b/extensions/test/v8tools_module.cc
@@ -7,14 +7,11 @@
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/in_process_browser_test.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionInstance;
-using xwalk::extensions::XWalkExtensionServer;
+using namespace xwalk::extensions;  // NOLINT
 
 class TestV8ToolsExtensionInstance : public XWalkExtensionInstance {
  public:
@@ -46,8 +43,9 @@ class TestV8ToolsExtension : public XWalkExtension {
 
 class XWalkExtensionsV8ToolsTest : public XWalkExtensionsTestBase {
  public:
-  void RegisterExtensions(XWalkExtensionServer* server) OVERRIDE {
-    ASSERT_TRUE(RegisterExtensionForTest(server, new TestV8ToolsExtension));
+  virtual void CreateExtensionsForUIThread(
+      XWalkExtensionVector* extensions) OVERRIDE {
+    extensions->push_back(new TestV8ToolsExtension);
   }
 };
 

--- a/extensions/test/xwalk_extensions_test_base.cc
+++ b/extensions/test/xwalk_extensions_test_base.cc
@@ -4,28 +4,35 @@
 
 #include "xwalk/extensions/test/xwalk_extensions_test_base.h"
 
+#include <vector>
 #include "base/path_service.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/strings/utf_string_conversions.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "net/base/net_util.h"
 
+using xwalk::extensions::XWalkExtensionVector;
 using xwalk::extensions::XWalkExtensionService;
 
 void XWalkExtensionsTestBase::SetUp() {
-  XWalkExtensionService::SetRegisterUIThreadExtensionsCallbackForTesting(
-      base::Bind(&XWalkExtensionsTestBase::RegisterExtensions,
+  XWalkExtensionService::SetCreateUIThreadExtensionsCallbackForTesting(
+      base::Bind(&XWalkExtensionsTestBase::CreateExtensionsForUIThread,
                  base::Unretained(this)));
-  XWalkExtensionService::SetRegisterExtensionThreadExtensionsCallbackForTesting(
-      base::Bind(&XWalkExtensionsTestBase::RegisterExtensionsOnExtensionThread,
+  XWalkExtensionService::SetCreateExtensionThreadExtensionsCallbackForTesting(
+      base::Bind(&XWalkExtensionsTestBase::CreateExtensionsForExtensionThread,
                  base::Unretained(this)));
   InProcessBrowserTest::SetUp();
 }
+
+void XWalkExtensionsTestBase::CreateExtensionsForUIThread(
+    XWalkExtensionVector* extensions) {}
+
+void XWalkExtensionsTestBase::CreateExtensionsForExtensionThread(
+    XWalkExtensionVector* extensions) {}
 
 GURL GetExtensionsTestURL(const base::FilePath& dir,
                           const base::FilePath& file) {
@@ -49,9 +56,4 @@ base::FilePath GetExternalExtensionTestPath(
                   .Append(FILE_PATH_LITERAL("extension"))
                   .Append(test);
   return extension_dir;
-}
-
-bool RegisterExtensionForTest(xwalk::extensions::XWalkExtensionServer* server,
-                              xwalk::extensions::XWalkExtension* extension) {
-  return server->RegisterExtension(make_scoped_ptr(extension));
 }

--- a/extensions/test/xwalk_extensions_test_base.h
+++ b/extensions/test/xwalk_extensions_test_base.h
@@ -5,23 +5,19 @@
 #ifndef XWALK_EXTENSIONS_TEST_XWALK_EXTENSIONS_TEST_BASE_H_
 #define XWALK_EXTENSIONS_TEST_XWALK_EXTENSIONS_TEST_BASE_H_
 
+#include <vector>
 #include "base/strings/utf_string_conversions.h"
 #include "xwalk/test/base/in_process_browser_test.h"
-
-namespace xwalk {
-namespace extensions {
-class XWalkExtension;
-class XWalkExtensionServer;
-}
-}
+#include "xwalk/extensions/common/xwalk_extension_vector.h"
 
 class XWalkExtensionsTestBase : public InProcessBrowserTest {
  public:
   virtual void SetUp() OVERRIDE;
-  virtual void RegisterExtensions(
-      xwalk::extensions::XWalkExtensionServer* server) {}
-  virtual void RegisterExtensionsOnExtensionThread(
-      xwalk::extensions::XWalkExtensionServer* server) {}
+
+  virtual void CreateExtensionsForUIThread(
+      xwalk::extensions::XWalkExtensionVector* extensions);
+  virtual void CreateExtensionsForExtensionThread(
+      xwalk::extensions::XWalkExtensionVector* extensions);
 };
 
 GURL GetExtensionsTestURL(const base::FilePath& dir,
@@ -29,9 +25,6 @@ GURL GetExtensionsTestURL(const base::FilePath& dir,
 
 base::FilePath GetExternalExtensionTestPath(
     const base::FilePath::CharType test[]);
-
-bool RegisterExtensionForTest(xwalk::extensions::XWalkExtensionServer* server,
-                              xwalk::extensions::XWalkExtension* extension);
 
 const string16 kPassString = ASCIIToUTF16("Pass");
 const string16 kFailString = ASCIIToUTF16("Fail");

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -12,21 +12,23 @@
 #include "content/public/browser/browser_main_parts.h"
 #include "content/public/common/main_function_params.h"
 #include "url/gurl.h"
-#include "xwalk/extensions/browser/xwalk_extension_service.h"
+#include "xwalk/extensions/common/xwalk_extension_vector.h"
+
+namespace content {
+class RenderProcessHost;
+}
 
 namespace xwalk {
-
-namespace extensions {
-class XWalkExtension;
-class XWalkExtensionServer;
-}
 
 class RuntimeContext;
 class RuntimeRegistry;
 class RemoteDebuggingServer;
 
-class XWalkBrowserMainParts : public content::BrowserMainParts,
-    public extensions::XWalkExtensionService::Delegate {
+namespace extensions {
+class XWalkExtensionService;
+}
+
+class XWalkBrowserMainParts : public content::BrowserMainParts {
  public:
   explicit XWalkBrowserMainParts(
       const content::MainFunctionParams& parameters);
@@ -42,11 +44,15 @@ class XWalkBrowserMainParts : public content::BrowserMainParts,
   virtual bool MainMessageLoopRun(int* result_code) OVERRIDE;
   virtual void PostMainMessageLoopRun() OVERRIDE;
 
-  // XWalkExtensionService::Delegate overrides.
-  virtual void RegisterInternalExtensionsInExtensionThreadServer(
-      extensions::XWalkExtensionServer* server) OVERRIDE;
-  virtual void RegisterInternalExtensionsInUIThreadServer(
-      extensions::XWalkExtensionServer* server) OVERRIDE;
+  // Create all the extensions to be hooked into a new
+  // RenderProcessHost. Base class implementation should be called by
+  // subclasses overriding this..
+  virtual void CreateInternalExtensionsForUIThread(
+      content::RenderProcessHost* host,
+      extensions::XWalkExtensionVector* extensions);
+  virtual void CreateInternalExtensionsForExtensionThread(
+      content::RenderProcessHost* host,
+      extensions::XWalkExtensionVector* extensions);
 
 #if defined(OS_ANDROID)
   RuntimeContext* runtime_context() { return runtime_context_.get(); }

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -27,8 +27,8 @@
 #include "ui/base/resource/resource_bundle.h"
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
+#include "xwalk/extensions/common/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/android/cookie_manager.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_registry.h"
@@ -111,7 +111,7 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopRun() {
 
   runtime_context_.reset(new RuntimeContext);
   runtime_registry_.reset(new RuntimeRegistry);
-  extension_service_.reset(new extensions::XWalkExtensionService(this));
+  extension_service_.reset(new extensions::XWalkExtensionService);
 
   // Prepare the cookie store.
   base::FilePath user_data_dir;
@@ -143,18 +143,18 @@ void XWalkBrowserMainPartsAndroid::PostMainMessageLoopRun() {
   base::MessageLoopForUI::current()->Start();
 }
 
-void
-XWalkBrowserMainPartsAndroid::RegisterInternalExtensionsInExtensionThreadServer(
-    extensions::XWalkExtensionServer* server) {
-  CHECK(server);
+void XWalkBrowserMainPartsAndroid::CreateInternalExtensions(
+    content::RenderProcessHost* host,
+    extensions::XWalkExtensionVector* extensions) {
+  // FIXME(cmarcelo): Android port keeps the ownership of extensions
+  // here in the XWalkBrowserMainParts for some reason, this is incorrect use
+  // of extensions system.
   ScopedVector<XWalkExtension>::const_iterator it = extensions_.begin();
   for (; it != extensions_.end(); ++it)
-    server->RegisterExtension(scoped_ptr<XWalkExtension>(*it));
+    extensions->push_back(*it);
 
-  if (XWalkRuntimeFeatures::isRawSocketsAPIEnabled()) {
-    server->RegisterExtension(scoped_ptr<XWalkExtension>(
-        new sysapps::RawSocketExtension()));
-  }
+  if (XWalkRuntimeFeatures::isRawSocketsAPIEnabled())
+    extensions->push_back(new sysapps::RawSocketExtension());
 }
 
 void XWalkBrowserMainPartsAndroid::RegisterExtension(

--- a/runtime/browser/xwalk_browser_main_parts_android.h
+++ b/runtime/browser/xwalk_browser_main_parts_android.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_RUNTIME_BROWSER_XWALK_BROWSER_MAIN_PARTS_ANDROID_H_
 #define XWALK_RUNTIME_BROWSER_XWALK_BROWSER_MAIN_PARTS_ANDROID_H_
 
+#include <vector>
+#include "base/memory/ref_counted.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
 
 namespace net {
@@ -25,8 +27,9 @@ class XWalkBrowserMainPartsAndroid : public XWalkBrowserMainParts {
   virtual void PreMainMessageLoopRun() OVERRIDE;
   virtual void PostMainMessageLoopRun() OVERRIDE;
 
-  virtual void RegisterInternalExtensionsInExtensionThreadServer(
-      extensions::XWalkExtensionServer* server) OVERRIDE;
+  virtual void CreateInternalExtensionsForExtensionThread(
+      content::RenderProcessHost* host,
+      extensions::XWalkExtensionVector* extensions) OVERRIDE;
 
   // XWalkExtensionAndroid needs to register its extensions on
   // XWalkBrowserMainParts so they get correctly registered on-demand

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -8,7 +8,6 @@
 #include "base/files/file_path.h"
 #include "content/public/common/content_switches.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "xwalk/runtime/extension/runtime_extension.h"
 #include "xwalk/sysapps/raw_socket/raw_socket_extension.h"
@@ -59,18 +58,16 @@ void XWalkBrowserMainPartsTizen::PreMainMessageLoopRun() {
   XWalkBrowserMainParts::PreMainMessageLoopRun();
 }
 
-void
-XWalkBrowserMainPartsTizen::RegisterInternalExtensionsInExtensionThreadServer(
-    extensions::XWalkExtensionServer* server) {
-  CHECK(server);
+void XWalkBrowserMainPartsTizen::CreateInternalExtensionsForExtensionThread(
+    content::RenderProcessHost* host,
+    extensions::XWalkExtensionVector* extensions) {
   if (XWalkRuntimeFeatures::isDeviceCapabilitiesAPIEnabled()) {
-    server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(
-        new sysapps::DeviceCapabilitiesExtension(runtime_registry_.get())));
+    extensions->push_back(
+        new sysapps::DeviceCapabilitiesExtension(runtime_registry_.get()));
   }
-  if (XWalkRuntimeFeatures::isRawSocketsAPIEnabled()) {
-    server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(
-        new sysapps::RawSocketExtension()));
-  }
+
+  if (XWalkRuntimeFeatures::isRawSocketsAPIEnabled())
+    extensions->push_back(new sysapps::RawSocketExtension);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts_tizen.h
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.h
@@ -5,7 +5,7 @@
 #ifndef XWALK_RUNTIME_BROWSER_XWALK_BROWSER_MAIN_PARTS_TIZEN_H_
 #define XWALK_RUNTIME_BROWSER_XWALK_BROWSER_MAIN_PARTS_TIZEN_H_
 
-#include <string>
+#include <vector>
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
 
 namespace xwalk {
@@ -19,8 +19,9 @@ class XWalkBrowserMainPartsTizen : public XWalkBrowserMainParts {
   virtual void PreMainMessageLoopStart() OVERRIDE;
   virtual void PreMainMessageLoopRun() OVERRIDE;
 
-  virtual void RegisterInternalExtensionsInExtensionThreadServer(
-      extensions::XWalkExtensionServer* server) OVERRIDE;
+  virtual void CreateInternalExtensionsForExtensionThread(
+      content::RenderProcessHost* host,
+      extensions::XWalkExtensionVector* extensions) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkBrowserMainPartsTizen);

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -136,10 +136,20 @@ XWalkContentBrowserClient::GetWebContentsViewDelegate(
 
 void XWalkContentBrowserClient::RenderProcessHostCreated(
     content::RenderProcessHost* host) {
-  xwalk::extensions::XWalkExtensionService* extension_service =
+  extensions::XWalkExtensionService* extension_service =
       main_parts_->extension_service();
-  if (extension_service)
-    extension_service->OnRenderProcessHostCreated(host);
+  if (extension_service) {
+    std::vector<extensions::XWalkExtension*> ui_thread_extensions;
+    main_parts_->CreateInternalExtensionsForUIThread(
+        host, &ui_thread_extensions);
+
+    std::vector<extensions::XWalkExtension*> extension_thread_extensions;
+    main_parts_->CreateInternalExtensionsForExtensionThread(
+        host, &extension_thread_extensions);
+
+    extension_service->OnRenderProcessHostCreated(
+        host, &ui_thread_extensions, &extension_thread_extensions);
+  }
 }
 
 content::MediaObserver* XWalkContentBrowserClient::GetMediaObserver() {

--- a/sysapps/common/common_api_browsertest.cc
+++ b/sysapps/common/common_api_browsertest.cc
@@ -12,15 +12,12 @@
 #include "net/base/net_util.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/sysapps/common/binding_object.h"
 #include "xwalk/test/base/in_process_browser_test.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionServer;
-using xwalk::extensions::XWalkExtensionService;
+using namespace xwalk::extensions;  // NOLINT
 using xwalk::sysapps::BindingObject;
 
 SysAppsTestExtension::SysAppsTestExtension() {
@@ -160,16 +157,14 @@ void SysAppsTestObject::OnMakeRejectedPromise(
 class SysAppsCommonTest : public InProcessBrowserTest {
  public:
   virtual void SetUp() {
-    XWalkExtensionService::SetRegisterUIThreadExtensionsCallbackForTesting(
-        base::Bind(&SysAppsCommonTest::RegisterExtensions,
+    XWalkExtensionService::SetCreateUIThreadExtensionsCallbackForTesting(
+        base::Bind(&SysAppsCommonTest::CreateExtensions,
                    base::Unretained(this)));
     InProcessBrowserTest::SetUp();
   }
 
-  void RegisterExtensions(XWalkExtensionServer* server) {
-    bool registered = server->RegisterExtension(
-        scoped_ptr<XWalkExtension>(new SysAppsTestExtension()));
-    ASSERT_TRUE(registered);
+  void CreateExtensions(XWalkExtensionVector* extensions) {
+    extensions->push_back(new SysAppsTestExtension);
   }
 };
 

--- a/sysapps/raw_socket/raw_socket_api_browsertest.cc
+++ b/sysapps/raw_socket/raw_socket_api_browsertest.cc
@@ -9,15 +9,11 @@
 #include "net/base/net_util.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/in_process_browser_test.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-using xwalk::extensions::XWalkExtension;
-using xwalk::extensions::XWalkExtensionInstance;
-using xwalk::extensions::XWalkExtensionServer;
-using xwalk::extensions::XWalkExtensionService;
+using namespace xwalk::extensions;  // NOLINT
 
 namespace {
 
@@ -44,16 +40,14 @@ class SysAppsRawSocketTestExtension : public XWalkExtension {
 class SysAppsRawSocketTest : public InProcessBrowserTest {
  public:
   virtual void SetUp() {
-    XWalkExtensionService::SetRegisterUIThreadExtensionsCallbackForTesting(
-        base::Bind(&SysAppsRawSocketTest::RegisterExtensions,
+    XWalkExtensionService::SetCreateUIThreadExtensionsCallbackForTesting(
+        base::Bind(&SysAppsRawSocketTest::CreateExtensions,
                    base::Unretained(this)));
     InProcessBrowserTest::SetUp();
   }
 
-  void RegisterExtensions(XWalkExtensionServer* server) {
-    bool registered = server->RegisterExtension(
-        scoped_ptr<XWalkExtension>(new SysAppsRawSocketTestExtension()));
-    ASSERT_TRUE(registered);
+  void CreateExtensions(XWalkExtensionVector* extensions) {
+    extensions->push_back(new SysAppsRawSocketTestExtension);
   }
 };
 


### PR DESCRIPTION
This patch changes slightly when we create the extensions, instead of
calling XWalkExtensionService::OnRenderProcessHostCreated() and waiting
for the delegate functions to be called, the interface now expects
vectors to be passed with the extensions.

There are three upsides:
- At extension creation time we have the reference to RenderProcessHost,
  allowing us to pass that to the extensions (and in the future pass the
  Application, which will have 1-1 relationship with RPH).
- We don't need to expose the XWalkExtensionServer. A full object
  interface was being included and passed around, just for using one
  function. Exposing less objects gives us more freedom to change things
  in the future.
- We simplify the usage of XWalkExtensionService, by removing the use of
  Delegate for creating the extensions.

There are two downsides, which I consider minor compared to the
benefits:
- It's not clear in the type that ownership is being passed to
  XWalkExtensionService. It is documented and we can add a more clear
  type in the future. For now we can live with this.
- We don't have the information whether the extension was registered
  successfully or not from the tests. However, other later assertions
  assured that the test passed.

The patch is quite big because we changed all the plumbing in the tests.
