### PR TITLE
[Tizen] Register Application Extensions on Tizen.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -91,6 +91,9 @@ OrientationMask XWalkBrowserMainPartsTizen::GetAllowedUAOrientations() {
 void XWalkBrowserMainPartsTizen::CreateInternalExtensionsForUIThread(
     content::RenderProcessHost* host,
     extensions::XWalkExtensionVector* extensions) {
+  XWalkBrowserMainParts::CreateInternalExtensionsForUIThread(
+      host, extensions);
+
   application::ApplicationSystem* app_system = xwalk_runner_->app_system();
   application::ApplicationService* app_service
       = app_system->application_service();


### PR DESCRIPTION
Application Runtime Extension and Application Event Extension are not
registered on Tizen. This causes Runtime API and Event API don't work on
Tizen.

This PR fix the above issue.
