### PR TITLE
[SysApps] Simplification of how to init the PathServices

### DIFF
--- a/sysapps/common/sysapps_manager_unittest.cc
+++ b/sysapps/common/sysapps_manager_unittest.cc
@@ -10,7 +10,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/path_service.h"
 #include "base/stl_util.h"
-#include "content/public/common/content_paths.h"
+#include "media/base/media.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
@@ -30,13 +30,7 @@ namespace {
 class XWalkSysAppsManagerTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    // Ensure the content::RegisterPathProvider() is called, but
-    // test first to make sure it is not registered twice. The ffmpeg
-    // codec provider needs it.
-    base::FilePath media_path;
-    PathService::Get(content::DIR_MEDIA_LIBS, &media_path);
-    if (media_path.empty())
-      content::RegisterPathProvider();
+    media::InitializeMediaLibraryForTesting();
 
     // We need to make sure the resource bundle is up because
     // the extensions we instantiate on this test depend on it.

--- a/sysapps/device_capabilities_new/av_codecs_provider_unittest.cc
+++ b/sysapps/device_capabilities_new/av_codecs_provider_unittest.cc
@@ -7,9 +7,7 @@
 
 #include <vector>
 
-#include "base/files/file_path.h"
-#include "base/path_service.h"
-#include "content/public/common/content_paths.h"
+#include "media/base/media.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "xwalk/sysapps/common/sysapps_manager.h"
 #include "xwalk/sysapps/device_capabilities_new/device_capabilities.h"
@@ -20,14 +18,7 @@ using xwalk::jsapi::device_capabilities::SystemAVCodecs;
 using xwalk::sysapps::AVCodecsProvider;
 
 TEST(XWalkSysAppsDeviceCapabilitiesTest, AVCodecsProvider) {
-  // Ensure the content::RegisterPathProvider() is called, but
-  // test first to make sure it is not registered twice. The ffmpeg
-  // codec provider needs it.
-  base::FilePath media_path;
-  PathService::Get(content::DIR_MEDIA_LIBS, &media_path);
-  if (media_path.empty())
-    content::RegisterPathProvider();
-
+  media::InitializeMediaLibraryForTesting();
   xwalk::sysapps::SysAppsManager manager;
 
   AVCodecsProvider* provider(manager.GetAVCodecsProvider());

--- a/sysapps/sysapps_tests.gyp
+++ b/sysapps/sysapps_tests.gyp
@@ -6,7 +6,6 @@
       'dependencies': [
         '../../base/base.gyp:base',
         '../../base/base.gyp:run_all_unittests',
-        '../../content/content.gyp:content_common',
         '../../testing/gtest.gyp:gtest',
         '../../ui/ui.gyp:ui',
         '../extensions/extensions.gyp:xwalk_extensions',


### PR DESCRIPTION
As suggested by Babu, there is a much easier way to start the
PathService specifically for testing.
