### PR TITLE
Fix compilation error with -Werror=delete-non-virtual-dtor flag set

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -65,6 +65,8 @@ void RunAsBrowser(xwalk::RuntimeContext* runtime_context,
     using xwalk::Runtime;
 
     class Observer : public Runtime::Observer {
+        virtual ~Observer() {}
+
         void OnRuntimeAdded(Runtime* runtime) {
           DCHECK(runtime);
           runtimes_.insert(runtime);


### PR DESCRIPTION
Added a virtual destructor to the local RunAsBrowser() 'Observer' class (even though it is not needed there) so that compiler does not complain.
