### PR TITLE
Add virtual destructor to xwalk::MultiOrientationScreen::Observer

### DIFF
--- a/runtime/browser/ui/screen_orientation.h
+++ b/runtime/browser/ui/screen_orientation.h
@@ -30,6 +30,7 @@ class MultiOrientationScreen {
 
   class Observer {
    public:
+    virtual ~Observer() {}
     virtual void OnOrientationChanged(Orientation orientation) = 0;
   };
 


### PR DESCRIPTION
Missing virtual destructor causes undefined behavior and build error
when code is compiled with gcc 4.8 and later.
