### PR TITLE
Make sure screen.orientation is always valid

### DIFF
--- a/runtime/extension/screen_orientation_api.js
+++ b/runtime/extension/screen_orientation_api.js
@@ -74,14 +74,6 @@ Object.defineProperty(window.screen, "onorientationchange", {
   }
 });
 
-var orientationValue = "portrait-primary";
-
-Object.defineProperty(window.screen, "orientation", {
-  configurable: false,
-  enumerable: true,
- get: function() { return orientationValue; }
-});
-
 function handleOrientationChange(newOrientation) {
   switch (newOrientation) {
     case PORTRAIT_PRIMARY:
@@ -116,5 +108,20 @@ function handleOrientationChange(newOrientation) {
 
   handleOrientationChange.shouldDispatchEvent = true;
 }
+
+var orientationValue = undefined;
+
+Object.defineProperty(window.screen, "orientation", {
+  configurable: false,
+  enumerable: true,
+  get: function() {
+    if (typeof orientationValue == 'undefined') {
+      var msg = JSON.stringify({'cmd' : 'GetScreenOrientation'});
+      var newOrientation = extension.internal.sendSyncMessage(msg);
+      handleOrientationChange(newOrientation);
+    }
+    return orientationValue;
+  }
+});
 
 extension.setMessageListener(handleOrientationChange);

--- a/runtime/extension/screen_orientation_extension.h
+++ b/runtime/extension/screen_orientation_extension.h
@@ -48,6 +48,7 @@ class ScreenOrientationInstance : public XWalkExtensionInstance,
  private:
   // XWalkExtensionInstance overrides:
   virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
+  virtual void HandleSyncMessage(scoped_ptr<base::Value> msg) OVERRIDE;
 
   // MultiOrientationScreen::Observer overrides:
   virtual void OnOrientationChanged(Orientation orientation) OVERRIDE;


### PR DESCRIPTION
If the orientation has not been set by the extension yet, query it
synchronously.
