### PR TITLE
Fix the coding style in the orientation ext JavaScript

### DIFF
--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/screen_orientation/ScreenOrientationExtension.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/screen_orientation/ScreenOrientationExtension.java
@@ -47,7 +47,7 @@ public class ScreenOrientationExtension extends XWalkExtension {
     }
 
     public static String getInsertedString() {
-        String insertedString = "var is_android_platform = true;\n";
+        String insertedString = "var isAndroid = true;\n";
         insertedString += "var uaDefault = ";
         insertedString += ANY;
         insertedString += ";\n";

--- a/runtime/extension/screen_orientation_api.js
+++ b/runtime/extension/screen_orientation_api.js
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// var uaDefault is set externally.
-
-var internal = requireNative("internal");
+var internal = requireNative('internal');
 internal.setupInternalExtension(extension);
 
 // These constants must correspond with C++ side:
@@ -17,37 +15,37 @@ var PORTRAIT            = PORTRAIT_PRIMARY | PORTRAIT_SECONDARY;
 var LANDSCAPE           = LANDSCAPE_PRIMARY | LANDSCAPE_SECONDARY;
 var ANY                 = PORTRAIT | LANDSCAPE;
 
+// Values that can be set externally.
+var uaDefault = uaDefault || ANY;
+var isAndroid = isAndroid || false;
+
 // Store the real Screen object.
 var realScreen = window.screen;
 
-// Create replacement Screen.
-function Screen() {}
+function cloneProperties(target, source) {
+  var props = Object.getOwnPropertyNames(source);
+  props.forEach(function(item) {
+    target[item] = source[item];
+  });
+}
 
-// Make it an EventTarget.
-Screen.prototype = window.__proto__.__proto__;
+// Create replacement Screen and make it an EventTarget.
+function Screen() { cloneProperties(this, realScreen); };
+Screen.prototype = Object.create(EventTarget.prototype);
+Screen.prototype.constructor = Screen;
 
 // Replace it.
 window.screen = new Screen();
 
-function handleScreenChange() {
-  var props = Object.getOwnPropertyNames(realScreen);
-  props.forEach(function(item) {
-    window.screen[item] = realScreen[item];
-  });
-}
-
-// Add or replace value properties.
-handleScreenChange();
-
 function postMessage(command, value) {
-  // Currently, internal.postMessage can't work on android platform.
-  // Please see: https://crosswalk-project.org/jira/browse/XWALK-855
-  if (typeof is_android_platform == "boolean" && is_android_platform) {
-    var message = {
-      'cmd' : command,
-      'value' : value.toString()
-    };
-    extension.postMessage(JSON.stringify(message));
+  // Currently, internal.postMessage can't work on Android.
+  // https://crosswalk-project.org/jira/browse/XWALK-855
+  if (isAndroid) {
+    var message = JSON.stringify({
+      cmd: command,
+      value: value.toString()
+    });
+    extension.postMessage(message);
   } else {
     internal.postMessage(command, value, null);
   }
@@ -55,7 +53,7 @@ function postMessage(command, value) {
 
 window.screen.lockOrientation = function(orientations) {
   if (!Array.isArray(orientations)) {
-    if (typeof orientations != "string")
+    if (typeof orientations != 'string')
       return false;
     orientations = [orientations];
   }
@@ -63,26 +61,26 @@ window.screen.lockOrientation = function(orientations) {
   var value = 0;
   for (var i = 0; i < orientations.length; ++i) {
     switch (orientations[i]) {
-      case "portrait-primary":
+      case 'portrait-primary':
         value |= PORTRAIT_PRIMARY;
         break;
-      case "portrait-secondary":
+      case 'portrait-secondary':
         value |= PORTRAIT_SECONDARY;
         break;
-      case "landscape-primary":
+      case 'landscape-primary':
         value |= LANDSCAPE_PRIMARY;
         break;
-      case "landscape-secondary":
+      case 'landscape-secondary':
         value |= LANDSCAPE_SECONDARY;
         break;
-      case "portrait":
+      case 'portrait':
         value |= PORTRAIT;
         break;
-      case "landscape":
+      case 'landscape':
         value |= LANDSCAPE;
         break;
       default:
-        console.error("Invalid screen orientation");
+        console.error('Invalid screen orientation');
         return false;
     }
     // If the orientations aren't all part of the default allowed
@@ -99,22 +97,22 @@ window.screen.unlockOrientation = function() {
 };
 
 // Create a HTMLUnknownElement and do not attach it to the DOM.
-var dispatcher = document.createElement("xwalk-EventDispatcher");
+var dispatcher = document.createElement('xwalk-EventDispatcher');
 
 // Implement EventTarget interface on object.
-Object.defineProperty(window.screen, "addEventListener", {
+Object.defineProperty(window.screen, 'addEventListener', {
   value: function(type, callback, capture) {
     dispatcher.addEventListener(type, callback, capture);
   }
 });
 
-Object.defineProperty(window.screen, "removeEventListener", {
+Object.defineProperty(window.screen, 'removeEventListener', {
   value: function(type, callback, capture) {
     dispatcher.removeEventListener(type, callback, capture);
   }
 });
 
-Object.defineProperty(window.screen, "dispatchEvent", {
+Object.defineProperty(window.screen, 'dispatchEvent', {
   value: function(e) {
     dispatcher.dispatchEvent(e);
   }
@@ -123,7 +121,7 @@ Object.defineProperty(window.screen, "dispatchEvent", {
 var orientationchangeCallback = null;
 var orientationchangeCallbackWrapper = null;
 
-Object.defineProperty(window.screen, "onorientationchange", {
+Object.defineProperty(window.screen, 'onorientationchange', {
   configurable: false,
   enumerable: true,
   get: function() { return orientationchangeCallback; },
@@ -134,14 +132,14 @@ Object.defineProperty(window.screen, "onorientationchange", {
     // as that would allow removeEventListener to remove it.
 
     // Remove existing (wrapped) listener.
-    window.screen.removeEventListener("orientationchange",
+    window.screen.removeEventListener('orientationchange',
         orientationchangeCallbackWrapper);
 
     // If valid, store and add a wrapped version as listener.
     if (callback instanceof Function) {
       orientationchangeCallback = callback;
       orientationchangeCallbackWrapper = function() { callback(); };
-      window.screen.addEventListener("orientationchange",
+      window.screen.addEventListener('orientationchange',
           orientationchangeCallbackWrapper);
     }
     // If not valid, reset to null.
@@ -155,40 +153,42 @@ Object.defineProperty(window.screen, "onorientationchange", {
 function handleOrientationChange(newOrientation) {
   switch (newOrientation) {
     case PORTRAIT_PRIMARY:
-      orientationValue = "portrait-primary";
+      orientationValue = 'portrait-primary';
       break;
     case PORTRAIT_SECONDARY:
-      orientationValue = "portrait-secondary";
+      orientationValue = 'portrait-secondary';
       break;
     case LANDSCAPE_PRIMARY:
-      orientationValue = "landscape-primary";
+      orientationValue = 'landscape-primary';
       break;
     case LANDSCAPE_SECONDARY:
-      orientationValue = "landscape-secondary";
+      orientationValue = 'landscape-secondary';
       break;
     default:
-      console.error("Received unknown value for current orientation.");
+      console.error('Received unknown value for current orientation');
       return;
   }
 
   // The first time the listener is called it is to set the current
   // orientation, so do not dispatch the orientationchange in that case.
   if (handleOrientationChange.shouldDispatchEvent) {
-    var event = new Event("orientationchange");
+    var event = new Event('orientationchange');
     dispatcher.dispatchEvent(event);
   }
 
   handleOrientationChange.shouldDispatchEvent = true;
 }
 
-var orientationValue = undefined;
+var orientationValue;
 
-Object.defineProperty(window.screen, "orientation", {
+Object.defineProperty(window.screen, 'orientation', {
   configurable: false,
   enumerable: true,
   get: function() {
     if (typeof orientationValue == 'undefined') {
-      var msg = JSON.stringify({'cmd' : 'GetScreenOrientation'});
+      var msg = JSON.stringify({
+        cmd: 'GetScreenOrientation'
+      });
       var newOrientation = extension.internal.sendSyncMessage(msg);
       handleOrientationChange(newOrientation);
     }


### PR DESCRIPTION
Fix valid cases pointed out by JSLint and avoid using
deprecated JavaScript methods.
