### PR TITLE
Fix Android crash when .build is called and Project name has spaces

### DIFF
--- a/build/android/xwalkcore_library_template/precompile.xml
+++ b/build/android/xwalkcore_library_template/precompile.xml
@@ -52,7 +52,7 @@
       <exec executable="python${pythonExt}" failonerror="true">
         <arg line="prepare_r_java.py --app-package ${project.app.package}" />
         <arg line="--packages ${project.additional.packages}" />
-        <arg line="--gen-path ${gen.absolute.dir}" />
+        <arg line="--gen-path '${gen.absolute.dir}'" />
       </exec>
   </target>
 </project>


### PR DESCRIPTION
[Android] Fix build error when .build is called and project name has spaces

It's because single quotation marks are needed for strings which have
spaces.

Here is the crash:

-pre-compile:
     [exec] /Users/Shared/Jenkins/Home/workspace/native-wrapper/projects/Arabian/org/xwalk/core/R.java does not exist (The name of the project is "Arabian Nights"

BUILD FAILED
/Users/Shared/Jenkins/Library/Developer/sdk/tools/ant/build.xml:601: The following error occurred while executing this line:
/Users/Shared/Jenkins/Home/workspace/native-wrapper/projects/Arabian Nights_google/platforms/android/CordovaLib/xwalk_core_library/precompile.xml:52: exec returned: 1
