### PR TITLE
[Android] Replace the remote url with the local url.

### DIFF
--- a/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
@@ -30,7 +30,7 @@ public class RuntimeClientApiTestBase<T extends Activity> {
     private ActivityInstrumentationTestCase2<T> mTestCase;
     private Timer mTimer = new Timer();
     private String mSocketName;
-    private String mUrl = "http://www.bing.com";
+    private String mUrl = "file:///android_asset/index.html";
     enum Relation {
         EQUAL,
         GREATERTHAN,


### PR DESCRIPTION
This patch is to replace the remote url with local url.
The test case about "testEnableRemoteDebugging" will be timed out if
the remote url can not be accessed. So replace the remote url with
local url.
