### PR TITLE
[Tizen] Enable -Dtizen flag for all Tizen builds

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -202,6 +202,7 @@ ${GYP_EXTRA_FLAGS} \
 -Dchromeos=0 \
 -Ddisable_nacl=1 \
 -Dpython_ver=2.7 \
+-Dtizen=1 \
 -Duse_aura=1 \
 -Duse_cups=0 \
 -Duse_gconf=0 \


### PR DESCRIPTION
Enable -Dtizen flag for all Tizen builds, so that Tizen generic code
could be shared between different Tizen versions.
