### PR TITLE
[application] Fix the remaining code pieces relying on single-app mode

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -72,16 +72,14 @@ template<>
 bool Application::TryLaunchAt<Application::AppMainKey>() {
   const MainDocumentInfo* main_info =
       ToMainDocumentInfo(application_data_->GetManifestData(keys::kAppMainKey));
-  if (!main_info || !main_info->GetMainURL().is_valid())
+  if (!main_info || !main_info->GetMainURL().is_valid()) {
+    LOG(WARNING) << "Can't find a valid main document URL for app.";
     return false;
+  }
 
+  DCHECK(HasMainDocument());
   main_runtime_ = Runtime::Create(runtime_context_, this);
   main_runtime_->LoadURL(main_info->GetMainURL());
-
-  ApplicationEventManager* event_manager =
-      XWalkRunner::GetInstance()->app_system()->event_manager();
-  event_manager->OnMainDocumentCreated(
-      application_data_->ID(), main_runtime_->web_contents());
   return true;
 }
 

--- a/application/browser/application_event_router.h
+++ b/application/browser/application_event_router.h
@@ -27,13 +27,11 @@ class WebContents;
 namespace xwalk {
 namespace application {
 
-class ApplicationSystem;
-
 // Per application event router. It will created when the application is loaded,
 // and destructed when the applicaiton is unloaded.
 class ApplicationEventRouter : public content::WebContentsObserver {
  public:
-  ApplicationEventRouter(ApplicationSystem* system, const std::string& app_id);
+  explicit ApplicationEventRouter(const std::string& app_id);
   virtual ~ApplicationEventRouter();
 
   // Implement content::WebContentsObserver.
@@ -42,10 +40,10 @@ class ApplicationEventRouter : public content::WebContentsObserver {
   virtual void RenderProcessGone(base::TerminationStatus status) OVERRIDE;
 
   void ObserveMainDocument(content::WebContents* contents);
-
+  // FIXME: do we still need it here (SetMainEvents)?
   void SetMainEvents(const std::set<std::string>& events);
   bool ContainsMainEvent(const std::string& event) const;
-
+  // FIXME: the methods below should return a boolean.
   void AttachObserver(const std::string& event_name, EventObserver* observer);
   void DetachObserver(const std::string& event_name, EventObserver* observer);
   void DetachObserver(EventObserver* observer);
@@ -80,11 +78,10 @@ class ApplicationEventRouter : public content::WebContentsObserver {
   // loaded.
   EventSet main_events_;
 
-  ApplicationSystem* system_;
   std::string app_id_;
 
   // True when application's main document or entry page is finished loading.
-  bool application_launched_;
+  bool main_document_loaded_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationEventRouter);
 };

--- a/application/browser/application_event_router_unittest.cc
+++ b/application/browser/application_event_router_unittest.cc
@@ -50,7 +50,7 @@ class ApplicationEventRouterTest : public testing::Test {
   virtual void SetUp() OVERRIDE {
     runtime_context_.reset(new xwalk::RuntimeContext);
     system_ = ApplicationSystem::Create(runtime_context_.get());
-    router_.reset(new ApplicationEventRouter(system_.get(), kMockAppId0));
+    router_.reset(new ApplicationEventRouter(kMockAppId0));
     event_manager_ = system_->event_manager();
   }
 

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -63,10 +63,6 @@ class ApplicationService : public Application::Observer {
   const ScopedVector<Application>& active_applications() const {
       return applications_; }
 
-  // FIXME: This method should go away when multiple applications
-  // running is supported.
-  Application* GetActiveApplication() const;
-
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -29,7 +29,7 @@ namespace application {
 ApplicationSystem::ApplicationSystem(RuntimeContext* runtime_context)
   : runtime_context_(runtime_context),
     application_storage_(new ApplicationStorage(runtime_context->GetPath())),
-    event_manager_(new ApplicationEventManager(this)),
+    event_manager_(new ApplicationEventManager()),
     application_service_(new ApplicationService(
         runtime_context,
         application_storage_.get(),

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -90,7 +90,7 @@ class ApplicationSystem {
  private:
   template <typename T>
   bool LaunchWithCommandLineParam(const T& param);
-
+  // Note: initialization order matters.
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationStorage> application_storage_;
   scoped_ptr<ApplicationEventManager> event_manager_;

--- a/application/test/application_apitest.cc
+++ b/application/test/application_apitest.cc
@@ -7,10 +7,14 @@
 #include <vector>
 #include "content/public/test/browser_test_utils.h"
 #include "net/base/net_util.h"
+#include "xwalk/application/browser/application.h"
+#include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/test/application_browsertest.h"
 #include "xwalk/application/test/application_testapi.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 
+using xwalk::application::Application;
 using namespace xwalk::extensions;  // NOLINT
 
 ApplicationApiTest::ApplicationApiTest()
@@ -27,13 +31,6 @@ void ApplicationApiTest::SetUp() {
   ApplicationBrowserTest::SetUp();
 }
 
-void ApplicationApiTest::SetUpCommandLine(CommandLine* command_line) {
-  ApplicationBrowserTest::SetUpCommandLine(command_line);
-  GURL url = net::FilePathToFileURL(test_data_dir_.Append(
-        FILE_PATH_LITERAL("api")));
-  command_line->AppendArg(url.spec());
-}
-
 void ApplicationApiTest::CreateExtensions(XWalkExtensionVector* extensions) {
   ApiTestExtension* extension = new ApiTestExtension;
   extension->SetObserver(test_runner_.get());
@@ -41,6 +38,11 @@ void ApplicationApiTest::CreateExtensions(XWalkExtensionVector* extensions) {
 }
 
 IN_PROC_BROWSER_TEST_F(ApplicationApiTest, ApiTest) {
+  xwalk::application::ApplicationService* service =
+      xwalk::XWalkRunner::GetInstance()->app_system()->application_service();
+  Application* app = service->Launch(
+      test_data_dir_.Append(FILE_PATH_LITERAL("api")));
+  ASSERT_TRUE(app);
   test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
 }

--- a/application/test/application_apitest.h
+++ b/application/test/application_apitest.h
@@ -18,7 +18,6 @@ class ApplicationApiTest : public ApplicationBrowserTest {
 
  protected:
   virtual void SetUp() OVERRIDE;
-  virtual void SetUpCommandLine(CommandLine* command_line) OVERRIDE;
 
   scoped_ptr<ApiTestRunner> test_runner_;
 

--- a/application/test/application_browsertest.cc
+++ b/application/test/application_browsertest.cc
@@ -18,9 +18,6 @@ bool WaitForRuntimeCountCallback(int* count) {
 }  // namespace
 
 ApplicationBrowserTest::ApplicationBrowserTest() {
-}
-
-void ApplicationBrowserTest::SetUpCommandLine(CommandLine* commond_line) {
   PathService::Get(base::DIR_SOURCE_ROOT, &test_data_dir_);
   test_data_dir_ = test_data_dir_
     .Append(FILE_PATH_LITERAL("xwalk"))

--- a/application/test/application_browsertest.h
+++ b/application/test/application_browsertest.h
@@ -6,20 +6,16 @@
 #define XWALK_APPLICATION_TEST_APPLICATION_BROWSERTEST_H_
 
 #include "base/command_line.h"
+#include "xwalk/application/browser/application.h"
+#include "xwalk/application/browser/application_service.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/test/base/in_process_browser_test.h"
 
 // Base class for application browser test.
-// TODO(xiang): Currently we don't support shared browser process model then
-// every time we test an app we need pass its path in command line. Should
-// provide load/unload, install/uninstall, launch support when shared browser
-// process model is supported.
 class ApplicationBrowserTest: public InProcessBrowserTest {
  protected:
   ApplicationBrowserTest();
   virtual ~ApplicationBrowserTest() {}
-
-  // InProcessBrowserTest implementation.
-  virtual void SetUpCommandLine(CommandLine* command_line) OVERRIDE;
 
   // Wait for Runtime number in RuntimeRegistry becomes |runtime_count|.
   void WaitForRuntimes(int runtime_count);

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -80,14 +80,16 @@ void XWalkBrowserMainPartsTizen::CreateInternalExtensionsForUIThread(
     extensions::XWalkExtensionVector* extensions) {
   XWalkBrowserMainParts::CreateInternalExtensionsForUIThread(
       host, extensions);
-
+  // FIXME(Mikhail): move this code to a dedicated XWalkComponent.
   application::ApplicationSystem* app_system = xwalk_runner_->app_system();
   application::ApplicationService* app_service
       = app_system->application_service();
-  if (Application* application = app_service->GetActiveApplication()) {
-    extensions->push_back(new ScreenOrientationExtension(
+  Application* application =
+      app_service->GetApplicationByRenderHostID(host->GetID());
+  if (!application)
+    return;
+  extensions->push_back(new ScreenOrientationExtension(
         application, GetAllowedUAOrientations()));
-  }
 }
 
 }  // namespace xwalk

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -136,10 +136,6 @@ void InProcessBrowserTest::PrepareTestCommandLine(CommandLine* command_line) {
   xwalk_test_utils::PrepareBrowserCommandLineForTests(command_line);
 }
 
-void InProcessBrowserTest::TearDown() {
-  BrowserTestBase::TearDown();
-}
-
 const InProcessBrowserTest::RuntimeList& InProcessBrowserTest::runtimes()
                                                                const {
   return g_runtime_registry->runtimes();

--- a/test/base/in_process_browser_test.h
+++ b/test/base/in_process_browser_test.h
@@ -47,9 +47,6 @@ class InProcessBrowserTest : public content::BrowserTestBase {
   // BrowserMain. BrowserMain ends up invoking RunTestOnMainThreadLoop.
   virtual void SetUp() OVERRIDE;
 
-  // Restores state configured in SetUp.
-  virtual void TearDown() OVERRIDE;
-
  protected:
   // Returns the runtime instance created by CreateRuntime.
   xwalk::Runtime* runtime() const { return runtime_; }


### PR DESCRIPTION
- Remove ApplicationService::GetActiveApplication and hence modify some of application tests accordingly
  (they use now ApplicationService::Launch API and work with the obtained Application instance).
- EventManager is considering Appplication's life-cycle.
- Clean-up
