### PR TITLE
[Android] Add support for specifying android version codes

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -87,6 +87,9 @@ def CustomizeXML(options, sanitized_name):
   CustomizeStringXML(options, sanitized_name)
   xmldoc = minidom.parse(manifest_path)
   EditElementAttribute(xmldoc, 'manifest', 'package', options.package)
+  if options.app_versionCode:
+    EditElementAttribute(xmldoc, 'manifest', 'android:versionCode',
+                         str(options.app_versionCode))
   if options.app_version:
     EditElementAttribute(xmldoc, 'manifest', 'android:versionName',
                          options.app_version)
@@ -307,6 +310,8 @@ def main():
   parser.add_option('--name', help=info)
   info = ('The version of the app. Such as: --app-version=TheVersionNumber')
   parser.add_option('--app-version', help=info)
+  info = ('The versionCode of the app. Such as: --app-versionCode=24')
+  parser.add_option('--app-versionCode', type='int', help=info)
   info = ('The application description. Such as:'
           '--description=YourApplicationdDescription')
   parser.add_option('--description', help=info)

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -94,6 +94,8 @@ def ParseManifest(options):
     options.name = parser.GetAppName()
   if not options.app_version:
     options.app_version = parser.GetVersion()
+  if not options.app_versionCode and not options.app_versionCodeBase:
+    options.app_versionCode = 1
   if parser.GetDescription():
     options.description = parser.GetDescription()
   if parser.GetPermissions():
@@ -155,6 +157,29 @@ def FindExtensionJars(root_path):
         extension_jars.append(extension_jar)
   return extension_jars
 
+# Follows the recommendation from
+# http://software.intel.com/en-us/blogs/2012/11/12/how-to-publish-
+# your-apps-on-google-play-for-x86-based-android-devices-using
+def MakeVersionCode(options):
+  ''' Construct a version code'''
+  if options.app_versionCode:
+    return '--app-versionCode=%s' % options.app_versionCode
+
+  # First digit is ABI, ARM=2, x86=6
+  abi = '0'
+  if options.arch == 'arm':
+    abi = '2'
+  if options.arch == 'x86':
+    abi = '6'
+  b = '0'
+  if options.app_versionCodeBase:
+    b = str(options.app_versionCodeBase)
+    if len(b) > 7:
+      print('Version code base must be 7 digits or less: versionCodeBase=%s' % (b))
+      sys.exit(12)
+  # zero pad to 7 digits, middle digits can be used for other
+  # features, according to recommendation in URL
+  return '--app-versionCode=%s%s' % (abi, b.zfill(7))
 
 def Customize(options):
   package = '--package=org.xwalk.app.template'
@@ -166,6 +191,7 @@ def Customize(options):
   app_version = '--app-version=1.0.0'
   if options.app_version:
     app_version = '--app-version=%s' % options.app_version
+  app_versionCode = MakeVersionCode(options)
   description = ''
   if options.description:
     description = '--description=%s' % options.description
@@ -197,8 +223,8 @@ def Customize(options):
   if options.orientation:
     orientation = '--orientation=%s' % options.orientation
   cmd = ['python', 'customize.py', package,
-          name, app_version, description, icon, permissions, app_url,
-          remote_debugging, app_root, app_local_path, fullscreen_flag,
+          name, app_version, app_versionCode, description, icon, permissions, 
+          app_url, remote_debugging, app_root, app_local_path, fullscreen_flag,
           extensions_list, orientation]
   RunCommand(cmd)
 
@@ -561,6 +587,13 @@ def main(argv):
   info = ('The version name of the application. '
           'For example, --app-version=1.0.0')
   group.add_option('--app-version', help=info)
+  info = ('The version code of the application. '
+          'For example, --app-versionCode=24')
+  group.add_option('--app-versionCode', type='int', help=info)
+  info = ('The version code base of the application. Version code will '
+          'be made by adding a prefix based on architecture to the version '
+          'code base. For example, --app-versionCodeBase=24')
+  group.add_option('--app-versionCodeBase', type='int', help=info)
   info = ('The description of the application. For example, '
           '--description=YourApplicationDescription')
   group.add_option('--description', help=info)
@@ -628,7 +661,7 @@ def main(argv):
       parser.error('The package name is required! '
                    'Please use "--package" option.')
     if not options.name:
