### PR TITLE
[Application] Refactor the implementation of Application::Launch()

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -104,8 +104,13 @@ class Application : public Runtime::Observer {
               Observer* observer);
   bool Launch(const LaunchParams& launch_params);
 
-  template<LaunchEntryPoint>
-  bool TryLaunchAt();
+  // Try to extract the URL from different possible keys for entry points in the
+  // manifest, returns it and the entry point used.
+  GURL GetURLForLaunch(const LaunchParams& params, LaunchEntryPoint* used);
+
+  GURL GetURLFromAppMainKey();
+  GURL GetURLFromLocalPathKey();
+  GURL GetURLFromURLKey();
 
   friend class FinishEventObserver;
   void CloseMainDocument();


### PR DESCRIPTION
The goal of this refactor is to reduce to remove the duplicated logic
for runtime creation, so that we can change to pass more attributes in
the future.

This patch splits the logic for launching into

(a) figure out the right entry point, based on the launch params;
(b) create the runtime.

We have three possible entry points for (a), but the logic for (b) is
pretty much independent. While we still record the use entry point to
decide whether a window will be shown, there's no "tentantive steps" so
we can write only one code for (b).
