### PR TITLE
Application extensions support multiple applications

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -31,15 +31,12 @@ class Manifest;
 // Application instances are owned by ApplicationService.
 // ApplicationService will delete an Application instance when it is
 // terminated.
-// FIXME(Mikhail): Add information about the relationship of the Application
-// and the render process.
+// There's one-to-one correspondence between Application and Render Process
+// Host, obtained from its "runtimes" (pages).
 class Application : public Runtime::Observer {
  public:
   virtual ~Application();
-  // Returns the unique application id which is used to distinguish the
-  // application amoung both running applications and installed ones
-  // (ApplicationData objects).
-  std::string id() const { return application_data_->ID(); }
+
   class Observer {
    public:
     // Invoked when application is terminated - all its pages (runtimes)
@@ -59,9 +56,16 @@ class Application : public Runtime::Observer {
   // if application has different entry point (local path manifest key).
   // See http://anssiko.github.io/runtime/app-lifecycle.html#dfn-main-document
   // The main document never has a visible window on its own.
-  Runtime* GetMainDocumentRuntime() const { return main_runtime_; }
+  Runtime* GetMainDocumentRuntime() const;
 
   const std::set<Runtime*>& runtimes() const { return runtimes_; }
+
+  // Returns the unique application id which is used to distinguish the
+  // application amoung both running applications and installed ones
+  // (ApplicationData objects).
+  std::string id() const { return application_data_->ID(); }
+  bool HasMainDocument() const { return application_data_->HasMainDocument(); }
+  int GetRenderProcessHostID() const;
 
   const ApplicationData* data() const { return application_data_; }
   ApplicationData* data() { return application_data_; }

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -321,6 +321,27 @@ Application* ApplicationService::GetActiveApplication() const {
   return applications_[0];  // Return the first item in the list.
 }
 
+namespace {
+
+struct ApplicationRenderHostIDComparator {
+    explicit ApplicationRenderHostIDComparator(int id) : id(id) { }
+    bool operator() (Application* application) {
+       return id == application->GetRenderProcessHostID();
+    }
+    int id;
+};
+
+}  // namespace
+
+Application* ApplicationService::GetApplicationByRenderHostID(int id) const {
+  ApplicationRenderHostIDComparator comparator(id);
+  ScopedVector<Application>::const_iterator found = std::find_if(
+                applications_.begin(), applications_.end(), comparator);
+  if (found != applications_.end())
+    return *found;
+  return NULL;
+}
+
 void ApplicationService::AddObserver(Observer* observer) {
   observers_.AddObserver(observer);
 }

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -47,6 +47,8 @@ class ApplicationService : public Application::Observer {
   Application* Launch(const std::string& id);
   Application* Launch(const base::FilePath& path);
 
+  Application* GetApplicationByRenderHostID(int id) const;
+
   const ScopedVector<Application>& active_applications() const {
       return applications_; }
 

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include "base/command_line.h"
 #include "base/file_util.h"
+#include "content/public/browser/render_process_host.h"
 #include "net/base/net_util.h"
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_event_manager.h"
@@ -157,13 +158,14 @@ bool ApplicationSystem::LaunchFromCommandLine(
 void ApplicationSystem::CreateExtensions(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
-  // FIXME(xiang): When service mode is enabled, we need to check whether the
-  // RPH belongs to an active application.
-  if (!application_service_->GetActiveApplication())
-    return;
+  Application* application =
+    application_service_->GetApplicationByRenderHostID(host->GetID());
+  if (!application)
+    return;  // We might be in browser mode.
 
-  extensions->push_back(new ApplicationRuntimeExtension(this));
-  extensions->push_back(new ApplicationEventExtension(this));
+  extensions->push_back(new ApplicationRuntimeExtension(application));
+  extensions->push_back(new ApplicationEventExtension(
+              event_manager_.get(), application_storage_.get(), application));
 }
 
 }  // namespace application

--- a/application/extension/application_event_extension.cc
+++ b/application/extension/application_event_extension.cc
@@ -14,10 +14,7 @@
 #include "ui/base/resource/resource_bundle.h"
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_event_manager.h"
-#include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_storage.h"
-#include "xwalk/application/browser/application_system.h"
-#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/event_names.h"
 #include "xwalk/runtime/browser/runtime.h"
 
@@ -25,40 +22,37 @@ namespace xwalk {
 namespace application {
 
 ApplicationEventExtension::ApplicationEventExtension(
-    ApplicationSystem* system)
-  : application_system_(system) {
+    ApplicationEventManager* event_manager,
+    ApplicationStorage* app_storage,
+    Application* app)
+  : event_manager_(event_manager),
+    app_storage_(app_storage),
+    application_(app) {
   set_name("xwalk.app.events");
   set_javascript_api(ResourceBundle::GetSharedInstance().GetRawDataResource(
       IDR_XWALK_APPLICATION_EVENT_API).as_string());
 }
 
 XWalkExtensionInstance* ApplicationEventExtension::CreateInstance() {
-  ApplicationService* service = application_system_->application_service();
-
   int main_routing_id = MSG_ROUTING_NONE;
-  // FIXME: return corresponding application info after shared runtime process
-  // model is enabled.
-  const Application* app = service->GetActiveApplication();
-  CHECK(app);
 
-  if (Runtime* runtime = app->GetMainDocumentRuntime())
+  if (Runtime* runtime = application_->GetMainDocumentRuntime())
     main_routing_id = runtime->web_contents()->GetRoutingID();
 
-  return new AppEventExtensionInstance(
-      application_system_,
-      app->id(), main_routing_id);
+  return new AppEventExtensionInstance(event_manager_, app_storage_,
+                                       application_, main_routing_id);
 }
 
 AppEventExtensionInstance::AppEventExtensionInstance(
-    ApplicationSystem* system,
-    const std::string& app_id,
+    ApplicationEventManager* event_manager,
+    ApplicationStorage* app_storage,
+    Application* app,
     int main_routing_id)
-  : EventObserver(system ? system->event_manager(): NULL),
-    app_system_(system),
-    app_id_(app_id),
+  : EventObserver(event_manager),
+    app_storage_(app_storage),
+    application_(app),
     main_routing_id_(main_routing_id),
     handler_(this) {
-  DCHECK(app_system_);
   handler_.Register("registerEvent",
                     base::Bind(&AppEventExtensionInstance::OnRegisterEvent,
                     base::Unretained(this)));
@@ -93,25 +87,24 @@ void AppEventExtensionInstance::OnRegisterEvent(
   if (!ContainsKey(registered_events_, event_name)) {
     registered_events_.insert(
         std::make_pair(event_name, info->post_result_cb()));
-    event_manager_->AttachObserver(app_id_, event_name, this);
+    event_manager_->AttachObserver(application_->id(), event_name, this);
 
     if (routing_id != main_routing_id_)
       return;
 
-    // If the event is from main document, add it into system database.
-    application::ApplicationStorage* app_storage =
-        app_system_->application_storage();
-    scoped_refptr<application::ApplicationData> app_data =
-        app_storage->GetApplicationData(app_id_);
+    // Check that application is present in the storage (installed app).
+    scoped_refptr<ApplicationData> app_data =
+        app_storage_->GetApplicationData(application_->id());
     if (!app_data)
       return;
 
+    // If the event is from main document, add it into system database.
     std::set<std::string> events = app_data->GetEvents();
     if (ContainsKey(events, event_name))
       return;
     events.insert(event_name);
     app_data->SetEvents(events);
-    app_storage->UpdateApplication(app_data);
+    app_storage_->UpdateApplication(app_data);
   }
 }
 
@@ -128,14 +121,12 @@ void AppEventExtensionInstance::OnUnregisterEvent(
     return;
 
   registered_events_.erase(event_name);
-  event_manager_->DetachObserver(app_id_, event_name, this);
+  event_manager_->DetachObserver(application_->id(), event_name, this);
 
   // If the event is from main document, remove it from system database.
   if (routing_id == main_routing_id_) {
-    application::ApplicationStorage* app_storage =
-        app_system_->application_storage();
-    scoped_refptr<application::ApplicationData> app_data =
-        app_storage->GetApplicationData(app_id_);
+    scoped_refptr<ApplicationData> app_data =
+        app_storage_->GetApplicationData(application_->id());
     if (!app_data)
       return;
 
@@ -144,7 +135,7 @@ void AppEventExtensionInstance::OnUnregisterEvent(
       return;
     events.erase(event_name);
     app_data->SetEvents(events);
-    app_storage->UpdateApplication(app_data);
+    app_storage_->UpdateApplication(app_data);
   }
 }
 
@@ -159,12 +150,12 @@ void AppEventExtensionInstance::OnDispatchEventFinish(
   args->AppendString(event_name);
   scoped_refptr<Event> event = Event::CreateEvent(
       kOnJavaScriptEventAck, args.Pass());
-  event_manager_->SendEvent(app_id_, event);
+  event_manager_->SendEvent(application_->id(), event);
 }
 
 void AppEventExtensionInstance::Observe(
     const std::string& app_id, scoped_refptr<Event> event) {
-  DCHECK(app_id_ == app_id);
+  DCHECK(application_->id() == app_id);
   EventCallbackMap::iterator it = registered_events_.find(event->name());
   if (it == registered_events_.end())
     return;

--- a/application/extension/application_event_extension.h
+++ b/application/extension/application_event_extension.h
@@ -15,8 +15,8 @@
 namespace xwalk {
 namespace application {
 class ApplicationEventManager;
-class ApplicationSystem;
-
+class ApplicationStorage;
+class Application;
 class AppEventExtensionInstance;
 
 using extensions::XWalkExtension;
@@ -26,20 +26,25 @@ using extensions::XWalkExtensionInstance;
 
 class ApplicationEventExtension : public XWalkExtension {
  public:
-  explicit ApplicationEventExtension(ApplicationSystem* system);
+  ApplicationEventExtension(ApplicationEventManager* event_manager,
+                            ApplicationStorage* app_storage,
+                            Application* application);
 
   // XWalkExtension implementation.
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
  private:
-  ApplicationSystem* application_system_;
+  ApplicationEventManager* event_manager_;
+  ApplicationStorage* app_storage_;
+  Application* application_;
 };
 
 class AppEventExtensionInstance : public XWalkExtensionInstance,
                                   public EventObserver {
  public:
-  AppEventExtensionInstance(ApplicationSystem* app_system,
-                            const std::string& app_id,
+  AppEventExtensionInstance(ApplicationEventManager* event_manager,
+                            ApplicationStorage* app_storage,
+                            Application* application,
                             int main_routing_id);
 
   virtual ~AppEventExtensionInstance();
@@ -59,8 +64,8 @@ class AppEventExtensionInstance : public XWalkExtensionInstance,
   typedef std::map<std::string, XWalkExtensionFunctionInfo::PostResultCallback>
       EventCallbackMap;
   EventCallbackMap registered_events_;
-  ApplicationSystem* app_system_;
-  std::string app_id_;
+  ApplicationStorage* app_storage_;
+  Application* application_;
   int main_routing_id_;  // routing id of the main document.
 
   XWalkExtensionFunctionHandler handler_;

--- a/application/extension/application_runtime_extension.cc
+++ b/application/extension/application_runtime_extension.cc
@@ -11,8 +11,6 @@
 #include "grit/xwalk_application_resources.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "xwalk/application/browser/application.h"
-#include "xwalk/application/browser/application_service.h"
-#include "xwalk/application/browser/application_system.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/runtime/browser/runtime.h"
 
@@ -22,20 +20,20 @@ namespace xwalk {
 namespace application {
 
 ApplicationRuntimeExtension::ApplicationRuntimeExtension(
-    ApplicationSystem* application_system)
-  : application_system_(application_system) {
+    Application* application)
+  : application_(application) {
   set_name("xwalk.app.runtime");
   set_javascript_api(ResourceBundle::GetSharedInstance().GetRawDataResource(
       IDR_XWALK_APPLICATION_RUNTIME_API).as_string());
 }
 
 XWalkExtensionInstance* ApplicationRuntimeExtension::CreateInstance() {
-  return new AppRuntimeExtensionInstance(application_system_);
+  return new AppRuntimeExtensionInstance(application_);
 }
 
 AppRuntimeExtensionInstance::AppRuntimeExtensionInstance(
-    ApplicationSystem* application_system)
-  : application_system_(application_system),
+    Application* application)
+  : application_(application),
     handler_(this) {
   handler_.Register(
       "getManifest",
@@ -54,12 +52,8 @@ void AppRuntimeExtensionInstance::HandleMessage(scoped_ptr<base::Value> msg) {
 void AppRuntimeExtensionInstance::OnGetManifest(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
-  base::DictionaryValue* manifest_data = NULL;
-  const ApplicationService* service =
-    application_system_->application_service();
-  const Application* app = service->GetActiveApplication();
-  if (app)
-    manifest_data = app->data()->GetManifest()->value()->DeepCopy();
+  base::DictionaryValue* manifest_data =
+          application_->data()->GetManifest()->value()->DeepCopy();
 
   scoped_ptr<base::ListValue> results(new base::ListValue());
   if (manifest_data)
@@ -75,9 +69,7 @@ void AppRuntimeExtensionInstance::OnGetMainDocumentID(
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
   int main_routing_id = MSG_ROUTING_NONE;
 
-  const Application* application =
-          application_system_->application_service()->GetActiveApplication();
-  if (Runtime* runtime = application->GetMainDocumentRuntime())
+  if (Runtime* runtime = application_->GetMainDocumentRuntime())
     main_routing_id = runtime->web_contents()->GetRoutingID();
 
   scoped_ptr<base::ListValue> results(new base::ListValue());

--- a/application/extension/application_runtime_extension.h
+++ b/application/extension/application_runtime_extension.h
@@ -12,7 +12,7 @@
 
 namespace xwalk {
 namespace application {
-class ApplicationSystem;
+class Application;
 
 using extensions::XWalkExtension;
 using extensions::XWalkExtensionFunctionHandler;
@@ -21,20 +21,18 @@ using extensions::XWalkExtensionInstance;
 
 class ApplicationRuntimeExtension : public XWalkExtension {
  public:
-  explicit ApplicationRuntimeExtension(
-      ApplicationSystem* application_system);
+  explicit ApplicationRuntimeExtension(Application* application);
 
   // XWalkExtension implementation.
   virtual XWalkExtensionInstance* CreateInstance() OVERRIDE;
 
  private:
-  ApplicationSystem* application_system_;
+  Application* application_;
 };
 
 class AppRuntimeExtensionInstance : public XWalkExtensionInstance {
  public:
-  explicit AppRuntimeExtensionInstance(
-      ApplicationSystem* application_system);
+  explicit AppRuntimeExtensionInstance(Application* application);
 
   virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
 
@@ -42,7 +40,7 @@ class AppRuntimeExtensionInstance : public XWalkExtensionInstance {
   void OnGetMainDocumentID(scoped_ptr<XWalkExtensionFunctionInfo> info);
   void OnGetManifest(scoped_ptr<XWalkExtensionFunctionInfo> info);
 
-  ApplicationSystem* application_system_;
+  Application* application_;
 
   XWalkExtensionFunctionHandler handler_;
 };

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -65,6 +65,16 @@ Runtime* Runtime::CreateWithDefaultWindow(
 }
 
 // static
+Runtime* Runtime::Create(
+    RuntimeContext* runtime_context, Observer* observer) {
+  WebContents::CreateParams params(runtime_context, NULL);
+  params.routing_id = MSG_ROUTING_NONE;
+  WebContents* web_contents = WebContents::Create(params);
+
+  return new Runtime(web_contents, observer);
+}
+
+// static
 void Runtime::SetGlobalObserverForTesting(Observer* observer) {
   g_observer_for_testing = observer;
 }

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -55,11 +55,13 @@ class Runtime : public content::WebContentsDelegate,
 
   void SetObserver(Observer* observer) { observer_ = observer; }
 
-  // Create a new Runtime instance with the given browsing context.
+  // Create a new Runtime instance with the given browsing context and URL.
   static Runtime* Create(RuntimeContext*, const GURL&, Observer* = NULL);
   // Create a new Runtime instance which binds to a default app window.
-  static Runtime* CreateWithDefaultWindow(RuntimeContext*, const GURL&,
-                                          Observer* = NULL);
+  static Runtime* CreateWithDefaultWindow(RuntimeContext*,
+                                          const GURL&, Observer* = NULL);
+  // Create a new Runtime instance with the given browsing context.
+  static Runtime* Create(RuntimeContext*, Observer* = NULL);
 
   // Attach to a default app window.
   void AttachDefaultWindow();


### PR DESCRIPTION
Application extensions are now provided with corresponding Application instances.
The corresponding application instance is found by Render Process Host (RPH) associated with it
(There's one-to-one correspondence between Application and RPH, obtained from its "runtimes").

RPH id getter is added to Application class. ApplicationService can lookup an application by the RPH id.
The rest of changes in the Application class (and all changes in Runtime class) are caused by the necessity for the application
to be aware of the associated RPH id before its first "Runtime" loads anything.
