### PR TITLE
[Application] Add permission storage logic

### DIFF
--- a/application/browser/application_storage_impl.cc
+++ b/application/browser/application_storage_impl.cc
@@ -33,6 +33,27 @@ static const int kVersionNumber = 1;
 
 namespace {
 
+const std::string StoredPermissionStr[] = {
+    "ALLOW",
+    "DENY",
+    "PROMPT",
+};
+
+std::string ToString(StoredPermission permission) {
+  if (permission == INVALID_STORED_PERM)
+    return std::string("");
+  return StoredPermissionStr[permission];
+}
+
+StoredPermission ToPermission(const std::string& str) {
+  unsigned int i;
+  for (i = 0; i < INVALID_STORED_PERM; ++i) {
+    if (str == StoredPermissionStr[i])
+      break;
+  }
+  return static_cast<StoredPermission>(i);
+}
+
 inline const base::FilePath GetDBPath(const base::FilePath& path) {
   return path.Append(ApplicationStorageImpl::kDBFileName);
 }
@@ -54,6 +75,48 @@ bool InitEventsTable(sql::Connection* db) {
   transaction.Begin();
   if (!db->DoesTableExist(db_fields::kEventTableName)) {
     if (!db->Execute(db_fields::kCreateEventTableOp))
+     return false;
+  }
+  return transaction.Commit();
+}
+
+// Permissions are stored like "bluetooth:ALLOW;calendar:DENY;contacts:ALLOW"
+std::string ToString(StoredPermissionMap permissions) {
+  std::string str;
+  StoredPermissionMap::iterator iter;
+  for (iter = permissions.begin(); iter != permissions.end(); ++iter) {
+    if (!str.empty())
+      str += ";";
+    str += (iter->first + ":" + ToString(iter->second));
+  }
+  return str;
+}
+
+StoredPermissionMap ToPermissionMap(const std::string& str) {
+  StoredPermissionMap map;
+  std::vector<std::string> vec;
+  base::SplitString(str, ';', &vec);
+  if (!vec.empty()) {
+    for (std::vector<std::string>::iterator iter = vec.begin();
+        iter != vec.end(); ++iter) {
+      std::vector<std::string> perm_item;
+      base::SplitString(*iter, ':', &perm_item);
+      if (perm_item.size() != 2) {
+        LOG(ERROR) << "Permission format error! Corrupted database?";
+        map.clear();
+        break;
+      }
+      map[perm_item[0]] = ToPermission(perm_item[1]);
+    }
+  }
+  return map;
+}
+
+bool InitPermissionsTable(sql::Connection* db) {
+  sql::Transaction transaction(db);
+  transaction.Begin();
+  if (!db->DoesTableExist(db_fields::kPermissionTableName)) {
+    if (!db->Execute(db_fields::kCreatePermissionTableOp))
      return false;
   }
   return transaction.Commit();
@@ -149,6 +212,11 @@ bool ApplicationStorageImpl::Init(
     return false;
   }
 
+  if (!InitPermissionsTable(sqlite_db.get())) {
+    LOG(ERROR) << "Unable to open registered permissions table.";
+    return false;
+  }
+
   if (!sqlite_db->Execute("PRAGMA foreign_keys=ON")) {
     LOG(ERROR) << "Unable to enforce foreign key contraints.";
     return false;
@@ -233,6 +301,8 @@ bool ApplicationStorageImpl::GetInstalledApplications(
           std::set<std::string>(events.begin(), events.end());
     }
 
+    application->permission_map_ = ToPermissionMap(smt.ColumnString(5));
+
     if (!Insert(application, applications)) {
       LOG(ERROR) << "An error occurred while"
                     "initializing the application cache data.";
@@ -252,7 +322,8 @@ bool ApplicationStorageImpl::AddApplication(const ApplicationData* application,
 
   return (SetApplicationValue(
       application, install_time, db_fields::kSetApplicationWithBindOp) &&
-          SetEvents(application->ID(), application->GetEvents()));
+          SetEvents(application->ID(), application->GetEvents()) &&
+          SetPermissions(application->ID(), application->permission_map_));
 }
 
 bool ApplicationStorageImpl::UpdateApplication(
@@ -264,7 +335,8 @@ bool ApplicationStorageImpl::UpdateApplication(
 
   if (SetApplicationValue(
           application, install_time, db_fields::kUpdateApplicationWithBindOp) &&
-      UpdateEvents(application->ID(), application->GetEvents())) {
+      UpdateEvents(application->ID(), application->GetEvents()) &&
+      UpdatePermissions(application->ID(), application->permission_map_)) {
     application->is_dirty_ = false;
     return true;
   }
@@ -387,6 +459,68 @@ bool ApplicationStorageImpl::SetEventsValue(
     return false;
   }
 
+  return transaction.Commit();
+}
+
+bool ApplicationStorageImpl::SetPermissions(const std::string& id,
+    const StoredPermissionMap& permissions) {
+  if (!db_initialized_) {
+    LOG(ERROR) << "Database is not initialized.";
+    return false;
+  }
+  return SetPermissionsValue(id, permissions,
+      db_fields::kInsertPermissionsWithBindOp);
+}
+
+bool ApplicationStorageImpl::UpdatePermissions(const std::string& id,
+    const StoredPermissionMap& permissions) {
+  if (!db_initialized_) {
+    LOG(ERROR) << "Database is not initialized.";
+    return false;
+  }
+  if (permissions.empty())
+    return RevokePermissions(id);
+
+  return SetPermissionsValue(id, permissions,
+      db_fields::kUpdatePermissionsWithBindOp);
+}
+
+bool ApplicationStorageImpl::RevokePermissions(const std::string& id) {
+  sql::Transaction transaction(sqlite_db_.get());
+  if (!transaction.Begin())
+    return false;
+
+  sql::Statement statement(sqlite_db_->GetUniqueStatement(
+      db_fields::kDeletePermissionsWithBindOp));
+  statement.BindString(0, id);
+
+  if (!statement.Run()) {
+    LOG(ERROR) <<
+        "An error occurred while removing permissions.";
+    return false;
+  }
+  return transaction.Commit();
+}
+
+bool ApplicationStorageImpl::SetPermissionsValue(
+    const std::string& id,
+    const StoredPermissionMap& permissions,
+    const std::string& operation) {
+  sql::Transaction transaction(sqlite_db_.get());
+  std::string permission_str = ToString(permissions);
+
+  if (!transaction.Begin())
+    return false;
+
+  sql::Statement statement(sqlite_db_->GetUniqueStatement(
+      operation.c_str()));
+  statement.BindString(0, permission_str);
+  statement.BindString(1, id);
+  if (!statement.Run()) {
+    LOG(ERROR) <<
+        "An error occurred while inserting permissions.";
+    return false;
+  }
   return transaction.Commit();
 }
 

--- a/application/browser/application_storage_impl.h
+++ b/application/browser/application_storage_impl.h
@@ -8,6 +8,7 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/files/file_path.h"
 #include "sql/connection.h"
@@ -29,7 +30,8 @@ class ApplicationStorageImpl {
   bool RemoveApplication(const std::string& key);
   bool UpdateApplication(ApplicationData* application,
                          const base::Time& install_time);
-  bool Init(ApplicationData::ApplicationDataMap& applications);
+  bool Init(
+      ApplicationData::ApplicationDataMap& applications);
   bool GetInstalledApplications(
       ApplicationData::ApplicationDataMap& applications);
 
@@ -38,7 +40,7 @@ class ApplicationStorageImpl {
   bool SetApplicationValue(const ApplicationData* application,
                            const base::Time& install_time,
                            const std::string& operation);
-
+  // Events helper functions
   bool SetEventsValue(const std::string& id,
                       const std::set<std::string>& events,
                       const std::string& operation);
@@ -47,6 +49,15 @@ class ApplicationStorageImpl {
   bool UpdateEvents(const std::string& id,
                     const std::set<std::string>& events);
   bool DeleteEvents(const std::string& id);
+  // Permissions helper functions
+  bool SetPermissionsValue(const std::string& id,
+                           const StoredPermissionMap& permissions,
+                           const std::string& operation);
+  bool SetPermissions(const std::string& id,
+                      const StoredPermissionMap& permissions);
+  bool UpdatePermissions(const std::string& id,
+                         const StoredPermissionMap& permissions);
+  bool RevokePermissions(const std::string& id);
 
   scoped_ptr<sql::Connection> sqlite_db_;
   sql::MetaTable meta_table_;

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -315,5 +315,24 @@ const std::set<std::string>& ApplicationData::GetEvents() const {
   return events_;
 }
 
+StoredPermission ApplicationData::GetPermission(
+    std::string& permission_name) const {
+  StoredPermissionMap::const_iterator iter =
+      permission_map_.find(permission_name);
+  if (iter == permission_map_.end())
+    return INVALID_STORED_PERM;
+  return iter->second;
+}
+
+bool ApplicationData::SetPermission(const std::string& permission_name,
+                                    StoredPermission perm) {
+  if (perm != INVALID_STORED_PERM) {
+    permission_map_[permission_name] = perm;
+    is_dirty_ = true;
+    return true;
+  }
+  return false;
+}
+
 }   // namespace application
 }   // namespace xwalk

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -24,6 +24,7 @@
 #include "url/gurl.h"
 #include "xwalk/application/common/install_warning.h"
 #include "xwalk/application/common/manifest.h"
+#include "xwalk/application/common/permission_types.h"
 
 namespace base {
 class DictionaryValue;
@@ -128,6 +129,12 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   bool IsPlatformApp() const;
   bool IsHostedApp() const;
 
+  // Permission related.
+  StoredPermission GetPermission(
+      std::string& permission_name) const;
+  bool SetPermission(const std::string& permission_name,
+                     StoredPermission perm);
+
   bool HasMainDocument() const;
 
  private:
@@ -210,6 +217,9 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   // initialization happens from the same thread (this can happen when certain
   // parts of the initialization process need information from previous parts).
   base::ThreadChecker thread_checker_;
+
+  // Application's persistent permissions.
+  StoredPermissionMap permission_map_;
 
 #if defined(OS_TIZEN_MOBILE)
   scoped_ptr<tizen::AppcoreContext> appcore_context_;

--- a/application/common/application_storage_constants.cc
+++ b/application/common/application_storage_constants.cc
@@ -10,6 +10,7 @@ namespace application_storage_constants {
 
 const char kAppTableName[] = "applications";
 const char kEventTableName[] = "registered_events";
+const char kPermissionTableName[] = "stored_permissions";
 
 const char kCreateAppTableOp[] =
     "CREATE TABLE applications ("
@@ -22,6 +23,14 @@ const char kCreateEventTableOp[] =
     "CREATE TABLE registered_events ("
     "id TEXT NOT NULL,"
     "event_names TEXT NOT NULL,"
+    "PRIMARY KEY (id),"
+    "FOREIGN KEY (id) REFERENCES applications(id)"
+    "ON DELETE CASCADE)";
+
+const char kCreatePermissionTableOp[] =
+    "CREATE TABLE stored_permissions ("
+    "id TEXT NOT NULL,"
+    "permission_names TEXT NOT NULL,"
     "PRIMARY KEY (id),"
     "FOREIGN KEY (id) REFERENCES applications(id)"
     "ON DELETE CASCADE)";
@@ -52,6 +61,16 @@ const char kUpdateEventsWithBindOp[] =
 
 const char kDeleteEventsWithBindOp[] =
     "DELETE FROM registered_events WHERE id = ?";
+
+const char kInsertPermissionsWithBindOp[] =
+    "INSERT INTO stored_permissions (permission_names, id) "
+    "VALUES(?,?)";
+
+const char kUpdatePermissionsWithBindOp[] =
+    "UPDATE stored_permissions SET permission_names = ? WHERE id = ?";
+
+const char kDeletePermissionsWithBindOp[] =
+    "DELETE FROM stored_permissions WHERE id = ?";
 
 }  // namespace application_storage_constants
 }  // namespace xwalk

--- a/application/common/application_storage_constants.h
+++ b/application/common/application_storage_constants.h
@@ -12,9 +12,11 @@ namespace xwalk {
 namespace application_storage_constants {
   extern const char kAppTableName[];
   extern const char kEventTableName[];
+  extern const char kPermissionTableName[];
 
   extern const char kCreateAppTableOp[];
   extern const char kCreateEventTableOp[];
+  extern const char kCreatePermissionTableOp[];
   extern const char kGetAllRowsFromAppEventTableOp[];
   extern const char kSetApplicationWithBindOp[];
   extern const char kUpdateApplicationWithBindOp[];
@@ -22,6 +24,9 @@ namespace application_storage_constants {
   extern const char kInsertEventsWithBindOp[];
   extern const char kUpdateEventsWithBindOp[];
   extern const char kDeleteEventsWithBindOp[];
+  extern const char kInsertPermissionsWithBindOp[];
+  extern const char kUpdatePermissionsWithBindOp[];
+  extern const char kDeletePermissionsWithBindOp[];
 
 }  // namespace application_storage_constants
 }  // namespace xwalk

--- a/application/common/permission_types.h
+++ b/application/common/permission_types.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_PERMISSION_TYPES_H_
+#define XWALK_APPLICATION_COMMON_PERMISSION_TYPES_H_
+
+#include <map>
+#include <set>
+#include <string>
+
+#include "base/callback.h"
+
+// TODO(Bai): Whenever this file is edited, make sure the content of
+// extensions/common/xwalk_extension_permission_types.h is aligned.
+// See comments there for more information.
+namespace xwalk {
+namespace application {
+
+enum PermissionType {
+  SESSION_PERMISSION,
+  PERSISTENT_PERMISSION,
+};
+
+enum RuntimePermission {
+  ALLOW_ONCE = 0,
+  ALLOW_SESSION,
+  ALLOW_ALWAYS,
+  DENY_ONCE,
+  DENY_SESSION,
+  DENY_FOREVER,
+  UNDEFINED_RUNTIME_PERM,
+};
+
+typedef base::Callback<void(RuntimePermission)> PermissionCallback;
+
+enum StoredPermission {
+  ALLOW = 0,
+  DENY,
+  PROMPT,
+  INVALID_STORED_PERM,
+};
+
+typedef std::map<std::string, StoredPermission> StoredPermissionMap;
+typedef std::set<std::string> PermissionSet;
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_PERMISSION_TYPES_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -68,6 +68,7 @@
         'common/manifest_handlers/main_document_handler.h',
         'common/manifest_handlers/permissions_handler.cc',
         'common/manifest_handlers/permissions_handler.h',
+        'common/permission_types.h',
 
         'extension/application_event_extension.cc',
         'extension/application_event_extension.h',


### PR DESCRIPTION
Permission storage: permissions should be stored in ApplicationData and
eventually the database, so now we have setter and getter in the
ApplicationData class and the actual db operations are done inside
ApplicationStorageImpl.
