### PR TITLE
[Runtime] Move application runtime& event extension under xwalk::application namespace.

### DIFF
--- a/application/extension/application_event_extension.cc
+++ b/application/extension/application_event_extension.cc
@@ -21,11 +21,10 @@
 #include "xwalk/runtime/browser/runtime.h"
 
 namespace xwalk {
-
-using application::Event;
+namespace application {
 
 ApplicationEventExtension::ApplicationEventExtension(
-    application::ApplicationSystem* system)
+    ApplicationSystem* system)
   : application_system_(system) {
   set_name("xwalk.app.events");
   set_javascript_api(ResourceBundle::GetSharedInstance().GetRawDataResource(
@@ -33,19 +32,17 @@ ApplicationEventExtension::ApplicationEventExtension(
 }
 
 XWalkExtensionInstance* ApplicationEventExtension::CreateInstance() {
-  application::ApplicationService* service =
-    application_system_->application_service();
+  ApplicationService* service = application_system_->application_service();
 
   int main_routing_id = MSG_ROUTING_NONE;
-  application::ApplicationProcessManager* pm =
-      application_system_->process_manager();
+  ApplicationProcessManager* pm = application_system_->process_manager();
   const Runtime* runtime = pm->GetMainDocumentRuntime();
   if (runtime)
     main_routing_id = runtime->web_contents()->GetRoutingID();
 
   // FIXME: return corresponding application info after shared runtime process
   // model is enabled.
-  const application::ApplicationData* app = service->GetRunningApplication();
+  const ApplicationData* app = service->GetRunningApplication();
   CHECK(app);
   return new AppEventExtensionInstance(
       application_system_,
@@ -53,10 +50,10 @@ XWalkExtensionInstance* ApplicationEventExtension::CreateInstance() {
 }
 
 AppEventExtensionInstance::AppEventExtensionInstance(
-    application::ApplicationSystem* system,
+    ApplicationSystem* system,
     const std::string& app_id,
     int main_routing_id)
-  : application::EventObserver(system ? system->event_manager(): NULL),
+  : EventObserver(system ? system->event_manager(): NULL),
     app_system_(system),
     app_id_(app_id),
     main_routing_id_(main_routing_id),
@@ -99,11 +96,9 @@ void AppEventExtensionInstance::OnRegisterEvent(
       return;
 
     // If the event is from main document, add it into system database.
-    application::ApplicationService* service =
-        app_system_->application_service();
-    application::ApplicationStorage* app_store =
-        service->application_storage();
-    scoped_refptr<application::ApplicationData> app_data =
+    ApplicationService* service = app_system_->application_service();
+    ApplicationStorage* app_store = service->application_storage();
+    scoped_refptr<ApplicationData> app_data =
         service->GetApplicationByID(app_id_);
     if (!app_data)
       return;
@@ -134,12 +129,10 @@ void AppEventExtensionInstance::OnUnregisterEvent(
 
   // If the event is from main document, remove it from system database.
   if (routing_id == main_routing_id_) {
-    application::ApplicationService* service =
-        app_system_->application_service();
-    scoped_refptr<application::ApplicationData> app_data =
+    ApplicationService* service = app_system_->application_service();
+    ApplicationStorage* app_store = service->application_storage();
+    scoped_refptr<ApplicationData> app_data =
         service->GetApplicationByID(app_id_);
-    application::ApplicationStorage* app_store =
-        service->application_storage();
     if (!app_data)
       return;
 
@@ -162,12 +155,12 @@ void AppEventExtensionInstance::OnDispatchEventFinish(
   scoped_ptr<base::ListValue> args(new base::ListValue());
   args->AppendString(event_name);
   scoped_refptr<Event> event = Event::CreateEvent(
-      application::kOnJavaScriptEventAck, args.Pass());
+      kOnJavaScriptEventAck, args.Pass());
   event_manager_->SendEvent(app_id_, event);
 }
 
 void AppEventExtensionInstance::Observe(
-    const std::string& app_id, scoped_refptr<application::Event> event) {
+    const std::string& app_id, scoped_refptr<Event> event) {
   DCHECK(app_id_ == app_id);
   EventCallbackMap::iterator it = registered_events_.find(event->name());
   if (it == registered_events_.end())
@@ -178,4 +171,5 @@ void AppEventExtensionInstance::Observe(
   it->second.Run(args.Pass());
 }
 
+}  // namespace application
 }  // namespace xwalk

--- a/application/extension/application_event_extension.h
+++ b/application/extension/application_event_extension.h
@@ -13,11 +13,9 @@
 #include "xwalk/extensions/common/xwalk_extension.h"
 
 namespace xwalk {
-
 namespace application {
 class ApplicationEventManager;
 class ApplicationSystem;
-}
 
 class AppEventExtensionInstance;
 
@@ -28,19 +26,19 @@ using extensions::XWalkExtensionInstance;
 
 class ApplicationEventExtension : public XWalkExtension {
  public:
-  explicit ApplicationEventExtension(application::ApplicationSystem* system);
+  explicit ApplicationEventExtension(ApplicationSystem* system);
 
   // XWalkExtension implementation.
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
  private:
-  application::ApplicationSystem* application_system_;
+  ApplicationSystem* application_system_;
 };
 
 class AppEventExtensionInstance : public XWalkExtensionInstance,
-                                  public application::EventObserver {
+                                  public EventObserver {
  public:
-  AppEventExtensionInstance(application::ApplicationSystem* app_system,
+  AppEventExtensionInstance(ApplicationSystem* app_system,
                             const std::string& app_id,
                             int main_routing_id);
 
@@ -50,7 +48,7 @@ class AppEventExtensionInstance : public XWalkExtensionInstance,
 
   // EventObserver implementation.
   virtual void Observe(const std::string& app_id,
-                       scoped_refptr<application::Event> event) OVERRIDE;
+                       scoped_refptr<Event> event) OVERRIDE;
 
  private:
   // Registered handlers for incoming JS messages.
@@ -61,13 +59,14 @@ class AppEventExtensionInstance : public XWalkExtensionInstance,
   typedef std::map<std::string, XWalkExtensionFunctionInfo::PostResultCallback>
       EventCallbackMap;
   EventCallbackMap registered_events_;
-  application::ApplicationSystem* app_system_;
+  ApplicationSystem* app_system_;
   std::string app_id_;
   int main_routing_id_;  // routing id of the main document.
 
   XWalkExtensionFunctionHandler handler_;
 };
 
+}  // namespace application
 }  // namespace xwalk
 
 #endif  // XWALK_APPLICATION_EXTENSION_APPLICATION_EVENT_EXTENSION_H_

--- a/application/extension/application_runtime_extension.cc
+++ b/application/extension/application_runtime_extension.cc
@@ -19,9 +19,10 @@
 using content::BrowserThread;
 
 namespace xwalk {
+namespace application {
 
 ApplicationRuntimeExtension::ApplicationRuntimeExtension(
-    application::ApplicationSystem* application_system)
+    ApplicationSystem* application_system)
   : application_system_(application_system) {
   set_name("xwalk.app.runtime");
   set_javascript_api(ResourceBundle::GetSharedInstance().GetRawDataResource(
@@ -33,7 +34,7 @@ XWalkExtensionInstance* ApplicationRuntimeExtension::CreateInstance() {
 }
 
 AppRuntimeExtensionInstance::AppRuntimeExtensionInstance(
-    application::ApplicationSystem* application_system)
+    ApplicationSystem* application_system)
   : application_system_(application_system),
     handler_(this) {
   handler_.Register(
@@ -54,9 +55,9 @@ void AppRuntimeExtensionInstance::OnGetManifest(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
   base::DictionaryValue* manifest_data = NULL;
-  const application::ApplicationService* service =
+  const ApplicationService* service =
     application_system_->application_service();
-  const application::ApplicationData* app = service->GetRunningApplication();
+  const ApplicationData* app = service->GetRunningApplication();
   if (app)
     manifest_data = app->GetManifest()->value()->DeepCopy();
 
@@ -73,7 +74,7 @@ void AppRuntimeExtensionInstance::OnGetMainDocumentID(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
   int main_routing_id = MSG_ROUTING_NONE;
-  const application::ApplicationProcessManager* pm =
+  const ApplicationProcessManager* pm =
     application_system_->process_manager();
   const Runtime* runtime = pm->GetMainDocumentRuntime();
   if (runtime)
@@ -84,4 +85,5 @@ void AppRuntimeExtensionInstance::OnGetMainDocumentID(
   info->PostResult(results.Pass());
 }
 
+}  // namespace application
 }  // namespace xwalk

--- a/application/extension/application_runtime_extension.h
+++ b/application/extension/application_runtime_extension.h
@@ -11,10 +11,8 @@
 #include "xwalk/extensions/common/xwalk_extension.h"
 
 namespace xwalk {
-
 namespace application {
 class ApplicationSystem;
-}
 
 using extensions::XWalkExtension;
 using extensions::XWalkExtensionFunctionHandler;
@@ -24,19 +22,19 @@ using extensions::XWalkExtensionInstance;
 class ApplicationRuntimeExtension : public XWalkExtension {
  public:
   explicit ApplicationRuntimeExtension(
-      application::ApplicationSystem* application_system);
+      ApplicationSystem* application_system);
 
   // XWalkExtension implementation.
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
  private:
-  application::ApplicationSystem* application_system_;
+  ApplicationSystem* application_system_;
 };
 
 class AppRuntimeExtensionInstance : public XWalkExtensionInstance {
  public:
   explicit AppRuntimeExtensionInstance(
-      application::ApplicationSystem* application_system);
+      ApplicationSystem* application_system);
 
   virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
 
@@ -44,11 +42,12 @@ class AppRuntimeExtensionInstance : public XWalkExtensionInstance {
   void OnGetMainDocumentID(scoped_ptr<XWalkExtensionFunctionInfo> info);
   void OnGetManifest(scoped_ptr<XWalkExtensionFunctionInfo> info);
 
-  application::ApplicationSystem* application_system_;
+  ApplicationSystem* application_system_;
 
   XWalkExtensionFunctionHandler handler_;
 };
 
+}  // namespace application
 }  // namespace xwalk
 
 #endif  // XWALK_APPLICATION_EXTENSION_APPLICATION_RUNTIME_EXTENSION_H_

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -232,8 +232,10 @@ void XWalkBrowserMainParts::CreateInternalExtensionsForUIThread(
     extensions::XWalkExtensionVector* extensions) {
   application::ApplicationSystem* app_system
       = runtime_context_->GetApplicationSystem();
-  extensions->push_back(new ApplicationRuntimeExtension(app_system));
-  extensions->push_back(new ApplicationEventExtension(app_system));
+  extensions->push_back(
+      new application::ApplicationRuntimeExtension(app_system));
+  extensions->push_back(
+      new application::ApplicationEventExtension(app_system));
 
   sysapps_manager_->CreateExtensionsForUIThread(extensions);
 }


### PR DESCRIPTION
Present ApplicationEventExtension & ApplicationRuntimeExtension are
located inside namespace "xwalk". Actually they are parts of
"application module". This PR moves the two inside namespace
"xwalk::application".
