### PR TITLE
[Application][Linux] Convert tools to C++

### DIFF
--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -28,22 +28,25 @@
         'gio',
       ],
       'include_dirs': [
-        '..',
+        '../../../..',
       ],
       'sources': [
         'xwalk_tizen_user.h',
-        'xwalk_tizen_user.c',
-        'xwalkctl_main.c',
+        'xwalk_tizen_user.cc',
+        'xwalkctl_main.cc',
       ],
     },
     {
       'target_name': 'xwalk_launcher',
       'type': 'executable',
       'product_name': 'xwalk-launcher',
+      'include_dirs': [
+        '../../../..',
+      ],
       'sources': [
         'xwalk_tizen_user.h',
-        'xwalk_tizen_user.c',
-        'xwalk_launcher_main.c',
+        'xwalk_tizen_user.cc',
+        'xwalk_launcher_main.cc',
       ],
       'conditions' : [
         ['OS=="linux"', {
@@ -61,9 +64,6 @@
             'xwalk_launcher_tizen.h',
           ],
         }],
-      ],
-      'include_dirs': [
-        '..',
       ],
     },
   ],

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -13,8 +13,8 @@
 #include <glib.h>
 #include <gio/gio.h>
 
-#include "xwalk_tizen_user.h"
-#include "xwalk_launcher_tizen.h"
+#include "xwalk/application/tools/linux/xwalk_tizen_user.h"
+#include "xwalk/application/tools/linux/xwalk_launcher_tizen.h"
 
 static const char* xwalk_service_name = "org.crosswalkproject.Runtime1";
 static const char* xwalk_running_path = "/running1";
@@ -93,21 +93,24 @@ int main(int argc, char** argv) {
     appid = basename(argv[0]);
   }
 
-  GDBusObjectManager* running_apps_om = g_dbus_object_manager_client_new_for_bus_sync(
-      G_BUS_TYPE_SESSION, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
-      xwalk_service_name, xwalk_running_path,
-      NULL, NULL, NULL, NULL, NULL);
+  GDBusObjectManager* running_apps_om =
+      g_dbus_object_manager_client_new_for_bus_sync(
+          G_BUS_TYPE_SESSION, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
+          xwalk_service_name, xwalk_running_path,
+          NULL, NULL, NULL, NULL, NULL);
   if (!running_apps_om) {
-    fprintf(stderr, "Service '%s' does could not be reached\n", xwalk_service_name);
+    fprintf(stderr, "Service '%s' does could not be reached\n",
+            xwalk_service_name);
     exit(1);
   }
 
   g_signal_connect(running_apps_om, "object-removed",
                    G_CALLBACK(object_removed), NULL);
 
-  GDBusProxy* running_proxy = g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
-		  G_DBUS_PROXY_FLAGS_NONE, NULL, xwalk_service_name,
-		  xwalk_running_path, xwalk_running_manager_iface, NULL, &error);
+  GDBusProxy* running_proxy = g_dbus_proxy_new_for_bus_sync(
+      G_BUS_TYPE_SESSION,
+      G_DBUS_PROXY_FLAGS_NONE, NULL, xwalk_service_name,
+      xwalk_running_path, xwalk_running_manager_iface, NULL, &error);
   if (!running_proxy) {
     g_print("Couldn't create proxy for '%s': %s\n", xwalk_running_manager_iface,
             error->message);
@@ -125,7 +128,8 @@ int main(int argc, char** argv) {
   }
 
   g_variant_get(result, "(o)", &application_object_path);
-  fprintf(stderr, "Application launched with path '%s'\n", application_object_path);
+  fprintf(stderr, "Application launched with path '%s'\n",
+          application_object_path);
 
   GDBusProxy* app_proxy = g_dbus_proxy_new_for_bus_sync(
       G_BUS_TYPE_SESSION,

--- a/application/tools/linux/xwalk_tizen_user.cc
+++ b/application/tools/linux/xwalk_tizen_user.cc
@@ -18,18 +18,20 @@ int xwalk_tizen_set_home_for_user_app(void) {
 
   // Tizen doesn't set HOME by default on login for user "app".
   uid_t uid = getuid();
-  struct passwd* passwd = getpwuid(uid);
+  struct passwd* passwd = getpwuid(uid);  // NOLINT
 
   if (!passwd)
     return -ENOENT;
 
   if (strcmp(passwd->pw_name, "app")) {
-    fprintf(stderr, "User is not 'app', launching an application will not work\n");
+    fprintf(stderr,
+            "User is not 'app', launching an application will not work\n");
     return -EINVAL;
   }
 
   if (setenv("HOME", passwd->pw_dir, true) != 0) {
-    fprintf(stderr, "Couldn't set 'HOME' env variable to '%s'\n", passwd->pw_dir);
+    fprintf(stderr, "Couldn't set 'HOME' env variable to '%s'\n",
+            passwd->pw_dir);
     return -EINVAL;
   }
 


### PR DESCRIPTION
We don't have strong reasons to keep them a C, so to keep consistency
and make use of our lint checks, moving those to C++.

We still use gdbus here (instead of src/dbus) due to it's convenient
sync API (for the case of the tools, this API is OK) and to avoid
needing to integrate appcore/aul with base::MessageLoop.
