### PR TITLE
[Runtime] Fix application extension registration issue

### DIFF
--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -12,6 +12,9 @@
 #include "xwalk/application/browser/application_process_manager.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/common/event_names.h"
+#include "xwalk/application/extension/application_event_extension.h"
+#include "xwalk/application/extension/application_runtime_extension.h"
+#include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 
@@ -144,6 +147,19 @@ void ApplicationSystem::SendOnLaunchedEvent() {
 
 bool ApplicationSystem::IsRunningAsService() const {
   return false;
+}
+
+void ApplicationSystem::RegisterExtensions(
+    extensions::XWalkExtensionServer* server) {
+  // FIXME(xiang): When service mode is enabled, we need to check whether the
+  // RPH belongs to an active application.
+  if (!application_service_->GetRunningApplication())
+    return;
+
+  server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(
+      new ApplicationRuntimeExtension(this)));
+  server->RegisterExtension(scoped_ptr<extensions::XWalkExtension>(
+      new ApplicationEventExtension(this)));
 }
 
 }  // namespace application

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -18,6 +18,11 @@ class RuntimeContext;
 }
 
 namespace xwalk {
+
+namespace extensions {
+class XWalkExtensionServer;
+}
+
 namespace application {
 
 class ApplicationEventManager;
@@ -78,6 +83,8 @@ class ApplicationSystem {
   // Return true if the application system is running in service mode,
   // i.e. taking requests from native IPC mechanism to launch applications.
   virtual bool IsRunningAsService() const;
+
+  void RegisterExtensions(extensions::XWalkExtensionServer* server);
 
  protected:
   explicit ApplicationSystem(RuntimeContext* runtime_context);

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -14,8 +14,6 @@
 #include "base/strings/string_number_conversions.h"
 #include "xwalk/application/browser/application_process_manager.h"
 #include "xwalk/application/browser/application_system.h"
-#include "xwalk/application/extension/application_event_extension.h"
-#include "xwalk/application/extension/application_runtime_extension.h"
 #include "xwalk/experimental/dialog/dialog_extension.h"
 #include "xwalk/extensions/common/xwalk_extension_server.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
@@ -243,11 +241,7 @@ void XWalkBrowserMainParts::RegisterInternalExtensionsInUIThreadServer(
     extensions::XWalkExtensionServer* server) {
   CHECK(server);
   DCHECK(runtime_context_);
-  server->RegisterExtension(scoped_ptr<XWalkExtension>(
-      new ApplicationRuntimeExtension(
-          runtime_context_->GetApplicationSystem())));
-  server->RegisterExtension(scoped_ptr<XWalkExtension>(
-      new ApplicationEventExtension(runtime_context_->GetApplicationSystem())));
+  runtime_context_->GetApplicationSystem()->RegisterExtensions(server);
 }
 
 }  // namespace xwalk


### PR DESCRIPTION
ISSUE: https://crosswalk-project.org/jira/browse/XWALK-759

When launched as an external web browser, the application extension instance
will be created and trigger "CHECK(application)" assertion failure if
xwalk.app.\* APIs are called.

To fix this, now we only register the application extensions after check whether
we have a currently running application in ApplicationService.
