### PR TITLE
[Tizen] Install support files for "run as service" mode

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -21,6 +21,7 @@
 #include "xwalk/application/common/event_names.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_context.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 #if defined(OS_TIZEN_MOBILE)
 #include "xwalk/application/browser/installer/tizen/package_installer.h"
@@ -131,6 +132,11 @@ bool InstallPackageOnTizen(xwalk::application::ApplicationService* service,
                            xwalk::application::ApplicationStorage* storage,
                            const std::string& app_id,
                            const base::FilePath& data_dir) {
+  // FIXME(cmarcelo): The Tizen-specific steps of installation in
+  // service mode are not supported yet. Remove when this is fixed.
+  if (xwalk::XWalkRunner::GetInstance()->is_running_as_service())
+    return true;
+
   scoped_ptr<xwalk::application::PackageInstaller> installer =
       xwalk::application::PackageInstaller::Create(service, storage,
                                                    app_id, data_dir);
@@ -145,6 +151,11 @@ bool UninstallPackageOnTizen(xwalk::application::ApplicationService* service,
                              xwalk::application::ApplicationStorage* storage,
                              const std::string& app_id,
                              const base::FilePath& data_dir) {
+  // FIXME(cmarcelo): The Tizen-specific steps of installation in
+  // service mode are not supported yet. Remove when this is fixed.
+  if (xwalk::XWalkRunner::GetInstance()->is_running_as_service())
+    return true;
+
   scoped_ptr<xwalk::application::PackageInstaller> installer =
       xwalk::application::PackageInstaller::Create(service, storage,
                                                    app_id, data_dir);

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -8,6 +8,8 @@ Group:          Web Framework/Web Run Time
 Url:            https://github.com/otcshare/crosswalk
 Source:         %{name}.tar
 Source1:        xwalk
+Source2:        org.crosswalkproject.Runtime1.service
+Source3:        xwalk.service
 Source1001:     crosswalk.manifest
 Source1002:     %{name}.xml.in
 Source1003:     %{name}.png
@@ -89,6 +91,8 @@ This package contains additional support files that are needed for running Cross
 
 %define _manifestdir /usr/share/packages
 %define _desktop_icondir /usr/share/icons/default/small
+%define _dbusservicedir /usr/share/dbus-1/services
+%define _systemduserservicedir /usr/lib/systemd/user
 
 %prep
 %setup -q -n crosswalk
@@ -191,6 +195,8 @@ cd src
 
 # Binaries.
 install -p -D %{SOURCE1} %{buildroot}%{_bindir}/xwalk
+install -p -D %{SOURCE2} %{buildroot}%{_dbusservicedir}/org.crosswalkproject.Runtime1.service
+install -p -D %{SOURCE3} %{buildroot}%{_systemduserservicedir}/xwalk.service
 install -p -D ${BUILDDIR_NAME}/out/Release/xwalk %{buildroot}%{_libdir}/xwalk/xwalk
 install -p -D ${BUILDDIR_NAME}/out/Release/xwalkctl %{buildroot}%{_bindir}/xwalkctl
 install -p -D ${BUILDDIR_NAME}/out/Release/xwalk-launcher %{buildroot}%{_bindir}/xwalk-launcher
@@ -217,6 +223,8 @@ install -p -D ../%{name}.png %{buildroot}%{_desktop_icondir}/%{name}.png
 %{_libdir}/xwalk/xwalk.pak
 %{_manifestdir}/%{name}.xml
 %{_desktop_icondir}/%{name}.png
+%{_dbusservicedir}/org.crosswalkproject.Runtime1.service
+%{_systemduserservicedir}/xwalk.service
 
 %files emulator-support
 %{_libdir}/xwalk/libosmesa.so

--- a/packaging/org.crosswalkproject.Runtime1.service
+++ b/packaging/org.crosswalkproject.Runtime1.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.crosswalkproject.Runtime1
+SystemdService=xwalk.service
+Exec=/bin/false

--- a/packaging/xwalk.service
+++ b/packaging/xwalk.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Crosswalk
+
+[Service]
+Type=dbus
+BusName=org.crosswalkproject.Runtime1
+ExecStart=/usr/lib/xwalk/xwalk --run-as-service --external-extensions-path=/usr/lib/tizen-extensions-crosswalk

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -9,6 +9,7 @@
 #include "base/logging.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/path_service.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 #if defined(OS_WIN)
 #include "base/base_paths_win.h"
@@ -30,7 +31,11 @@ base::FilePath GetConfigPath() {
 #endif
 
 bool GetXWalkDataPath(base::FilePath* path) {
-  base::FilePath::StringType xwalk_suffix = FILE_PATH_LITERAL("xwalk");
+  base::FilePath::StringType xwalk_suffix;
+  if (XWalkRunner::GetInstance()->is_running_as_service())
+    xwalk_suffix = FILE_PATH_LITERAL("xwalk-service");
+  else
+    xwalk_suffix = FILE_PATH_LITERAL("xwalk");
   base::FilePath cur;
 
 #if defined(OS_WIN)
@@ -38,7 +43,10 @@ bool GetXWalkDataPath(base::FilePath* path) {
   cur = cur.Append(xwalk_suffix);
 
 #elif defined(OS_TIZEN_MOBILE)
-  cur = base::FilePath("/opt/usr/apps");
+  if (XWalkRunner::GetInstance()->is_running_as_service())
+    cur = GetConfigPath().Append(xwalk_suffix);
+  else
+    cur = base::FilePath("/opt/usr/apps");
 
 #elif defined(OS_LINUX)
   cur = GetConfigPath().Append(xwalk_suffix);


### PR DESCRIPTION
This commit adds to the installation the support files for D-Bus and
systemd to make Crosswalk auto activated by D-Bus and managed by
systemd (in the user session). The xwalkctl and xwalk-launcher
applications should be used to interact with service mode.

Crosswalk is installed as a systemd user service, named
xwalk.service. To check it's status, you can use (always with app user
on Tizen 2.x)

```
$ whoami
app

[ Because shell via sdb doesn't set the right D-Bus session address,
  we need to set it manually because systemctl uses it. Our xwalk
  tools on Tizen will automatically find the right address. ]

$ export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/app/dbus/user_bus_socket
$ systemctl --user status xwalk.service
```

Other regular systemd commands (restart, stop, start) should work as
well. Because of D-Bus auto activation feature, Crosswalk doesn't need
to be manually started. Just invoke xwalkctl or xwalk-launcher, and
Crosswalk will be started behind the scenes.

In service mode, the logs of Crosswalk go to systemd's "journal". You
can check that by using (as root, at the moment)

```
[ Trick to show more information ]

# export COLUMNS=1000
# systemd-journalctl _COMM=xwalk
```

For debugging it might be useful to directly run Crosswalk (to use gdb
or other tools), in that case, stop the current running Crosswalk using
'systemctl --user stop xwalk.service' and run xwalk binary directly
passing '--run-as-service'.

For now, we still support the current (non-service) way of using
Crosswalk. To avoid conflicts in the configuration files, we use a
different data directory (in $HOME). This means that we have different
app database, so do not expect apps installed in one way to work in
another.

Once we make sure service mode is running OK, we plan to remove the
current way of using Crosswalk (at least on Tizen)
- remove the "xwalk --install and --uninstall" switches;
- remove the "xwalk" script from $PATH;
- and then make the service mode default.

What is still missing in service mode is support for the Tizen-specific
steps of the installation (making the installed app appear on the
homescreen) and tighter integration with Tizen task switcher. Those will
come in following patches.
