### PR TITLE
[Application][D-Bus] Fix crash when shutting down

### DIFF
--- a/application/browser/application_system_linux.h
+++ b/application/browser/application_system_linux.h
@@ -24,8 +24,8 @@ class ApplicationSystemLinux : public ApplicationSystem {
   DBusManager& dbus_manager();
 
  private:
-  scoped_ptr<ApplicationServiceProviderLinux> service_provider_;
   scoped_ptr<DBusManager> dbus_manager_;
+  scoped_ptr<ApplicationServiceProviderLinux> service_provider_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationSystemLinux);
 };


### PR DESCRIPTION
DBusManager owns the Bus connection and was being destroyed before the
service provider that uses it.

TEST=Loaded xwalk --run-as-service and xwalkctl <APP_ID> then closed the
window. The first process should not crash but exit cleanly.
