### PR TITLE
[Android] Fix the issue of enabling remote debugging in packaging tool.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -119,7 +119,6 @@ def ParseManifest(options):
       if icon_dict:
         icon_file = max(icon_dict.iteritems(), key=operator.itemgetter(0))[1]
         options.icon = os.path.join(options.app_root, icon_file)
-  options.enable_remote_debugging = False
   if parser.GetFullScreenFlag().lower() == 'true':
     options.fullscreen = True
   elif parser.GetFullScreenFlag().lower() == 'false':

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -307,6 +307,17 @@ class TestMakeApk(unittest.TestCase):
     self.assertTrue(content.find('setRemoteDebugging') != -1)
     self.checkApks('Example')
     Clean('Example')
+    manifest_path = os.path.join('test_data', 'manifest', 'manifest.json')
+    cmd = ['python', 'make_apk.py', '--enable-remote-debugging',
+           '--manifest=%s' % manifest_path, self._mode]
+    RunCommand(cmd)
+    activity = 'Example/src/org/xwalk/example/ExampleActivity.java'
+    with open(activity, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(activity))
+    self.assertTrue(content.find('setRemoteDebugging') != -1)
+    self.checkApks('Example')
+    Clean('Example')
 
   def testKeystore(self):
     keystore_path = os.path.join('test_data', 'keystore', 'xwalk-test.keystore')


### PR DESCRIPTION
Remote debugging cannot work when the application is packaged with
--enable-remote-debugging for that remote debugging is disabled when
manifest.json file is used. This patch fixes this issue by removing
the related code of disabling remote debugging in packaging tool.
And the corresponding test case is added.

BUG=https://crosswalk-project.org/jira/browse/XWALK-933
(cherry picked from commit 93ab700478)
