### PR TITLE
[Extensions] Avoid running CrashExtensionTest when --disable-extension-p...

### DIFF
--- a/extensions/test/crash_extension_process.cc
+++ b/extensions/test/crash_extension_process.cc
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "base/command_line.h"
 #include "base/native_library.h"
 #include "base/path_service.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
+#include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/extensions/test/xwalk_extensions_test_base.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
@@ -22,6 +24,13 @@ class CrashExtensionTest : public XWalkExtensionsTestBase {
 };
 
 IN_PROC_BROWSER_TEST_F(CrashExtensionTest, CrashExtensionProcessKeepBPAlive) {
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kXWalkDisableExtensionProcess)) {
+    LOG(INFO) << "--disable-extension-process not supported by " \
+                 "CrashExtensionProcessKeepBPAlive. Skipping test.";
+    return;
+  }
+
   GURL url = GetExtensionsTestURL(base::FilePath(),
                                   base::FilePath().AppendASCII("crash.html"));
   content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);


### PR DESCRIPTION
...rocess is set.

Using the ExtensionProcess is mandatory for this test, so we avoid running it.
