### PR TITLE
[Tizen] Fix a crash in NativeAppWindowTizen::~NativeAppWindowTizen()

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -52,9 +52,6 @@ void NativeAppWindowTizen::Initialize() {
 NativeAppWindowTizen::~NativeAppWindowTizen() {
   if (SensorProvider::GetInstance())
     SensorProvider::GetInstance()->RemoveObserver(this);
-  aura::Window* root_window = GetNativeWindow()->GetRootWindow();
-  DCHECK(root_window);
-  root_window->RemoveObserver(this);
 }
 
 void NativeAppWindowTizen::ViewHierarchyChanged(
@@ -79,6 +76,12 @@ void NativeAppWindowTizen::OnWindowBoundsChanged(
   GetNativeWindow()->SetBounds(new_bounds);
 
   GetWidget()->GetRootView()->SetSize(new_bounds.size());
+}
+
+void NativeAppWindowTizen::OnWindowDestroying(aura::Window* window) {
+  // Must be removed here and not in the destructor, as the aura::Window is
+  // already destroyed when our destructor runs.
+  window->RemoveObserver(this);
 }
 
 void NativeAppWindowTizen::OnWindowVisibilityChanging(

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -39,6 +39,7 @@ class NativeAppWindowTizen
   virtual void OnWindowBoundsChanged(aura::Window* window,
                                      const gfx::Rect& old_bounds,
                                      const gfx::Rect& new_bounds) OVERRIDE;
+  virtual void OnWindowDestroying(aura::Window* window) OVERRIDE;
 
   // views::View overrides:
   virtual void ViewHierarchyChanged(


### PR DESCRIPTION
Observer must be removed in OnWindowDestroying and not in the destructor,
as the aura::Window is already destroyed when the NativeAppWindowTizen
destructor runs.

BUG=https://crosswalk-project.org/jira/browse/XWALK-782
