### PR TITLE
Roll chromium-crosswalk to 8baebce.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '32.0.1700.14'
-chromium_crosswalk_point = '6d2ee63e495ff0c3e7591b2053f34efa4898db60'
+chromium_crosswalk_point = '8baebcea225140abd8f9c54037aa1408c7fc6dec'
 blink_crosswalk_point = '2cb175435ece6896eabf6fe2ff9f1bf6ea8969e3'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
8baebce [SysApps] Add MEDIA_EXPORT to fix linking errors in the component build
