### PR TITLE
BACKPORT: [Tools] Unbreak fetch_deps.py after Chromium r249077.

### DIFF
--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -55,7 +55,8 @@ class DepsFetcher(object):
   def DoGclientSyncForChromium(self):
     gclient_cmd = ['gclient', 'sync', '--verbose', '--reset',
                    '--force', '--with_branch_heads']
-    gclient_cmd.append('--gclientfile=%s' % self._new_gclient_file)
+    gclient_cmd.append('--gclientfile=%s' %
+                       os.path.basename(self._new_gclient_file))
     gclient_utils.CheckCallAndFilterAndHeader(gclient_cmd,
         always=self._options.verbose, cwd=self._root_dir)
     # CheckCallAndFilterAndHeader will raise exception if return


### PR DESCRIPTION
depot_tools commit 249077 broke our fetch_deps.py because gclient does not 
accept absolute paths in --gclient-file anymore.

Since we already set cwd when calling 
gclient_utils.CheckCallAndFilterAndHeader(), we can just strip the rest of the
path in self._new_gclient_file to fix things.

BUG=https://crosswalk-project.org/jira/browse/XWALK-930

(cherry picked from commit db574173408c8dd4dddd9102400a0decb80ebd96)
