### PR TITLE
Fix build for G++ 4.8.2 (Fedora 20)

### DIFF
--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -50,7 +50,7 @@ class Runtime : public content::WebContentsDelegate,
       virtual void OnRuntimeRemoved(Runtime* runtime) = 0;
 
     protected:
-      ~Observer() {}
+      virtual ~Observer() {}
   };
 
   void SetObserver(Observer* observer) { observer_ = observer; }


### PR DESCRIPTION
The issue here is that G++ warns about a potential misuse of delete on a
polymorphic object which the base class hasn't a virtual destructor. In
our code that's not a problem because by design, we make the destructor
protected so we can't delete "by the base class pointer type".

However G++ is being picky here, as described in
http://gcc.gnu.org/wiki/VerboseDiagnostics#delete-non-virtual-dtor "the
warning will sometimes be issued for correct code". The workaround of
marking the class final is not widely available yet, so we live with the
simplest fix.
