### PR TITLE
[Packaging] Add all necessary spec file changes to support Tizen IVI.

### DIFF
--- a/packaging/crosswalk-mesa-ozone-typedefs.patch
+++ b/packaging/crosswalk-mesa-ozone-typedefs.patch
@@ -1,0 +1,23 @@
+Author: Tiago Vignatti <tiago.vignatti@intel.com>
+
+There is currently a mismatch in the way GL headers are picked up between
+third_party/khronos and third_party/mesa which can cause crashes in some
+architectures due to different pointer sizes.
+
+Upstream bug: https://code.google.com/p/chromium/issues/detail?id=266310
+
+--- src/third_party/mesa/src/include/EGL/eglplatform.h
++++ src/third_party/mesa/src/include/EGL/eglplatform.h
+@@ -104,6 +104,12 @@ typedef struct ANativeWindow        *EGLNativeWindowType;
+ typedef struct egl_native_pixmap_t  *EGLNativePixmapType;
+ typedef void                        *EGLNativeDisplayType;
+ 
++#elif defined(USE_OZONE)
++
++typedef intptr_t EGLNativeDisplayType;
++typedef intptr_t EGLNativeWindowType;
++typedef intptr_t EGLNativePixmapType;
++
+ #elif defined(__unix__)
+ 
+ #ifdef MESA_EGL_NO_X11_HEADERS

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -20,6 +20,7 @@ Patch4:         %{name}-disable-ffmpeg-pragmas.patch
 Patch5:         Chromium-Fix-gcc-4.5.3-uninitialized-warnings.patch
 Patch6:         Blink-Fix-gcc-4.5.3-uninitialized-warnings.patch
 Patch7:         %{name}-tizen-audio-session-manager.patch
+Patch8:         %{name}-mesa-ozone-typedefs.patch
 
 BuildRequires:  bison
 BuildRequires:  bzip2-devel
@@ -137,6 +138,10 @@ cp -a src/xwalk/LICENSE LICENSE.xwalk
 %patch4
 %patch5 -p1
 %patch6 -p1
+%endif
+
+%if %{with wayland}
+%patch8
 %endif
 
 %build


### PR DESCRIPTION
Following up after the recent commits to fetch and build Ozone-Wayland, this
patch set introduces the changes we need to make on the RPM spec file in
order to build Crosswalk for both Tizen 2.1 Mobile and Tizen IVI. It
involves looking for the presence of certain features and, in some cases,
Tizen's major version and then depending on some packages or passing some
flags to gyp based on those factors.
