### PR TITLE
[Packaging] Prefer pkgconfig(package) in BuildRequires when possible.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -27,13 +27,12 @@ BuildRequires:  expat-devel
 BuildRequires:  flex
 BuildRequires:  gperf
 BuildRequires:  gst-plugins-atomisp-devel
-BuildRequires:  libasound-devel
 BuildRequires:  libcap-devel
-BuildRequires:  pkgmgr-info-parser-devel
 BuildRequires:  python
 BuildRequires:  python-xml
 BuildRequires:  perl
 BuildRequires:  which
+BuildRequires:  pkgconfig(alsa)
 BuildRequires:  pkgconfig(appcore-common)
 BuildRequires:  pkgconfig(appcore-efl)
 BuildRequires:  pkgconfig(aul)


### PR DESCRIPTION
The recommended way to depend on packages is to use BuildRequires: 
pkgconfig(foo) instead of explicitly using BuildRequires: libfoo-devel.

Use that where possible, and remove a duplicate entry for 
pkgmgr-info-parser-devel, which already has a pkgconfig() entry.
