### PR TITLE
[Application] Added permission policy manager

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -23,6 +23,7 @@
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/event_names.h"
 #include "xwalk/application/common/id_util.h"
+#include "xwalk/application/common/permission_policy_manager.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
@@ -214,7 +215,8 @@ ApplicationService::ApplicationService(RuntimeContext* runtime_context,
                                        ApplicationEventManager* event_manager)
     : runtime_context_(runtime_context),
       application_storage_(app_storage),
-      event_manager_(event_manager) {
+      event_manager_(event_manager),
+      permission_policy_handler_(new PermissionPolicyManager()) {
   AddObserver(event_manager);
 }
 

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -11,6 +11,7 @@
 #include "base/memory/scoped_vector.h"
 #include "base/observer_list.h"
 #include "xwalk/application/browser/application.h"
+#include "xwalk/application/common/permission_policy_manager.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/application/common/application_data.h"
 
@@ -82,6 +83,7 @@ class ApplicationService : public Application::Observer {
   ApplicationEventManager* event_manager_;
   ScopedVector<Application> applications_;
   ObserverList<Observer> observers_;
+  scoped_ptr<PermissionPolicyManager> permission_policy_handler_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationService);
 };

--- a/application/common/permission_policy_manager.cc
+++ b/application/common/permission_policy_manager.cc
@@ -1,0 +1,25 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/permission_policy_manager.h"
+
+namespace xwalk {
+namespace application {
+
+PermissionPolicyManager::PermissionPolicyManager() {
+  // TODO(Bai): Initialize this class with the external policy file.
+}
+
+PermissionPolicyManager::~PermissionPolicyManager() {
+}
+
+StoredPermission PermissionPolicyManager::GetPermission(
+    const std::string& app_id, const std::string& permission_name) const {
+  // TODO(Bai): The filtering logic will be implemented after the policy
+  // file format is defined.
+  return ALLOW;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/permission_policy_manager.h
+++ b/application/common/permission_policy_manager.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_PERMISSION_POLICY_MANAGER_H_
+#define XWALK_APPLICATION_COMMON_PERMISSION_POLICY_MANAGER_H_
+
+#include <string>
+
+#include "base/basictypes.h"
+#include "xwalk/application/common/permission_types.h"
+
+namespace xwalk {
+namespace application {
+
+// During application installation, the permission stored in the manifest
+// has to be filtered and converted into the stored permission list. During
+// this process, the permission policy manager is responsible for generating
+// the appropriate permission value based on either internal or external
+// (OEM) policies.
+// For example, we may have ["bluetooth"] in the manifest, but according
+// to the policies, any bluetooth request should be confirmed by user,
+// therefore, instead of writing "bluetooth:ALLOW", we write
+// "bluetooth:PROMPT" into database.
+class PermissionPolicyManager {
+ public:
+  PermissionPolicyManager();
+  ~PermissionPolicyManager();
+  StoredPermission GetPermission(const std::string& app_id,
+                                 const std::string& permission_name) const;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(PermissionPolicyManager);
+};
+
+}  // namespace application
+}  // namespace xwalk
+#endif  // XWALK_APPLICATION_COMMON_PERMISSION_POLICY_MANAGER_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -68,6 +68,8 @@
         'common/manifest_handlers/main_document_handler.h',
         'common/manifest_handlers/permissions_handler.cc',
         'common/manifest_handlers/permissions_handler.h',
+        'common/permission_policy_manager.cc',
+        'common/permission_policy_manager.h',
         'common/permission_types.h',
 
         'extension/application_event_extension.cc',


### PR DESCRIPTION
It is the second PR split from PR #1375 
This patch include a initial support of application policy management which will work together with the application permission management system. Here is a brief introduction about the policy handling process.
During application installation, the permission stored in the manifest has to be filtered and converted into the stored permission list. In this process, the permission policy manager is responsible for generating the appropriate permission value based on either internal or external (OEM) policies. For example, we may have ["bluetooth"] in the manifest, but according to the policies, any bluetooth request should be confirmed by user, therefore, instead of writing "bluetooth:ALLOW", we write "bluetooth:PROMPT" into database.