-      parser.error('The APK name is required! Pleaes use "--name" option.')
+      parser.error('The APK name is required! Please use "--name" option.')
     if not ((options.app_url and not options.app_root
         and not options.app_local_path) or ((not options.app_url)
             and options.app_root and options.app_local_path)):

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -194,6 +194,67 @@ class TestMakeApk(unittest.TestCase):
     self.checkApks('Example')
     Clean('Example')
 
+  def testAppVersionCode(self):
+    cmd = ['python', 'make_apk.py', '--name=Example',
+           '--package=org.xwalk.example', '--app-version=1.0.0',
+           '--description=a sample application',
+           '--app-versionCode=3',
+           '--app-url=http://www.intel.com', self._mode]
+    RunCommand(cmd)
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('versionCode="3"') != -1)
+    self.checkApks('Example')
+    Clean('Example')
+
+  def testAppVersionCodeBase(self):
+    # Arch option only works for embedded mode,
+    # so only test it for embedded mode.
+    if self._mode.find('embedded') == -1:
+      return
+    if 'x86' in self.archs():
+      arch = '--arch=x86'
+      versionCode = 'versionCode="60000003"'
+    else:
+      arch = '--arch=arm'
+      versionCode = 'versionCode="20000003"'
+    cmd = ['python', 'make_apk.py', '--name=Example',
+           '--package=org.xwalk.example', '--app-version=1.0.0',
+           '--description=a sample application',
+           '--app-versionCodeBase=3',
+           arch,
+           '--app-url=http://www.intel.com', self._mode]
+    RunCommand(cmd)
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find(versionCode) != -1)
+    self.checkApks('Example')
+    Clean('Example')
+
+  def testAppBigVersionCodeBase(self):
+    # Arch option only works for embedded mode,
+    # so only test it for embedded mode.
+    if self._mode.find('embedded') == -1:
+      return
+    if 'x86' in self.archs():
+      arch = '--arch=x86'
+    else:
+      arch = '--arch=arm'
+    cmd = ['python', 'make_apk.py', '--name=Example',
+           '--package=org.xwalk.example', '--app-version=1.0.0',
+           '--description=a sample application',
+           '--app-versionCodeBase=30000000',
+           arch,
+           '--app-url=http://www.intel.com', self._mode]
+    RunCommand(cmd)
+    manifest = 'Example/AndroidManifest.xml'
+    self.assertFalse(os.path.exists(manifest))
+    Clean('Example')
+
   def testPermissions(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--permissions=geolocation',
@@ -578,6 +639,9 @@ class TestMakeApk(unittest.TestCase):
 def SuiteWithModeOption():
   # Gather all the tests for the specified mode option.
   test_suite = unittest.TestSuite()
+  test_suite.addTest(TestMakeApk('testAppBigVersionCodeBase'))
+  test_suite.addTest(TestMakeApk('testAppVersionCode'))
+  test_suite.addTest(TestMakeApk('testAppVersionCodeBase'))
   test_suite.addTest(TestMakeApk('testAppDescriptionAndVersion'))
   test_suite.addTest(TestMakeApk('testArch'))
   test_suite.addTest(TestMakeApk('testEnableRemoteDebugging'))

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -110,7 +110,7 @@ class ManifestJsonParser(object):
     if self.data_src.has_key('icons'):
       ret_dict['icons'] = self.data_src['icons']
     else:
-      ret_dict['icons'] = ''
+      ret_dict['icons'] = {}
     app_root = file_path_prefix
     ret_dict['description'] = ''
     if self.data_src.has_key('description'):


### PR DESCRIPTION
Add support for specifying android version codes, which is necessary for publishing multiple apk to google play. Follows the recommendation for including ABI in version code from  http://software.intel.com/en-us/blogs/2012/11/12/how-to-publish-your-apps-on-google-play-for-x86-based-android-devices-using. The schemes ensures that all x86 version codes are higher than arm version codes so google play will never install an arm version on an x86 device if there also is an x86 apk in the store.

Added some tests to make_apk_test and published x86 and arm crosswalk apk to google play.
Use --app-versionCodeBase=n and --arch=x86 or --arch=arm to use this feature and it will set version code that includes ABI, which enables multiple apk's

You can also specify the full version code yourself
 --app-versionCode=n

Before this change, script was setting versionName, but not versionCode so it was not possible to update an APK in the store or publish multiple APK's
