### PR TITLE
[Android] Add the permission identifier for the API of ScreenOrientation.

### DIFF
--- a/app/tools/android/handle_permissions.py
+++ b/app/tools/android/handle_permissions.py
@@ -38,7 +38,8 @@ permission_mapping_table = {
   'devicecapabilities' : [],
   'fullscreen' : [],
   'presentation' : [],
-  'rawsockets' : []
+  'rawsockets' : [],
+  'screenorientation' : []
 }
 
 


### PR DESCRIPTION
  Since the ScreenOrientation related API is implemented, the related
permission identifier should be added. This fix is to resolve this issue.
