### PR TITLE
Application extensions support multiple WEB apps

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -38,7 +38,7 @@ class Application : public Runtime::Observer {
     ~Observer() {}
   };
 
-  Application(scoped_refptr<const ApplicationData> data,
+  Application(scoped_refptr<ApplicationData> data,
               RuntimeContext* context, Observer* observer);
   virtual ~Application();
 
@@ -46,13 +46,15 @@ class Application : public Runtime::Observer {
   bool is_active() const { return !runtimes_.empty(); }
   void Close();
 
+  bool HasMainDocument() const { return application_data_->HasMainDocument(); }
   std::string id() const { return application_data_->ID(); }
 
-  Runtime* GetMainDocumentRuntime() const { return main_runtime_; }
+  Runtime* GetMainDocumentRuntime() const;
 
   int GetRenderProcessHostID() const;
 
   const ApplicationData* data() const { return application_data_; }
+  ApplicationData* data() { return application_data_; }
 
  protected:
   // Runtime::Observer implementation.
@@ -67,9 +69,8 @@ class Application : public Runtime::Observer {
   bool IsOnSuspendHandlerRegistered(const std::string& app_id) const;
 
   RuntimeContext* runtime_context_;
-  scoped_refptr<const ApplicationData> application_data_;
+  scoped_refptr<ApplicationData> application_data_;
   Runtime* main_runtime_;
-  int render_process_host_id_;
   std::set<Runtime*> runtimes_;
   scoped_ptr<EventObserver> finish_observer_;
   Observer* observer_;

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -45,6 +45,8 @@ class ApplicationService : public Application::Observer {
   Application* Launch(const std::string& id);
   Application* Launch(const base::FilePath& path);
 
+  Application* GetApplicationByRenderHostID(int id) const;
+
   const ScopedVector<Application>& active_applications() const {
       return applications_; }
 
@@ -55,7 +57,7 @@ class ApplicationService : public Application::Observer {
   // Implementation of Application::Observer
   virtual void OnApplicationTerminated(Application*) OVERRIDE;
 
-  Application* Launch(scoped_refptr<const ApplicationData> application_data);
+  Application* Launch(scoped_refptr<ApplicationData> application_data);
 
   xwalk::RuntimeContext* runtime_context_;
   ApplicationStorage* app_storage_;

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -7,12 +7,15 @@
 #include <string>
 #include "base/command_line.h"
 #include "base/file_util.h"
+#include "content/public/browser/render_process_host.h"
 #include "net/base/net_util.h"
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_event_manager.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_storage.h"
 #include "xwalk/application/common/event_names.h"
+#include "xwalk/application/extension/application_event_extension.h"
+#include "xwalk/application/extension/application_runtime_extension.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 
@@ -154,6 +157,19 @@ bool ApplicationSystem::LaunchFromCommandLine(
 
 bool ApplicationSystem::IsRunningAsService() const {
   return false;
+}
+
+void ApplicationSystem::CreateApplicationExtensions(content::RenderProcessHost* host,
+                                                    extensions::XWalkExtensionVector* extensions) const {
+  Application* application = application_service_->GetApplicationByRenderHostID(host->GetID());
+  if (!application) {
+    return; // We might be in browser mode.
+  }
+
+  extensions->push_back(new ApplicationRuntimeExtension(application));
+  extensions->push_back(new ApplicationEventExtension(
+                        event_manager_.get(), app_storage_.get(), application));
+
 }
 
 }  // namespace application

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -9,9 +9,14 @@
 
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_ptr.h"
+#include "xwalk/extensions/common/xwalk_extension_vector.h"
 
 class CommandLine;
 class GURL;
+
+namespace content {
+class RenderProcessHost;
+}
 
 namespace xwalk {
 class RuntimeContext;
@@ -78,6 +83,9 @@ class ApplicationSystem {
   // Return true if the application system is running in service mode,
   // i.e. taking requests from native IPC mechanism to launch applications.
   virtual bool IsRunningAsService() const;
+
+  virtual void CreateApplicationExtensions(content::RenderProcessHost* host,
+                                           extensions::XWalkExtensionVector* extensions) const;
 
  protected:
   explicit ApplicationSystem(RuntimeContext* runtime_context);

--- a/application/extension/application_event_extension.h
+++ b/application/extension/application_event_extension.h
@@ -16,7 +16,8 @@ namespace xwalk {
 
 namespace application {
 class ApplicationEventManager;
-class ApplicationSystem;
+class ApplicationStorage;
+class Application;
 }
 
 class AppEventExtensionInstance;
@@ -28,20 +29,25 @@ using extensions::XWalkExtensionInstance;
 
 class ApplicationEventExtension : public XWalkExtension {
  public:
-  explicit ApplicationEventExtension(application::ApplicationSystem* system);
+  ApplicationEventExtension(application::ApplicationEventManager* event_manager,
+                            application::ApplicationStorage* app_storage,
+                            application::Application* app);
 
   // XWalkExtension implementation.
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
  private:
-  application::ApplicationSystem* application_system_;
+  application::ApplicationEventManager* event_manager_;
+  application::ApplicationStorage* app_storage_;
+  application::Application* application_;
 };
 
 class AppEventExtensionInstance : public XWalkExtensionInstance,
                                   public application::EventObserver {
  public:
-  AppEventExtensionInstance(application::ApplicationSystem* app_system,
-                            const std::string& app_id,
+  AppEventExtensionInstance(application::ApplicationEventManager* event_manager,
+                            application::ApplicationStorage* app_storage,
+                            application::Application* app,
                             int main_routing_id);
 
   virtual ~AppEventExtensionInstance();
@@ -61,8 +67,8 @@ class AppEventExtensionInstance : public XWalkExtensionInstance,
   typedef std::map<std::string, XWalkExtensionFunctionInfo::PostResultCallback>
       EventCallbackMap;
   EventCallbackMap registered_events_;
-  application::ApplicationSystem* app_system_;
-  std::string app_id_;
+  application::ApplicationStorage* app_storage_;
+  application::Application* application_;
   int main_routing_id_;  // routing id of the main document.
 
   XWalkExtensionFunctionHandler handler_;

--- a/application/extension/application_runtime_extension.h
+++ b/application/extension/application_runtime_extension.h
@@ -10,10 +10,14 @@
 #include "xwalk/extensions/browser/xwalk_extension_function_handler.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
 
+namespace content {
+class RenderProcessHost;
+}
+
 namespace xwalk {
 
 namespace application {
-class ApplicationSystem;
+class Application;
 }
 
 using extensions::XWalkExtension;
@@ -23,20 +27,18 @@ using extensions::XWalkExtensionInstance;
 
 class ApplicationRuntimeExtension : public XWalkExtension {
  public:
-  explicit ApplicationRuntimeExtension(
-      application::ApplicationSystem* application_system);
+  explicit ApplicationRuntimeExtension(application::Application* app);
 
   // XWalkExtension implementation.
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
  private:
-  application::ApplicationSystem* application_system_;
+  application::Application* application_;
 };
 
 class AppRuntimeExtensionInstance : public XWalkExtensionInstance {
  public:
-  explicit AppRuntimeExtensionInstance(
-      application::ApplicationSystem* application_system);
+  explicit AppRuntimeExtensionInstance(application::Application* app);
 
   virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
 
@@ -44,7 +46,7 @@ class AppRuntimeExtensionInstance : public XWalkExtensionInstance {
   void OnGetMainDocumentID(scoped_ptr<XWalkExtensionFunctionInfo> info);
   void OnGetManifest(scoped_ptr<XWalkExtensionFunctionInfo> info);
 
-  application::ApplicationSystem* application_system_;
+  application::Application* application_;
 
   XWalkExtensionFunctionHandler handler_;
 };

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -65,6 +65,16 @@ Runtime* Runtime::CreateWithDefaultWindow(
 }
 
 // static
+Runtime* Runtime::Create(
+    RuntimeContext* runtime_context, Observer* observer) {
+  WebContents::CreateParams params(runtime_context, NULL);
+  params.routing_id = MSG_ROUTING_NONE;
+  WebContents* web_contents = WebContents::Create(params);
+
+  return new Runtime(web_contents, observer);
+}
+
+// static
 void Runtime::SetGlobalObserverForTesting(Observer* observer) {
   g_observer_for_testing = observer;
 }

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -54,6 +54,8 @@ class Runtime : public content::WebContentsDelegate,
   static Runtime* Create(RuntimeContext*, const GURL&, Observer* = NULL);
   // Create a new Runtime instance which binds to a default app window.
   static Runtime* CreateWithDefaultWindow(RuntimeContext*, const GURL&, Observer* = NULL);
+  // FIXME: This class vitally needs refactoring.
+  static Runtime* Create(RuntimeContext*, Observer* = NULL);
 
   // Attach to a default app window.
   void AttachDefaultWindow();

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -250,9 +250,7 @@ void XWalkBrowserMainParts::CreateInternalExtensionsForUIThread(
     extensions::XWalkExtensionVector* extensions) {
   application::ApplicationSystem* app_system
       = runtime_context_->GetApplicationSystem();
-  extensions->push_back(new ApplicationRuntimeExtension(app_system));
-  extensions->push_back(new ApplicationEventExtension(app_system));
-
+  app_system->CreateApplicationExtensions(host, extensions);
   sysapps_manager_->CreateExtensionsForUIThread(extensions);
 }
 


### PR DESCRIPTION
Application extensions support multiple WEB apps: the corresponding application instance is found by the aliased render process host id.

The initialization of application extensions is moved to ApplicationSystem class which contains the needed context to init the extensions. The application lookup is also done there.

The rest of changes in the patch is related to a necessity for the application to obtain the render process host id even before its first "Runtime" is created.
