### PR TITLE
Revert "Fix compilation error with -Werror=delete-non-virtual-dtor flag set"

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -65,8 +65,6 @@ void RunAsBrowser(xwalk::RuntimeContext* runtime_context,
     using xwalk::Runtime;
 
     class Observer : public Runtime::Observer {
-        virtual ~Observer() {}
-
         virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE {
           DCHECK(runtime);
           runtimes_.insert(runtime);


### PR DESCRIPTION
It turns out my checkout was probably outdated at the time I got this warning,
as GCC 4.8 does not complain about this anymore.

This reverts commit 01c4780c6ecd9901f965ded475e8f9b638738921.

Conflicts:
runtime/browser/xwalk_browser_main_parts.cc
