### PR TITLE
Add mapping for vibration permission in make_apk

### DIFF
--- a/app/tools/android/handle_permissions.py
+++ b/app/tools/android/handle_permissions.py
@@ -39,7 +39,8 @@ permission_mapping_table = {
   'fullscreen' : [],
   'presentation' : [],
   'rawsockets' : [],
-  'screenorientation' : []
+  'screenorientation' : [],
+  'vibration' : ['android.permission.VIBRATE']
 }
 
 


### PR DESCRIPTION
While investigating XWALK-803, it turned out that the mapping of vibration permission in Android is not yet implemented. This PR modifies handle_permissions.py so that the permission "vibration' is manifest.json is mapped to the android.permission.VIBRATE in the Android manifest. With this change, vibration works fine once the permission is specified in manifest.json.

Fixes XWALK-803
