### PR TITLE
Fix orientation sometimes getting stuck in current orientation after unlock

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -179,8 +179,13 @@ void NativeAppWindowTizen::OnAllowedOrientationsChanged(
     OrientationMask orientations) {
   allowed_orientations_ = orientations;
 
-  gfx::Display::Rotation rotation
-      = GetClosestAllowedRotation(display_.rotation());
+  // As we might have been locked before our current orientation
+  // might not fit with the sensor orienation.
+  gfx::Display::Rotation rotation = display_.rotation();
+  if (SensorProvider* sensor = SensorProvider::GetInstance())
+    rotation = sensor->GetCurrentRotation();
+
+  rotation = GetClosestAllowedRotation(rotation);
   if (display_.rotation() == rotation)
     return;
 


### PR DESCRIPTION
While we are locked the display_.rotation() can get out of sync with the
actual device orientation, so we need to find the best orientation given
the actual orientation, not the old one.
