### PR TITLE
[Extensions] "Fix" and enable test MultipleEntryPointsExtension.Multiple...

### DIFF
--- a/extensions/test/external_extension.cc
+++ b/extensions/test/external_extension.cc
@@ -27,7 +27,7 @@ class MultipleEntryPointsExtension : public XWalkExtensionsTestBase {
  public:
   virtual void SetUp() OVERRIDE {
     XWalkExtensionService::SetExternalExtensionsPathForTesting(
-        GetExternalExtensionTestPath(FILE_PATH_LITERAL("mutiple_extension")));
+        GetExternalExtensionTestPath(FILE_PATH_LITERAL("multiple_extension")));
     XWalkExtensionsTestBase::SetUp();
   }
 };
@@ -67,8 +67,7 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionTest, ExternalExtensionSync) {
   EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }
 
-IN_PROC_BROWSER_TEST_F(MultipleEntryPointsExtension,
-                       DISABLED_MultipleEntryPoints) {
+IN_PROC_BROWSER_TEST_F(MultipleEntryPointsExtension, MultipleEntryPoints) {
   content::RunAllPendingInMessageLoop();
   GURL url = GetExtensionsTestURL(
       base::FilePath(),


### PR DESCRIPTION
...EntryPoints

This test was added by commit 77bcab7bd3ba998196da6958c590af9fe32a1cd7
"[Extensions] Add tests for loading extension with multiple entry points", but
it was never enabled.

Later then, commit 76dbc259ef6e58c1667f763403201c50d4803bc5 "[Extensions] Reduce
boilerplate for external extension tests" mispelled the path for the
multiple_entry_points_extension.so.

This patch fixes this and enables this test.
