### PR TITLE
[Tizen] Display the top window when resume application from background.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -191,6 +191,9 @@ void Application::OnRuntimeRemoved(Runtime* runtime) {
   runtimes_.erase(runtime);
 
   if (runtimes_.empty()) {
+#if defined(OS_TIZEN_MOBILE)
+    runtime->CloseRootWindow();
+#endif
     base::MessageLoop::current()->PostTask(FROM_HERE,
         base::Bind(&Application::NotifyTermination,
                    weak_factory_.GetWeakPtr()));

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -76,6 +76,10 @@ class Runtime : public content::WebContentsDelegate,
 
   static void SetGlobalObserverForTesting(Observer* observer);
 
+#if defined(OS_TIZEN_MOBILE)
+  void CloseRootWindow();
+#endif
+
  protected:
   Runtime(content::WebContents* web_contents, Observer* observer);
   virtual ~Runtime();
@@ -147,6 +151,13 @@ class Runtime : public content::WebContentsDelegate,
   virtual void OnWindowDestroyed() OVERRIDE;
 
   void ApplyWindowDefaultParams(NativeAppWindow::CreateParams* params);
+  void ApplyFullScreenParam(NativeAppWindow::CreateParams* params);
+
+#if defined(OS_TIZEN_MOBILE)
+  void ApplyRootWindowParams(NativeAppWindow::CreateParams* params);
+  void SetRootWindow(NativeAppWindow* window);
+  void InitRootWindow();
+#endif
 
   // The browsing context.
   xwalk::RuntimeContext* runtime_context_;
@@ -158,6 +169,10 @@ class Runtime : public content::WebContentsDelegate,
   scoped_ptr<content::WebContents> web_contents_;
 
   NativeAppWindow* window_;
+
+#if defined(OS_TIZEN_MOBILE)
+  NativeAppWindow* root_window_;
+#endif
 
   gfx::Image app_icon_;
 

--- a/runtime/browser/ui/native_app_window.cc
+++ b/runtime/browser/ui/native_app_window.cc
@@ -11,7 +11,8 @@ NativeAppWindow::CreateParams::CreateParams()
     web_contents(NULL),
     state(ui::SHOW_STATE_NORMAL),
     resizable(true),
-    net_wm_pid(0) {
+    net_wm_pid(0),
+    parent(NULL) {
 }
 
 }  // namespace xwalk

--- a/runtime/browser/ui/native_app_window.h
+++ b/runtime/browser/ui/native_app_window.h
@@ -51,6 +51,8 @@ class NativeAppWindow {
     bool resizable;
     // Used only by X11. Specifies the PID set in _NET_WM_PID window property.
     int32 net_wm_pid;
+    // The parent view which this window belongs to. NULL if it is root window.
+    gfx::NativeView parent;
   };
 
   // Do one time initialization at application startup.

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -51,6 +51,7 @@ void NativeAppWindowViews::Initialize() {
   params.use_system_default_icon = true;
   params.top_level = true;
   params.show_state = create_params_.state;
+  params.parent = create_params_.parent;
 #if defined(OS_TIZEN_MOBILE)
   params.type = views::Widget::InitParams::TYPE_WINDOW_FRAMELESS;
   // On Tizen apps are sized to the work area.


### PR DESCRIPTION
For XPK applications with multipages, whenever a new page(window) is
created, it is saved as a root window inside current Crosswalk. In other
words, a list of root windows are created when running such kind application.

While Tizen app framework resumes the root window with stacking order
from bottommost(first) to topmost(last). As a result, the bottommost page is
showed when resume from background.

This PR provides only one root window per application, and all application
pages(windows) belong to this root window.

BUG = https://crosswalk-project.org/jira/browse/XWALK-900
