### PR TITLE
[Android] Implement Screen Orientation API through extension (Part 2)

### DIFF
--- a/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
+++ b/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
@@ -21,7 +21,11 @@ public abstract class XWalkExtensionAndroid {
     private int mXWalkExtension;
 
     public XWalkExtensionAndroid(String name, String jsApi) {
-        mXWalkExtension = nativeGetOrCreateExtension(name, jsApi);
+        mXWalkExtension = nativeGetOrCreateExtension(name, jsApi, null);
+    }
+
+    public XWalkExtensionAndroid(String name, String jsApi, String[] entryPoints) {
+        mXWalkExtension = nativeGetOrCreateExtension(name, jsApi, entryPoints);
     }
 
     protected void destroyExtension() {
@@ -58,7 +62,7 @@ public abstract class XWalkExtensionAndroid {
     @CalledByNative
     public abstract String handleSyncMessage(int instanceID, String message);
 
-    private native int nativeGetOrCreateExtension(String name, String jsApi);
+    private native int nativeGetOrCreateExtension(String name, String jsApi, String[] entryPoints);
     private native void nativePostMessage(int nativeXWalkExtensionAndroid, int instanceID, String message);
     private native void nativeBroadcastMessage(int nativeXWalkExtensionAndroid, String message);
     private native void nativeDestroyExtension(int nativeXWalkExtensionAndroid);

--- a/extensions/common/android/xwalk_extension_android.h
+++ b/extensions/common/android/xwalk_extension_android.h
@@ -46,7 +46,8 @@ class XWalkExtensionAndroidInstance;
 // created for the same extension identified the extension name.
 class XWalkExtensionAndroid : public XWalkExtension {
  public:
-  XWalkExtensionAndroid(JNIEnv* env, jobject obj, jstring name, jstring js_api);
+  XWalkExtensionAndroid(JNIEnv* env, jobject obj, jstring name,
+                        jstring js_api, jobjectArray js_entry_ports);
   virtual ~XWalkExtensionAndroid();
 
   // JNI interface to post message from Java to JS

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkCoreExtensionBridge.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkCoreExtensionBridge.java
@@ -19,7 +19,7 @@ class XWalkCoreExtensionBridge extends XWalkExtensionAndroid implements XWalkExt
     private XWalkExtension mExtension;
 
     public XWalkCoreExtensionBridge(XWalkExtension extension) {
-        super(extension.getExtensionName(), extension.getJsApi());
+        super(extension.getExtensionName(), extension.getJsApi(), extension.getEntryPoints());
         mExtension = extension;
     }
 

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtension.java
@@ -20,6 +20,10 @@ public abstract class XWalkExtension {
     // The JavaScript code stub. Will be injected to JS engine.
     protected String mJsApi;
 
+    // The entry points are used when extension needs to have objects outside
+    // the namespace that is implicitly created using its name.
+    protected String[] mEntryPoints;
+
     // The context used by extensions.
     protected XWalkExtensionContext mExtensionContext;
 
@@ -33,6 +37,23 @@ public abstract class XWalkExtension {
     public XWalkExtension(String name, String jsApi, XWalkExtensionContext context) {
         mName = name;
         mJsApi = jsApi;
+        mEntryPoints = null;
+        mExtensionContext = context;
+        mExtensionContext.registerExtension(this);
+    }
+
+    /**
+     * Constructor with the information of an extension.
+     * @param name the extension name.
+     * @param apiVersion the version of API.
+     * @param jsApi the code stub of JavaScript for this extension.
+     * @param entryPoints the entry points of JavaScript for this extension.
+     * @param context the extension context.
+     */
+    public XWalkExtension(String name, String jsApi, String[] entryPoints, XWalkExtensionContext context) {
+        mName = name;
+        mJsApi = jsApi;
+        mEntryPoints = entryPoints;
         mExtensionContext = context;
         mExtensionContext.registerExtension(this);
     }
@@ -51,6 +72,14 @@ public abstract class XWalkExtension {
      */
     public String getJsApi() {
         return mJsApi;
+    }
+
+    /**
+     * Get the entry points of extension.
+     * @return the entry points.
+     */
+    public String[] getEntryPoints() {
+        return mEntryPoints;
     }
 
     /**

--- a/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/XWalkExtensionManager.java
@@ -149,14 +149,12 @@ public class XWalkExtensionManager implements XWalkExtensionContext {
         }
 
         {
-            String jsApiContent = "var is_android_platform = true;\n";
-            jsApiContent += "var uaDefault = ";
-            jsApiContent += ScreenOrientationExtension.ANY;
-            jsApiContent += ";\n";
+            String jsApiContent = ScreenOrientationExtension.getInsertedString();
             try {
                 jsApiContent += getAssetsFileContent(mContext.getAssets(),
                                                      ScreenOrientationExtension.JS_API_PATH);
-                new ScreenOrientationExtension(ScreenOrientationExtension.NAME, jsApiContent, this);
+                new ScreenOrientationExtension(ScreenOrientationExtension.NAME, jsApiContent,
+                                               ScreenOrientationExtension.JS_ENTRY_POINTS, this);
             } catch (IOException e) {
                 Log.e(TAG, "Failed to read JS API file: " + ScreenOrientationExtension.JS_API_PATH);
             }

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/screen_orientation/ScreenOrientationExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/screen_orientation/ScreenOrientationExtension.java
@@ -20,6 +20,10 @@ public class ScreenOrientationExtension extends XWalkExtension {
     public final static String NAME = "xwalk.screen";
     public final static String JS_API_PATH = "jsapi/screen_orientation_api.js";
     public final static String JS_VALUE_TYPE = "value";
+    public final static String[] JS_ENTRY_POINTS = {
+        "window.screen.lockOrientation",
+        "window.screen.unlockOrientation"
+    };
     public final static int PORTRAIT_PRIMARY = 1 << 0;
     public final static int LANDSCAPE_PRIMARY = 1 << 1;
     public final static int PORTRAIT_SECONDARY  = 1 << 2;
@@ -42,8 +46,17 @@ public class ScreenOrientationExtension extends XWalkExtension {
         }
     }
 
-    public ScreenOrientationExtension(String name, String jsApi, XWalkExtensionContext context) {
-        super(name, jsApi, context);
+    public static String getInsertedString() {
+        String insertedString = "var is_android_platform = true;\n";
+        insertedString += "var uaDefault = ";
+        insertedString += ANY;
+        insertedString += ";\n";
+
+        return insertedString;
+    }
+
+    public ScreenOrientationExtension(String name, String jsApi, String[] entryPoints, XWalkExtensionContext context) {
+        super(name, jsApi, entryPoints, context);
     }
 
     @Override

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/ScreenOrientationTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/ScreenOrientationTest.java
@@ -16,9 +16,8 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  * Test suite for W3C Screen Orientation API.
  */
 public class ScreenOrientationTest extends XWalkRuntimeClientTestBase {
-    // @SmallTest
-    // @Feature({"ScreenOrientationTest"})
-    @DisabledTest
+    @SmallTest
+    @Feature({"ScreenOrientationTest"})
     public void testScreenOrientation() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/ScreenOrientationTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/ScreenOrientationTest.java
@@ -16,9 +16,8 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  * Test suite for W3C Screen Orientation API.
  */
 public class ScreenOrientationTest extends XWalkRuntimeClientTestBase {
-    // @SmallTest
-    // @Feature({"ScreenOrientationTest"})
-    @DisabledTest
+    @SmallTest
+    @Feature({"ScreenOrientationTest"})
     public void testScreenOrientation() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(


### PR DESCRIPTION
Expose entry points functionality for extension on Android platform, since
screen orientation api is needed to binding to name space "window.screen",
we are using set entry point functionality to implement it like what tizen
is doing.

Add a new construct for XWalkExtension, which won't affect existing extension.
