### PR TITLE
[application] HasMainDocument() should consider actual entry point

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -86,13 +86,13 @@ class Application : public Runtime::Observer {
   // application amoung both running applications and installed ones
   // (ApplicationData objects).
   std::string id() const { return application_data_->ID(); }
-  bool HasMainDocument() const { return application_data_->HasMainDocument(); }
   int GetRenderProcessHostID() const;
 
   const ApplicationData* data() const { return application_data_; }
   ApplicationData* data() { return application_data_; }
 
  private:
+  bool HasMainDocument() const;
   // Runtime::Observer implementation.
   virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE;
   virtual void OnRuntimeRemoved(Runtime* runtime) OVERRIDE;
@@ -122,6 +122,8 @@ class Application : public Runtime::Observer {
   std::set<Runtime*> runtimes_;
   scoped_ptr<EventObserver> finish_observer_;
   Observer* observer_;
+  // The entry point used as part of Launch().
+  LaunchEntryPoint entry_point_used_;
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };


### PR DESCRIPTION
Application::HasMainDocument() should consider the application entry point (whether application has actually started from 'app.main') rather than just check presence of this field in the manifest.
Otherwise we'll have a bug if the manifest has an invalid value at 'app.main' and the corresponding app has started from a different entry point.

A side change: 2 Application methods were rearranged in .cc file accordingly to their declaration order.
