### PR TITLE
[Android] Fix app packaging tool can't return its version.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -76,7 +76,7 @@ def Find(name, path):
 
 def GetVersion(path):
   """Get the version of this python tool."""
-  version_str = 'XWalk packaging tool version '
+  version_str = 'Crosswalk app packaging tool version is '
   file_handle = open(path, 'r')
   src_content = file_handle.read()
   version_nums = re.findall(r'\d+', src_content)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -162,6 +162,11 @@ class TestMakeApk(unittest.TestCase):
         self.assertTrue(out.find('Illegal character') != -1)
         Clean('Example_')
 
+  def testToolVersion(self):
+    cmd = ['python', 'make_apk.py', '--version']
+    out = RunCommand(cmd)
+    self.assertTrue(out.find('Crosswalk app packaging tool version') != -1)
+
   def testAppDescriptionAndVersion(self):
     cmd = ['python', 'make_apk.py', '--name=Example',
            '--package=org.xwalk.example', '--app-version=1.0.0',
@@ -538,6 +543,7 @@ def SuiteWithEmptyModeOption():
   # Gather all the tests for empty mode option.
   test_suite = unittest.TestSuite()
   test_suite.addTest(TestMakeApk('testEmptyMode'))
+  test_suite.addTest(TestMakeApk('testToolVersion'))
   return test_suite
 
 

--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -47,8 +47,7 @@ def PrepareFromXwalk(src_dir, target_dir):
 
   # The source file/directory list to be copied and the target directory list.
   source_target_list = [
-    (os.path.join(source_code_dir, 'xwalk/VERSION'),
-     os.path.join(target_dir, 'VERSION')),
+    (os.path.join(source_code_dir, 'xwalk/VERSION'), target_dir),
 
     # This jar is needed for 'javac' compile.
     (os.path.join(jar_src_dir, 'xwalk_app_runtime_java.jar'), jar_target_dir),


### PR DESCRIPTION
The issue is due to the wrong directory it's stored. Put
VERSION file in the root target directory.

BUG=https://crosswalk-project.org/jira/browse/XWALK-737
