### PR TITLE
Fix more warnings for Tizen

### DIFF
--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -133,10 +133,10 @@ class URLRequestApplicationJob : public net::URLRequestFileJob {
       bool is_authority_match)
       : net::URLRequestFileJob(
           request, network_delegate, base::FilePath(), file_task_runner),
-      relative_path_(relative_path),
-      resource_(application_id, directory_path, relative_path),
-      is_authority_match_(is_authority_match),
-      weak_factory_(this) {
+        relative_path_(relative_path),
+        is_authority_match_(is_authority_match),
+        resource_(application_id, directory_path, relative_path),
+        weak_factory_(this) {
   }
 
   virtual void GetResponseInfo(net::HttpResponseInfo* info) OVERRIDE {

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -155,8 +155,8 @@ bool ApplicationData::InitApplicationID(xwalk::application::Manifest* manifest,
 ApplicationData::ApplicationData(const base::FilePath& path,
                      scoped_ptr<xwalk::application::Manifest> manifest)
     : manifest_version_(0),
-      manifest_(manifest.release()),
       is_dirty_(false),
+      manifest_(manifest.release()),
       finished_parsing_manifest_(false) {
   DCHECK(path.empty() || path.IsAbsolute());
   path_ = path;


### PR DESCRIPTION
Initialization order complaints from G++ 4.5.
