### PR TITLE
Revert "[Tizen] Enable -Dtizen flag for all Tizen builds"

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -202,7 +202,6 @@ ${GYP_EXTRA_FLAGS} \
 -Dchromeos=0 \
 -Ddisable_nacl=1 \
 -Dpython_ver=2.7 \
--Dtizen=1 \
 -Duse_aura=1 \
 -Duse_cups=0 \
 -Duse_gconf=0 \


### PR DESCRIPTION
This reverts commit 1f23d934ff94a43866d2c7b134c212968685ac7f.
Geolocation provider code should be made generic first, then
-Dtizen=1 should be enabled.
