### PR TITLE
[Android] Enable multiple threads for rasterization

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -10,6 +10,8 @@
 #include "base/file_util.h"
 #include "base/message_loop/message_loop.h"
 #include "base/path_service.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/sys_info.h"
 #include "base/threading/sequenced_worker_pool.h"
 #include "cc/base/switches.h"
 #include "content/public/browser/android/compositor.h"
@@ -91,6 +93,14 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   // blacklist.
   command_line->AppendSwitch(switches::kDisableWebRtcHWDecoding);
   command_line->AppendSwitch(switches::kDisableWebRtcHWEncoding);
+
+  if (!command_line->HasSwitch(cc::switches::kNumRasterThreads)) {
+    // Enable multiple threads for rasterization to take advantage of multi CPU
+    // cores. Only valid when ImplSidePainting is enabled.
+    const int num_of_cpu_cores = base::SysInfo::NumberOfProcessors();
+    command_line->AppendSwitchASCII(cc::switches::kNumRasterThreads,
+                                    base::IntToString(num_of_cpu_cores));
+  }
 
   XWalkBrowserMainParts::PreMainMessageLoopStart();
 


### PR DESCRIPTION
On Android, since impl side painting is enabled as default, the
rasterization is scheduled to a seperate threads. However, the default
number of threads for rasterization is 1.

This commit is to calculate the appropriate number of raster threads
according to the number of CPU cores. It could take advantage of the
multi-core hardware capability and bring performance boost in
rasterizing, according to the result of some experiments.
