### PR TITLE
[Tizen] Change MouseDown method

### DIFF
--- a/tizen/mobile/ui/tizen_system_indicator.cc
+++ b/tizen/mobile/ui/tizen_system_indicator.cc
@@ -39,7 +39,8 @@ gfx::Size TizenSystemIndicator::GetPreferredSize() {
 bool TizenSystemIndicator::OnMousePressed(const ui::MouseEvent& event) {
   if (!IsConnected())
     return false;
-  watcher_->OnMouseDown();
+  const gfx::Point position = event.location();
+  watcher_->OnMouseDown(position.x(), position.y());
   return true;
 }
 
@@ -70,7 +71,7 @@ void TizenSystemIndicator::OnTouchEvent(ui::TouchEvent* event) {
       watcher_->OnMouseUp();
       break;
     case ui::ET_TOUCH_PRESSED:
-      watcher_->OnMouseDown();
+      watcher_->OnMouseDown(position.x(), position.y());
       break;
     case ui::ET_TOUCH_MOVED:
       watcher_->OnMouseMove(position.x(), position.y());

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.cc
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.cc
@@ -127,8 +127,12 @@ bool TizenSystemIndicatorWatcher::Connect() {
   return success;
 }
 
-void TizenSystemIndicatorWatcher::OnMouseDown() {
+void TizenSystemIndicatorWatcher::OnMouseDown(int x, int y) {
   struct IPCDataEvMouseDown ipc;
+  // Mouse down event in Elementary Plug don't send it's coordinates,
+  // it gets from the last mouse move. Some mouse down events need this
+  // coordinates correctly, to solve this we trigger OnMouseMove here.
+  OnMouseMove(x, y);
   writer_.SendEvent(OP_EV_MOUSE_DOWN, &ipc, sizeof(ipc));
 }
 

--- a/tizen/mobile/ui/tizen_system_indicator_watcher.h
+++ b/tizen/mobile/ui/tizen_system_indicator_watcher.h
@@ -38,7 +38,7 @@ class TizenSystemIndicatorWatcher : public base::MessagePumpLibevent::Watcher {
   void StopWatching();
   bool Connect();
 
-  void OnMouseDown();
+  void OnMouseDown(int x, int y);
   void OnMouseUp();
   void OnMouseMove(int x, int y);
 


### PR DESCRIPTION
Mouse down event in Elementary Plug don't send it's coordinates, it gets
from the last mouse move. We changed the MouseDown method to trigger the
MouseMove method before.

The dropdown in TizenSystemIndicator landscape mode needs the
last coordinates to succeed.
