### PR TITLE
[application] Fix invalid memory write at Application termination.

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -68,6 +68,10 @@ class Application : public Runtime::Observer {
   };
 
   // Closes all the application's runtimes (application pages).
+  // NOTE: Application is terminated asynchronously.
+  // Please use ApplicationService::Observer::WillDestroyApplication()
+  // interface to be notified about actual app termination.
+  //
   // NOTE: ApplicationService deletes an Application instance
   // immediately after its termination.
   void Terminate();
@@ -114,6 +118,7 @@ class Application : public Runtime::Observer {
 
   friend class FinishEventObserver;
   void CloseMainDocument();
+  void NotifyTermination();
   bool IsOnSuspendHandlerRegistered() const;
 
   RuntimeContext* runtime_context_;
@@ -124,6 +129,7 @@ class Application : public Runtime::Observer {
   Observer* observer_;
   // The entry point used as part of Launch().
   LaunchEntryPoint entry_point_used_;
+  base::WeakPtrFactory<Application> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/application/test/application_multi_app_test.cc
+++ b/application/test/application_multi_app_test.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
 #include "net/base/net_util.h"
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_service.h"
@@ -62,14 +63,11 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
   EXPECT_EQ(service->GetApplicationByID(app1->id()), app1);
   EXPECT_EQ(service->GetApplicationByID(app2->id()), app2);
 
-  // As we do not have subscription to "onsuspend" event, the app
-  // closing should be sync.
-  // FIXME: Closing of a runtime having a window causes tcmalloc exception
-  // on Linux debug bots and the test cannot complete.
-  // Below should be uncommented, when the issue is treated.
-  // app1->Close();
-  // EXPECT_EQ(service->active_applications().size(), 1);
+  app1->Terminate();
+  content::RunAllPendingInMessageLoop();
+  EXPECT_EQ(service->active_applications().size(), 1);
 
-  // app2->Close();
-  // EXPECT_EQ(service->active_applications().size(), 0);
+  app2->Terminate();
+  content::RunAllPendingInMessageLoop();
+  EXPECT_EQ(service->active_applications().size(), 0);
 }


### PR DESCRIPTION
Whereas Application notified its termination to ApplicationService synchronously
it was deleted in the same call chain, so any access to Application's own data
members after the termination notification led to invalid memory read or write.

Now termination notification is proceeded within a different call chain so the
described problem is solved.
