### PR TITLE
[Android] Load manifest.json if it exists but not specified in options.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -616,6 +616,12 @@ def main(argv):
     xpk_temp_dir = xpk_name + '_xpk'
     ParseXPK(options, xpk_temp_dir)
 
+  if options.app_root and not options.manifest:
+    manifest_path = os.path.join(options.app_root, 'manifest.json')
+    if os.path.exists(manifest_path):
+      print('Using manifest.json distributed with the application.')
+      options.manifest = manifest_path
+
   if not options.manifest:
     if not options.package:
       parser.error('The package name is required! '


### PR DESCRIPTION
Because the manifest has been supported by packaging tool, and it's the
recommended source for packaging. So manifest.json will be loaded 
if it does exist.
