### PR TITLE
[Application][Tools] Fix warning about missing strcmp() definition

### DIFF
--- a/application/tools/linux/xwalk_tizen_user.c
+++ b/application/tools/linux/xwalk_tizen_user.c
@@ -4,6 +4,7 @@
 
 #include <unistd.h>
 #include <sys/types.h>
+#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>


### PR DESCRIPTION
The #include <string.h> directive was missing.
