### PR TITLE
[Android] Customize the resource loading of MediaPlayer

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/AndroidProtocolHandler.java
+++ b/runtime/android/java/src/org/xwalk/core/AndroidProtocolHandler.java
@@ -30,9 +30,9 @@ public class AndroidProtocolHandler {
 
     // Supported URL schemes. This needs to be kept in sync with
     // clank/native/framework/chrome/url_request_android_job.cc.
-    private static final String FILE_SCHEME = "file";
+    public static final String FILE_SCHEME = "file";
     private static final String CONTENT_SCHEME = "content";
-    private static final String APP_SCHEME = "app";
+    public static final String APP_SCHEME = "app";
     private static final String APP_SRC = "www";
     private static final String SCHEME_SEPARATOR = "//";
 
@@ -73,8 +73,19 @@ public class AndroidProtocolHandler {
         return null;
     }
 
+    // Get the asset path of file:///android_asset/* url.
+    public static String getAssetPath(Uri uri) {
+        assert(uri.getScheme().equals(FILE_SCHEME));
+        assert(uri.getPath() != null);
+        assert(uri.getPath().startsWith(nativeGetAndroidAssetPath()));
+        String path = uri.getPath();
+        // Remove duplicate slashes and normalize the URL.
+        path = (new java.io.File(path)).getAbsolutePath();
+        return path.replaceFirst(nativeGetAndroidAssetPath(), "");
+    }
+
     // Convert app uri to file uri to access the actual files in assets.
-    private static Uri appUriToFileUri(Uri uri) {
+    public static Uri appUriToFileUri(Uri uri) {
         assert(uri.getScheme().equals(APP_SCHEME));
         assert(uri.getPath() != null);
 
@@ -152,16 +163,9 @@ public class AndroidProtocolHandler {
     }
 
     private static InputStream openAsset(Context context, Uri uri) {
-        assert(uri.getScheme().equals(FILE_SCHEME));
-        assert(uri.getPath() != null);
-        assert(uri.getPath().startsWith(nativeGetAndroidAssetPath()));
-        String path = uri.getPath();
-        // Remove duplicate slashes and normalize the URL.
-        path = (new java.io.File(path)).getAbsolutePath();
-        path = path.replaceFirst(nativeGetAndroidAssetPath(), "");
         try {
             AssetManager assets = context.getAssets();
-            return assets.open(path, AssetManager.ACCESS_STREAMING);
+            return assets.open(getAssetPath(uri), AssetManager.ACCESS_STREAMING);
         } catch (IOException e) {
             Log.e(TAG, "Unable to open asset URL: " + uri);
             return null;

--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -28,6 +28,7 @@ import org.chromium.content.browser.ContentViewRenderView;
 import org.chromium.content.browser.ContentViewStatics;
 import org.chromium.content.browser.LoadUrlParams;
 import org.chromium.content.browser.NavigationHistory;
+import org.chromium.media.MediaPlayerBridge;
 import org.chromium.ui.WindowAndroid;
 
 @JNINamespace("xwalk")
@@ -112,6 +113,9 @@ public class XWalkContent extends FrameLayout {
 
         SharedPreferences sharedPreferences = new InMemorySharedPreferences();
         mGeolocationPermissions = new XWalkGeolocationPermissions(sharedPreferences);
+
+        MediaPlayerBridge.setResourceLoadingFilter(
+                new XWalkMediaPlayerResourceLoadingFilter());
     }
 
     void doLoadUrl(String url) {

--- a/runtime/android/java/src/org/xwalk/core/XWalkMediaPlayerResourceLoadingFilter.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkMediaPlayerResourceLoadingFilter.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.content.Context;
+import android.content.res.AssetFileDescriptor;
+import android.media.MediaPlayer;
+import android.net.Uri;
+
+import org.chromium.media.MediaPlayerBridge;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * This class inherits from MediaPlayerBridge.ResourceLoadingFilter to
+ * customize the resource loading process in xwalk.
+ */
+
+public class XWalkMediaPlayerResourceLoadingFilter extends
+        MediaPlayerBridge.ResourceLoadingFilter {
+    @Override
+    public boolean shouldOverrideResourceLoading(MediaPlayer mediaPlayer,
+            Context context, Uri uri) {
+        if (uri.getScheme().equals(AndroidProtocolHandler.APP_SCHEME)) {
+            uri = AndroidProtocolHandler.appUriToFileUri(uri);
+        }
+
+        String scheme = uri.getScheme();
+
+        if (!scheme.equals(AndroidProtocolHandler.FILE_SCHEME)) return false;
+
+        try {
+            AssetFileDescriptor afd =
+                    context.getAssets().openFd(AndroidProtocolHandler.getAssetPath(uri));
+            mediaPlayer.setDataSource(
+                    afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Add XWalkMediaPlayerResourceLoadingFilter which inherits
MediaPlayerBridge.ResourceLoadingFilter. Then we can customize
the MediaPlayer in xwalk. Now we have two customized items:
    Support app scheme in the resource loading of MediaPlayer.
    Support file://android_asset/ url in MediaPlayer.

BUG=https://crosswalk-project.org/jira/browse/XWALK-880
