### PR TITLE
[Runtime] Add install_time field in ApplicationData

### DIFF
--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -18,6 +18,7 @@
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/synchronization/lock.h"
+#include "base/time/time.h"
 #include "base/threading/thread_checker.h"
 #include "xwalk/application/common/manifest.h"
 #include "xwalk/application/common/install_warning.h"
@@ -113,6 +114,8 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   bool IsDirty() const { return is_dirty_; }
 
+  const base::Time& install_time() const { return install_time_; }
+
   // App-related.
   bool IsPlatformApp() const;
   bool IsHostedApp() const;
@@ -190,6 +193,8 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   // Set to true at the end of InitValue when initialization is finished.
   bool finished_parsing_manifest_;
+
+  base::Time install_time_;
 
   // Ensures that any call to GetManifestData() prior to finishing
   // initialization happens from the same thread (this can happen when certain

--- a/application/common/application_storage_impl.cc
+++ b/application/common/application_storage_impl.cc
@@ -223,6 +223,8 @@ bool ApplicationStorageImpl::GetInstalledApplications(
       return false;
     }
 
+    application->install_time_ = base::Time::FromDoubleT(install_time);
+
     if (!events.empty()) {
       application->events_ =
           std::set<std::string>(events.begin(), events.end());


### PR DESCRIPTION
The time of application installing should be stored in ApplicationData
as application meta data. It is a constant, so just have a getter method
for it.
