### PR TITLE
[application] Normalize Application termination API

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -148,7 +148,7 @@ bool Application::Launch(const LaunchParams& launch_params) {
   return false;
 }
 
-void Application::Close() {
+void Application::Terminate() {
   std::set<Runtime*> to_be_closed(runtimes_);
   if (HasMainDocument() && to_be_closed.size() > 1) {
     // The main document runtime is closed separately

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -68,7 +68,9 @@ class Application : public Runtime::Observer {
   };
 
   // Closes all the application's runtimes (application pages).
-  void Close();
+  // NOTE: ApplicationService deletes an Application instance
+  // immediately after its termination.
+  void Terminate();
 
   // Returns Runtime (application page) containing the application's
   // 'main document'. The main document is the main entry point of

--- a/application/browser/linux/running_application_object.cc
+++ b/application/browser/linux/running_application_object.cc
@@ -69,17 +69,17 @@ RunningApplicationObject::RunningApplicationObject(
 
 RunningApplicationObject::~RunningApplicationObject() {
   if (watching_launcher_)
-    CloseApplication();
+    TerminateApplication();
 }
 
-void RunningApplicationObject::CloseApplication() {
+void RunningApplicationObject::TerminateApplication() {
   bus_->UnlistenForServiceOwnerChange(
       launcher_name_,
       base::Bind(&RunningApplicationObject::OnNameOwnerChanged,
                  base::Unretained(this)));
   watching_launcher_ = false;
 
-  application_->Close();
+  application_->Terminate();
 }
 
 void RunningApplicationObject::OnExported(const std::string& interface_name,
@@ -105,7 +105,7 @@ void RunningApplicationObject::OnTerminate(
     return;
   }
 
-  CloseApplication();
+  TerminateApplication();
 
   scoped_ptr<dbus::Response> response =
       dbus::Response::FromMethodCall(method_call);
@@ -122,7 +122,7 @@ void RunningApplicationObject::OnNameOwnerChanged(
 }
 
 void RunningApplicationObject::OnLauncherDisappeared() {
-  CloseApplication();
+  TerminateApplication();
 }
 
 }  // namespace application

--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -28,7 +28,7 @@ class RunningApplicationObject : public dbus::ManagedObject {
   ~RunningApplicationObject();
 
  private:
-  void CloseApplication();
+  void TerminateApplication();
 
   void OnExported(const std::string& interface_name,
                   const std::string& method_name,


### PR DESCRIPTION
We should use the word "Terminate" in every method name concerning an application's termination.
