### PR TITLE
[Runtime] Fix application extension registration issue

### DIFF
--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -12,6 +12,8 @@
 #include "xwalk/application/browser/application_process_manager.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/common/event_names.h"
+#include "xwalk/application/extension/application_event_extension.h"
+#include "xwalk/application/extension/application_runtime_extension.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 
@@ -150,6 +152,18 @@ void ApplicationSystem::SendOnLaunchedEvent() {
 
 bool ApplicationSystem::IsRunningAsService() const {
   return false;
+}
+
+void ApplicationSystem::CreateExtensions(
+    content::RenderProcessHost* host,
+    extensions::XWalkExtensionVector* extensions) {
+  // FIXME(xiang): When service mode is enabled, we need to check whether the
+  // RPH belongs to an active application.
+  if (!application_service_->GetRunningApplication())
+    return;
+
+  extensions->push_back(new ApplicationRuntimeExtension(this));
+  extensions->push_back(new ApplicationEventExtension(this));
 }
 
 }  // namespace application

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -9,9 +9,14 @@
 
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_ptr.h"
+#include "xwalk/extensions/common/xwalk_extension_vector.h"
 
 class CommandLine;
 class GURL;
+
+namespace content {
+class RenderProcessHost;
+}
 
 namespace xwalk {
 class RuntimeContext;
@@ -79,6 +84,9 @@ class ApplicationSystem {
   // Return true if the application system is running in service mode,
   // i.e. taking requests from native IPC mechanism to launch applications.
   virtual bool IsRunningAsService() const;
+
+  void CreateExtensions(content::RenderProcessHost* host,
+                        extensions::XWalkExtensionVector* extensions);
 
  protected:
   explicit ApplicationSystem(RuntimeContext* runtime_context);

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -14,8 +14,6 @@
 #include "base/strings/string_number_conversions.h"
 #include "xwalk/application/browser/application_process_manager.h"
 #include "xwalk/application/browser/application_system.h"
-#include "xwalk/application/extension/application_event_extension.h"
-#include "xwalk/application/extension/application_runtime_extension.h"
 #include "xwalk/experimental/dialog/dialog_extension.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
@@ -233,13 +231,7 @@ void XWalkBrowserMainParts::PostMainMessageLoopRun() {
 void XWalkBrowserMainParts::CreateInternalExtensionsForUIThread(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
-  application::ApplicationSystem* app_system
-      = runtime_context_->GetApplicationSystem();
-  extensions->push_back(
-      new application::ApplicationRuntimeExtension(app_system));
-  extensions->push_back(
-      new application::ApplicationEventExtension(app_system));
-
+  runtime_context_->GetApplicationSystem()->CreateExtensions(host, extensions);
   sysapps_manager_->CreateExtensionsForUIThread(extensions);
 }
 


### PR DESCRIPTION
ISSUE: https://crosswalk-project.org/jira/browse/XWALK-691

When launched as an external web browser, the application extension instance will be created and trigger "CHECK(application)" assertion failure if xwalk.app.\* APIs are called.

To fix this, now we only create the application extensions after check whether we have a currently running application in ApplicationService.
