### PR TITLE
[SysApps] Fixed unit test crashing

### DIFF
--- a/sysapps/common/sysapps_manager_unittest.cc
+++ b/sysapps/common/sysapps_manager_unittest.cc
@@ -6,9 +6,11 @@
 
 #include "base/command_line.h"
 #include "base/file_util.h"
+#include "base/files/file_path.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/path_service.h"
 #include "base/stl_util.h"
+#include "content/public/common/content_paths.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
@@ -31,6 +33,14 @@ const char kDisableSysAppsSwitch[] = "--disable-sysapps";
 class XWalkSysAppsManagerTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
+    // Ensure the content::RegisterPathProvider() is called, but
+    // test first to make sure it is not registered twice. The ffmpeg
+    // codec provider needs it.
+    base::FilePath media_path;
+    PathService::Get(content::DIR_MEDIA_LIBS, &media_path);
+    if (media_path.empty())
+      content::RegisterPathProvider();
+
     // We need to make sure the resource bundle is up because
     // the extensions we instantiate on this test depend on it.
     base::FilePath pak_dir;

--- a/sysapps/device_capabilities_new/av_codecs_provider_unittest.cc
+++ b/sysapps/device_capabilities_new/av_codecs_provider_unittest.cc
@@ -7,6 +7,9 @@
 
 #include <vector>
 
+#include "base/files/file_path.h"
+#include "base/path_service.h"
+#include "content/public/common/content_paths.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "xwalk/sysapps/common/sysapps_manager.h"
 #include "xwalk/sysapps/device_capabilities_new/device_capabilities.h"
@@ -17,6 +20,14 @@ using xwalk::jsapi::device_capabilities::SystemAVCodecs;
 using xwalk::sysapps::AVCodecsProvider;
 
 TEST(XWalkSysAppsDeviceCapabilitiesTest, AVCodecsProvider) {
+  // Ensure the content::RegisterPathProvider() is called, but
+  // test first to make sure it is not registered twice. The ffmpeg
+  // codec provider needs it.
+  base::FilePath media_path;
+  PathService::Get(content::DIR_MEDIA_LIBS, &media_path);
+  if (media_path.empty())
+    content::RegisterPathProvider();
+
   xwalk::sysapps::SysAppsManager manager;
 
   AVCodecsProvider* provider(manager.GetAVCodecsProvider());

--- a/sysapps/sysapps.gyp
+++ b/sysapps/sysapps.gyp
@@ -64,6 +64,8 @@
       'conditions': [
         ['OS!="android"', {
           'dependencies': [
+            '../../content/content.gyp:content_common',
+            '../../media/media.gyp:media',
             '../../third_party/ffmpeg/ffmpeg.gyp:ffmpeg',
           ],
           'sources': [

--- a/sysapps/sysapps_tests.gyp
+++ b/sysapps/sysapps_tests.gyp
@@ -6,6 +6,7 @@
       'dependencies': [
         '../../base/base.gyp:base',
         '../../base/base.gyp:run_all_unittests',
+        '../../content/content.gyp:content_common',
         '../../testing/gtest.gyp:gtest',
         '../../ui/ui.gyp:ui',
         '../extensions/extensions.gyp:xwalk_extensions',


### PR DESCRIPTION
Make sure the content:: path provider is registered. We need to test
first to make sure we are not registering it twice, otherwise the second
test to register the path provider will crash.

Also add the proper dependencies on the build system.
