### PR TITLE
[Android] Refactor the xwalk settings.

### DIFF
--- a/runtime/browser/android/xwalk_settings.h
+++ b/runtime/browser/android/xwalk_settings.h
@@ -18,14 +18,13 @@ class XWalkRenderViewHostExt;
 
 class XWalkSettings : public content::WebContentsObserver {
  public:
-  XWalkSettings(JNIEnv* env, jobject obj);
+  XWalkSettings(JNIEnv* env, jobject obj, jint web_contents);
   virtual ~XWalkSettings();
 
   // Called from Java.
   void Destroy(JNIEnv* env, jobject obj);
   void ResetScrollAndScaleState(JNIEnv* env, jobject obj);
-  void SetWebContents(JNIEnv* env, jobject obj, jint web_contents);
-  void UpdateEverything(JNIEnv* env, jobject obj);
+  void UpdateEverythingLocked(JNIEnv* env, jobject obj);
   void UpdateInitialPageScale(JNIEnv* env, jobject obj);
   void UpdateUserAgent(JNIEnv* env, jobject obj);
   void UpdateWebkitPreferences(JNIEnv* env, jobject obj);


### PR DESCRIPTION
  The native layer of xwalk settings interfaces of updating everything
should grab lock, the constructor should directly initialize the base
class not to involve the member of base class. The unused codes in java
 layer of xwalk settings should be removed and the ui thread should be
handled correctly. This fix is to refactor the xwalk settings to resovle
these issues.

BUG=https://crosswalk-project.org/jira/browse/XWALK-767
