### PR TITLE
[Runtime] Polish application browser test

### DIFF
--- a/application/test/application_apitest.cc
+++ b/application/test/application_apitest.cc
@@ -41,9 +41,6 @@ void ApplicationApiTest::CreateExtensions(XWalkExtensionVector* extensions) {
 }
 
 IN_PROC_BROWSER_TEST_F(ApplicationApiTest, ApiTest) {
-  // Wait for main document and its opened test window ready.
-  WaitForRuntimes(2);
-
-  test_runner_->WaitForTestComplete();
+  test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
 }

--- a/application/test/application_event_test.cc
+++ b/application/test/application_event_test.cc
@@ -19,6 +19,6 @@ class ApplicationEventTest : public ApplicationApiTest {
 };
 
 IN_PROC_BROWSER_TEST_F(ApplicationEventTest, EventTest) {
-  test_runner_->WaitForTestComplete();
+  test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
 }

--- a/application/test/application_eventapi_test.cc
+++ b/application/test/application_eventapi_test.cc
@@ -99,17 +99,14 @@ class ApplicationEventApiTest : public ApplicationApiTest {
 };
 
 IN_PROC_BROWSER_TEST_F(ApplicationEventApiTest, EventApiTest) {
-  test_runner_->WaitForTestComplete();
-  ASSERT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
-
-  PrepareFinishObserver();
-  test_runner_->ResetResult();
-
-  // Send event to test JS listeners and event finish observer.
-  SendEvent();
-  test_runner_->WaitForTestComplete();
+  test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
-  content::RunAllPendingInMessageLoop();
+
+  test_runner_->PostResultToNotificationCallback();
+  PrepareFinishObserver();
+  SendEvent();
+  test_runner_->WaitForTestNotification();
+  EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
   EXPECT_TRUE(EventFinishObserverNotified());
   CloseFinishObserver();
 }

--- a/application/test/application_testapi.js
+++ b/application/test/application_testapi.js
@@ -1,10 +1,55 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 var internal = requireNative("internal");
 internal.setupInternalExtension(extension);
 
+function assert(condition, message) {
+  if (!condition)
+    throw message || "Assertion failed";
+};
+
+// If all tests are not finished before 'maxWaitingTime' milliseconds, then the
+// TIMEOUT notification will be sent.
+function runTests(tests, maxWaitingTime) {
+  var idx = 0;
+  function runTestCase(func) {
+    return new Promise(function(resolve) {
+      func.call(null, resolve);
+      }).then(function() {
+        idx++;
+        if (idx == tests.length) {
+          xwalk.app.test.notifyPass();
+          return;
+        }
+        runTestCase(tests[idx]);
+      }, function(e) {
+        console.error(e);
+        xwalk.app.test.notifyFail(); 
+      });
+  };
+
+  if (typeof(maxWaitingTime) === 'number' && isFinite(maxWaitingTime)) {
+    setTimeout(function() {
+      xwalk.app.test.notifyTimeout();
+      }, maxWaitingTime);
+  }
+
+  runTestCase(tests[idx]);
+};
+
 exports.notifyPass = function(callback) {
   internal.postMessage('notifyPass', [], callback);
-}
+};
 
 exports.notifyFail = function(callback) {
   internal.postMessage('notifyFail', [], callback);
-}
+};
+
+exports.notifyTimeout = function(callback) {
+  internal.postMessage('notifyTimeout', [], callback);
+};
+
+exports.assert = assert;
+exports.runTests = runTests;

--- a/application/test/application_testapi_test.cc
+++ b/application/test/application_testapi_test.cc
@@ -20,14 +20,19 @@ void ApplicationTestApiTest::SetUpCommandLine(CommandLine* command_line) {
 }
 
 IN_PROC_BROWSER_TEST_F(ApplicationTestApiTest, TestApiTest) {
-  // Wait for main document open.
-  WaitForRuntimes(1);
-
-  test_runner_->WaitForTestComplete();
+  test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::FAILURE);
 
-  // We must reset the result before wait again.
-  test_runner_->ResetResult();
-  test_runner_->WaitForTestComplete();
+  test_runner_->PostResultToNotificationCallback();
+  test_runner_->WaitForTestNotification();
+  EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
+
+  test_runner_->PostResultToNotificationCallback();
+  test_runner_->WaitForTestNotification();
+  EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::TIMEOUT);
+
+  // xwalk.app.test.runTest will notify pass when all tests are finished.
+  test_runner_->PostResultToNotificationCallback();
+  test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
 }

--- a/application/test/data/api/test.html
+++ b/application/test/data/api/test.html
@@ -4,56 +4,32 @@
 </head>
 <body>
   <script>
