### PR TITLE
[Runtime] Move "is_running_as_service" flag to XWalkRunner

### DIFF
--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -154,10 +154,6 @@ void ApplicationSystem::SendOnLaunchedEvent() {
       application_service_->GetActiveApplication()->id(), event);
 }
 
-bool ApplicationSystem::IsRunningAsService() const {
-  return false;
-}
-
 void ApplicationSystem::CreateExtensions(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -80,10 +80,6 @@ class ApplicationSystem {
   bool LaunchFromCommandLine(const CommandLine& cmd_line, const GURL& url,
                              bool* run_default_message_loop_);
 
-  // Return true if the application system is running in service mode,
-  // i.e. taking requests from native IPC mechanism to launch applications.
-  virtual bool IsRunningAsService() const;
-
   void CreateExtensions(content::RenderProcessHost* host,
                         extensions::XWalkExtensionVector* extensions);
 

--- a/application/browser/application_system_linux.cc
+++ b/application/browser/application_system_linux.cc
@@ -8,7 +8,7 @@
 #include "dbus/bus.h"
 #include "xwalk/application/browser/application_service_provider_linux.h"
 #include "xwalk/dbus/dbus_manager.h"
-#include "xwalk/runtime/common/xwalk_switches.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 namespace xwalk {
 namespace application {
@@ -16,7 +16,7 @@ namespace application {
 ApplicationSystemLinux::ApplicationSystemLinux(RuntimeContext* runtime_context)
     : ApplicationSystem(runtime_context) {
   CommandLine* cmd_line = CommandLine::ForCurrentProcess();
-  if (cmd_line->HasSwitch(switches::kXWalkRunAsService)) {
+  if (XWalkRunner::GetInstance()->is_running_as_service()) {
     service_provider_.reset(
         new ApplicationServiceProviderLinux(application_service(),
                                             application_storage(),
@@ -25,10 +25,6 @@ ApplicationSystemLinux::ApplicationSystemLinux(RuntimeContext* runtime_context)
 }
 
 ApplicationSystemLinux::~ApplicationSystemLinux() {}
-
-bool ApplicationSystemLinux::IsRunningAsService() const {
-  return service_provider_;
-}
 
 DBusManager& ApplicationSystemLinux::dbus_manager() {
   if (!dbus_manager_)

--- a/application/browser/application_system_linux.h
+++ b/application/browser/application_system_linux.h
@@ -24,9 +24,6 @@ class ApplicationSystemLinux : public ApplicationSystem {
   DBusManager& dbus_manager();
 
  private:
-  // ApplicationSystem implementation.
-  virtual bool IsRunningAsService() const OVERRIDE;
-
   scoped_ptr<ApplicationServiceProviderLinux> service_provider_;
   scoped_ptr<DBusManager> dbus_manager_;
 

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -219,7 +219,7 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     return;
   }
 
-  if (app_system->IsRunningAsService()) {
+  if (xwalk_runner_->is_running_as_service()) {
     // In service mode, Crosswalk doesn't launch anything, just waits
     // for external requests to launch apps.
     VLOG(1) << "Crosswalk running as Service.";

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -10,6 +10,7 @@
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/xwalk_content_browser_client.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 namespace xwalk {
 
@@ -19,13 +20,16 @@ XWalkRunner* g_xwalk_runner = NULL;
 
 }  // namespace
 
-XWalkRunner::XWalkRunner() {
+XWalkRunner::XWalkRunner()
+    : is_running_as_service_(false) {
   VLOG(1) << "Creating XWalkRunner object.";
   DCHECK(!g_xwalk_runner);
   g_xwalk_runner = this;
 
   XWalkRuntimeFeatures::GetInstance()->Initialize(
       CommandLine::ForCurrentProcess());
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  is_running_as_service_ = cmd_line->HasSwitch(switches::kXWalkRunAsService);
 
   // Initializing after the g_xwalk_runner is set to ensure
   // XWalkRunner::GetInstance() can be used in all sub objects if needed.

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -50,6 +50,10 @@ class XWalkRunner {
   RuntimeContext* runtime_context() { return runtime_context_.get(); }
   application::ApplicationSystem* app_system() { return app_system_.get(); }
 
+  // Return true if Crosswalk is running in service mode, i.e. taking
+  // requests from native IPC mechanism to launch applications.
+  bool is_running_as_service() const { return is_running_as_service_; }
+
   // Stages of main parts. See content/browser_main_parts.h for description.
   void PreMainMessageLoopRun();
   void PostMainMessageLoopRun();
@@ -73,6 +77,8 @@ class XWalkRunner {
   scoped_ptr<content::ContentBrowserClient> content_browser_client_;
   scoped_ptr<RuntimeContext> runtime_context_;
   scoped_ptr<application::ApplicationSystem> app_system_;
+
+  bool is_running_as_service_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRunner);
 };


### PR DESCRIPTION
This distinction will be used later in xwalk_paths, to setup different
data paths for Crosswalk in Tizen.
