### PR TITLE
Fix browser tests regressions

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -174,23 +174,20 @@ Application* ApplicationService::Launch(const std::string& id) {
           app_storage_->GetApplicationData(id);
   if (!application_data) {
     LOG(ERROR) << "Application with id " << id << " haven't installed.";
-    return false;
+    return NULL;
   }
 
   return Launch(application_data);
 }
 
 Application* ApplicationService::Launch(const base::FilePath& path) {
-  if (!base::DirectoryExists(path))
-    return false;
-
   std::string error;
   scoped_refptr<const ApplicationData> application_data =
       LoadApplication(path, Manifest::COMMAND_LINE, &error);
 
   if (!application_data) {
     LOG(ERROR) << "Error during launch application: " << error;
-    return false;
+    return NULL;
   }
 
   return Launch(application_data);
@@ -218,14 +215,15 @@ Application* ApplicationService::Launch(
   ApplicationEventManager* event_manager = system->event_manager();
   event_manager->OnAppLoaded(application_data->ID());
 
-  scoped_ptr<Application> application(new Application(application_data,
-                                                      runtime_context_, this));
-
-  if (!application->Launch())
-    return NULL;
-
-  applications_.push_back(application.release());
-  return applications_.back();
+  Application* application = new Application(application_data,
+                                             runtime_context_, this);
+  applications_.push_back(application);
+  if (!application->Launch()) {
+    applications_.get().pop_back();
+    delete application;
+    application = NULL;
+  }
+  return application;
 }
 
 }  // namespace application

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -138,7 +138,7 @@ bool ApplicationSystem::LaunchFromCommandLine(
 
   // Handles local directory.
   base::FilePath path;
-  if (net::FileURLToFilePath(url, &path)) {
+  if (net::FileURLToFilePath(url, &path) && base::DirectoryExists(path)) {
     *run_default_message_loop = LaunchFromCommandLineParam(path);
     return true;
   }

--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -45,6 +45,7 @@ scoped_refptr<ApplicationData> LoadApplication(
     const std::string& application_id,
     Manifest::SourceType source_type,
     std::string* error) {
+  DCHECK(base::DirectoryExists(application_path));
   scoped_ptr<DictionaryValue> manifest(LoadManifest(application_path, error));
   if (!manifest.get())
     return NULL;

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -82,9 +82,10 @@ Runtime::Runtime(content::WebContents* web_contents, Observer* observer)
        xwalk::NOTIFICATION_RUNTIME_OPENED,
        content::Source<Runtime>(this),
        content::NotificationService::NoDetails());
-
-  if (GetObserver())
-    GetObserver()->OnRuntimeAdded(this);
+  if (observer_)
+    observer_->OnRuntimeAdded(this);
+  if (g_observer_for_testing)
+    g_observer_for_testing->OnRuntimeAdded(this);
 }
 
 Runtime::~Runtime() {
@@ -92,8 +93,11 @@ Runtime::~Runtime() {
           xwalk::NOTIFICATION_RUNTIME_CLOSED,
           content::Source<Runtime>(this),
           content::NotificationService::NoDetails());
-  if (GetObserver())
-    GetObserver()->OnRuntimeRemoved(this);
+
+  if (observer_)
+    observer_->OnRuntimeRemoved(this);
+  if (g_observer_for_testing)
+    g_observer_for_testing->OnRuntimeRemoved(this);
 }
 
 void Runtime::AttachDefaultWindow() {
@@ -225,7 +229,7 @@ void Runtime::WebContentsCreated(
     const string16& frame_name,
     const GURL& target_url,
     content::WebContents* new_contents) {
-  Runtime* new_runtime = new Runtime(new_contents, GetObserver());
+  Runtime* new_runtime = new Runtime(new_contents, observer_);
   new_runtime->AttachDefaultWindow();
 }
 
@@ -323,12 +327,6 @@ void Runtime::Observe(int type,
 
 void Runtime::OnWindowDestroyed() {
   Close();
-}
-
-inline Runtime::Observer* Runtime::GetObserver() const {
-  if (g_observer_for_testing)
-    return g_observer_for_testing;
-  return observer_;
 }
 
 void Runtime::RequestMediaAccessPermission(

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -50,8 +50,6 @@ class Runtime : public content::WebContentsDelegate,
       ~Observer() {}
   };
 
-  void SetObserver(Observer* observer) { observer_ = observer; }
-
   // Create a new Runtime instance with the given browsing context.
   static Runtime* Create(RuntimeContext*, const GURL&, Observer* = NULL);
   // Create a new Runtime instance which binds to a default app window.
@@ -141,8 +139,6 @@ class Runtime : public content::WebContentsDelegate,
 
   // NativeAppWindowDelegate implementation.
   virtual void OnWindowDestroyed() OVERRIDE;
-
-  Observer* GetObserver() const;
 
   // The browsing context.
   xwalk::RuntimeContext* runtime_context_;

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -176,13 +176,11 @@ net::URLRequestContextGetter* RuntimeContext::CreateRequestContext(
 
   // FIXME : this is called only once, what do we do when an app is terminated
   // or a new app is launched?
-  for (ScopedVector<Application>::const_iterator it =
-       service->active_applications().begin();
-       it != service->active_applications().end(); ++it) {
+  if (!service->active_applications().empty()) {
     protocol_handlers->insert(std::pair<std::string,
         linked_ptr<net::URLRequestJobFactory::ProtocolHandler> >(
           application::kApplicationScheme,
-          CreateApplicationProtocolHandler(*it)));
+          CreateApplicationProtocolHandler(service->active_applications()[0])));
   }
 
   url_request_getter_ = new RuntimeURLRequestContextGetter(


### PR DESCRIPTION
1) An application should be present in "active applications" list even before it is launched, otherwise a protocol handler won't be registered for it
2) We should make sure that applications can be launched only from local directory URLs (not local file URLs)
