### PR TITLE
Add screen.onorientationchange event listener

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -182,6 +182,26 @@ void NativeAppWindowTizen::OnRotationChanged(
     return;
 
   display_.set_rotation(rotation);
+
+  if (observer()) {
+    Orientation orientation;
+    switch (rotation) {
+      case gfx::Display::ROTATE_0:
+        orientation = PORTRAIT_PRIMARY;
+        break;
+      case gfx::Display::ROTATE_90:
+        orientation = LANDSCAPE_PRIMARY;
+        break;
+      case gfx::Display::ROTATE_180:
+        orientation = PORTRAIT_SECONDARY;
+        break;
+      case gfx::Display::ROTATE_270:
+        orientation = LANDSCAPE_SECONDARY;
+        break;
+    }
+    observer()->OnOrientationChanged(orientation);
+  }
+
   ApplyDisplayRotation();
 }
 

--- a/runtime/browser/ui/screen_orientation.h
+++ b/runtime/browser/ui/screen_orientation.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_RUNTIME_BROWSER_UI_SCREEN_ORIENTATION_H_
 #define XWALK_RUNTIME_BROWSER_UI_SCREEN_ORIENTATION_H_
 
+#include "base/memory/scoped_ptr.h"
+
 namespace xwalk {
 
 enum Orientation {
@@ -25,7 +27,21 @@ typedef unsigned OrientationMask;
 class MultiOrientationScreen {
  public:
   virtual ~MultiOrientationScreen() {}
+
+  class Observer {
+   public:
+    virtual void OnOrientationChanged(Orientation orientation) = 0;
+  };
+
+  void SetObserver(Observer* observer) {
+    observer_.reset(observer);
+  }
+  Observer* observer() const { return observer_.get(); }
+
   virtual void OnAllowedOrientationsChanged(OrientationMask orientations) = 0;
+
+ private:
+  scoped_ptr<Observer> observer_;
 };
 
 }  // namespace xwalk

--- a/runtime/extension/screen_orientation_api.js
+++ b/runtime/extension/screen_orientation_api.js
@@ -61,3 +61,26 @@ window.screen.lockOrientation = function(orientations) {
 window.screen.unlockOrientation = function() {
   internal.postMessage('lock', [uaDefault], null);
 };
+
+var orientationchangeCallback = null;
+
+Object.defineProperty(window.screen, "onorientationchange", {
+  configurable: false,
+  enumerable: true,
+  get: function() { return orientationchangeCallback; },
+  set: function(callback) {
+    if (callback === null || callback instanceof Function)
+      orientationchangeCallback = callback;
+  }
+});
+
+extension.setMessageListener(function (value) {
+  var event = new Event("orientationchange");
+  if (screen.onorientationchange) {
+    try {
+      screen.onorientationchange.call(window.screen, event);
+    } catch (e) {
+      // Discard exceptions: http://www.w3.org/TR/DOM-Level-3-Events/#event-flow
+    }
+  }
+});

--- a/runtime/extension/screen_orientation_extension.cc
+++ b/runtime/extension/screen_orientation_extension.cc
@@ -52,8 +52,14 @@ ScreenOrientationExtension::ScreenOrientationExtension(
   DCHECK(application_);
 
   std::vector<std::string> entry_points;
-  entry_points.push_back("screen.lockOrientation");
-  entry_points.push_back("screen.unlockOrientation");
+
+  // FIXME: The on demand loading doesn't work:
+  // Test case: http://jsbin.com/IJapIVE/6
+  entry_points.push_back("screen");
+  //entry_points.push_back("screen.lockOrientation");
+  //entry_points.push_back("screen.unlockOrientation");
+  //entry_points.push_back("screen.onorientationchange");
+
   set_name("xwalk.screen");
   set_entry_points(entry_points);
 
@@ -78,12 +84,20 @@ ScreenOrientationInstance::ScreenOrientationInstance(Application* app)
   : handler_(this)
   , screen_(GetMultiOrientationScreen(app))
   , application_(app) {
+
+  screen_->SetObserver(this);
+
   handler_.Register("lock",
       base::Bind(&ScreenOrientationInstance::OnAllowedOrientationsChanged,
       base::Unretained(this)));
 }
 
 ScreenOrientationInstance::~ScreenOrientationInstance() {
+}
+
+void ScreenOrientationInstance::OnOrientationChanged(Orientation orientation) {
+  PostMessageToJS(scoped_ptr<base::Value>(
+      base::Value::CreateIntegerValue(orientation)));
 }
 
 void ScreenOrientationInstance::HandleMessage(scoped_ptr<base::Value> msg) {

--- a/runtime/extension/screen_orientation_extension.h
+++ b/runtime/extension/screen_orientation_extension.h
@@ -39,7 +39,8 @@ class ScreenOrientationExtension : public XWalkExtension {
   application::Application* application_;
 };
 
-class ScreenOrientationInstance : public XWalkExtensionInstance {
+class ScreenOrientationInstance : public XWalkExtensionInstance,
+                                  public MultiOrientationScreen::Observer {
  public:
   explicit ScreenOrientationInstance(application::Application* app);
   virtual ~ScreenOrientationInstance();
@@ -47,6 +48,9 @@ class ScreenOrientationInstance : public XWalkExtensionInstance {
  private:
   // XWalkExtensionInstance overrides:
   virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
+
+  // MultiOrientationScreen::Observer overrides:
+  virtual void OnOrientationChanged(Orientation orientation) OVERRIDE;
 
   void OnAllowedOrientationsChanged(
       scoped_ptr<XWalkExtensionFunctionInfo> info);

--- a/test/data/screenlock.html
+++ b/test/data/screenlock.html
@@ -5,6 +5,14 @@
 <meta name="viewport" content="width=device-width">
 <title>lockOrientation</title>
 <script>
+count = 0;
+
+screen.onorientationchange = function() {
+   count += 1;
+   ocon = document.getElementById("orientationconsole");
+   ocon.innerHTML = "unknown (Changed " + count + ") times";
+}
+
 function apply(lock) {
   var orientations = [];
 
@@ -47,7 +55,8 @@ function apply(lock) {
 <br>
   <center><button onclick="apply(true)">Lock</button><button onclick="apply(false)">Unlock</button></center>
   </div>
-<br><br>
+<br>
   Allowed orientations: <div id="console">[]</div>
+  Current orientation: <div id="orientationconsole">unknown</div>
 </body>
 </html>


### PR DESCRIPTION
The function set is fired whenever the orientation changes.
The test has been updated to count how many times the orientation
has changed so far.

The entries have been changed as there are some unresolved bugs
with the ondemand loading making this not work otherwise.
