### PR TITLE
[Application][Tizen] Specify session bus address in Tizen

### DIFF
--- a/application/tools/linux/dbus_connection.cc
+++ b/application/tools/linux/dbus_connection.cc
@@ -1,0 +1,21 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/tools/linux/dbus_connection.h"
+
+GDBusConnection* get_session_bus_connection(GError** error) {
+#if defined(OS_TIZEN_MOBILE)
+  // In Tizen the session bus is created in /run/user/app/dbus/user_bus_socket
+  // but this information isn't set in DBUS_SESSION_BUS_ADDRESS, neither when
+  // logging via 'sdb shell' and changing user to 'app', nor when an application
+  // is launched.
+  return g_dbus_connection_new_for_address_sync(
+      "unix:path=/run/user/app/dbus/user_bus_socket",
+      GDBusConnectionFlags(G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT
+                           | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION),
+      NULL, NULL, error);
+#else
+  return g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, error);
+#endif
+}

--- a/application/tools/linux/dbus_connection.h
+++ b/application/tools/linux/dbus_connection.h
@@ -1,0 +1,12 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_TOOLS_LINUX_DBUS_CONNECTION_H_
+#define XWALK_APPLICATION_TOOLS_LINUX_DBUS_CONNECTION_H_
+
+#include <gio/gio.h>
+
+GDBusConnection* get_session_bus_connection(GError** error);
+
+#endif  // XWALK_APPLICATION_TOOLS_LINUX_DBUS_CONNECTION_H_

--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -31,6 +31,8 @@
         '../../../..',
       ],
       'sources': [
+        'dbus_connection.h',
+        'dbus_connection.cc',
         'xwalk_tizen_user.h',
         'xwalk_tizen_user.cc',
         'xwalkctl_main.cc',
@@ -44,6 +46,8 @@
         '../../../..',
       ],
       'sources': [
+        'dbus_connection.h',
+        'dbus_connection.cc',
         'xwalk_tizen_user.h',
         'xwalk_tizen_user.cc',
         'xwalk_launcher_main.cc',


### PR DESCRIPTION
In Tizen the session bus is not available for us by peeking at the
DBUS_SESSION_BUS_ADDRESS, it will be created in a well-known place
instead.

The code change so instead of using the '_for_bus' variants of the
functions, we explicit create the GDBusConnection.

This patch also improves the error message for the case where we fail to
create the object manager client and fix the include rules to follow our
standards.
