### PR TITLE
Fix warnings in Tizen build

### DIFF
--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -133,8 +133,8 @@ class URLRequestApplicationJob : public net::URLRequestFileJob {
       bool is_authority_match)
       : net::URLRequestFileJob(
           request, network_delegate, base::FilePath(), file_task_runner),
-      resource_(application_id, directory_path, relative_path),
       relative_path_(relative_path),
+      resource_(application_id, directory_path, relative_path),
       is_authority_match_(is_authority_match),
       weak_factory_(this) {
   }

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -156,8 +156,8 @@ ApplicationData::ApplicationData(const base::FilePath& path,
                      scoped_ptr<xwalk::application::Manifest> manifest)
     : manifest_version_(0),
       manifest_(manifest.release()),
-      finished_parsing_manifest_(false),
-      is_dirty_(false) {
+      is_dirty_(false),
+      finished_parsing_manifest_(false) {
   DCHECK(path.empty() || path.IsAbsolute());
   path_ = path;
 }

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -153,8 +153,8 @@ void ManifestHandlerRegistry::ReorderHandlersGivenDependencies() {
 
   // If there are any leftover unsorted handlers, they must have had
   // circular dependencies.
-  CHECK_EQ(unsorted_handlers.size(), 0) << "Application manifest handlers have "
-                                        << "circular dependencies!";
+  CHECK(unsorted_handlers.empty()) << "Application manifest handlers have "
+                                   << "circular dependencies!";
 }
 
 }  // namespace application

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.cc
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.cc
@@ -65,11 +65,11 @@ TizenSystemIndicatorWatcher::TizenSystemIndicatorWatcher(TizenSystemIndicator*
                                                          indicator)
   : indicator_(indicator),
     writer_(&fd_),
+    fd_(-1),
     width_(-1),
     height_(-1),
     alpha_(-1),
     updated_(false),
-    fd_(-1),
     weak_ptr_factory_(this) {
   memset(&current_msg_header_, 0, sizeof(current_msg_header_));
   SetSizeFromEnvVar();


### PR DESCRIPTION
Tizen uses an old G++ version, but doesn't hurt keeping its build
warning free when possible.

Three cases of initialization list ordering mismatch and one case of G++
considering taking 0 as a signed literal and concern about comparing
unsigned (size_t) with signed (the literal).
