### PR TITLE
[application] Add a multiple applications test

### DIFF
--- a/application/test/application_multi_app_test.cc
+++ b/application/test/application_multi_app_test.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/public/test/browser_test_utils.h"
+#include "net/base/net_util.h"
+#include "xwalk/application/browser/application.h"
+#include "xwalk/application/browser/application_service.h"
+#include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/test/application_apitest.h"
+#include "xwalk/application/test/application_testapi.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
+
+using xwalk::application::Application;
+
+class ApplicationMultiAppTest : public ApplicationApiTest {
+};
+
+IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
+  xwalk::application::ApplicationSystem* system =
+      xwalk::XWalkRunner::GetInstance()->app_system();
+  xwalk::application::ApplicationService* service =
+      system->application_service();
+  // Launch the first app.
+  Application* app1 = service->Launch(
+      test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app1")));
+  ASSERT_TRUE(app1);
+  // Wait for app is fully loaded.
+  test_runner_->WaitForTestNotification();
+  EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
+  // The App1 has 2 pages: main doc page and "main.html" page.
+  EXPECT_EQ(app1->runtimes().size(), 2);
+  ASSERT_TRUE(app1->GetMainDocumentRuntime());
+
+  EXPECT_EQ(service->active_applications().size(), 1);
+  EXPECT_EQ(service->GetApplicationByID(app1->id()), app1);
+
+  // Verify that no new App instance was created, if one exists
+  // with the same ID.
+  Application* failed_app1 = service->Launch(
+      test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app1")));
+  ASSERT_FALSE(failed_app1);
+
+  // Launch the second app.
+  Application* app2 = service->Launch(
+      test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app2")));
+  ASSERT_TRUE(app2);
+  // Wait for app is fully loaded.
+  test_runner_->PostResultToNotificationCallback();
+  test_runner_->WaitForTestNotification();
+  EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
+
+  // The App2 also has 2 pages: main doc page and "main.html" page.
+  EXPECT_EQ(app2->runtimes().size(), 2);
+  ASSERT_TRUE(app2->GetMainDocumentRuntime());
+
+  // Check that the apps have different IDs and RPH IDs.
+  EXPECT_NE(app1->id(), app2->id());
+  EXPECT_NE(app1->GetRenderProcessHostID(), app2->GetRenderProcessHostID());
+
+  EXPECT_EQ(service->active_applications().size(), 2);
+  EXPECT_EQ(service->GetApplicationByID(app1->id()), app1);
+  EXPECT_EQ(service->GetApplicationByID(app2->id()), app2);
+
+  // As we do not have subscription to "onsuspend" event, the app
+  // closing should be sync.
+  // FIXME: Closing of a runtime having a window causes tcmalloc exception
+  // on Linux debug bots and the test cannot complete.
+  // Below should be uncommented, when the issue is treated.
+  // app1->Close();
+  // EXPECT_EQ(service->active_applications().size(), 1);
+
+  // app2->Close();
+  // EXPECT_EQ(service->active_applications().size(), 0);
+}

--- a/application/test/data/dummy_app1/main.html
+++ b/application/test/data/dummy_app1/main.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body onload="xwalk.app.test.notifyPass()">
+    <h1>Dummy App #1</h1>
+  </body>
+</html>

--- a/application/test/data/dummy_app1/main.js
+++ b/application/test/data/dummy_app1/main.js
@@ -1,0 +1,4 @@
+setTimeout(
+  function(){
+    window.open("main.html");
+  }, 100);

--- a/application/test/data/dummy_app1/manifest.json
+++ b/application/test/data/dummy_app1/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "dummy_app_1",
+  "manifest_version": 1,
+  "version": "1.0",
+  "app": {
+    "main": {
+      "scripts": ["main.js"]
+    }
+  }
+}

--- a/application/test/data/dummy_app2/main.html
+++ b/application/test/data/dummy_app2/main.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body onload="xwalk.app.test.notifyPass()">
+    <h1>Dummy App #2</h1>
+  </body>
+</html>

--- a/application/test/data/dummy_app2/main.js
+++ b/application/test/data/dummy_app2/main.js
@@ -1,0 +1,4 @@
+setTimeout(
+  function(){
+    window.open("main.html");
+  }, 100);

--- a/application/test/data/dummy_app2/manifest.json
+++ b/application/test/data/dummy_app2/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "dummy_app_2",
+  "manifest_version": 1,
+  "version": "1.0",
+  "app": {
+    "main": {
+      "scripts": ["main.js"]
+    }
+  }
+}

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -91,6 +91,7 @@
         'application/test/application_event_test.cc',
         'application/test/application_eventapi_test.cc',
         'application/test/application_main_document_browsertest.cc',
+        'application/test/application_multi_app_test.cc',
         'application/test/application_testapi.cc',
         'application/test/application_testapi.h',
         'application/test/application_testapi_test.cc',


### PR DESCRIPTION
Add an in-browser test making sure that running of multiple applications within XWalk runtime process works correctly.
Besides this patch contains a fix of a crash on Application exit (crash had been discovered with the newly added test).
