### PR TITLE
[SysApps] Remove usage of XWalkRuntimeFeatures

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -184,7 +184,13 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
   extension_service_ = xwalk_runner_->extension_service();
 
   if (extension_service_) {
-    sysapps_manager_.reset(new sysapps::SysAppsManager());
+    if (XWalkRuntimeFeatures::isSysAppsEnabled()) {
+      sysapps_manager_.reset(new sysapps::SysAppsManager());
+      if (!XWalkRuntimeFeatures::isDeviceCapabilitiesAPIEnabled())
+        sysapps_manager_->DisableDeviceCapabilities();
+      if (!XWalkRuntimeFeatures::isRawSocketsAPIEnabled())
+        sysapps_manager_->DisableRawSockets();
+    }
     RegisterExternalExtensions();
   }
 
@@ -255,7 +261,8 @@ void XWalkBrowserMainParts::CreateInternalExtensionsForUIThread(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
   xwalk_runner_->app_system()->CreateExtensions(host, extensions);
-  sysapps_manager_->CreateExtensionsForUIThread(extensions);
+  if (sysapps_manager_)
+    sysapps_manager_->CreateExtensionsForUIThread(extensions);
 }
 
 void XWalkBrowserMainParts::CreateInternalExtensionsForExtensionThread(
@@ -267,7 +274,8 @@ void XWalkBrowserMainParts::CreateInternalExtensionsForExtensionThread(
   extensions->push_back(
       new experimental::DialogExtension(app_system));
 
-  sysapps_manager_->CreateExtensionsForExtensionThread(extensions);
+  if (sysapps_manager_)
+    sysapps_manager_->CreateExtensionsForExtensionThread(extensions);
 }
 
 }  // namespace xwalk

--- a/sysapps/common/sysapps_manager.cc
+++ b/sysapps/common/sysapps_manager.cc
@@ -5,7 +5,6 @@
 #include "xwalk/sysapps/common/sysapps_manager.h"
 
 #include "base/basictypes.h"
-#include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "xwalk/sysapps/device_capabilities_new/cpu_info_provider.h"
 #include "xwalk/sysapps/device_capabilities_new/memory_info_provider.h"
 #include "xwalk/sysapps/device_capabilities_new/device_capabilities_extension_new.h"
@@ -14,29 +13,33 @@
 namespace xwalk {
 namespace sysapps {
 
-SysAppsManager::SysAppsManager() {}
+SysAppsManager::SysAppsManager()
+    : device_capabilities_enabled_(true),
+      raw_sockets_enabled_(true) {}
 
 SysAppsManager::~SysAppsManager() {}
 
+void SysAppsManager::DisableDeviceCapabilities() {
+  device_capabilities_enabled_ = false;
+}
+
+void SysAppsManager::DisableRawSockets() {
+  raw_sockets_enabled_ = false;
+}
+
 void SysAppsManager::CreateExtensionsForUIThread(
     XWalkExtensionVector* extensions) {
-  if (!XWalkRuntimeFeatures::isSysAppsEnabled())
-    return;
-
   // FIXME(tmpsantos): Device Capabilities needs to be in the UI Thread because
   // it uses Chromium's StorageMonitor, which requires that. We can move it back
   // to the ExtensionThread if we make StorageMonitor a truly self-contained
   // module on Chromium upstream.
-  if (XWalkRuntimeFeatures::isDeviceCapabilitiesAPIEnabled())
+  if (device_capabilities_enabled_)
     extensions->push_back(new experimental::DeviceCapabilitiesExtension());
 }
 
 void SysAppsManager::CreateExtensionsForExtensionThread(
     XWalkExtensionVector* extensions) {
-  if (!XWalkRuntimeFeatures::isSysAppsEnabled())
-    return;
-
-  if (XWalkRuntimeFeatures::isRawSocketsAPIEnabled())
+  if (raw_sockets_enabled_)
     extensions->push_back(new RawSocketExtension());
 }
 

--- a/sysapps/common/sysapps_manager.h
+++ b/sysapps/common/sysapps_manager.h
@@ -25,12 +25,19 @@ class SysAppsManager {
   SysAppsManager();
   ~SysAppsManager();
 
+  void DisableDeviceCapabilities();
+  void DisableRawSockets();
+
   void CreateExtensionsForUIThread(XWalkExtensionVector* extensions);
   void CreateExtensionsForExtensionThread(XWalkExtensionVector* extensions);
 
   static AVCodecsProvider* GetAVCodecsProvider();
   static CPUInfoProvider* GetCPUInfoProvider();
   static MemoryInfoProvider* GetMemoryInfoProvider();
+
+ private:
+  bool device_capabilities_enabled_;
+  bool raw_sockets_enabled_;
 };
 
 }  // namespace sysapps

--- a/sysapps/sysapps.gyp
+++ b/sysapps/sysapps.gyp
@@ -3,9 +3,6 @@
     {
       'target_name': 'sysapps',
       'type': 'static_library',
-      # FIXME(tmpsantos): In theory we depend on the whole runtime because
-      # of the XWalkRuntimeFeatures and this is a layer violation that must
-      # be fixed.
       'dependencies': [
         '../../base/base.gyp:base',
         '../../net/net.gyp:net',

--- a/sysapps/sysapps_tests.gyp
+++ b/sysapps/sysapps_tests.gyp
@@ -10,7 +10,6 @@
         '../../testing/gtest.gyp:gtest',
         '../../ui/ui.gyp:ui',
         '../extensions/extensions.gyp:xwalk_extensions',
-        '../xwalk.gyp:xwalk_runtime',
         'sysapps.gyp:sysapps',
       ],
       'sources': [


### PR DESCRIPTION
This was the only dependency that sysapps/ had from runtime/. We keep
the usage of the XWalkRuntimeFeatures (which parses command line) in
runtime/ and add specific functions to disable each API.

This patch is a first step to clean up the handling of extension
creation in the Android and Tizen variants. At the moment, creation of
the extensions in those ports is bypassing the SysAppsManager.
