### PR TITLE
Roll chromium to 55fcd09 to fix compile fail.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '31.0.1650.57'
-chromium_crosswalk_point = '4b75b5fa6af4cf8c601c748b75c0176ef7ec175c'
+chromium_crosswalk_point = '55fcd09703d0aeab6ee662ef31dd56e352704438'
 blink_crosswalk_point = '690163cbfa45ca0a5237e79745f342034aabda70'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
Bring in 7 commits:
55fcd09 Fix errata related to multi touch.
137e736 Build fix linux aura without USE_XI2_MT.
6dd5ac8 Revert "[Tizen] Camera driver integration for Tizen"
55fef92 [Backport] Aura: enable the touch events dispatch in DesktopRootWindowHostX11
94f1301 Use XmbSetWMProperties to set window title for i18n issue
7105ed7 [Temp] Add test interface for device motion/orientation.
afe0d86 [Tizen] Camera driver integration for Tizen

BUG=https://crosswalk-project.org/jira/browse/XWALK-689
