### PR TITLE
[Runtime] Move ApplicationSystem to XWalkRunner

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -19,6 +19,7 @@
 #include "xwalk/application/common/event_names.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_context.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 namespace xwalk {
 
@@ -102,7 +103,7 @@ void Application::OnRuntimeRemoved(Runtime* runtime) {
 
   if (runtimes_.size() == 1 &&
       ContainsKey(runtimes_, main_runtime_)) {
-    ApplicationSystem* system = runtime_context_->GetApplicationSystem();
+    ApplicationSystem* system = XWalkRunner::GetInstance()->app_system();
     ApplicationEventManager* event_manager = system->event_manager();
 
     // If onSuspend is not registered in main document,
@@ -135,7 +136,7 @@ bool Application::RunMainDocument() {
   main_runtime_ = Runtime::Create(runtime_context_,
                                   main_info->GetMainURL(), this);
   ApplicationEventManager* event_manager =
-      runtime_context_->GetApplicationSystem()->event_manager();
+      XWalkRunner::GetInstance()->app_system()->event_manager();
   event_manager->OnMainDocumentCreated(
       application_data_->ID(), main_runtime_->web_contents());
   return true;
@@ -169,7 +170,7 @@ bool Application::RunFromLocalPath() {
 
 bool Application::IsOnSuspendHandlerRegistered(
     const std::string& app_id) const {
-  ApplicationSystem* system = runtime_context_->GetApplicationSystem();
+  ApplicationSystem* system = XWalkRunner::GetInstance()->app_system();
   ApplicationStorage* storage = system->application_storage();
 
   const std::set<std::string>& events =

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -165,10 +165,11 @@ const base::FilePath::CharType kApplicationsDir[] =
     FILE_PATH_LITERAL("applications");
 
 ApplicationService::ApplicationService(RuntimeContext* runtime_context,
-                                       ApplicationStorage* app_storage)
+                                       ApplicationStorage* app_storage,
+                                       ApplicationEventManager* event_manager)
     : runtime_context_(runtime_context),
-      application_storage_(app_storage) {
-}
+      application_storage_(app_storage),
+      event_manager_(event_manager) {}
 
 ApplicationService::~ApplicationService() {
 }
@@ -250,8 +251,7 @@ bool ApplicationService::Install(const base::FilePath& path, std::string* id) {
   // We need to run main document after installation in order to
   // register system events.
   if (application->HasMainDocument() && Launch(application->ID())) {
-    ApplicationSystem* system = runtime_context_->GetApplicationSystem();
-    WaitForFinishLoad(application, system->event_manager(),
+    WaitForFinishLoad(application, event_manager_,
         application_->GetMainDocumentRuntime()->web_contents());
   }
 
@@ -322,10 +322,7 @@ void ApplicationService::RemoveObserver(Observer* observer) {
 
 bool ApplicationService::Launch(
     scoped_refptr<const ApplicationData> application_data) {
-  ApplicationSystem* system = runtime_context_->GetApplicationSystem();
-  ApplicationEventManager* event_manager = system->event_manager();
-  event_manager->OnAppLoaded(application_data->ID());
-
+  event_manager_->OnAppLoaded(application_data->ID());
   application_.reset(new Application(application_data, runtime_context_));
   return application_->Launch();
 }

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -21,13 +21,15 @@ namespace application {
 
 class Application;
 class ApplicationStorage;
+class ApplicationEventManager;
 
 // This will manages applications install, uninstall, update and so on. It'll
 // also maintain all installed applications' info.
 class ApplicationService {
  public:
   ApplicationService(RuntimeContext* runtime_context,
-                     ApplicationStorage* app_storage);
+                     ApplicationStorage* app_storage,
+                     ApplicationEventManager* event_manager);
   virtual ~ApplicationService();
 
   bool Install(const base::FilePath& path, std::string* id);
@@ -58,6 +60,7 @@ class ApplicationService {
 
   xwalk::RuntimeContext* runtime_context_;
   ApplicationStorage* application_storage_;
+  ApplicationEventManager* event_manager_;
   scoped_ptr<Application> application_;
   ObserverList<Observer> observers_;
 

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -28,9 +28,11 @@ namespace application {
 ApplicationSystem::ApplicationSystem(RuntimeContext* runtime_context)
   : runtime_context_(runtime_context),
     application_storage_(new ApplicationStorage(runtime_context->GetPath())),
-    application_service_(new ApplicationService(runtime_context,
-                                                application_storage_.get())),
-    event_manager_(new ApplicationEventManager(this)) {}
+    event_manager_(new ApplicationEventManager(this)),
+    application_service_(new ApplicationService(
+        runtime_context,
+        application_storage_.get(),
+        event_manager_.get())) {}
 
 ApplicationSystem::~ApplicationSystem() {
 }

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -96,8 +96,8 @@ class ApplicationSystem {
 
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationStorage> application_storage_;
-  scoped_ptr<ApplicationService> application_service_;
   scoped_ptr<ApplicationEventManager> event_manager_;
+  scoped_ptr<ApplicationService> application_service_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationSystem);
 };

--- a/application/test/application_eventapi_test.cc
+++ b/application/test/application_eventapi_test.cc
@@ -12,7 +12,7 @@
 #include "xwalk/application/common/event_names.h"
 #include "xwalk/application/test/application_apitest.h"
 #include "xwalk/application/test/application_testapi.h"
-#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 using xwalk::application::ApplicationEventManager;
 using xwalk::application::Event;
@@ -38,10 +38,8 @@ class ApplicationEventApiTest : public ApplicationApiTest {
   }
 
   void PrepareFinishObserver() {
-    xwalk::Runtime* main_runtime = runtimes()[0];
-    xwalk::RuntimeContext* runtime_context = main_runtime->runtime_context();
     xwalk::application::ApplicationSystem* system =
-      runtime_context->GetApplicationSystem();
+        xwalk::XWalkRunner::GetInstance()->app_system();
     DCHECK(system->application_service()->GetActiveApplication());
 
     app_id_ = system->application_service()->GetActiveApplication()->id();

--- a/application/test/application_main_document_browsertest.cc
+++ b/application/test/application_main_document_browsertest.cc
@@ -12,7 +12,7 @@
 #include "xwalk/application/common/constants.h"
 #include "xwalk/application/test/application_browsertest.h"
 #include "xwalk/runtime/browser/runtime.h"
-#include "xwalk/runtime/browser/runtime_context.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 using xwalk::application::ApplicationData;
 
@@ -36,9 +36,8 @@ IN_PROC_BROWSER_TEST_F(ApplicationMainDocumentBrowserTest, MainDocument) {
   ASSERT_GE(GetRuntimeCount(), 1);
 
   xwalk::Runtime* main_runtime = runtimes()[0];
-  xwalk::RuntimeContext* runtime_context = main_runtime->runtime_context();
   xwalk::application::ApplicationService* service =
-    runtime_context->GetApplicationSystem()->application_service();
+      xwalk::XWalkRunner::GetInstance()->app_system()->application_service();
   const ApplicationData* app_data = service->GetActiveApplication()->data();
   GURL generated_url =
   app_data->GetResourceURL(xwalk::application::kGeneratedMainDocumentFilename);

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -23,6 +23,7 @@
 #include "xwalk/runtime/browser/runtime_download_manager_delegate.h"
 #include "xwalk/runtime/browser/runtime_geolocation_permission_context.h"
 #include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 
@@ -62,7 +63,6 @@ class RuntimeContext::RuntimeResourceContext : public content::ResourceContext {
 RuntimeContext::RuntimeContext()
   : resource_context_(new RuntimeResourceContext) {
   InitWhileIOAllowed();
-  application_system_ = application::ApplicationSystem::Create(this);
 }
 
 RuntimeContext::~RuntimeContext() {
@@ -161,18 +161,14 @@ quota::SpecialStoragePolicy* RuntimeContext::GetSpecialStoragePolicy() {
   return NULL;
 }
 
-xwalk::application::ApplicationSystem* RuntimeContext::GetApplicationSystem() {
-  return application_system_.get();
-}
-
 net::URLRequestContextGetter* RuntimeContext::CreateRequestContext(
     content::ProtocolHandlerMap* protocol_handlers) {
   DCHECK(!url_request_getter_);
 
-  xwalk::application::ApplicationService* service =
-    application_system_.get()->application_service();
-  const xwalk::application::Application* running_app =
-          service->GetActiveApplication();
+  application::ApplicationService* service =
+      XWalkRunner::GetInstance()->app_system()->application_service();
+  const application::Application* running_app =
+      service->GetActiveApplication();
   if (running_app) {
     protocol_handlers->insert(std::pair<std::string,
         linked_ptr<net::URLRequestJobFactory::ProtocolHandler> >(

--- a/runtime/browser/runtime_context.h
+++ b/runtime/browser/runtime_context.h
@@ -22,12 +22,6 @@ class DownloadManagerDelegate;
 }
 
 namespace xwalk {
-namespace application {
-class ApplicationSystem;
-}
-}
-
-namespace xwalk {
 
 class RuntimeDownloadManagerDelegate;
 class RuntimeURLRequestContextGetter;
@@ -72,8 +66,6 @@ class RuntimeContext : public content::BrowserContext {
       int bridge_id,
       const GURL& requesting_frame) OVERRIDE {}
 
-  xwalk::application::ApplicationSystem* GetApplicationSystem();
-
   net::URLRequestContextGetter* CreateRequestContext(
       content::ProtocolHandlerMap* protocol_handlers);
   net::URLRequestContextGetter* CreateRequestContextForStoragePartition(
@@ -89,7 +81,6 @@ class RuntimeContext : public content::BrowserContext {
   void InitWhileIOAllowed();
 
   scoped_ptr<RuntimeResourceContext> resource_context_;
-  scoped_ptr<xwalk::application::ApplicationSystem> application_system_;
   scoped_refptr<RuntimeDownloadManagerDelegate> download_manager_delegate_;
   scoped_refptr<RuntimeURLRequestContextGetter> url_request_getter_;
   scoped_refptr<content::GeolocationPermissionContext>

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -101,7 +101,7 @@ namespace xwalk {
 
 XWalkBrowserMainParts::XWalkBrowserMainParts(
     const content::MainFunctionParams& parameters)
-    : xwalk_runner_(XWalkRunner::Get()),
+    : xwalk_runner_(XWalkRunner::GetInstance()),
       startup_url_(content::kAboutBlankURL),
       parameters_(parameters),
       run_default_message_loop_(true) {
@@ -204,8 +204,7 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
 
   NativeAppWindow::Initialize();
 
-  xwalk::application::ApplicationSystem* app_system =
-      runtime_context_->GetApplicationSystem();
+  application::ApplicationSystem* app_system = xwalk_runner_->app_system();
   if (app_system->HandleApplicationManagementCommands(
       *command_line, startup_url_,
       run_default_message_loop_)) {
@@ -252,7 +251,7 @@ void XWalkBrowserMainParts::PostMainMessageLoopRun() {
 void XWalkBrowserMainParts::CreateInternalExtensionsForUIThread(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
-  runtime_context_->GetApplicationSystem()->CreateExtensions(host, extensions);
+  xwalk_runner_->app_system()->CreateExtensions(host, extensions);
   sysapps_manager_->CreateExtensionsForUIThread(extensions);
 }
 
@@ -260,7 +259,7 @@ void XWalkBrowserMainParts::CreateInternalExtensionsForExtensionThread(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
   application::ApplicationSystem* app_system
-        = runtime_context_->GetApplicationSystem();
+        = xwalk_runner_->app_system();
   extensions->push_back(new RuntimeExtension);
   extensions->push_back(
       new experimental::DialogExtension(app_system));

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -11,6 +11,7 @@
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "xwalk/runtime/extension/runtime_extension.h"
 #include "xwalk/sysapps/raw_socket/raw_socket_extension.h"
@@ -79,8 +80,7 @@ void XWalkBrowserMainPartsTizen::CreateInternalExtensionsForExtensionThread(
 void XWalkBrowserMainPartsTizen::CreateInternalExtensionsForUIThread(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
-  application::ApplicationSystem* app_system
-      = runtime_context_->GetApplicationSystem();
+  application::ApplicationSystem* app_system = xwalk_runner_->app_system();
   application::ApplicationService* app_service
       = app_system->application_service();
   if (Application* application = app_service->GetActiveApplication())

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -6,6 +6,7 @@
 
 #include "base/command_line.h"
 #include "base/logging.h"
+#include "xwalk/application/browser/application_system.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/xwalk_content_browser_client.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
@@ -26,8 +27,8 @@ XWalkRunner::XWalkRunner() {
   XWalkRuntimeFeatures::GetInstance()->Initialize(
       CommandLine::ForCurrentProcess());
 
-  // Initializing after the g_xwalk_runner is set to ensure XWalkRunner::Get()
-  // can be used in all sub objects if needed.
+  // Initializing after the g_xwalk_runner is set to ensure
+  // XWalkRunner::GetInstance() can be used in all sub objects if needed.
   content_browser_client_.reset(new XWalkContentBrowserClient);
 }
 
@@ -38,15 +39,18 @@ XWalkRunner::~XWalkRunner() {
 }
 
 // static
-XWalkRunner* XWalkRunner::Get() {
+XWalkRunner* XWalkRunner::GetInstance() {
   return g_xwalk_runner;
 }
 
 void XWalkRunner::PreMainMessageLoopRun() {
   runtime_context_.reset(new RuntimeContext);
+  app_system_ =
+      application::ApplicationSystem::Create(runtime_context_.get());
 }
 
 void XWalkRunner::PostMainMessageLoopRun() {
+  app_system_.reset();
   runtime_context_.reset();
 }
 

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -17,12 +17,16 @@ namespace xwalk {
 
 class RuntimeContext;
 
+namespace application {
+class ApplicationSystem;
+}
+
 // Main object for the Browser Process execution in Crosswalk. It is created and
 // owned by XWalkMainDelegate. It's role is to own, setup and teardown all the
 // subsystems of Crosswalk.
 class XWalkRunner {
  public:
-  static XWalkRunner* Get();
+  static XWalkRunner* GetInstance();
   virtual ~XWalkRunner();
 
   // All sub objects should have their dependencies passed during their
@@ -44,7 +48,7 @@ class XWalkRunner {
   //   object. Certain APIs doesn't allow us to pass the dependencies, so we
   //   need to reach them some way.
   RuntimeContext* runtime_context() { return runtime_context_.get(); }
-
+  application::ApplicationSystem* app_system() { return app_system_.get(); }
 
   // Stages of main parts. See content/browser_main_parts.h for description.
   void PreMainMessageLoopRun();
@@ -68,6 +72,7 @@ class XWalkRunner {
 
   scoped_ptr<content::ContentBrowserClient> content_browser_client_;
   scoped_ptr<RuntimeContext> runtime_context_;
+  scoped_ptr<application::ApplicationSystem> app_system_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRunner);
 };


### PR DESCRIPTION
ApplicationSystem was being created in RuntimeContext, we now create it
in XWalkRunner.

I've also removed RuntimeContext::GetActiveApplication(), and changed
the callers to use XWalkRunner::Get()->app_system() for now. While it's
usually OK for the tests continue to rely on XWalkRunner, other uses
should be removed in future steps.

I'm targetting first moving the construction to the right place, then
making sure dependencies are passed correctly and we avoid reaching the
global.

Note there's a circular dependency between RuntimeContext and
ApplicationSystem. The current plan is to provide a hook for adding
protocol handlers so that ApplicationSystem (or XWalkRunner) can use it
without RuntimeContext needing to be aware. I'm postponing this change
until there's more knowledge of these relationships.
