### PR TITLE
[Tizen] Fix window can't resume when running in service mode

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -23,6 +23,10 @@
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 
+#if defined(OS_TIZEN_MOBILE)
+#include "xwalk/runtime/browser/ui/native_app_window_tizen.h"
+#endif
+
 namespace xwalk {
 
 namespace keys = application_manifest_keys;
@@ -83,6 +87,8 @@ bool Application::Launch(const LaunchParams& launch_params) {
   main_runtime_->LoadURL(url);
   if (entry_point_used != AppMainKey)
     main_runtime_->AttachDefaultWindow();
+
+  launcher_pid_ = launch_params.launcher_pid;
 
   return true;
 }
@@ -204,6 +210,17 @@ void Application::OnRuntimeRemoved(Runtime* runtime) {
         xwalk::application::kOnSuspend, event_args.Pass());
     event_manager->SendEvent(application_data_->ID(), event);
   }
+}
+
+void Application::OnRuntimeWindowAttached(Runtime* runtime) {
+#if defined(OS_TIZEN_MOBILE)
+  CHECK_GE(launcher_pid_, 2);
+  if (runtime->window()) {
+    NativeAppWindowTizen* window =
+        static_cast<NativeAppWindowTizen*>(runtime->window());
+    window->UpdateXWindowPid(launcher_pid_);
+  }
+#endif
 }
 
 void Application::CloseMainDocument() {

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -62,9 +62,11 @@ class Application : public Runtime::Observer {
 
   struct LaunchParams {
     LaunchParams() :
-        entry_points(Default) {}
+        entry_points(Default),
+        launcher_pid(-1) {}
 
     LaunchEntryPoints entry_points;
+    base::ProcessId launcher_pid;
   };
 
   // Closes all the application's runtimes (application pages).
@@ -96,6 +98,7 @@ class Application : public Runtime::Observer {
   // Runtime::Observer implementation.
   virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE;
   virtual void OnRuntimeRemoved(Runtime* runtime) OVERRIDE;
+  virtual void OnRuntimeWindowAttached(Runtime* runtime) OVERRIDE;
 
   // We enforce ApplicationService ownership.
   friend class ApplicationService;
@@ -122,6 +125,7 @@ class Application : public Runtime::Observer {
   std::set<Runtime*> runtimes_;
   scoped_ptr<EventObserver> finish_observer_;
   Observer* observer_;
+  base::ProcessId launcher_pid_;
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -476,6 +476,25 @@ Application* ApplicationService::Launch(const std::string& id) {
   return Launch(application_data, Application::LaunchParams());
 }
 
+Application* ApplicationService::Launch(const std::string& id,
+                                        base::ProcessId launcher_pid) {
+  if (launcher_pid <= 1) {
+    LOG(ERROR) << "App-launcher pid is invalid.";
+    return NULL;
+  }
+
+  scoped_refptr<ApplicationData> application_data =
+    application_storage_->GetApplicationData(id);
+  if (!application_data) {
+    LOG(ERROR) << "Application with id " << id << " is not installed.";
+    return NULL;
+  }
+
+  Application::LaunchParams params;
+  params.launcher_pid = launcher_pid;
+  return Launch(application_data, params);
+}
+
 Application* ApplicationService::Launch(const base::FilePath& path) {
   if (!base::DirectoryExists(path))
     return NULL;

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -51,6 +51,8 @@ class ApplicationService : public Application::Observer {
   bool Update(const std::string& id, const base::FilePath& path);
   // Launch an installed application using application id.
   Application* Launch(const std::string& id);
+  // Launch with application id the launcher pid in service mode.
+  Application* Launch(const std::string& id, base::ProcessId launcher_pid);
   // Launch an unpacked application using path to a local directory which
   // contains manifest file.
   Application* Launch(const base::FilePath& path);

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -80,7 +80,19 @@ void RunningApplicationsManager::OnLaunch(
     return;
   }
 
+#if defined(OS_TIZEN_MOBILE)
+  pid_t launcher_pid;
+  if (!reader.PopInt32(&launcher_pid)) {
+    scoped_ptr<dbus::Response> response =
+        CreateError(method_call,
+                    "Error parsing message. Missing launcher_pid argument.");
+    response_sender.Run(response.Pass());
+    return;
+  }
+  Application* application = application_service_->Launch(app_id, launcher_pid);
+#else
   Application* application = application_service_->Launch(app_id);
+#endif
   if (!application) {
     scoped_ptr<dbus::Response> response =
         CreateError(method_call,

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -124,10 +124,11 @@ int main(int argc, char** argv) {
     exit(1);
   }
 
-  GVariant* result = g_dbus_proxy_call_sync(running_proxy, "Launch",
-                                            g_variant_new("(s)", appid),
-                                            G_DBUS_CALL_FLAGS_NONE,
-                                            -1, NULL, &error);
+  GVariant* result = g_dbus_proxy_call_sync(
+      running_proxy, "Launch",
+      g_variant_new("(si)", appid, getpid()),
+      G_DBUS_CALL_FLAGS_NONE,
+      -1, NULL, &error);
   if (!result) {
     fprintf(stderr, "Couldn't call 'Launch' method: %s\n", error->message);
     exit(1);

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -132,6 +132,8 @@ void Runtime::AttachWindow(const NativeAppWindow::CreateParams& params) {
   if (!app_icon_.IsEmpty())
     window_->UpdateIcon(app_icon_);
   window_->Show();
+
+  FOR_EACH_RUNTIME_OBSERVER(OnRuntimeWindowAttached(this));
 #endif
 }
 

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -49,6 +49,9 @@ class Runtime : public content::WebContentsDelegate,
       // Called when a Runtime instance is removed.
       virtual void OnRuntimeRemoved(Runtime* runtime) = 0;
 
+      // Called when a Runtime attached to a window.
+      virtual void OnRuntimeWindowAttached(Runtime* runtime) {}
+
     protected:
       virtual ~Observer() {}
   };

--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -7,6 +7,7 @@
 #include "base/logging.h"
 #include "base/memory/scoped_ptr.h"
 #include "ui/aura/root_window.h"
+#include "ui/base/x/x11_util.h"
 #include "ui/gfx/transform.h"
 #include "ui/gfx/rect.h"
 #include "ui/gfx/screen.h"
@@ -52,6 +53,16 @@ void NativeAppWindowTizen::Initialize() {
 NativeAppWindowTizen::~NativeAppWindowTizen() {
   if (SensorProvider::GetInstance())
     SensorProvider::GetInstance()->RemoveObserver(this);
+}
+
+void NativeAppWindowTizen::UpdateXWindowPid(base::ProcessId pid) {
+  XID xid = GetNativeWindow()->GetDispatcher()->GetAcceleratedWidget();
+  base::ProcessId curr_pid;
+  if (!ui::GetIntProperty(xid, "_NET_WM_PID", &curr_pid) ||
+      curr_pid == pid)
+    return;
+
+  ui::SetIntProperty(xid, "_NET_WM_PID", "CARDINAL", pid);
 }
 
 void NativeAppWindowTizen::ViewHierarchyChanged(

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -25,6 +25,7 @@ class NativeAppWindowTizen
   explicit NativeAppWindowTizen(const NativeAppWindow::CreateParams& params);
   virtual ~NativeAppWindowTizen();
 
+  void UpdateXWindowPid(pid_t pid);
 
  private:
   gfx::Transform GetRotationTransform() const;


### PR DESCRIPTION
Tizen app-core will find and raise X window when app is resumed. The window
finding is implemented by find a window which has a _NET_WM_PID property equals
to current PID. However in service mode, the window's _NET_WM_PID is the daemon
process's PID.

In order to fix this, when launched the xwalk-launcher will pass its PID to
xwalk-daemon, and the Application::Launch will save the launcher's PID. After a
window is created, the Application object will update its X window's property to
the xwalk-launcher's PID.
