### PR TITLE
Make the Tizen indicator take the current Display configuration

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -50,12 +50,9 @@ void NativeAppWindowTizen::ViewHierarchyChanged(
     const ViewHierarchyChangedDetails& details) {
   if (details.is_add && details.child == this) {
     NativeAppWindowViews::ViewHierarchyChanged(details);
-    if (indicator_->IsConnected()) {
-      AddChildView(indicator_.get());
-      top_view_layout()->set_top_view(indicator_.get());
-    } else {
-      indicator_.reset();
-    }
+
+    AddChildView(indicator_.get());
+    top_view_layout()->set_top_view(indicator_.get());
   }
 }
 
@@ -103,27 +100,10 @@ gfx::Transform NativeAppWindowTizen::GetRotationTransform() const {
   return rotate;
 }
 
-namespace {
-
-TizenSystemIndicator::Orientation ToOrientation(
-    gfx::Display::Rotation rotation) {
-  switch (rotation) {
-  case gfx::Display::ROTATE_0:
-  case gfx::Display::ROTATE_180:
-    return TizenSystemIndicator::PORTRAIT;
-  default:
-    return TizenSystemIndicator::LANDSCAPE;
-  }
-}
-
-}  // namespace
-
 void NativeAppWindowTizen::ApplyDisplayRotation() {
   aura::Window* root_window = GetNativeWindow()->GetRootWindow();
   root_window->SetTransform(GetRotationTransform());
-
-  if (indicator_)
-    indicator_->SetOrientation(ToOrientation(display_.rotation()));
+  indicator_->SetDisplay(display_);
 }
 
 void NativeAppWindowTizen::OnRotationChanged(

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -21,7 +21,11 @@ class NativeAppWindowTizen : public aura::WindowObserver,
   explicit NativeAppWindowTizen(const NativeAppWindow::CreateParams& params);
   virtual ~NativeAppWindowTizen();
 
+
  private:
+  gfx::Transform GetRotationTransform() const;
+  void ApplyDisplayRotation();
+
   // NativeAppWindowViews overrides:
   virtual void Initialize() OVERRIDE;
 
@@ -35,9 +39,6 @@ class NativeAppWindowTizen : public aura::WindowObserver,
   // views::View overrides:
   virtual void ViewHierarchyChanged(
       const ViewHierarchyChangedDetails& details) OVERRIDE;
-
-  gfx::Transform GetRotationTransform() const;
-  void ApplyDisplayRotation();
 
   // SensorProvider::Observer overrides:
   virtual void OnRotationChanged(gfx::Display::Rotation rotation) OVERRIDE;

--- a/tizen/mobile/ui/tizen_system_indicator.cc
+++ b/tizen/mobile/ui/tizen_system_indicator.cc
@@ -20,20 +20,8 @@ SkColor kBGColor = SkColorSetARGB(255, 52, 52, 50);
 
 namespace xwalk {
 
-TizenSystemIndicator::TizenSystemIndicator()
-    : orientation_(PORTRAIT),
-      watcher_(new TizenSystemIndicatorWatcher(this)) {
-  if (!watcher_->Connect()) {
-    watcher_.reset();
-    return;
-  }
-
+TizenSystemIndicator::TizenSystemIndicator() {
   set_background(views::Background::CreateSolidBackground(kBGColor));
-
-  content::BrowserThread::PostTask(
-      content::BrowserThread::IO, FROM_HERE,
-      base::Bind(&TizenSystemIndicatorWatcher::StartWatching,
-                 base::Unretained(watcher_.get())));
 }
 
 TizenSystemIndicator::~TizenSystemIndicator() {
@@ -126,12 +114,12 @@ void TizenSystemIndicator::OnMouseMoved(const ui::MouseEvent& event) {
   watcher_->OnMouseMove(position.x(), position.y());
 }
 
-void TizenSystemIndicator::SetOrientation(Orientation orientation) {
-  orientation_ = orientation;
+void TizenSystemIndicator::SetDisplay(const gfx::Display& display) {
   SetImage(0);
 
   // TODO(ricardotk): Add overlaying layout and event support to landscape mode.
-  watcher_.reset(new TizenSystemIndicatorWatcher(this));
+  watcher_.reset(new TizenSystemIndicatorWatcher(this, display));
+
   if (!watcher_->Connect()) {
     watcher_.reset();
     return;
@@ -141,10 +129,6 @@ void TizenSystemIndicator::SetOrientation(Orientation orientation) {
       content::BrowserThread::IO, FROM_HERE,
       base::Bind(&TizenSystemIndicatorWatcher::StartWatching,
                  base::Unretained(watcher_.get())));
-}
-
-TizenSystemIndicator::Orientation TizenSystemIndicator::GetOrientation() const {
-  return orientation_;
 }
 
 }  // namespace xwalk

--- a/tizen/mobile/ui/tizen_system_indicator.h
+++ b/tizen/mobile/ui/tizen_system_indicator.h
@@ -5,7 +5,7 @@
 #ifndef XWALK_TIZEN_MOBILE_UI_TIZEN_SYSTEM_INDICATOR_H_
 #define XWALK_TIZEN_MOBILE_UI_TIZEN_SYSTEM_INDICATOR_H_
 
-#include <string>
+#include "ui/gfx/display.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/views/controls/image_view.h"
 
@@ -23,9 +23,8 @@ class TizenSystemIndicator : public views::ImageView {
 
   bool IsConnected() const;
 
-  enum Orientation { LANDSCAPE, PORTRAIT };
-  void SetOrientation(Orientation orientation);
-  Orientation GetOrientation() const;
+  // Apply new display configuration.
+  void SetDisplay(const gfx::Display& display);
 
   // views::View implementation.
   gfx::Size GetPreferredSize() OVERRIDE;
@@ -36,7 +35,6 @@ class TizenSystemIndicator : public views::ImageView {
   virtual void OnMouseMoved(const ui::MouseEvent& event) OVERRIDE;
   virtual void OnTouchEvent(ui::TouchEvent* event) OVERRIDE;
 
-  Orientation orientation_;
   scoped_ptr<TizenSystemIndicatorWatcher> watcher_;
   friend class TizenSystemIndicatorWatcher;
 };

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.cc
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.cc
@@ -61,9 +61,11 @@ enum PlugOperation {
 
 namespace xwalk {
 
-TizenSystemIndicatorWatcher::TizenSystemIndicatorWatcher(TizenSystemIndicator*
-                                                         indicator)
+TizenSystemIndicatorWatcher::TizenSystemIndicatorWatcher(
+    TizenSystemIndicator* indicator,
+    const gfx::Display& display)
   : indicator_(indicator),
+    display_(display),
     writer_(&fd_),
     width_(-1),
     height_(-1),
@@ -74,10 +76,12 @@ TizenSystemIndicatorWatcher::TizenSystemIndicatorWatcher(TizenSystemIndicator*
   memset(&current_msg_header_, 0, sizeof(current_msg_header_));
   SetSizeFromEnvVar();
 
-  if (indicator_->GetOrientation() == TizenSystemIndicator::PORTRAIT)
+  if (display.rotation() == gfx::Display::ROTATE_0 ||
+      display.rotation() == gfx::Display::ROTATE_180) {
     service_name_ = kServicePortrait;
-  else
+  } else {
     service_name_ = kServiceLandscape;
+  }
 }
 
 TizenSystemIndicatorWatcher::~TizenSystemIndicatorWatcher() {}
@@ -494,9 +498,8 @@ void TizenSystemIndicatorWatcher::UpdateIndicatorImage() {
   bitmap.setPixels(shared_memory_->memory());
 
   gfx::ImageSkia img_skia;
-  gfx::Display display = gfx::Screen::GetNativeScreen()->GetPrimaryDisplay();
   img_skia.AddRepresentation(gfx::ImageSkiaRep(bitmap,
-      display.device_scale_factor()));
+      display_.device_scale_factor()));
   indicator_->SetImage(img_skia);
 }
 
@@ -523,8 +526,8 @@ void TizenSystemIndicatorWatcher::SetSizeFromEnvVar() {
 }
 
 void TizenSystemIndicatorWatcher::ResizeIndicator() {
-  indicator_->PreferredSizeChanged();
   UpdateIndicatorImage();
+  indicator_->PreferredSizeChanged();
 }
 
 }  // namespace xwalk

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.h
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.h
@@ -12,6 +12,7 @@
 #include "base/memory/shared_memory.h"
 #include "base/memory/weak_ptr.h"
 #include "base/message_loop/message_pump_libevent.h"
+#include "ui/gfx/display.h"
 #include "ui/gfx/size.h"
 #include "xwalk/tizen/mobile/ui/tizen_system_indicator.h"
 #include "xwalk/tizen/mobile/ui/tizen_plug_message_writer.h"
@@ -25,7 +26,7 @@ class TizenSystemIndicator;
 // TizenSystemIndicator to update its image.
 class TizenSystemIndicatorWatcher : public base::MessagePumpLibevent::Watcher {
  public:
-  explicit TizenSystemIndicatorWatcher(TizenSystemIndicator* indicator);
+  TizenSystemIndicatorWatcher(TizenSystemIndicator* indicator, const gfx::Display& display);
   virtual ~TizenSystemIndicatorWatcher();
 
   // base::MessagePumpLibevent::Watcher implementation.
@@ -58,6 +59,8 @@ class TizenSystemIndicatorWatcher : public base::MessagePumpLibevent::Watcher {
   void ResizeIndicator();
 
   TizenSystemIndicator* indicator_;
+  gfx::Display display_;
+
   TizenPlugMessageWriter writer_;
 
   int fd_;


### PR DESCRIPTION
The Display knows about device scale as well as current orientation.
This avoid passing specific or invalid orientation information

Also do not create a watcher before valid display information is set.

When xwalk is launched in landscape mode, it now has the right
indicator size.
