### PR TITLE
[Android]  Add the permission identifies for the APIs of DeviceCapabilit...

### DIFF
--- a/app/tools/android/handle_permissions.py
+++ b/app/tools/android/handle_permissions.py
@@ -35,8 +35,10 @@ permission_mapping_table = {
                  'android.permission.RECEIVE_SMS',
                  'android.permission.SEND_SMS',
                  'android.permission.WRITE_SMS'],
+  'devicecapabilities' : [],
   'fullscreen' : [],
-  'presentation' : []
+  'presentation' : [],
+  'rawsockets' : []
 }
 
 


### PR DESCRIPTION
...ies and RawSockets.

  Since the Crosswalk APIs of DeviceCapabilities and RawSockets are supported, need to add
the corresponding permission identifies. This is fix to resolve these issues.

BUG=https://crosswalk-project.org/jira/browse/XWALK-872
