### PR TITLE
[Extensions] Make it "safe" to use v8 after a WillReleaseScriptContext.

### DIFF
--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -100,6 +100,7 @@ void XWalkExtensionRendererController::DidCreateScriptContext(
 
 void XWalkExtensionRendererController::WillReleaseScriptContext(
     WebKit::WebFrame* frame, v8::Handle<v8::Context> context) {
+  v8::Context::Scope contextScope(context);
   XWalkModuleSystem::ResetModuleSystemFromContext(context);
 }
 


### PR DESCRIPTION
Before this patch, running ./out/Release/xwalk_browsertest --single-process
--gtest_filter="ExternalExtensionTest.ExternalExtension" was leading to a crash at RP with the following trace:

[0x0000014ba080] v8::Object::Delete()
[0x000000e5af67] xwalk::extensions::XWalkExtensionModule::~XWalkExtensionModule()
[0x000000e5d24f] xwalk::extensions::XWalkModuleSystem::DeleteExtensionModules()
[0x000000e5dfd5] xwalk::extensions::XWalkModuleSystem::~XWalkModuleSystem()
[0x000000e5e104] xwalk::extensions::XWalkModuleSystem::ResetModuleSystemFromContext()
[0x000000e5b079] xwalk::extensions::XWalkExtensionRendererController::WillReleaseScriptContext()
[0x0000025dc923] WebCore::V8WindowShell::disposeContext()
[0x0000025acf3d] WebCore::ScriptController::clearForClose()

This was happening because we thought that just using v8 at ~XWalkExtensionModule() was safe,
hence that we had an "already entered" v8::Context and could just perform any v8 operation.
It turns out we were wrong.

By having a look at WebCore::V8WindowShell, we can see that the function calling
WillReleaseScriptContext is V8WindowShell::disposeContext(). The callers from
that function sometimes "enter" their v8::Context by using a v8::Context::Scope,
but sometimes they don't. For instance, V8WindowShell::clearForNavigation() has
a context Scope on it (before calling disposeContext()), but V8WindowShell::clearForClose
doesn't. That explains why browsertests that doesn't have any sort of navigation were
crashing, while the others weren't.

When asking on #blink @freenode, I was told that "it doesn't seem strictly necessary to create
a Context::Scope for willRelease(). If the embedder needs to call into some V8 API that
expects being in some context, they can do it themselves.". Thus, this patch.

BUG=https://crosswalk-project.org/jira/browse/XWALK-718

TEST=./out/Release/xwalk_browsertest --single-process gtest_filter="ExternalExtensionTest.ExternalExtension"
