### PR TITLE
[Android] Clean term AwContent in IO thread Client and remove AwURLRequestJobFactory in cookie_manager.h.

### DIFF
--- a/runtime/browser/android/cookie_manager.h
+++ b/runtime/browser/android/cookie_manager.h
@@ -12,7 +12,6 @@ class CookieMonster;
 }  // namespace net
 
 namespace xwalk {
-class AwURLRequestJobFactory;
 
 void SetCookieMonsterOnNetworkStackInit(net::CookieMonster* cookie_monster);
 

--- a/runtime/browser/android/xwalk_contents_io_thread_client.h
+++ b/runtime/browser/android/xwalk_contents_io_thread_client.h
@@ -30,10 +30,10 @@ class InterceptedRequestData;
 // obtain a new instance of the class rather than holding on to one for
 // prolonged periods of time (see note for more details).
 //
-// Note: The native AwContentsIoThreadClient instance has a Global ref to
-// the Java object. By keeping the native AwContentsIoThreadClient
+// Note: The native XWalkContentsIoThreadClient instance has a Global ref to
+// the Java object. By keeping the native XWalkContentsIoThreadClient
 // instance alive you're also prolonging the lifetime of the Java instance, so
-// don't keep a AwContentsIoThreadClient if you don't need to.
+// don't keep a XWalkContentsIoThreadClient if you don't need to.
 class XWalkContentsIoThreadClient {
  public:
   // Corresponds to WebSettings cache mode constants.
@@ -51,7 +51,7 @@ class XWalkContentsIoThreadClient {
   // with the java counter part.
   virtual bool PendingAssociation() const = 0;
 
-  // Retrieve CacheMode setting value of this AwContents.
+  // Retrieve CacheMode setting value of this XWalkContent.
   // This method is called on the IO thread only.
   virtual CacheMode GetCacheMode() const = 0;
 
@@ -67,15 +67,15 @@ class XWalkContentsIoThreadClient {
       const GURL& location,
       const net::URLRequest* request) = 0;
 
-  // Retrieve the AllowContentAccess setting value of this AwContents.
+  // Retrieve the AllowContentAccess setting value of this XWalkContent.
   // This method is called on the IO thread only.
   virtual bool ShouldBlockContentUrls() const = 0;
 
-  // Retrieve the AllowFileAccess setting value of this AwContents.
+  // Retrieve the AllowFileAccess setting value of this XWalkContent.
   // This method is called on the IO thread only.
   virtual bool ShouldBlockFileUrls() const = 0;
 
-  // Retrieve the BlockNetworkLoads setting value of this AwContents.
+  // Retrieve the BlockNetworkLoads setting value of this XWalkContent.
   // This method is called on the IO thread only.
   virtual bool ShouldBlockNetworkLoads() const = 0;
 

--- a/runtime/browser/android/xwalk_contents_io_thread_client_impl.h
+++ b/runtime/browser/android/xwalk_contents_io_thread_client_impl.h
@@ -30,7 +30,7 @@ class InterceptedRequestData;
 
 class XWalkContentsIoThreadClientImpl : public XWalkContentsIoThreadClient {
  public:
-  // Called when AwContents is created before there is a Java client.
+  // Called when XWalkContent is created before there is a Java client.
   static void RegisterPendingContents(content::WebContents* web_contents);
 
   // Associates the |jclient| instance (which must implement the
@@ -46,7 +46,7 @@ class XWalkContentsIoThreadClientImpl : public XWalkContentsIoThreadClient {
       const base::android::JavaRef<jobject>& jclient);
   virtual ~XWalkContentsIoThreadClientImpl() OVERRIDE;
 
-  // Implementation of AwContentsIoThreadClient.
+  // Implementation of XWalkContentsIoThreadClient.
   virtual bool PendingAssociation() const OVERRIDE;
   virtual CacheMode GetCacheMode() const OVERRIDE;
   virtual scoped_ptr<InterceptedRequestData> ShouldInterceptRequest(


### PR DESCRIPTION
  In io thread client related header files, the AwContents comments should be refined
and in the cookie manager header file, unused code of AwURLRequestJobFactory should be removed.
This fix is to resolve these issues.

BUG=https://crosswalk-project.org/jira/browse/XWALK-768
