### PR TITLE
[application] Use 'url' manifest key for launching "dummy" applications

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -108,10 +108,10 @@ bool Application::TryLaunchAt<Application::LaunchLocalPathKey>() {
 }
 
 template<>
-bool Application::TryLaunchAt<Application::LaunchWebURLKey>() {
+bool Application::TryLaunchAt<Application::URLKey>() {
   const Manifest* manifest = application_data_->GetManifest();
   std::string url_string;
-  if (manifest->GetString(application_manifest_keys::kLaunchWebURLKey,
+  if (manifest->GetString(application_manifest_keys::kURLKey,
       &url_string)) {
     GURL url(url_string);
     if (!url.is_valid()) {
@@ -142,7 +142,7 @@ bool Application::Launch() {
     return true;
   if ((entry_points_ & LaunchLocalPathKey) && TryLaunchAt<LaunchLocalPathKey>())
     return true;
-  if ((entry_points_ & LaunchWebURLKey) && TryLaunchAt<LaunchWebURLKey>())
+  if ((entry_points_ & URLKey) && TryLaunchAt<URLKey>())
     return true;
 
   return false;

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -51,7 +51,11 @@ class Application : public Runtime::Observer {
   enum LaunchEntryPoint {
     AppMainKey = 1 << 0,  // app.main
     LaunchLocalPathKey = 1 << 1,  // app.launch.local_path
-    LaunchWebURLKey = 1 << 2,  // app.launch.web_url
+    // NOTE: The following key is only used for "dummy" hosted apps,
+    // which can be using any arbitrary URL, incl. remote ones.
+    // For now this should be disabled for all other cases as this will
+    // require special care with permissions etc.
+    URLKey = 1 << 2,  // url
     Default = AppMainKey | LaunchLocalPathKey
   };
   typedef unsigned LaunchEntryPoints;

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -485,7 +485,7 @@ Application* ApplicationService::Launch(const GURL& url) {
 
   base::DictionaryValue manifest;
   // FIXME: define permissions!
-  manifest.SetString(keys::kLaunchWebURLKey, url_spec);
+  manifest.SetString(keys::kURLKey, url_spec);
   manifest.SetString(keys::kNameKey, "XWalk Browser");
   manifest.SetString(keys::kVersionKey, "0");
   manifest.SetInteger(keys::kManifestVersionKey, 1);
@@ -498,7 +498,7 @@ Application* ApplicationService::Launch(const GURL& url) {
     return NULL;
   }
 
-  return Launch(application_data, Application::LaunchWebURLKey);
+  return Launch(application_data, Application::URLKey);
 }
 
 namespace {

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -18,6 +18,7 @@ const char kLaunchWebURLKey[] = "app.launch.web_url";
 const char kManifestVersionKey[] = "manifest_version";
 const char kNameKey[] = "name";
 const char kPermissionsKey[] = "permissions";
+const char kURLKey[] = "url";
 const char kVersionKey[] = "version";
 const char kWebURLsKey[] = "app.urls";
 

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -19,6 +19,7 @@ namespace application_manifest_keys {
   extern const char kManifestVersionKey[];
   extern const char kNameKey[];
   extern const char kPermissionsKey[];
+  extern const char kURLKey[];
   extern const char kVersionKey[];
   extern const char kWebURLsKey[];
 


### PR DESCRIPTION
Use 'url' manifest key for launching "dummy" applications (applications that were created internally
for rendering and arbitrary URL) instead of currently used 'app.launch.web_url'.

Spec: http://w3c.github.io/manifest/#url-member
