### PR TITLE
[Extensions] Make our include_rules stricter

### DIFF
--- a/extensions/DEPS
+++ b/extensions/DEPS
@@ -1,3 +1,15 @@
 include_rules = [
+  # Extension system doesn't depend on the other parts of Crosswalk.
+  "-xwalk",
+  "+xwalk/extensions",
+
+  # Android.
+  "+jni",
+
+  # FIXME(cmarcelo): These are here for Android bindings. See
+  # https://crosswalk-project.org/jira/browse/XWALK-749, should be removed.
+  "!xwalk/runtime/browser/xwalk_browser_main_parts_android.h",
+  "!xwalk/runtime/browser/xwalk_content_browser_client.h",
+
   "+grit/xwalk_extensions_resources.h"
 ]

--- a/extensions/test/DEPS
+++ b/extensions/test/DEPS
@@ -1,0 +1,6 @@
+include_rules = [
+  "+xwalk/test",
+
+  # For "browser tests" we run entire Crosswalk system.
+  "+xwalk/runtime"
+]


### PR DESCRIPTION
These are used by tools/check-xwalk-deps. The extension system doesn't
depend on other parts of Crosswalk.