-    function assert(condition, message) {
-      if (!condition)
-        throw message || "Assertion failed";
-    }
+  var assert = xwalk.app.test.assert;
+  var getManifestTest = function(resolve) {
+    xwalk.app.runtime.getManifest(function(manifest) {
+      assert(manifest);
+      assert(manifest.name === "xwalk.app API Test");
+      assert(manifest.version === "1.0");
+      assert(manifest.manifest_version === 1);
+      resolve();
+    });
+  };
 
-    function runTestCase(fn) {
-      try {
-        fn();
-      } catch(e) {
-        console.log(e);
-        console.log(new Error().stack);
-        xwalk.app.test.notifyFail(function(){});
-      }
-    }
+  var getMainDocumentTest = function(resolve) {
+    xwalk.app.runtime.getMainDocument(function(main) {
+      assert(main);
+      assert(main.initialized);
+      resolve();
+    });
+  };
 
-    function runNextTest() {
-      currIdx++;
-      if (currIdx == tests.length) {
-        xwalk.app.test.notifyPass(function(){});
-        return;
-      }
-      tests[currIdx].call();
-    }
+  var tests = [
+    getManifestTest,
+    getMainDocumentTest,
+  ];
 
-    var tests = [
-      function testGetManifest() {
-        xwalk.app.runtime.getManifest(function(manifest) {
-          runTestCase(function() {
-            assert(manifest);
-            assert(manifest.name === "xwalk.app API Test");
-            assert(manifest.version === "1.0");
-            assert(manifest.manifest_version === 1);
-            runNextTest();
-          });
-        });
-      },
-
-      function testGetMainDocument() {
-        xwalk.app.runtime.getMainDocument(function(main) {
-          runTestCase(function() {
-            assert(main);
-            assert(main.initialized);
-            runNextTest();
-          });
-        });
-      }
-    ];
-
-    var currIdx = 0;
-    tests[currIdx].call();
+  // Wait at most 10 seconds, see commen in eventapi/main.js
+  xwalk.app.test.runTests(tests, 10000);
   </script>
 </body>
 </html>

--- a/application/test/data/event/index.html
+++ b/application/test/data/event/index.html
@@ -1,9 +1,0 @@
-<html>
-<body>
-  <script>
-    window.onload = function() {
-      xwalk.app.test.notifyPass();
-    };
-  </script>
-</body>
-</html>

--- a/application/test/data/event/main.js
+++ b/application/test/data/event/main.js
@@ -1,20 +1,10 @@
-function assert(condition, message) {
-  if (!condition)
-    throw message || "Assertion failed";
-};
+var tests = [
+  function(resolve) {
+    xwalk.app.runtime.onLaunched.addListener(function() {
+        resolve();
+    });
+  },
+];
 
-function runTestCase(fn) {
-  try {
-    fn();
-  } catch(e) {
-    console.log(e);
-    console.log(new Error().stack);
-    xwalk.app.test.notifyFail(function(){});
-  }
-};
-
-runTestCase(function() {
-  xwalk.app.runtime.onLaunched.addListener(function() {
-    window.open("index.html");
-  });
-});
+// Wait at most 10 seconds, see commen in eventapi/main.js
+xwalk.app.test.runTests(tests, 10000);

--- a/application/test/data/testapi/main.js
+++ b/application/test/data/testapi/main.js
@@ -1,7 +1,31 @@
-setTimeout(function() {
-  xwalk.app.test.notifyFail(function() {
-    setTimeout(function() {
-      xwalk.app.test.notifyPass(function() {});
-    }, 500);
-  });
-}, 200);
+var notifyFailTest = function(resolve) {
+  setTimeout(function() {
+    xwalk.app.test.notifyFail(function() {
+      resolve();
+    });
+  }, 100);
+};
+
+var notifyPassTest = function(resolve) {
+  setTimeout(function() {
+    xwalk.app.test.notifyPass(function() {
+      resolve();
+    });
+  }, 100);
+};
+
+var notifyTimeoutTest = function(resolve) {
+  setTimeout(function() {
+    xwalk.app.test.notifyTimeout(function() {
+      resolve();
+    });
+  }, 100);
+};
+
+var tests = [
+  notifyFailTest,
+  notifyPassTest,
+  notifyTimeoutTest,
+];
+
+xwalk.app.test.runTests(tests);


### PR DESCRIPTION
1. Make test API extension running on UI thread. And let the client to return
   the xwalk.app.test.notifyPass/Fail callback explicitly when it's ready.
2. Using Promise to provide a common asynchronous test driver. The JS can now
   write code like below to test:

```
  function test1(resolve) { ... } // calls resolve() when test is done

  function test2(resolve) { ... } // calls resolve() when test is done

  var tests = [test1, test2];

  xwalk.app.test.runTests(tests);
```
