### PR TITLE
Add Tizen native view code for handling orientation lock

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -5,6 +5,7 @@
 #ifndef XWALK_RUNTIME_BROWSER_UI_NATIVE_APP_WINDOW_TIZEN_H_
 #define XWALK_RUNTIME_BROWSER_UI_NATIVE_APP_WINDOW_TIZEN_H_
 
+#include "xwalk/runtime/browser/ui/screen_orientation.h"
 #include "xwalk/runtime/browser/ui/native_app_window_views.h"
 #include "xwalk/tizen/mobile/sensor/sensor_provider.h"
 #include "xwalk/tizen/mobile/ui/tizen_system_indicator.h"
@@ -14,9 +15,11 @@ namespace xwalk {
 
 // Tizen uses the Views native window but adds its own features like orientation
 // handling and integration with system indicator bar.
-class NativeAppWindowTizen : public aura::WindowObserver,
-                             public NativeAppWindowViews,
-                             public SensorProvider::Observer {
+class NativeAppWindowTizen
+    : public aura::WindowObserver,
+      public NativeAppWindowViews,
+      public SensorProvider::Observer,
+      public ScreenOrientationAPISupplement {
  public:
   explicit NativeAppWindowTizen(const NativeAppWindow::CreateParams& params);
   virtual ~NativeAppWindowTizen();
@@ -43,8 +46,17 @@ class NativeAppWindowTizen : public aura::WindowObserver,
   // SensorProvider::Observer overrides:
   virtual void OnRotationChanged(gfx::Display::Rotation rotation) OVERRIDE;
 
+  // ScreenOrientationAPISupplement overrides:
+  virtual OrientationMask GetAllowedUAOrientations() const OVERRIDE;
+  virtual void OnAllowedOrientationsChanged(
+      OrientationMask orientations) OVERRIDE;
+
+  gfx::Display::Rotation GetClosestAllowedRotation(
+      gfx::Display::Rotation) const;
+
   scoped_ptr<TizenSystemIndicator> indicator_;
   gfx::Display display_;
+  OrientationMask allowed_orientations_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeAppWindowTizen);
 };

--- a/runtime/browser/ui/screen_orientation.h
+++ b/runtime/browser/ui/screen_orientation.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_SCREEN_ORIENTATION_H_
+#define XWALK_RUNTIME_BROWSER_UI_SCREEN_ORIENTATION_H_
+
+namespace xwalk {
+
+enum Orientation {
+// These are ordered as they appear clockwise.
+PORTRAIT_PRIMARY    = 1 << 0,
+LANDSCAPE_PRIMARY   = 1 << 1,
+PORTRAIT_SECONDARY  = 1 << 2,
+LANDSCAPE_SECONDARY = 1 << 3,
+
+// Combinations
+PORTRAIT            = PORTRAIT_PRIMARY | PORTRAIT_SECONDARY,
+LANDSCAPE           = LANDSCAPE_PRIMARY | LANDSCAPE_SECONDARY,
+ANY                 = PORTRAIT | LANDSCAPE
+};
+
+typedef unsigned OrientationMask;
+
+class ScreenOrientationAPISupplement {
+ public:
+  virtual ~ScreenOrientationAPISupplement() {}
+  virtual OrientationMask GetAllowedUAOrientations() const = 0;
+  virtual void OnAllowedOrientationsChanged(OrientationMask orientations) = 0;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_SCREEN_ORIENTATION_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -175,6 +175,7 @@
             'runtime/browser/geolocation/tizen/location_provider_tizen.h',
             'runtime/browser/ui/native_app_window_tizen.cc',
             'runtime/browser/ui/native_app_window_tizen.h',
+            'runtime/browser/ui/screen_orientation.h',
             'runtime/browser/xwalk_browser_main_parts_tizen.cc',
             'runtime/browser/xwalk_browser_main_parts_tizen.h',
             'runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc',


### PR DESCRIPTION
Allow setting the system allowed orientations using an environment
variable TIZEN_ALLOWED_ORIENTATIONS. This is useful for testing.
