### PR TITLE
[Android] Enable the disabled test case about remote debug.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -11,6 +11,7 @@ import android.graphics.Rect;
 import android.os.Bundle;
 import android.os.Looper;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.ViewGroup;
 import android.webkit.WebSettings;
 import android.widget.FrameLayout;
@@ -228,8 +229,9 @@ public class XWalkView extends FrameLayout {
 
     public void disableRemoteDebugging() {
         checkThreadSafety();
+        Log.e("XWalkView.java", "disableRemoteDebugging mDevToolsServer=" + mDevToolsServer);
         if (mDevToolsServer ==  null) return;
-
+        Log.e("XWalkView.java", "disableRemoteDebugging isRemoteDebuggingEnabled=" + mDevToolsServer.isRemoteDebuggingEnabled());
         if (mDevToolsServer.isRemoteDebuggingEnabled()) {
             mDevToolsServer.setRemoteDebuggingEnabled(false);
         }

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/EnableRemoteDebuggingTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/EnableRemoteDebuggingTest.java
@@ -7,7 +7,6 @@ package org.xwalk.runtime.client.test;
 
 import android.content.Context;
 import android.test.suitebuilder.annotation.SmallTest;
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.shell.XWalkRuntimeClientShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -26,11 +25,8 @@ public class EnableRemoteDebuggingTest extends XWalkRuntimeClientTestBase {
         helper.testEnableRemoteDebugging(getActivity(), context);
     }
 
-    // This test case failed on trybot, but passed on buildbot and local machine.
-    // Disabled it first, It will be enabled later.
-    // @SmallTest
-    // @Feature({"DisableRemoteDebugging"})
-    @DisabledTest
+    @SmallTest
+    @Feature({"DisableRemoteDebugging"})
     public void testDisableRemoteDebugging() throws Throwable {
         Context context = getActivity();
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/EnableRemoteDebuggingTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/EnableRemoteDebuggingTest.java
@@ -7,7 +7,6 @@ package org.xwalk.runtime.client.embedded.test;
 
 import android.content.Context;
 import android.test.suitebuilder.annotation.SmallTest;
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.embedded.shell.XWalkRuntimeClientEmbeddedShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -26,11 +25,8 @@ public class EnableRemoteDebuggingTest extends XWalkRuntimeClientTestBase {
         helper.testEnableRemoteDebugging(getActivity(), context);
     }
 
-    // This test case failed on trybot, but passed on buildbot and local machine.
-    // Disabled it first, It will be enabled later.
-    // @SmallTest
-    // @Feature({"DisableRemoteDebugging"})
-    @DisabledTest
+    @SmallTest
+    @Feature({"DisableRemoteDebugging"})
     public void testDisableRemoteDebugging() throws Throwable {
         Context context = getActivity();
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =


### PR DESCRIPTION
Reenable the test case about testDisableRemoteDebugging, it has been
crashed in trybot.
Maybe it is the device issue. Now retest it on trybot.

BUG=https://crosswalk-project.org/jira/browse/XWALK-345
