### PR TITLE
[Runtime] Add CSP parsing handler for manifest.json

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -11,6 +11,7 @@ const char kAppKey[] = "app";
 const char kAppMainKey[] = "app.main";
 const char kAppMainScriptsKey[] = "app.main.scripts";
 const char kAppMainSourceKey[] = "app.main.source";
+const char kCSPKey[] = "content_security_policy";
 const char kDescriptionKey[] = "description";
 const char kLaunchLocalPathKey[] = "app.launch.local_path";
 const char kLaunchWebURLKey[] = "app.launch.web_url";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -12,6 +12,7 @@ namespace application_manifest_keys {
   extern const char kAppMainKey[];
   extern const char kAppMainScriptsKey[];
   extern const char kAppMainSourceKey[];
+  extern const char kCSPKey[];
   extern const char kDescriptionKey[];
   extern const char kLaunchLocalPathKey[];
   extern const char kLaunchWebURLKey[];

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -7,6 +7,7 @@
 #include <set>
 
 #include "base/stl_util.h"
+#include "xwalk/application/common/manifest_handlers/csp_handler.h"
 #include "xwalk/application/common/manifest_handlers/main_document_handler.h"
 #include "xwalk/application/common/manifest_handlers/permissions_handler.h"
 
@@ -55,6 +56,7 @@ ManifestHandlerRegistry* ManifestHandlerRegistry::GetInstance() {
     std::vector<ManifestHandler*> handlers;
     // FIXME: Add manifest handlers here like this:
     // handlers.push_back(new xxxHandler);
+    handlers.push_back(new CSPHandler);
     handlers.push_back(new MainDocumentHandler);
     handlers.push_back(new PermissionsHandler);
 

--- a/application/common/manifest_handlers/csp_handler.cc
+++ b/application/common/manifest_handlers/csp_handler.cc
@@ -1,0 +1,67 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/csp_handler.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "base/strings/string_split.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_manifest_keys;
+
+namespace application {
+
+CSPInfo::CSPInfo() {
+}
+
+CSPInfo::~CSPInfo() {
+}
+
+CSPHandler::CSPHandler() {
+}
+
+CSPHandler::~CSPHandler() {
+}
+
+bool CSPHandler::Parse(scoped_refptr<ApplicationData> application,
+                       string16* error) {
+  scoped_ptr<CSPInfo> csp_info(new CSPInfo);
+  std::string policies_str = "script-src 'self'; object-src 'self'";
+  if (application->GetManifest()->HasKey(keys::kCSPKey) &&
+      !application->GetManifest()->GetString(keys::kCSPKey, &policies_str)) {
+    *error = ASCIIToUTF16("Invalid value of Content Security Policy (CSP).");
+    return false;
+  }
+
+  std::vector<std::string> policies;
+  base::SplitString(policies_str, ';', &policies);
+  for (size_t i = 0; i < policies.size(); ++i) {
+    size_t found = policies[i].find(' ');
+    if (found == std::string::npos) {
+      *error = ASCIIToUTF16("Invalid value of directive: " + policies[i]);
+      return false;
+    }
+    const std::string& directive_name = policies[i].substr(0, found);
+    const std::string& directive_value_str = policies[i].substr(found+1);
+    std::vector<std::string> directive_value;
+    base::SplitStringAlongWhitespace(directive_value_str, &directive_value);
+    csp_info->SetDirective(directive_name, directive_value);
+  }
+  application->SetManifestData(keys::kCSPKey, csp_info.release());
+
+  return true;
+}
+
+bool CSPHandler::AlwaysParseForType(Manifest::Type type) const {
+  return true;
+}
+
+std::vector<std::string> CSPHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kCSPKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/csp_handler.h
+++ b/application/common/manifest_handlers/csp_handler.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_CSP_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_CSP_HANDLER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest_handler.h"
+
+namespace xwalk {
+namespace application {
+
+class CSPInfo : public ApplicationData::ManifestData {
+ public:
+  CSPInfo();
+  virtual ~CSPInfo();
+
+  void SetDirective(const std::string& directive_name,
+                    const std::vector<std::string>& directive_value) {
+    policies_[directive_name] = directive_value;
+  }
+  const std::map<std::string, std::vector<std::string> >&
+      GetDirectives() const { return policies_; }
+
+ private:
+  std::map<std::string, std::vector<std::string> > policies_;
+};
+
+class CSPHandler : public ManifestHandler {
+ public:
+  CSPHandler();
+  virtual ~CSPHandler();
+
+  virtual bool Parse(scoped_refptr<ApplicationData> application,
+                     string16* error) OVERRIDE;
+  virtual bool AlwaysParseForType(Manifest::Type type) const OVERRIDE;
+  virtual std::vector<std::string> Keys() const OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(CSPHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_CSP_HANDLER_H_

--- a/application/common/manifest_handlers/csp_handler_unittest.cc
+++ b/application/common/manifest_handlers/csp_handler_unittest.cc
@@ -1,0 +1,69 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/csp_handler.h"
+
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace xwalk {
+
+namespace keys = application_manifest_keys;
+
+namespace application {
+
+class CSPHandlerTest: public testing::Test {
+ public:
+  virtual void SetUp() OVERRIDE {
+    manifest.SetString(keys::kNameKey, "no name");
+    manifest.SetString(keys::kVersionKey, "0");
+  }
+
+  scoped_refptr<ApplicationData> CreateApplication() {
+    std::string error;
+    scoped_refptr<ApplicationData> application = ApplicationData::Create(
+        base::FilePath(), Manifest::INVALID_TYPE, manifest, "", &error);
+    return application;
+  }
+
+  const CSPInfo* GetCSPInfo(
+      scoped_refptr<ApplicationData> application) {
+    const CSPInfo* info = static_cast<CSPInfo*>(
+        application->GetManifestData(keys::kCSPKey));
+    DCHECK(info);
+    return info;
+  }
+
+  base::DictionaryValue manifest;
+};
+
+TEST_F(CSPHandlerTest, NoCSP) {
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 2);
+}
+
+TEST_F(CSPHandlerTest, EmptyCSP) {
+  manifest.SetString(keys::kCSPKey, "");
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 0);
+}
+
+TEST_F(CSPHandlerTest, CSP) {
+  manifest.SetString(keys::kCSPKey, "default-src    'self'   ");
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  const std::map<std::string, std::vector<std::string> >& policies =
+      GetCSPInfo(application)->GetDirectives();
+  EXPECT_EQ(policies.size(), 1);
+  std::map<std::string, std::vector<std::string> >::const_iterator it =
+      policies.find("default-src");
+  ASSERT_NE(it, policies.end());
+  EXPECT_EQ(it->second.size(), 1);
+  EXPECT_STREQ((it->second)[0].c_str(), "'self'");
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -63,6 +63,8 @@
         'common/manifest.h',
         'common/manifest_handler.cc',
         'common/manifest_handler.h',
+        'common/manifest_handlers/csp_handler.cc',
+        'common/manifest_handlers/csp_handler.h',
         'common/manifest_handlers/main_document_handler.cc',
         'common/manifest_handlers/main_document_handler.h',
         'common/manifest_handlers/permissions_handler.cc',

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -79,6 +79,7 @@
       'application/common/application_file_util_unittest.cc',
       'application/common/application_storage_impl_unittest.cc',
       'application/common/id_util_unittest.cc',
+      'application/common/manifest_handlers/csp_handler_unittest.cc',
       'application/common/manifest_handlers/main_document_handler_unittest.cc',
       'application/common/manifest_handlers/permissions_handler_unittest.cc',
       'application/common/manifest_handler_unittest.cc',


### PR DESCRIPTION
The CSP information will be parsed and stored in ApplicationData so that
other components can use the structured information instead of the raw
data from manifest.json.

The specification can refer to the W3C Content Security Policy 1.0 spec:
https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-1.0-specification.html
