### PR TITLE
[Extensions] Fix entry points for Screen Orientation Extension

### DIFF
--- a/runtime/extension/screen_orientation_extension.cc
+++ b/runtime/extension/screen_orientation_extension.cc
@@ -52,13 +52,10 @@ ScreenOrientationExtension::ScreenOrientationExtension(
   DCHECK(application_);
 
   std::vector<std::string> entry_points;
-
-  // FIXME: The on demand loading doesn't work:
-  // Test case: http://jsbin.com/IJapIVE/6
-  entry_points.push_back("screen");
-  // entry_points.push_back("screen.lockOrientation");
-  // entry_points.push_back("screen.unlockOrientation");
-  // entry_points.push_back("screen.onorientationchange");
+  entry_points.push_back("screen.orientation");
+  entry_points.push_back("screen.lockOrientation");
+  entry_points.push_back("screen.unlockOrientation");
+  entry_points.push_back("screen.onorientationchange");
 
   set_name("xwalk.screen");
   set_entry_points(entry_points);


### PR DESCRIPTION
After commit 856353beba8a8318c51da3d672af187d7fd58ada, entitled
"[Extensions] Add a setter callback accessor to trampolines",
we can now use screen.onorientationchange as a valid entry point.
