### PR TITLE
Support restricting the allowed orientations (UA wise)

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -13,6 +13,7 @@
 #include "ui/views/view.h"
 #include "ui/views/widget/widget.h"
 #include "xwalk/runtime/browser/ui/top_view_layout_views.h"
+#include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 
 namespace xwalk {
 
@@ -35,7 +36,10 @@ void NativeAppWindowTizen::Initialize() {
   DCHECK(root_window);
   root_window->AddObserver(this);
 
-  OnAllowedOrientationsChanged(GetAllowedUAOrientations());
+  OrientationMask ua_default =
+      XWalkBrowserMainPartsTizen::GetAllowedUAOrientations();
+  OnAllowedOrientationsChanged(ua_default);
+
   if (SensorProvider* sensor = SensorProvider::GetInstance()) {
     gfx::Display::Rotation rotation
       = GetClosestAllowedRotation(sensor->GetCurrentRotation());
@@ -110,16 +114,6 @@ gfx::Transform NativeAppWindowTizen::GetRotationTransform() const {
   return rotate;
 }
 
-OrientationMask NativeAppWindowTizen::GetAllowedUAOrientations() const {
-  char* env = getenv("TIZEN_ALLOWED_ORIENTATIONS");
-  int value = env ? atoi(env) : 0;
-  if (value > 0 && value < (1 << 4))
-    return static_cast<OrientationMask>(value);
-
-  // Tizen mobile supports all orientations by default.
-  return ANY;
-}
-
 namespace {
 
 // Rotates a binary mask of 4 positions to the left.
@@ -167,8 +161,7 @@ gfx::Display::Rotation NativeAppWindowTizen::GetClosestAllowedRotation(
 
 void NativeAppWindowTizen::OnAllowedOrientationsChanged(
     OrientationMask orientations) {
-  allowed_orientations_ = (orientations == UA_DEFAULTS)
-      ? GetAllowedUAOrientations() : orientations;
+  allowed_orientations_ = orientations;
 
   gfx::Display::Rotation rotation
       = GetClosestAllowedRotation(display_.rotation());

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -20,7 +20,7 @@ class NativeAppWindowTizen
     : public aura::WindowObserver,
       public NativeAppWindowViews,
       public SensorProvider::Observer,
-      public ScreenOrientationAPISupplement {
+      public MultiOrientationScreen {
  public:
   explicit NativeAppWindowTizen(const NativeAppWindow::CreateParams& params);
   virtual ~NativeAppWindowTizen();
@@ -50,7 +50,6 @@ class NativeAppWindowTizen
   void UpdateTopViewOverlay();
 
   // ScreenOrientationAPISupplement overrides:
-  virtual OrientationMask GetAllowedUAOrientations() const OVERRIDE;
   virtual void OnAllowedOrientationsChanged(
       OrientationMask orientations) OVERRIDE;
 

--- a/runtime/browser/ui/screen_orientation.h
+++ b/runtime/browser/ui/screen_orientation.h
@@ -18,17 +18,13 @@ LANDSCAPE_SECONDARY = 1 << 3,
 PORTRAIT            = PORTRAIT_PRIMARY | PORTRAIT_SECONDARY,
 LANDSCAPE           = LANDSCAPE_PRIMARY | LANDSCAPE_SECONDARY,
 ANY                 = PORTRAIT | LANDSCAPE,
-
-// Special
-UA_DEFAULTS         = 0
 };
 
 typedef unsigned OrientationMask;
 
-class ScreenOrientationAPISupplement {
+class MultiOrientationScreen {
  public:
-  virtual ~ScreenOrientationAPISupplement() {}
-  virtual OrientationMask GetAllowedUAOrientations() const = 0;
+  virtual ~MultiOrientationScreen() {}
   virtual void OnAllowedOrientationsChanged(OrientationMask orientations) = 0;
 };
 

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -77,14 +77,27 @@ void XWalkBrowserMainPartsTizen::CreateInternalExtensionsForExtensionThread(
     extensions->push_back(new sysapps::RawSocketExtension);
 }
 
+// static.
+OrientationMask XWalkBrowserMainPartsTizen::GetAllowedUAOrientations() {
+  char* env = getenv("TIZEN_ALLOWED_ORIENTATIONS");
+  int value = env ? atoi(env) : 0;
+  if (value > 0 && value < (1 << 4))
+    return static_cast<OrientationMask>(value);
+
+  // Tizen mobile supports all orientations by default.
+  return ANY;
+}
+
 void XWalkBrowserMainPartsTizen::CreateInternalExtensionsForUIThread(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
   application::ApplicationSystem* app_system = xwalk_runner_->app_system();
   application::ApplicationService* app_service
       = app_system->application_service();
-  if (Application* application = app_service->GetActiveApplication())
-    extensions->push_back(new ScreenOrientationExtension(application));
+  if (Application* application = app_service->GetActiveApplication()) {
+    extensions->push_back(new ScreenOrientationExtension(
+        application, GetAllowedUAOrientations()));
+  }
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts_tizen.h
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
+#include "xwalk/runtime/browser/ui/screen_orientation.h"
 
 namespace xwalk {
 
@@ -25,6 +26,8 @@ class XWalkBrowserMainPartsTizen : public XWalkBrowserMainParts {
   virtual void CreateInternalExtensionsForUIThread(
       content::RenderProcessHost* host,
       extensions::XWalkExtensionVector* extensions) OVERRIDE;
+
+  static OrientationMask GetAllowedUAOrientations();
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkBrowserMainPartsTizen);
 };

--- a/runtime/extension/screen_orientation_api.js
+++ b/runtime/extension/screen_orientation_api.js
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// var uaDefault is set externally.
+
 var internal = requireNative("internal");
 internal.setupInternalExtension(extension);
 
@@ -14,7 +16,6 @@ var LANDSCAPE_SECONDARY = 1 << 3;
 var PORTRAIT            = PORTRAIT_PRIMARY | PORTRAIT_SECONDARY;
 var LANDSCAPE           = LANDSCAPE_PRIMARY | LANDSCAPE_SECONDARY;
 var ANY                 = PORTRAIT | LANDSCAPE;
-var UA_DEFAULTS         = 0;
 
 window.screen.lockOrientation = function(orientations) {
   if (!Array.isArray(orientations)) {
@@ -48,11 +49,15 @@ window.screen.lockOrientation = function(orientations) {
         console.error("Invalid screen orientation");
         return false;
     }
+    // If the orientations aren't all part of the default allowed
+    // orientations, the steps must stop here and return false.
+    if ((uaDefault & value) != value)
+      return false;
   }
   internal.postMessage('lock', [value], null);
   return true;
 };
 
 window.screen.unlockOrientation = function() {
-  internal.postMessage('lock', [UA_DEFAULTS], null);
+  internal.postMessage('lock', [uaDefault], null);
 };

--- a/runtime/extension/screen_orientation_extension.h
+++ b/runtime/extension/screen_orientation_extension.h
@@ -28,7 +28,8 @@ using extensions::XWalkExtensionInstance;
 
 class ScreenOrientationExtension : public XWalkExtension {
  public:
-  explicit ScreenOrientationExtension(application::Application* app);
+  explicit ScreenOrientationExtension(
+      application::Application* app, OrientationMask ua_default);
   virtual ~ScreenOrientationExtension();
 
  private:
@@ -50,8 +51,8 @@ class ScreenOrientationInstance : public XWalkExtensionInstance {
   void OnAllowedOrientationsChanged(
       scoped_ptr<XWalkExtensionFunctionInfo> info);
 
-  ScreenOrientationAPISupplement* supplement_;
   XWalkExtensionFunctionHandler handler_;
+  MultiOrientationScreen* screen_;
 
   application::Application* application_;
 };


### PR DESCRIPTION
- Move the UA default to a global place and use it from the app window.
- Give the UA default to the ScreenOrientationExtension ctor.
- Set the UA default as part of the JS source string.
- Enforce (according to spec) that any web facing orientation lock
  much be a subset of the UA defaults.
