### PR TITLE
[Extensions] Make extension namespace read-only

### DIFF
--- a/extensions/extensions_tests.gyp
+++ b/extensions/extensions_tests.gyp
@@ -52,6 +52,7 @@
         'test/internal_extension_browsertest.cc',
         'test/internal_extension_browsertest.h',
         'test/nested_namespace.cc',
+        'test/namespace_read_only.cc',
         'test/test.idl',
         'test/v8tools_module.cc',
         'test/xwalk_extensions_browsertest.cc',

--- a/extensions/renderer/xwalk_module_system.h
+++ b/extensions/renderer/xwalk_module_system.h
@@ -93,6 +93,9 @@ class XWalkModuleSystem {
   void MarkModulesWithTrampoline();
   void DeleteExtensionModules();
 
+  void EnsureExtensionNamespaceIsReadOnly(v8::Handle<v8::Context> context,
+                                          const std::string& extension_name);
+
   typedef std::vector<ExtensionModuleEntry> ExtensionModules;
   ExtensionModules extension_modules_;
 

--- a/extensions/test/data/namespace_read_only.html
+++ b/extensions/test/data/namespace_read_only.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+try {
+  xwalk.sample = "dummyValue";
+  if (typeof xwalk.sample === 'object' && xwalk.sample.also_should_exist)
+    document.title = "Pass";
+} catch(e) {
+    console.log(e);
+    document.title = "Fail";
+}
+</script>
+</body>
+</html>

--- a/extensions/test/data/namespace_read_only_with_entrypoint.html
+++ b/extensions/test/data/namespace_read_only_with_entrypoint.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+try {
+  // Should exist is an entry point of xwalk.sample extension.
+  var my_should_exist = should_exist;
+  if (xwalk.sample.also_should_exist && my_should_exist) {
+    xwalk.sample = "dummyValue";
+    if (typeof xwalk.sample === 'object')
+      document.title = "Pass";
+  }
+} catch(e) {
+    console.log(e);
+    document.title = "Fail";
+}
+</script>
+</body>
+</html>

--- a/extensions/test/namespace_read_only.cc
+++ b/extensions/test/namespace_read_only.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/command_line.h"
+#include "base/native_library.h"
+#include "base/path_service.h"
+#include "xwalk/extensions/browser/xwalk_extension_service.h"
+#include "xwalk/extensions/common/xwalk_extension_switches.h"
+#include "xwalk/extensions/test/xwalk_extensions_test_base.h"
+#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/test/base/xwalk_test_utils.h"
+#include "content/public/test/browser_test_utils.h"
+
+using xwalk::extensions::XWalkExtensionService;
+
+class NamespaceReadOnlyExtensionTest : public XWalkExtensionsTestBase {
+ public:
+  virtual void SetUp() OVERRIDE {
+    XWalkExtensionService::SetExternalExtensionsPathForTesting(
+        GetExternalExtensionTestPath(FILE_PATH_LITERAL("multiple_extension")));
+    XWalkExtensionsTestBase::SetUp();
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(NamespaceReadOnlyExtensionTest, NamespaceReadOnly) {
+  GURL url = GetExtensionsTestURL(base::FilePath(),
+                                  base::FilePath().AppendASCII(
+                                      "namespace_read_only.html"));
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+
+  xwalk_test_utils::NavigateToURL(runtime(), url);
+  WaitForLoadStop(runtime()->web_contents());
+
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}
+
+IN_PROC_BROWSER_TEST_F(
+    NamespaceReadOnlyExtensionTest, NamespaceReadOnlyAfterEntryPointCalled) {
+  GURL url = GetExtensionsTestURL(base::FilePath(),
+      base::FilePath().AppendASCII("namespace_read_only_with_entrypoint.html"));
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+
+  xwalk_test_utils::NavigateToURL(runtime(), url);
+  WaitForLoadStop(runtime()->web_contents());
+
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}


### PR DESCRIPTION
Extensions export their JS content under their namespace,
which is created with the extension name. That means an
extension called "xwalk.sample" will export its functions
below the "xwalk.sample" object in JS.
This patch avoids that one do things like "xwalk.sample = null",
by marking the extension namespace object as read-only whenever
an extension's code was loaded.

We don't touch entry_points (changing their properties to read-only)
because this is something the extension writer should do him/herself
when writing the JS shim, by JS means, since we can't predict
which entry_points should be marked as read-only or not.
In other words, that is part of the extension API being implemented.

BUG=https://crosswalk-project.org/jira/browse/XWALK-605
BUG=https://crosswalk-project.org/jira/browse/XWALK-600
TEST=./out/Release/xwalk_extensions_browsertest --gtest_filter="NamespaceReadOnlyExtensionTest.*"
TEST= Also covered by TCT in the "_in_tizen" tests.
