### PR TITLE
[Runtime] Move initialization of XWalkRuntimeFeatures

### DIFF
--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -17,7 +17,6 @@
 #include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_quota_permission_context.h"
-#include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents.h"
@@ -69,8 +68,6 @@ XWalkContentBrowserClient::~XWalkContentBrowserClient() {
 
 content::BrowserMainParts* XWalkContentBrowserClient::CreateBrowserMainParts(
     const content::MainFunctionParams& parameters) {
-  XWalkRuntimeFeatures::GetInstance()->Initialize(
-    CommandLine::ForCurrentProcess());
 #if defined(OS_MACOSX)
   main_parts_ = new XWalkBrowserMainPartsMac(parameters);
 #elif defined(OS_ANDROID)

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -4,9 +4,11 @@
 
 #include "xwalk/runtime/browser/xwalk_runner.h"
 
+#include "base/command_line.h"
 #include "base/logging.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/xwalk_content_browser_client.h"
+#include "xwalk/runtime/common/xwalk_runtime_features.h"
 
 namespace xwalk {
 
@@ -20,6 +22,9 @@ XWalkRunner::XWalkRunner() {
   VLOG(1) << "Creating XWalkRunner object.";
   DCHECK(!g_xwalk_runner);
   g_xwalk_runner = this;
+
+  XWalkRuntimeFeatures::GetInstance()->Initialize(
+      CommandLine::ForCurrentProcess());
 
   // Initializing after the g_xwalk_runner is set to ensure XWalkRunner::Get()
   // can be used in all sub objects if needed.


### PR DESCRIPTION
Move this out from XWalkContentBrowserClient::CreateBrowserMainParts()
to a point earlier and more adequated for that initialization.
