### PR TITLE
Fix leak of DictionaryValue in ApplicationStorageImpl::GetInstalledApplications()

### DIFF
--- a/application/browser/application_storage_impl.cc
+++ b/application/browser/application_storage_impl.cc
@@ -198,8 +198,11 @@ bool ApplicationStorageImpl::GetInstalledApplications(
     int error_code;
     std::string manifest_str = smt.ColumnString(1);
     JSONStringValueSerializer serializer(&manifest_str);
-    base::Value* manifest = serializer.Deserialize(&error_code, &error_msg);
-    if (manifest == NULL) {
+    scoped_ptr<base::DictionaryValue> manifest(
+        static_cast<base::DictionaryValue*>(
+            serializer.Deserialize(&error_code, &error_msg)));
+
+    if (!manifest) {
       LOG(ERROR) << "An error occured when deserializing the manifest, "
                     "the error message is: "
                  << error_msg;
@@ -215,7 +218,7 @@ bool ApplicationStorageImpl::GetInstalledApplications(
         ApplicationData::Create(
             base::FilePath::FromUTF8Unsafe(path),
             Manifest::INTERNAL,
-            *(static_cast<base::DictionaryValue*>(manifest)),
+            *manifest,
             id,
             &error);
     if (!application) {


### PR DESCRIPTION
This patch fixes the leak of DictionaryValue returned by JSONFileValueSerializer::Deserialize().

valgrind log:
==9706== 2,576 (48 direct, 2,528 indirect) bytes in 1 blocks are definitely lost in loss record 4,268 of 4,344
==9706==    at 0x95173FC: operator new(unsigned long) (vg_replace_malloc.c:1140)
.....
==9706==    by 0x5026B9: JSONStringValueSerializer::Deserialize(int_, std::string_) (json_string_value_serializer.cc:47)
==9706==    by 0x3532E25: xwalk::application::ApplicationStorageImpl::GetInstalledApplications(std::map<std::string, scoped_refptr<xwalk::application::ApplicationData>, std::lessstd::string, std::allocator<std::pair<std::string const, scoped_refptr<xwalk::application::ApplicationData> > > >&) (application_storage_impl.cc:201)
