### PR TITLE
ApplicationProtocolHandler supports multi apps

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -102,7 +102,7 @@ class Application : public Runtime::Observer {
   bool IsOnSuspendHandlerRegistered() const;
 
   RuntimeContext* runtime_context_;
-  scoped_refptr<ApplicationData> application_data_;
+  const scoped_refptr<ApplicationData> application_data_;
   Runtime* main_runtime_;
   std::set<Runtime*> runtimes_;
   scoped_ptr<EventObserver> finish_observer_;

--- a/application/browser/application_protocols.h
+++ b/application/browser/application_protocols.h
@@ -11,14 +11,14 @@
 
 namespace xwalk {
 namespace application {
-class ApplicationData;
-}
-}
+
+class ApplicationService;
 
 // Creates the handlers for the app:// scheme.
 linked_ptr<net::URLRequestJobFactory::ProtocolHandler>
-CreateApplicationProtocolHandler(
-    const xwalk::application::ApplicationData* application);
+CreateApplicationProtocolHandler(ApplicationService* service);
 
+}  // namespace application
+}  // namespace xwalk
 
 #endif  // XWALK_APPLICATION_BROWSER_APPLICATION_PROTOCOLS_H_

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -58,6 +58,7 @@ class ApplicationService : public Application::Observer {
   Application* Launch(const GURL& url);
 
   Application* GetApplicationByRenderHostID(int id) const;
+  Application* GetApplicationByID(const std::string& app_id) const;
 
   const ScopedVector<Application>& active_applications() const {
       return applications_; }

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -167,14 +167,10 @@ net::URLRequestContextGetter* RuntimeContext::CreateRequestContext(
 
   application::ApplicationService* service =
       XWalkRunner::GetInstance()->app_system()->application_service();
-  const application::Application* running_app =
-      service->GetActiveApplication();
-  if (running_app) {
-    protocol_handlers->insert(std::pair<std::string,
+  protocol_handlers->insert(std::pair<std::string,
         linked_ptr<net::URLRequestJobFactory::ProtocolHandler> >(
           application::kApplicationScheme,
-          CreateApplicationProtocolHandler(running_app->data())));
-  }
+          application::CreateApplicationProtocolHandler(service)));
 
   url_request_getter_ = new RuntimeURLRequestContextGetter(
       false, /* ignore_certificate_error = false */


### PR DESCRIPTION
This is a step in enabling of Shared process model.
ApplicationProtocolHandler is given with ApplicationService instance and the corresponding application instance
is fetched from the service via newly added "GetApplicationByID" method.
