### PR TITLE
[Android] Use interceptor for app scheme on Android

### DIFF
--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -187,13 +187,6 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
                 base::SequencedWorkerPool::SKIP_ON_SHUTDOWN)));
     DCHECK(set_protocol);
 
-#if defined(OS_ANDROID)
-    set_protocol = job_factory_impl->SetProtocolHandler(
-        xwalk::kAppScheme,
-        CreateAppSchemeProtocolHandler().release());
-    DCHECK(set_protocol);
-#endif
-
     // Step 3:
     // Add the scheme interceptors.
     // Create a chain of URLRequestJobFactories. The handlers will be invoked
@@ -207,6 +200,8 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
         CreateContentSchemeProtocolHandler().release());
     protocol_interceptors.push_back(
         CreateAssetFileProtocolHandler().release());
+    protocol_interceptors.push_back(
+        CreateAppSchemeProtocolHandler().release());
     // The XWalkRequestInterceptor must come after the content and asset
     // file job factories. This for WebViewClassic compatibility where it
     // was not possible to intercept resource loads to resolvable content://


### PR DESCRIPTION
It's a hot fix, the app scheme protocol handler need to polish
for different platform.
The previous commit 1a01300019d3 removes the condition for adding
app scheme handler. But on Android, the app scheme handler is
different and added in UrlRequestContextGetter, which is more appropriate
place to add protocol handler by the way.

This commit uses interceptor for android app scheme handler instead to
avoid set app scheme handler multiple times. Otherwise, it causes crash
on debug build and white screen for app url on release build.

BUG=https://crosswalk-project.org/jira/browse/XWALK-867
