### PR TITLE
[Runtime] Remove unused overload of Runtime::Create()

### DIFF
--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -45,21 +45,10 @@ static Runtime::Observer* g_observer_for_testing;
 }  // namespace
 
 // static
-Runtime* Runtime::Create(
-        RuntimeContext* runtime_context, const GURL& url, Observer* observer) {
-  WebContents::CreateParams params(runtime_context, NULL);
-  params.routing_id = MSG_ROUTING_NONE;
-  WebContents* web_contents = WebContents::Create(params);
-
-  Runtime* runtime = new Runtime(web_contents, observer);
-  runtime->LoadURL(url);
-  return runtime;
-}
-
-// static
 Runtime* Runtime::CreateWithDefaultWindow(
     RuntimeContext* runtime_context, const GURL& url, Observer* observer) {
-  Runtime* runtime = Runtime::Create(runtime_context, url, observer);
+  Runtime* runtime = Runtime::Create(runtime_context, observer);
+  runtime->LoadURL(url);
   runtime->AttachDefaultWindow();
   return runtime;
 }

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -55,8 +55,6 @@ class Runtime : public content::WebContentsDelegate,
 
   void SetObserver(Observer* observer) { observer_ = observer; }
 
-  // Create a new Runtime instance with the given browsing context and URL.
-  static Runtime* Create(RuntimeContext*, const GURL&, Observer* = NULL);
   // Create a new Runtime instance which binds to a default app window.
   static Runtime* CreateWithDefaultWindow(RuntimeContext*,
                                           const GURL&, Observer* = NULL);


### PR DESCRIPTION
The extra Create() call is equivalent to Create() then calling
LoadURL(), but less readable.
