### PR TITLE
[Tizen] Remove scoped_ptr for TizenSystemIndicatorWidget

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -22,7 +22,7 @@ NativeAppWindowTizen::NativeAppWindowTizen(
     : NativeAppWindowViews(create_params),
       indicator_widget_(new TizenSystemIndicatorWidget()),
       allowed_orientations_(ANY) {
-  indicator_container_.reset(new WidgetContainerView(indicator_widget_.get()));
+  indicator_container_.reset(new WidgetContainerView(indicator_widget_));
 }
 
 void NativeAppWindowTizen::Initialize() {

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -62,7 +62,8 @@ class NativeAppWindowTizen
   // content, regular views do not support this. We add it to the container,
   // that is a view that doesn't draw anything, just passes the bounds
   // information to the topview layout.
-  scoped_ptr<TizenSystemIndicatorWidget> indicator_widget_;
+  // The |indicator_widget_| is owned by the WidgetContainerView.
+  TizenSystemIndicatorWidget* indicator_widget_;
   scoped_ptr<WidgetContainerView> indicator_container_;
   gfx::Display display_;
   OrientationMask allowed_orientations_;


### PR DESCRIPTION
Fix a crash by removing scoped_ptr for TizenSystemIndicatorWidget since it has the same lifetime with its owner WidgetContainerView.

Stacktrace of the crash: https://crosswalk-project.org/jira/secure/attachment/10756/xwalk_1390198714.txt
