### PR TITLE
[Android] Fix packaging tool fails to build application when manifest.json doesn't include "icons" object.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -108,14 +108,17 @@ def ParseManifest(options):
   if parser.GetAppRoot():
     options.app_root = parser.GetAppRoot()
     temp_dict = parser.GetIcons()
-    try:
-      icon_dict = dict((int(k), v) for k, v in temp_dict.iteritems())
-    except ValueError:
-      print 'The key of icon in the manifest file should be a number.'
-    # TODO(junmin): add multiple icons support.
-    if icon_dict:
-      icon_file = max(icon_dict.iteritems(), key=operator.itemgetter(0))[1]
-      options.icon = os.path.join(options.app_root, icon_file)
+    if temp_dict:
+      try:
+        icon_dict = dict((int(k), v) for k, v in temp_dict.iteritems())
+      except ValueError:
+        print ('\'icon\' object in manifest.json contains pair-members, which '
+               'consists of a number-string and a value representing an image. '
+               'And the number-string should be valid.')
+      # TODO(junmin): add multiple icons support.
+      if icon_dict:
+        icon_file = max(icon_dict.iteritems(), key=operator.itemgetter(0))[1]
+        options.icon = os.path.join(options.app_root, icon_file)
   options.enable_remote_debugging = False
   if parser.GetFullScreenFlag().lower() == 'true':
     options.fullscreen = True

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -110,7 +110,7 @@ class ManifestJsonParser(object):
     if self.data_src.has_key('icons'):
       ret_dict['icons'] = self.data_src['icons']
     else:
-      ret_dict['icons'] = ''
+      ret_dict['icons'] = {}
     app_root = file_path_prefix
     ret_dict['description'] = ''
     if self.data_src.has_key('description'):


### PR DESCRIPTION
In the manifest_json_parser.py, "icons" object with multiple entries in manifest.json
is represented as a dictionary, so it should not be a string if it's empty.

Packaging tool would fail when iterating the dictionary if "icons" object was unset
in manifest.json.

BUG=https://crosswalk-project.org/jira/browse/XWALK-909
