### PR TITLE
Fix build error on non Android platform.

### DIFF
--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -60,7 +60,9 @@ void XWalkContentRendererClient::RenderThreadStarted() {
 
 void XWalkContentRendererClient::RenderFrameCreated(
     content::RenderFrame* render_frame) {
+#if defined(OS_ANDROID)
   new XWalkPermissionClient(render_frame);
+#endif
 }
 
 void XWalkContentRendererClient::RenderViewCreated(


### PR DESCRIPTION
xwalk_permission_client.h is only added for Android, so calling on
XWalkPermissionClient should be protected with OS_ANDROID macro.
