### PR TITLE
[Runtime] Fill the default window params in AttachWindow()

### DIFF
--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -146,6 +146,8 @@ class Runtime : public content::WebContentsDelegate,
   // NativeAppWindowDelegate implementation.
   virtual void OnWindowDestroyed() OVERRIDE;
 
+  void ApplyWindowDefaultParams(NativeAppWindow::CreateParams* params);
+
   // The browsing context.
   xwalk::RuntimeContext* runtime_context_;
 


### PR DESCRIPTION
This makes Runtime::AttachWindow() more useful, since we can change just
some parameters for window creation and the defaults would still apply.
A later patch will make use of this to pass specific information from
the application launching to the native window creation (NET_WM_PID).

The fullscreen override was moved to that apply function, so strictly
speaking we can't attach a non-fullscreen window when the fullscreen is
passed. However, we were not trying to do this anyway. Added a comment
pointing that this policy check was probably in the wrong place.
