### PR TITLE
Fix Application Storage ownership

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -11,6 +11,7 @@
 #include "net/base/net_util.h"
 #include "xwalk/application/browser/application_event_manager.h"
 #include "xwalk/application/browser/application_service.h"
+#include "xwalk/application/browser/application_storage.h"
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/constants.h"
@@ -18,9 +19,6 @@
 #include "xwalk/application/common/event_names.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_context.h"
-
-using xwalk::Runtime;
-using xwalk::RuntimeContext;
 
 namespace xwalk {
 
@@ -173,10 +171,10 @@ bool Application::RunFromLocalPath() {
 bool Application::IsOnSuspendHandlerRegistered(
     const std::string& app_id) const {
   ApplicationSystem* system = runtime_context_->GetApplicationSystem();
-  ApplicationService* service = system->application_service();
+  ApplicationStorage* storage = system->application_storage();
 
   const std::set<std::string>& events =
-      service->GetApplicationByID(app_id)->GetEvents();
+      storage->GetApplicationData(app_id)->GetEvents();
   if (events.find(kOnSuspend) == events.end())
     return false;
 

--- a/application/browser/application_event_manager.cc
+++ b/application/browser/application_event_manager.cc
@@ -8,7 +8,7 @@
 #include "content/public/browser/web_contents_observer.h"
 #include "xwalk/application/browser/application_event_router.h"
 #include "xwalk/application/browser/application.h"
-#include "xwalk/application/browser/application_service.h"
+#include "xwalk/application/browser/application_storage.h"
 #include "xwalk/application/browser/application_system.h"
 
 using content::BrowserThread;
@@ -40,7 +40,7 @@ ApplicationEventManager::~ApplicationEventManager() {
 
 void ApplicationEventManager::OnAppLoaded(const std::string& app_id) {
   scoped_refptr<const ApplicationData> app_data =
-      system_->application_service()->GetApplicationByID(app_id);
+      system_->application_storage()->GetApplicationData(app_id);
   std::set<std::string> events;
   if (app_data)
     events = app_data->GetEvents();

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -9,7 +9,6 @@
 #include "base/files/file_path.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/observer_list.h"
-#include "xwalk/application/browser/application_storage.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/application/common/application_data.h"
 
@@ -21,12 +20,14 @@ namespace xwalk {
 namespace application {
 
 class Application;
+class ApplicationStorage;
 
 // This will manages applications install, uninstall, update and so on. It'll
 // also maintain all installed applications' info.
 class ApplicationService {
  public:
-  explicit ApplicationService(xwalk::RuntimeContext* runtime_context);
+  ApplicationService(RuntimeContext* runtime_context,
+                     ApplicationStorage* app_storage);
   virtual ~ApplicationService();
 
   bool Install(const base::FilePath& path, std::string* id);
@@ -34,9 +35,6 @@ class ApplicationService {
   bool Launch(const std::string& id);
   bool Launch(const base::FilePath& path);
 
-  scoped_refptr<ApplicationData> GetApplicationByID(
-       const std::string& id) const;
-  const ApplicationData::ApplicationDataMap& GetInstalledApplications() const;
   // Currently there's only one running application at a time.
   // FIXME: This method should go away when multiple applications
   // running is supported.
@@ -54,13 +52,12 @@ class ApplicationService {
 
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
-  ApplicationStorage* application_storage();
 
  private:
   bool Launch(scoped_refptr<const ApplicationData> application_data);
 
   xwalk::RuntimeContext* runtime_context_;
-  scoped_ptr<ApplicationStorage> app_storage_;
+  ApplicationStorage* application_storage_;
   scoped_ptr<Application> application_;
   ObserverList<Observer> observers_;
 

--- a/application/browser/application_service_provider_linux.cc
+++ b/application/browser/application_service_provider_linux.cc
@@ -17,10 +17,13 @@ namespace xwalk {
 namespace application {
 
 ApplicationServiceProviderLinux::ApplicationServiceProviderLinux(
-    ApplicationService* app_service, scoped_refptr<dbus::Bus> session_bus)
+    ApplicationService* app_service,
+    ApplicationStorage* app_storage,
+    scoped_refptr<dbus::Bus> session_bus)
     : session_bus_(session_bus) {
   installed_apps_.reset(new InstalledApplicationsManager(session_bus_,
-                                                         app_service));
+                                                         app_service,
+                                                         app_storage));
   running_apps_.reset(new RunningApplicationsManager(session_bus_,
                                                      app_service));
 

--- a/application/browser/application_service_provider_linux.h
+++ b/application/browser/application_service_provider_linux.h
@@ -17,6 +17,7 @@ namespace xwalk {
 namespace application {
 
 class ApplicationService;
+class ApplicationStorage;
 class InstalledApplicationsManager;
 class RunningApplicationsManager;
 
@@ -25,6 +26,7 @@ class RunningApplicationsManager;
 class ApplicationServiceProviderLinux {
  public:
   ApplicationServiceProviderLinux(ApplicationService* app_service,
+                                  ApplicationStorage* app_storage,
                                   scoped_refptr<dbus::Bus> session_bus);
   virtual ~ApplicationServiceProviderLinux();
 

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -28,6 +28,7 @@ namespace application {
 class ApplicationEventManager;
 class ApplicationService;
 class ApplicationServiceProvider;
+class ApplicationStorage;
 
 // The ApplicationSystem manages the creation and destruction of services which
 // related to applications' runtime model.
@@ -47,6 +48,10 @@ class ApplicationSystem {
   // The ApplicationEventManager is created at startup.
   ApplicationEventManager* event_manager() {
     return event_manager_.get();
+  }
+
+  ApplicationStorage* application_storage() {
+    return application_storage_.get();
   }
 
   // Parse the command line and process the --install, --uninstall and
@@ -90,6 +95,7 @@ class ApplicationSystem {
   void SendOnLaunchedEvent();
 
   xwalk::RuntimeContext* runtime_context_;
+  scoped_ptr<ApplicationStorage> application_storage_;
   scoped_ptr<ApplicationService> application_service_;
   scoped_ptr<ApplicationEventManager> event_manager_;
 

--- a/application/browser/application_system_linux.cc
+++ b/application/browser/application_system_linux.cc
@@ -19,6 +19,7 @@ ApplicationSystemLinux::ApplicationSystemLinux(RuntimeContext* runtime_context)
   if (cmd_line->HasSwitch(switches::kXWalkRunAsService)) {
     service_provider_.reset(
         new ApplicationServiceProviderLinux(application_service(),
+                                            application_storage(),
                                             dbus_manager().session_bus()));
   }
 }

--- a/application/browser/linux/installed_applications_manager.cc
+++ b/application/browser/linux/installed_applications_manager.cc
@@ -40,9 +40,11 @@ namespace xwalk {
 namespace application {
 
 InstalledApplicationsManager::InstalledApplicationsManager(
-    scoped_refptr<dbus::Bus> bus, ApplicationService* service)
+    scoped_refptr<dbus::Bus> bus, ApplicationService* service,
+    ApplicationStorage* app_storage)
     : weak_factory_(this),
       application_service_(service),
+      app_storage_(app_storage),
       adaptor_(bus, kInstalledManagerDBusPath) {
   application_service_->AddObserver(this);
 
@@ -62,7 +64,7 @@ InstalledApplicationsManager::~InstalledApplicationsManager() {
 
 void InstalledApplicationsManager::OnApplicationInstalled(
     const std::string& app_id) {
-  AddObject(application_service_->GetApplicationByID(app_id));
+  AddObject(app_storage_->GetApplicationData(app_id));
 }
 
 void InstalledApplicationsManager::OnApplicationUninstalled(
@@ -72,7 +74,7 @@ void InstalledApplicationsManager::OnApplicationUninstalled(
 
 void InstalledApplicationsManager::AddInitialObjects() {
   const ApplicationData::ApplicationDataMap& apps =
-      application_service_->GetInstalledApplications();
+      app_storage_->GetInstalledApplications();
   ApplicationData::ApplicationDataMap::const_iterator it;
   for (it = apps.begin(); it != apps.end(); ++it)
     AddObject(it->second);

--- a/application/browser/linux/installed_applications_manager.h
+++ b/application/browser/linux/installed_applications_manager.h
@@ -26,7 +26,8 @@ class InstalledApplicationObject;
 class InstalledApplicationsManager : public ApplicationService::Observer {
  public:
   InstalledApplicationsManager(scoped_refptr<dbus::Bus> bus,
-                               ApplicationService* service);
+                               ApplicationService* service,
+                               ApplicationStorage* app_storage);
   ~InstalledApplicationsManager();
 
  private:
@@ -51,6 +52,7 @@ class InstalledApplicationsManager : public ApplicationService::Observer {
 
   base::WeakPtrFactory<InstalledApplicationsManager> weak_factory_;
   ApplicationService* application_service_;
+  ApplicationStorage* app_storage_;
   dbus::ObjectManagerAdaptor adaptor_;
 };
 

--- a/application/extension/application_event_extension.cc
+++ b/application/extension/application_event_extension.cc
@@ -95,10 +95,10 @@ void AppEventExtensionInstance::OnRegisterEvent(
       return;
 
     // If the event is from main document, add it into system database.
-    ApplicationService* service = app_system_->application_service();
-    ApplicationStorage* app_store = service->application_storage();
-    scoped_refptr<ApplicationData> app_data =
-        service->GetApplicationByID(app_id_);
+    application::ApplicationStorage* app_storage =
+        app_system_->application_storage();
+    scoped_refptr<application::ApplicationData> app_data =
+        app_storage->GetApplicationData(app_id_);
     if (!app_data)
       return;
 
@@ -107,7 +107,7 @@ void AppEventExtensionInstance::OnRegisterEvent(
       return;
     events.insert(event_name);
     app_data->SetEvents(events);
-    app_store->UpdateApplication(app_data);
+    app_storage->UpdateApplication(app_data);
   }
 }
 
@@ -128,10 +128,10 @@ void AppEventExtensionInstance::OnUnregisterEvent(
 
   // If the event is from main document, remove it from system database.
   if (routing_id == main_routing_id_) {
-    ApplicationService* service = app_system_->application_service();
-    ApplicationStorage* app_store = service->application_storage();
-    scoped_refptr<ApplicationData> app_data =
-        service->GetApplicationByID(app_id_);
+    application::ApplicationStorage* app_storage =
+        app_system_->application_storage();
+    scoped_refptr<application::ApplicationData> app_data =
+        app_storage->GetApplicationData(app_id_);
     if (!app_data)
       return;
 
@@ -140,7 +140,7 @@ void AppEventExtensionInstance::OnUnregisterEvent(
       return;
     events.erase(event_name);
     app_data->SetEvents(events);
-    app_store->UpdateApplication(app_data);
+    app_storage->UpdateApplication(app_data);
   }
 }
 


### PR DESCRIPTION
Application storage should be owned by application system and then it should be given to anyone interested in it (including Application Service).
The benefits:
- those who need storage but do not need service now are able to get it from ApplicationSystem directly
- initialization order of storage and service is easier to handle (now it is being handled from the generic place - ApplicationSystem)
- we're decoupling storage and service and ApplicationService interface can be cleaned from unneeded methods.
