### PR TITLE
[Android] Enable the test case about testNormalUrl().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadUrlTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadUrlTest.java
@@ -7,8 +7,6 @@ package org.xwalk.core.xwview.test;
 
 import android.graphics.Bitmap;
 import android.test.suitebuilder.annotation.SmallTest;
-import android.util.Log;
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkClient;
@@ -40,11 +38,8 @@ public class LoadUrlTest extends XWalkViewTestBase {
         });
     }
 
-    // @SmallTest
-    // @Feature({"LoadUrl"})
-    // TODO(hengzhi): Since the device issue, it can not access the network,
-    // so disabled this test temporarily. It will be enabled later.
-    @DisabledTest
+    @SmallTest
+    @Feature({"LoadUrl"})
     public void testNormalUrl() throws Throwable {
         final String url = "http://www.webkit.org/";
         final String expected_title = "The WebKit Open Source Project";


### PR DESCRIPTION
This test case ever cannot access the network since the device issue.
Now enable it.

BUG=https://crosswalk-project.org/jira/browse/XWALK-25
