### PR TITLE
[Android] Fix the crash issue of loading app from app:// scheme

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/AndroidProtocolHandler.java
+++ b/runtime/android/java/src/org/xwalk/core/AndroidProtocolHandler.java
@@ -59,8 +59,9 @@ public class AndroidProtocolHandler {
         } else if (uri.getScheme().equals(CONTENT_SCHEME)) {
             return openContent(context, uri);
         } else if (uri.getScheme().equals(APP_SCHEME)) {
-            // Use package name as the host.
-            if (!uri.getHost().equals(context.getPackageName())) return null;
+            // The host should be the same as the lower case of the package
+            // name, otherwise the resource request should be rejected.
+            if (!uri.getHost().equals(context.getPackageName().toLowerCase())) return null;
 
             // path == "/" or path == ""
             if (path.length() <= 1) return null;


### PR DESCRIPTION
As the resource rquest URL was canonicalized to lowercase by core,
the host name exacted from the URL may be inconsitent with the app
package name, if there is captical capital letter in the package
name. So convert package name to lowercase before comparing these
2 strings.

BUG=https://crosswalk-project.org/jira/browse/XWALK-808
