### PR TITLE
[Tizen][DBus] Use current user's Session bus.

### DIFF
--- a/dbus/dbus_manager_tizen.cc
+++ b/dbus/dbus_manager_tizen.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/dbus/dbus_manager.h"
+
+#include <glib.h>
+#include <string>
+#include "base/bind.h"
+#include "base/strings/stringprintf.h"
+#include "base/threading/thread.h"
+#include "dbus/bus.h"
+
+namespace xwalk {
+
+DBusManager::DBusManager() {}
+
+DBusManager::~DBusManager() {
+  if (session_bus_)
+    session_bus_->ShutdownOnDBusThreadAndBlock();
+}
+
+scoped_refptr<dbus::Bus> DBusManager::session_bus() {
+  if (!session_bus_) {
+    base::Thread::Options thread_options;
+    thread_options.message_loop_type = base::MessageLoop::TYPE_IO;
+    std::string thread_name = "Crosswalk D-Bus thread";
+    dbus_thread_.reset(new base::Thread(thread_name.c_str()));
+    dbus_thread_->StartWithOptions(thread_options);
+
+    dbus::Bus::Options options;
+    options.dbus_task_runner = dbus_thread_->message_loop_proxy();
+
+    // On Tizen 2.x DBUS_SESSION_ADDRESS points to a wrong path, so we set
+    // the correct one here.
+    options.bus_type = dbus::Bus::CUSTOM_ADDRESS;
+    options.address = base::StringPrintf(
+        "unix:path=/run/user/%s/dbus/user_bus_socket", g_get_user_name());
+
+    session_bus_ = new dbus::Bus(options);
+  }
+
+  return session_bus_;
+}
+
+}  // namespace xwalk

--- a/dbus/xwalk_dbus.gyp
+++ b/dbus/xwalk_dbus.gyp
@@ -9,7 +9,6 @@
         '../../dbus/dbus.gyp:dbus',
       ],
       'sources': [
-        'dbus_manager.cc',
         'dbus_manager.h',
         'object_manager_adaptor.cc',
         'object_manager_adaptor.h',
@@ -18,6 +17,17 @@
         'xwalk_service_name.cc',
         'xwalk_service_name.h',
       ],
+      'conditions': [
+        [ 'tizen_mobile == 1', {
+          'sources': [
+            'dbus_manager_tizen.cc',
+          ],
+        }, { # tizen_mobile == 0
+          'sources': [
+            'dbus_manager.cc',
+          ],
+        }],
+      ]
     },
     {
       'target_name': 'xwalk_dbus_unittests',


### PR DESCRIPTION
## CHERRY PICKING this from trunk into Crosswalk-4

Nowadays if you xwalk --run-as-service and then
ps aux | grep dbus-daemon, you will see that a 3rd
dbus-daemon was launched by crosswalk. This patch
fixes this by pointing the session bus path to the
current user's user_bus_socket.
