### PR TITLE
[Android] Fix crash issue in Android extension system 

### DIFF
--- a/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
+++ b/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
@@ -21,7 +21,7 @@ public abstract class XWalkExtensionAndroid {
     private int mXWalkExtension;
 
     public XWalkExtensionAndroid(String name, String jsApi) {
-        mXWalkExtension = nativeCreateExtension(name, jsApi);
+        mXWalkExtension = nativeGetOrCreateExtension(name, jsApi);
     }
 
     protected void destroyExtension() {
@@ -58,7 +58,7 @@ public abstract class XWalkExtensionAndroid {
     @CalledByNative
     public abstract String handleSyncMessage(int instanceID, String message);
 
-    private native int nativeCreateExtension(String name, String jsApi);
+    private native int nativeGetOrCreateExtension(String name, String jsApi);
     private native void nativePostMessage(int nativeXWalkExtensionAndroid, int instanceID, String message);
     private native void nativeBroadcastMessage(int nativeXWalkExtensionAndroid, String message);
     private native void nativeDestroyExtension(int nativeXWalkExtensionAndroid);

--- a/extensions/common/android/xwalk_extension_android.h
+++ b/extensions/common/android/xwalk_extension_android.h
@@ -21,14 +21,29 @@ namespace extensions {
 
 class XWalkExtensionAndroidInstance;
 
-// This class (together with XWalkExtensionAndroidInstance) is counterpart of
-// XWalkExtensionAndroid.java, allow implement message passing based extension
-// written by Java.
+// This class (together with XWalkExtensionAndroidInstance) is the native part
+// of XWalkExtensionAndroid on Java side for message-passing based extension
+// system works on Android platform.
 //
-// When new a Java object that inherit from XWalkExtensionAndroid.java, it will
-// create a XWalkExtensionAndroid via the JNI interface CreateExtension.
-// Then C++ extension framework will create XWalkExtensionInstance(s) on the
-// fly. Thus instance(s) can bridge messages between JS and Java.
+// Once a XWalkExtensionAndroid-derived instance is created on Java side, the
+// native part is also created accordingly. Meanwhile, the native part has to
+// hold a reference to the Java-side object for routing message from native side
+// to Java side.
+//
+// The native-side XWalkExtensionAndroid/XWalkExtensionInstance objects are
+// actually owned by XWalkExtensionServer, it means that XWalkExtensionServer
+// is the right place to delete those objects. The native XWalkExtensionAndroid
+// object is always alive in memory until the process is terminated after it is
+// registered into extension server.
+//
+// The Java-side object may be destroyed due to the lifecycle of Activity, e.g.
+// when pressing back button, the Activity will invoke onDestroyed callback and
+// hence Java-side objects are treated to be invalid.
+//
+// Since the native part of XWalkExtensionAndroid is designed to be reused
+// during the whole process lifecycle. For each native part, its referenced
+// Java-side object needs to be re-assigned once a new Java extension object is
+// created for the same extension identified the extension name.
 class XWalkExtensionAndroid : public XWalkExtension {
  public:
   XWalkExtensionAndroid(JNIEnv* env, jobject obj, jstring name, jstring js_api);
@@ -44,11 +59,19 @@ class XWalkExtensionAndroid : public XWalkExtension {
 
   void RemoveInstance(int instance);
 
+  // Each Extension object created on Java side is backed by this native object,
+  // and the native object also has a reference to Java-side object for message
+  // routing from native side to Java side. However, the Java extension object
+  // might be destroyed due to activity lifecycle. This method is used to
+  // re-bind the native object to an valid Java-side extension object.
+  void BindToJavaObject(JNIEnv* env, jobject obj);
+
  private:
   bool is_valid();
 
   typedef std::map<int, XWalkExtensionAndroidInstance*> InstanceMap;
   InstanceMap instances_;
+  // Hold a reference to Java-side extension object for message routing.
   JavaObjectWeakGlobalRef java_ref_;
   int next_instance_id_;
 
@@ -76,6 +99,7 @@ class XWalkExtensionAndroidInstance : public XWalkExtensionInstance {
   virtual void HandleSyncMessage(scoped_ptr<base::Value> msg) OVERRIDE;
 
   XWalkExtensionAndroid* extension_;
+  // Hold a refenerence to Java-side XWalkExtensionAndroid object.
   JavaObjectWeakGlobalRef java_ref_;
   int id_;
 

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -157,10 +157,11 @@ void XWalkBrowserMainPartsAndroid::PostMainMessageLoopRun() {
 void XWalkBrowserMainPartsAndroid::CreateInternalExtensionsForExtensionThread(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
-  // FIXME(cmarcelo): Android port keeps the ownership of extensions
-  // here in the XWalkBrowserMainParts for some reason, this is incorrect use
-  // of extensions system.
-  ScopedVector<XWalkExtension>::const_iterator it = extensions_.begin();
+  // On Android part, the ownership of each extension object will be transferred
+  // to XWalkExtensionServer after this method is called. It is a rule enforced
+  // by extension system that XWalkExtensionServer must own the extension
+  // objects and extension instances.
+  extensions::XWalkExtensionVector::const_iterator it = extensions_.begin();
   for (; it != extensions_.end(); ++it)
     extensions->push_back(*it);
 
@@ -182,19 +183,24 @@ void XWalkBrowserMainPartsAndroid::CreateInternalExtensionsForUIThread(
 
 void XWalkBrowserMainPartsAndroid::RegisterExtension(
     scoped_ptr<XWalkExtension> extension) {
+  // Since the creation of extension object is driven by Java side, and each
+  // Java extension is backed by a native extension object. However, the Java
+  // object may be destroyed by Android lifecycle management without destroying
+  // the native side object. We keep the reference to native extension object
+  // to make sure we can reuse the native object if Java extension is re-created
+  // on resuming.
   extensions_.push_back(extension.release());
 }
 
-void XWalkBrowserMainPartsAndroid::UnregisterExtension(
-    scoped_ptr<XWalkExtension> extension) {
-  ScopedVector<XWalkExtension>::iterator it = extensions_.begin();
+XWalkExtension* XWalkBrowserMainPartsAndroid::LookupExtension(
+    const std::string& name) {
+  extensions::XWalkExtensionVector::const_iterator it = extensions_.begin();
   for (; it != extensions_.end(); ++it) {
-    // FIXME: how is that possible we have 2 scoped_ptrs to the same pointer?
-    if (*it == extension.release()) break;
+    XWalkExtension* extension = *it;
+    if (name == extension->name()) return extension;
   }
 
-  if (it != extensions_.end())
-    extensions_.erase(it);
+  return NULL;
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts_android.h
+++ b/runtime/browser/xwalk_browser_main_parts_android.h
@@ -39,10 +39,13 @@ class XWalkBrowserMainPartsAndroid : public XWalkBrowserMainParts {
   // XWalkBrowserMainParts so they get correctly registered on-demand
   // by XWalkExtensionService each time a in_process Server is created.
   void RegisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
-  void UnregisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
+
+  // Lookup the extension with the given name from the extension list that is
+  // already registered. Returns NULL if no such extension exists.
+  extensions::XWalkExtension* LookupExtension(const std::string& name);
 
  private:
-  ScopedVector<extensions::XWalkExtension> extensions_;
+  extensions::XWalkExtensionVector extensions_;
   scoped_refptr<net::CookieStore> cookie_store_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkBrowserMainPartsAndroid);


### PR DESCRIPTION
```
On Android, the extension objects and instances are deleted explicitly
by JNI invokation from Java side. However, both extension objects and
instances are designed to be owned by XWalkExtensionServer, it means
that only XWalkExtensionServer is allowed to delete them, otherwise a
pointer would be deleted twice and cause crash issue.

This fix is to address the above issue and make sure the extension
objects and instances are owned by XWalkExtensionServer. Moreover, the
extension objects on native side will be alive in the whole process
lifecycle and reused by Java-side if resuming back.

BUG=https://crosswalk-project.org/jira/browse/XWALK-821
```
