### PR TITLE
[Android] Clean java compiling warnings in client and webchrome client tests.

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/XWalkClientForTest.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkClientForTest.java
@@ -27,7 +27,7 @@ public class XWalkClientForTest extends XWalkDefaultClient {
             String description, String failingUrl) {
         if (mCallbackForTest != null) {
             try {
-                Class objectClass = mCallbackForTest.getClass();
+                Class<?> objectClass = mCallbackForTest.getClass();
                 Method onReceivedError = objectClass.getMethod(
                         "onReceivedError", int.class, String.class, String.class);
                 onReceivedError.invoke(mCallbackForTest, errorCode, description, failingUrl);
@@ -42,7 +42,7 @@ public class XWalkClientForTest extends XWalkDefaultClient {
             SslError error) {
         if (mCallbackForTest != null) {
             try {
-                Class objectClass = mCallbackForTest.getClass();
+                Class<?> objectClass = mCallbackForTest.getClass();
                 Method onReceivedSslError = objectClass.getMethod(
                         "onReceivedSslError", SslErrorHandler.class, SslError.class);
                 onReceivedSslError.invoke(mCallbackForTest, handler, error);
@@ -56,7 +56,7 @@ public class XWalkClientForTest extends XWalkDefaultClient {
     public void onPageStarted(XWalkView view, String url, Bitmap favicon) {
         if (mCallbackForTest != null) {
             try {
-                Class objectClass = mCallbackForTest.getClass();
+                Class<?> objectClass = mCallbackForTest.getClass();
                 Method onPageStarted = objectClass.getMethod("onPageStarted", String.class);
                 onPageStarted.invoke(mCallbackForTest, url);
             } catch (Exception e) {
@@ -69,7 +69,7 @@ public class XWalkClientForTest extends XWalkDefaultClient {
     public void onPageFinished(XWalkView view, String url) {
         if (mCallbackForTest != null) {
             try {
-                Class objectClass = mCallbackForTest.getClass();
+                Class<?> objectClass = mCallbackForTest.getClass();
                 Method onPageStarted = objectClass.getMethod("onPageFinished", String.class);
                 onPageStarted.invoke(mCallbackForTest, url);
             } catch (Exception e) {

--- a/runtime/android/java/src/org/xwalk/runtime/XWalkWebChromeClientForTest.java
+++ b/runtime/android/java/src/org/xwalk/runtime/XWalkWebChromeClientForTest.java
@@ -26,7 +26,7 @@ public class XWalkWebChromeClientForTest extends XWalkDefaultWebChromeClient{
     public void onReceivedTitle(XWalkView view, String title) {
         if (mCallbackForTest != null) {
             try {
-                Class objectClass = mCallbackForTest.getClass();
+                Class<?> objectClass = mCallbackForTest.getClass();
                 Method onReceivedTitle = objectClass.getMethod("onReceivedTitle", String.class);
                 onReceivedTitle.invoke(mCallbackForTest, title);
             } catch (Exception e) {


### PR DESCRIPTION
  The warnings are for java reflection definition.
Use Class<?> instead of Class to declare Class type to resolve these issues.

BUG=https://crosswalk-project.org/jira/browse/XWALK-771
