### PR TITLE
[Application][D-Bus] Unlisten for D-Bus name with the correct callback

### DIFF
--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -7,17 +7,20 @@
 
 #include <string>
 #include "base/memory/ref_counted.h"
+#include "dbus/bus.h"
 #include "xwalk/dbus/object_manager_adaptor.h"
-
-namespace dbus {
-class Bus;
-}
 
 namespace xwalk {
 namespace application {
 
 class Application;
 
+// Represents the running application inside D-Bus hierarchy of
+// RunningApplicationsManager.
+//
+// Watches for the D-Bus presence of the launcher, when it disappears (e.g. the
+// launcher was ended by a task manager) will terminate the corresponding
+// application in Crosswalk.
 class RunningApplicationObject : public dbus::ManagedObject {
  public:
   RunningApplicationObject(scoped_refptr<dbus::Bus> bus,
@@ -37,14 +40,16 @@ class RunningApplicationObject : public dbus::ManagedObject {
   void OnTerminate(dbus::MethodCall* method_call,
                    dbus::ExportedObject::ResponseSender response_sender);
 
+  void ListenForOwnerChange();
+  void UnlistenForOwnerChange();
   void OnNameOwnerChanged(const std::string& service_owner);
 
   void OnLauncherDisappeared();
 
   scoped_refptr<dbus::Bus> bus_;
   std::string launcher_name_;
+  dbus::Bus::GetServiceOwnerCallback owner_change_callback_;
   Application* application_;
-  bool watching_launcher_;
 };
 
 }  // namespace application


### PR DESCRIPTION
When running xwalk --run-as-service in Debug mode, Crosswalk was
crashing during shutdown. Reason was that we were creating a new
base::Callback() via bind to unlisten, but we need to use the
same instance.

This commit stores the callback instance so we can unlisten the
correct callback. Because the callback can be cleared, we can use
it instead of keeping a separated boolean.

TEST=Run out/Debug/xwalk --run-as-service and xwalkctl <APP_ID> then
close the window. The first process should not crash but exit cleanly.
