### PR TITLE
Disable NoCSP unit test

### DIFF
--- a/application/common/manifest_handlers/csp_handler_unittest.cc
+++ b/application/common/manifest_handlers/csp_handler_unittest.cc
@@ -38,7 +38,9 @@ class CSPHandlerTest: public testing::Test {
   base::DictionaryValue manifest;
 };
 
-TEST_F(CSPHandlerTest, NoCSP) {
+// FIXME: the default CSP policy settings in CSP manifest handler
+// are temporally removed, since they had affected some tests and legacy apps.
+TEST_F(CSPHandlerTest, DISABLED_NoCSP) {
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());
   EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 2);


### PR DESCRIPTION
Disable NoCSP unit test as the default CSP policy settings in CSP manifest handler
were removed (since they had affected some tests and legacy apps).
The test shall be enabled again when we have default CSP settings back.
