### PR TITLE
Prepare ApplicationService for multiple applications handling.

### DIFF
--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -106,6 +106,17 @@ bool ApplicationSystem::HandleApplicationManagementCommands(
   return false;
 }
 
+template <typename T>
+bool ApplicationSystem::LaunchWithCommandLineParam(const T& param) {
+  scoped_refptr<Event> event = Event::CreateEvent(
+        kOnLaunched, scoped_ptr<base::ListValue>(new base::ListValue));
+  if (Application* application = application_service_->Launch(param)) {
+    event_manager_->SendEvent(application->id(), event);
+    return true;
+  }
+  return false;
+}
+
 bool ApplicationSystem::LaunchFromCommandLine(
     const CommandLine& cmd_line, const GURL& url,
     bool* run_default_message_loop) {
@@ -115,8 +126,7 @@ bool ApplicationSystem::LaunchFromCommandLine(
 #if defined(OS_TIZEN_MOBILE)
   std::string command_name = cmd_line.GetProgram().BaseName().MaybeAsASCII();
   if (ApplicationData::IsIDValid(command_name)) {
-    *run_default_message_loop = application_service_->Launch(command_name);
-    SendOnLaunchedEvent();
+    *run_default_message_loop = LaunchWithCommandLineParam(command_name);
     return true;
   }
 #endif
@@ -129,29 +139,19 @@ bool ApplicationSystem::LaunchFromCommandLine(
   if (!args.empty()) {
     std::string app_id = std::string(args[0].begin(), args[0].end());
     if (ApplicationData::IsIDValid(app_id)) {
-        *run_default_message_loop = application_service_->Launch(app_id);
-        SendOnLaunchedEvent();
-        return true;
+      *run_default_message_loop = LaunchWithCommandLineParam(app_id);
+      return true;
     }
   }
 
   // Handles local directory.
   base::FilePath path;
   if (net::FileURLToFilePath(url, &path) && base::DirectoryExists(path)) {
-    *run_default_message_loop = application_service_->Launch(path);
-    SendOnLaunchedEvent();
+    *run_default_message_loop = LaunchWithCommandLineParam(path);
     return true;
   }
 
   return false;
-}
-
-void ApplicationSystem::SendOnLaunchedEvent() {
-  scoped_refptr<Event> event = Event::CreateEvent(
-      kOnLaunched, scoped_ptr<base::ListValue>(new base::ListValue));
-  DCHECK(application_service_->GetActiveApplication());
-  event_manager_->SendEvent(
-      application_service_->GetActiveApplication()->id(), event);
 }
 
 void ApplicationSystem::CreateExtensions(

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -87,8 +87,8 @@ class ApplicationSystem {
   explicit ApplicationSystem(RuntimeContext* runtime_context);
 
  private:
-  // Dispatch the onLaunched event to current running application.
-  void SendOnLaunchedEvent();
+  template <typename T>
+  bool LaunchWithCommandLineParam(const T& param);
 
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationStorage> application_storage_;


### PR DESCRIPTION
Prepare ApplicationService for multiple applications handling: ApplicationService now owns a ScopedVector of Applications.
Application::Observer class is introduced so that application can notify about its termination and deletion.
Application::Launch methods return a pointer to the corresponding Application instance, ApplicationSystem methods are modified accordingly.
