### PR TITLE
Move background handling to the watcher

### DIFF
--- a/tizen/mobile/ui/tizen_system_indicator.cc
+++ b/tizen/mobile/ui/tizen_system_indicator.cc
@@ -12,16 +12,9 @@
 #include "ui/views/widget/root_view.h"
 #include "ui/aura/root_window.h"
 
-namespace {
-
-SkColor kBGColor = SkColorSetARGB(255, 52, 52, 50);
-
-}  // namespace
-
 namespace xwalk {
 
 TizenSystemIndicator::TizenSystemIndicator() {
-  set_background(views::Background::CreateSolidBackground(kBGColor));
 }
 
 TizenSystemIndicator::~TizenSystemIndicator() {
@@ -115,8 +108,6 @@ void TizenSystemIndicator::OnMouseMoved(const ui::MouseEvent& event) {
 }
 
 void TizenSystemIndicator::SetDisplay(const gfx::Display& display) {
-  SetImage(0);
-
   // TODO(ricardotk): Add overlaying layout and event support to landscape mode.
   watcher_.reset(new TizenSystemIndicatorWatcher(this, display));
 

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.cc
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.cc
@@ -22,6 +22,8 @@ using content::BrowserThread;
 
 namespace {
 
+SkColor kBGColor = SkColorSetARGB(255, 52, 52, 50);
+
 const char kServicePortrait[] = "elm_indicator_portrait";
 const char kServiceLandscape[] = "elm_indicator_landscape";
 const char kServiceNumber[] = "0";
@@ -76,11 +78,19 @@ TizenSystemIndicatorWatcher::TizenSystemIndicatorWatcher(
   memset(&current_msg_header_, 0, sizeof(current_msg_header_));
   SetSizeFromEnvVar();
 
+  indicator_->SetImage(0);
+
   if (display.rotation() == gfx::Display::ROTATE_0 ||
       display.rotation() == gfx::Display::ROTATE_180) {
     service_name_ = kServicePortrait;
+    indicator_->set_background(
+        views::Background::CreateSolidBackground(kBGColor));
   } else {
     service_name_ = kServiceLandscape;
+    // FIXME: We should use NULL here and find out
+    // to draw the indicator on top of the web content
+    indicator_->set_background(
+        views::Background::CreateSolidBackground(SK_ColorWHITE));
   }
 }
 


### PR DESCRIPTION
As the watcher handles the image (landscape vs portrait), it should
also handle the background color.

Show white for now for landscape. In the future it should be transparent
and the indicator should be painted on top of the content in landscape.
