### PR TITLE
[application] Use Application for external URLs.

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -47,6 +47,17 @@ class Application : public Runtime::Observer {
     virtual ~Observer() {}
   };
 
+  // Manifest keys that can be used as application entry points.
+  enum LaunchEntryPoint {
+    AppMainKey = 1 << 0,  // app.main
+    LaunchLocalPathKey = 1 << 1,  // app.launch.local_path
+    LaunchWebURLKey = 1 << 2,  // app.launch.web_url
+    Default = AppMainKey | LaunchLocalPathKey
+  };
+  typedef unsigned LaunchEntryPoints;
+
+  LaunchEntryPoints entry_points() const { return entry_points_; }
+
   // Closes all the application's runtimes (application pages).
   void Close();
 
@@ -82,9 +93,11 @@ class Application : public Runtime::Observer {
               Observer* observer);
   bool Launch();
 
+  template<LaunchEntryPoint>
+  bool TryLaunchAt();
+  void set_entry_points(LaunchEntryPoints entry_points);
+
   friend class FinishEventObserver;
-  bool RunMainDocument();
-  bool RunFromLocalPath();
   void CloseMainDocument();
   bool IsOnSuspendHandlerRegistered(const std::string& app_id) const;
 
@@ -94,6 +107,7 @@ class Application : public Runtime::Observer {
   std::set<Runtime*> runtimes_;
   scoped_ptr<EventObserver> finish_observer_;
   Observer* observer_;
+  LaunchEntryPoints entry_points_;
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -44,8 +44,15 @@ class ApplicationService : public Application::Observer {
 
   bool Install(const base::FilePath& path, std::string* id);
   bool Uninstall(const std::string& id);
+  // Launch an installed application using application id.
   Application* Launch(const std::string& id);
+  // Launch an unpacked application using path to a local directory which
+  // contains manifest file.
   Application* Launch(const base::FilePath& path);
+  // Launch an application created from arbitrary url.
+  // FIXME: This application should have the same strict permissions
+  // as common browser apps.
+  Application* Launch(const GURL& url);
 
   Application* GetApplicationByRenderHostID(int id) const;
 
@@ -63,7 +70,8 @@ class ApplicationService : public Application::Observer {
   // Implementation of Application::Observer.
   virtual void OnApplicationTerminated(Application* app) OVERRIDE;
 
-  Application* Launch(scoped_refptr<ApplicationData> application_data);
+  Application* Launch(scoped_refptr<ApplicationData> application_data,
+                      Application::LaunchEntryPoints = Application::Default);
 
   xwalk::RuntimeContext* runtime_context_;
   ApplicationStorage* application_storage_;

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -77,8 +77,9 @@ class ApplicationSystem {
   //
   // A return value of true indicates that ApplicationSystem handled the command
   // line, so the caller shouldn't try to load the url by itself.
-  bool LaunchFromCommandLine(const CommandLine& cmd_line, const GURL& url,
-                             bool* run_default_message_loop_);
+  bool LaunchFromCommandLine(const CommandLine& cmd_line,
+                             const GURL& url,
+                             bool& run_default_message_loop_);
 
   void CreateExtensions(content::RenderProcessHost* host,
                         extensions::XWalkExtensionVector* extensions);

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -224,8 +224,12 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     return;
   }
 
-  if (!app_system->LaunchFromCommandLine(*command_line, startup_url_,
-                                        &run_default_message_loop_)) {
+  if (!app_system->LaunchFromCommandLine(
+      *command_line, startup_url_,
+      run_default_message_loop_)) {
+    // VLOG(1) << "Crosswalk has failed to launch from command line. Exiting."
+    // FIXME(Mikhail): We should just return here, but browser tests atm need
+    // runtime running even without any meaningful command line argument.
     RunAsBrowser(runtime_context_, startup_url_);
   }
 


### PR DESCRIPTION
Use Application for external URLs. Rationals:
1) allows web pages to use some of XWalk APIs
2) makes in-browser testing simpler: no need in APIs like "Rungtime::SetGlobalObserverForTesting"
3) External URLs and applications share the same code path, which is better for both testing and maintainance

The  "app.launch.web_url" manifest key is used as application entry point for external URLs loading.

WIP: in-browser tests should be updated accordingly.
