### PR TITLE
[Extensions] Add a setter callback accessor to trampolines

### DIFF
--- a/extensions/renderer/xwalk_module_system.h
+++ b/extensions/renderer/xwalk_module_system.h
@@ -88,6 +88,13 @@ class XWalkModuleSystem {
   static void TrampolineCallback(
       v8::Local<v8::String> property,
       const v8::PropertyCallbackInfo<v8::Value>& info);
+  static void TrampolineSetterCallback(
+      v8::Local<v8::String> property,
+      v8::Local<v8::Value> value,
+      const v8::PropertyCallbackInfo<void>& info);
+  static void LoadExtensionForTrampoline(
+      v8::Isolate* isolate,
+      v8::Local<v8::Value> data);
 
   bool ContainsEntryPoint(const std::string& entry_point);
   void MarkModulesWithTrampoline();

--- a/extensions/test/data/setter_callback_entry_point.html
+++ b/extensions/test/data/setter_callback_entry_point.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+try {
+  window.onsomething = function() { return true; };
+
+  if (typeof xwalk.sample === 'object'
+      && typeof window.onsomething === 'function'
+      && window.onsomething()
+      && xwalk.sample.also_should_exist) {
+    document.title = "Pass";
+  } else {
+    document.title = "Fail";
+  }
+} catch(e) {
+    console.log(e);
+    document.title = "Fail";
+}
+</script>
+</body>
+</html>

--- a/extensions/test/external_extension.cc
+++ b/extensions/test/external_extension.cc
@@ -77,3 +77,14 @@ IN_PROC_BROWSER_TEST_F(MultipleEntryPointsExtension, MultipleEntryPoints) {
   xwalk_test_utils::NavigateToURL(runtime(), url);
   EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }
+
+IN_PROC_BROWSER_TEST_F(MultipleEntryPointsExtension, SetterLoadsExtension) {
+  content::RunAllPendingInMessageLoop();
+  GURL url = GetExtensionsTestURL(
+      base::FilePath(),
+      base::FilePath().AppendASCII("setter_callback_entry_point.html"));
+  content::TitleWatcher title_watcher(runtime()->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+  xwalk_test_utils::NavigateToURL(runtime(), url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}

--- a/extensions/test/multiple_entry_points_extension.c
+++ b/extensions/test/multiple_entry_points_extension.c
@@ -19,8 +19,9 @@ const XW_Internal_EntryPointsInterface* g_entry_points = NULL;
 int32_t XW_Initialize(XW_Extension extension, XW_GetInterface get_interface) {
   static const char* kAPI =
       "window.should_exist = true;"
-      "exports.also_should_exist = true;";
-  static const char* entry_points[] = { "should_exist", NULL };
+      "exports.also_should_exist = true;"
+      "window.onsomething = {}";
+  static const char* entry_points[] = { "should_exist", "onsomething", NULL };
 
   g_extension = extension;
   g_core = get_interface(XW_CORE_INTERFACE);


### PR DESCRIPTION
Prior to this patch we didn't support trampolines with setter
callbacks. This patch enables extensions so can implement an API
to be used like:

"xwalk.sample.onFooChanged = function() { foo("teste"); };"

and use xwalk.sample.onFooChanged as an entry point to xwalk.sample.

BUG=https://crosswalk-project.org/jira/browse/XWALK-835
TEST=./out/Release/xwalk_extensions_browsertest --gtest_filter="MultipleEntryPointsExtension.*"
