### PR TITLE
[Android] Add adb_gdb_xwalk_runtime_client_embedded_shell for extension ...

### DIFF
--- a/build/android/adb_gdb_xwalk_runtime_client_embedded_shell
+++ b/build/android/adb_gdb_xwalk_runtime_client_embedded_shell
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Attach to or start a ContentShell process and debug it.
+# See --help for details.
+#
+cd ${CHROME_SRC}
+
+PROGDIR=${CHROME_SRC}/build/android
+export ADB_GDB_PROGNAME=$(basename "$0")
+export ADB_GDB_ACTIVITY=.XWalkRuntimeClientEmbeddedShellActivity
+"$PROGDIR"/adb_gdb \
+    --program-name=XWalkRuntimeClientEmbeddedShellActivity \
+    --package-name=org.xwalk.runtime.client.embedded.shell \
+    "$@"


### PR DESCRIPTION
...debugging

Xwalk extension is not attched to xwalk_core_shell, we needed to run xwalk_runtime_client_embedded_shell
to debug extension.
