### PR TITLE
[Android] Disable 2 extensions for application and application event.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -157,6 +157,17 @@ XWalkBrowserMainPartsAndroid::RegisterInternalExtensionsInExtensionThreadServer(
   }
 }
 
+void XWalkBrowserMainPartsAndroid::RegisterInternalExtensionsInUIThreadServer(
+    extensions::XWalkExtensionServer* server) {
+  // This empty function tries to override the implementation in the class
+  // XWalkBrowserMainParts. It's because application runtime and event related
+  // extensions are not ready for Android port. Need to re-design these 2
+  // mechanisms on Android. Please see JIRA issue:
+  // https://crosswalk-project.org/jira/browse/XWALK-674
+  // TODO(yongsheng): Remove this implementation once above 2 features
+  // are ready for Android.
+}
+
 void XWalkBrowserMainPartsAndroid::RegisterExtension(
     scoped_ptr<XWalkExtension> extension) {
   extensions_.push_back(extension.release());

--- a/runtime/browser/xwalk_browser_main_parts_android.h
+++ b/runtime/browser/xwalk_browser_main_parts_android.h
@@ -28,6 +28,9 @@ class XWalkBrowserMainPartsAndroid : public XWalkBrowserMainParts {
   virtual void RegisterInternalExtensionsInExtensionThreadServer(
       extensions::XWalkExtensionServer* server) OVERRIDE;
 
+  virtual void RegisterInternalExtensionsInUIThreadServer(
+      extensions::XWalkExtensionServer* server) OVERRIDE;
+
   // XWalkExtensionAndroid needs to register its extensions on
   // XWalkBrowserMainParts so they get correctly registered on-demand
   // by XWalkExtensionService each time a in_process Server is created.


### PR DESCRIPTION
Currently these 2 extensions are not supported on Android port.
Disable them since they're not supposed to work because it makes crashes.
Will enable them once Android port starts to fix them.

BUG=https://crosswalk-project.org/jira/browse/XWALK-674
