### PR TITLE
[Android] Implement the functions of application working from SD-Card.

### DIFF
--- a/app/android/app_template/AndroidManifest.xml
+++ b/app/android/app_template/AndroidManifest.xml
@@ -7,7 +7,8 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.xwalk.app.template">
+    package="org.xwalk.app.template"
+    android:installLocation="auto">
 
     <application android:name="android.app.Application"
         android:label="XWalkAppTemplate" android:hardwareAccelerated="true"

--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -41,6 +41,8 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
     @Override
     public void onCreate(Bundle savedInstanceState) {
         IntentFilter intentFilter = new IntentFilter("org.xwalk.intent");
+        intentFilter.addAction("android.intent.action.EXTERNAL_APPLICATIONS_AVAILABLE");
+        intentFilter.addAction("android.intent.action.EXTERNAL_APPLICATIONS_UNAVAILABLE");
         mReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {


### PR DESCRIPTION
  Crosswalk for Android port doesn't support the functions of application
moving to SD-card and working from SD-Card. This is because the AndroidManifest.xml
in xwalk app template doesn't support the application installation settings for
"preferExternal" or "Auto", and the corresponding intent actions should be registered
as response to the mounting and unmounting of SD-Card. This feature is to enable
the SD-Card related function supports.

BUG=https://crosswalk-project.org/jira/browse/XWALK-774
