### PR TITLE
[Application] Create LaunchParams for Application::Launch

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -58,8 +58,7 @@ Application::Application(
     : runtime_context_(runtime_context),
       application_data_(data),
       main_runtime_(NULL),
-      observer_(observer),
-      entry_points_(Default) {
+      observer_(observer) {
   DCHECK(runtime_context_);
   DCHECK(application_data_);
   DCHECK(observer_);
@@ -131,25 +130,22 @@ bool Application::TryLaunchAt<Application::URLKey>() {
   return false;
 }
 
-bool Application::Launch() {
+bool Application::Launch(const LaunchParams& launch_params) {
   if (!runtimes_.empty()) {
     LOG(ERROR) << "Attempt to launch app: " << id()
                << " that was already launched.";
     return false;
   }
 
-  if ((entry_points_ & AppMainKey) && TryLaunchAt<AppMainKey>())
+  if ((launch_params.entry_points & AppMainKey) && TryLaunchAt<AppMainKey>())
     return true;
-  if ((entry_points_ & LaunchLocalPathKey) && TryLaunchAt<LaunchLocalPathKey>())
+  if ((launch_params.entry_points & LaunchLocalPathKey)
+      && TryLaunchAt<LaunchLocalPathKey>())
     return true;
-  if ((entry_points_ & URLKey) && TryLaunchAt<URLKey>())
+  if ((launch_params.entry_points & URLKey) && TryLaunchAt<URLKey>())
     return true;
 
   return false;
-}
-
-void Application::set_entry_points(LaunchEntryPoints entry_points) {
-  entry_points_ = entry_points;
 }
 
 void Application::Close() {

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -60,7 +60,12 @@ class Application : public Runtime::Observer {
   };
   typedef unsigned LaunchEntryPoints;
 
-  LaunchEntryPoints entry_points() const { return entry_points_; }
+  struct LaunchParams {
+    LaunchParams() :
+        entry_points(Default) {}
+
+    LaunchEntryPoints entry_points;
+  };
 
   // Closes all the application's runtimes (application pages).
   void Close();
@@ -95,11 +100,10 @@ class Application : public Runtime::Observer {
   Application(scoped_refptr<ApplicationData> data,
               RuntimeContext* context,
               Observer* observer);
-  bool Launch();
+  bool Launch(const LaunchParams& launch_params);
 
   template<LaunchEntryPoint>
   bool TryLaunchAt();
-  void set_entry_points(LaunchEntryPoints entry_points);
 
   friend class FinishEventObserver;
   void CloseMainDocument();
@@ -111,7 +115,6 @@ class Application : public Runtime::Observer {
   std::set<Runtime*> runtimes_;
   scoped_ptr<EventObserver> finish_observer_;
   Observer* observer_;
-  LaunchEntryPoints entry_points_;
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -341,7 +341,7 @@ Application* ApplicationService::Launch(const std::string& id) {
     return NULL;
   }
 
-  return Launch(application_data);
+  return Launch(application_data, Application::LaunchParams());
 }
 
 Application* ApplicationService::Launch(const base::FilePath& path) {
@@ -358,7 +358,7 @@ Application* ApplicationService::Launch(const base::FilePath& path) {
     return NULL;
   }
 
-  return Launch(application_data);
+  return Launch(application_data, Application::LaunchParams());
 }
 
 Application* ApplicationService::Launch(const GURL& url) {
@@ -385,7 +385,9 @@ Application* ApplicationService::Launch(const GURL& url) {
     return NULL;
   }
 
-  return Launch(application_data, Application::URLKey);
+  Application::LaunchParams launch_params;
+  launch_params.entry_points = Application::URLKey;
+  return Launch(application_data, launch_params);
 }
 
 namespace {
@@ -452,7 +454,7 @@ void ApplicationService::OnApplicationTerminated(
 
 Application* ApplicationService::Launch(
     scoped_refptr<ApplicationData> application_data,
-    Application::LaunchEntryPoints entry_points) {
+    const Application::LaunchParams& launch_params) {
   if (GetApplicationByID(application_data->ID()) != NULL) {
     LOG(INFO) << "Application with id: " << application_data->ID()
               << " is already running.";
@@ -465,11 +467,10 @@ Application* ApplicationService::Launch(
   Application* application(new Application(application_data,
                                            runtime_context_,
                                            this));
-  application->set_entry_points(entry_points);
   ScopedVector<Application>::iterator app_iter =
       applications_.insert(applications_.end(), application);
 
-  if (!application->Launch()) {
+  if (!application->Launch(launch_params)) {
     event_manager_->RemoveEventRouterForApp(application_data);
     applications_.erase(app_iter);
     return NULL;

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -71,7 +71,7 @@ class ApplicationService : public Application::Observer {
   virtual void OnApplicationTerminated(Application* app) OVERRIDE;
 
   Application* Launch(scoped_refptr<ApplicationData> application_data,
-                      Application::LaunchEntryPoints = Application::Default);
+                      const Application::LaunchParams& launch_params);
 
   xwalk::RuntimeContext* runtime_context_;
   ApplicationStorage* application_storage_;


### PR DESCRIPTION
Use a struct to hold the launching parameters for the Application, this
will enable us in the future to set some window-related properties
without causing too much churn.

This commit also removes unused getter, and trade the setter for an
extra parameter in Launch, strongly linking the parameters to the Launch
function, since that's what the code expects.
