### PR TITLE
[Application] Allow passing the NET_WM_PID as a LaunchParam

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -81,8 +81,11 @@ bool Application::Launch(const LaunchParams& launch_params) {
 
   main_runtime_ = Runtime::Create(runtime_context_, this);
   main_runtime_->LoadURL(url);
-  if (entry_point_used_ != AppMainKey)
-    main_runtime_->AttachDefaultWindow();
+  if (entry_point_used_ != AppMainKey) {
+    NativeAppWindow::CreateParams params;
+    params.net_wm_pid = launch_params.launcher_pid;
+    main_runtime_->AttachWindow(params);
+  }
 
   return true;
 }

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -62,9 +62,14 @@ class Application : public Runtime::Observer {
 
   struct LaunchParams {
     LaunchParams() :
-        entry_points(Default) {}
+        entry_points(Default),
+        launcher_pid(0) {}
 
     LaunchEntryPoints entry_points;
+
+    // Used only when running as service. Specifies the PID of the launcher
+    // process.
+    int32 launcher_pid;
   };
 
   // Closes all the application's runtimes (application pages).

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -465,7 +465,8 @@ bool ApplicationService::Uninstall(const std::string& id) {
   return result;
 }
 
-Application* ApplicationService::Launch(const std::string& id) {
+Application* ApplicationService::Launch(
+    const std::string& id, const Application::LaunchParams& params) {
   scoped_refptr<ApplicationData> application_data =
     application_storage_->GetApplicationData(id);
   if (!application_data) {
@@ -473,7 +474,7 @@ Application* ApplicationService::Launch(const std::string& id) {
     return NULL;
   }
 
-  return Launch(application_data, Application::LaunchParams());
+  return Launch(application_data, params);
 }
 
 Application* ApplicationService::Launch(const base::FilePath& path) {

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -50,7 +50,9 @@ class ApplicationService : public Application::Observer {
   bool Uninstall(const std::string& id);
   bool Update(const std::string& id, const base::FilePath& path);
   // Launch an installed application using application id.
-  Application* Launch(const std::string& id);
+  Application* Launch(
+      const std::string& id,
+      const Application::LaunchParams& params = Application::LaunchParams());
   // Launch an unpacked application using path to a local directory which
   // contains manifest file.
   Application* Launch(const base::FilePath& path);

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -80,7 +80,9 @@ void RunningApplicationsManager::OnLaunch(
     return;
   }
 
-  Application* application = application_service_->Launch(app_id);
+  Application::LaunchParams params;
+  // TODO(cmarcelo): Set params.launcher_pid.
+  Application* application = application_service_->Launch(app_id, params);
   if (!application) {
     scoped_ptr<dbus::Response> response =
         CreateError(method_call,

--- a/runtime/browser/ui/native_app_window.cc
+++ b/runtime/browser/ui/native_app_window.cc
@@ -10,7 +10,8 @@ NativeAppWindow::CreateParams::CreateParams()
   : delegate(NULL),
     web_contents(NULL),
     state(ui::SHOW_STATE_NORMAL),
-    resizable(true) {
+    resizable(true),
+    net_wm_pid(0) {
 }
 
 }  // namespace xwalk

--- a/runtime/browser/ui/native_app_window.h
+++ b/runtime/browser/ui/native_app_window.h
@@ -49,6 +49,8 @@ class NativeAppWindow {
     ui::WindowShowState state;
     // True if the window can be resized.
     bool resizable;
+    // Used only by X11. Specifies the PID set in _NET_WM_PID window property.
+    int32 net_wm_pid;
   };
 
   // Do one time initialization at application startup.

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -61,6 +61,7 @@ void NativeAppWindowViews::Initialize() {
   params.type = views::Widget::InitParams::TYPE_WINDOW;
   params.bounds = create_params_.bounds;
 #endif
+  params.net_wm_pid = create_params_.net_wm_pid;
 
   window_->Init(params);
 


### PR DESCRIPTION
In Tizen, the windows of applications launched in service mode should
have their X11 property NET_WM_PID set to the launcher PID, so that the
task manager can find the right X11 window associated with each
application launched.

This commit prepares the ground, a separate patch will actually get the
PID information and set the launcher_pid parameter.
