### PR TITLE
[Application] Added permission check logic and getter/setters in application classes.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -253,5 +253,50 @@ bool Application::IsOnSuspendHandlerRegistered() const {
   return true;
 }
 
+bool Application::UseExtension(const std::string& extension_name) const {
+  // TODO(Bai): Tells whether the application contains the specified extension
+  return true;
+}
+
+std::string Application::GetRegisteredPermissionName(
+    const std::string& extension_name,
+    const std::string& api_name) const {
+  std::map<std::string, std::string>::const_iterator iter =
+      name_perm_map_.find(api_name);
+  if (iter == name_perm_map_.end())
+    return std::string("");
+  return iter->second;
+}
+
+StoredPermission Application::GetPermission(PermissionType type,
+                               std::string& permission_name) const {
+  if (type == SESSION_PERMISSION) {
+    StoredPermissionMap::const_iterator iter =
+        permission_map_.find(permission_name);
+    if (iter == permission_map_.end())
+      return UNDEFINED_STORED_PERM;
+    return iter->second;
+  }
+  if (type == PERSISTENT_PERMISSION) {
+    return application_data_->GetPermission(permission_name);
+  }
+  NOTREACHED();
+  return UNDEFINED_STORED_PERM;
+}
+
+bool Application::SetPermission(PermissionType type,
+                                const std::string& permission_name,
+                                StoredPermission perm) {
+  if (type == SESSION_PERMISSION) {
+    permission_map_[permission_name] = perm;
+    return true;
+  }
+  if (type == PERSISTENT_PERMISSION)
+    return application_data_->SetPermission(permission_name, perm);
+
+  NOTREACHED();
+  return false;
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -104,6 +104,23 @@ class Application : public Runtime::Observer {
   const ApplicationData* data() const { return application_data_; }
   ApplicationData* data() { return application_data_; }
 
+  // Tells whether the application use the specified extension.
+  bool UseExtension(const std::string& extension_name) const;
+
+  // The runtime permission mapping is registered by extension which
+  // implements some specific API, for example:
+  // "bluetooth" -> "bluetooth.read, bluetooth.write, bluetooth.management"
+  // Whenever there comes a API permission request, we can tell whether
+  // this API is registered, if yes, return the according permission name.
+  std::string GetRegisteredPermissionName(const std::string& extension_name,
+                                          const std::string& api_name) const;
+
+  StoredPermission GetPermission(PermissionType type,
+                                 std::string& permission_name) const;
+  bool SetPermission(PermissionType type,
+                     const std::string& permission_name,
+                     StoredPermission perm);
+
  private:
   bool HasMainDocument() const;
   // Runtime::Observer implementation.
@@ -141,6 +158,9 @@ class Application : public Runtime::Observer {
   LaunchEntryPoint entry_point_used_;
   TerminationMode termination_mode_used_;
   base::WeakPtrFactory<Application> weak_factory_;
+  std::map<std::string, std::string> name_perm_map_;
+  // Application's session permissions.
+  StoredPermissionMap permission_map_;
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -258,6 +258,11 @@ bool ApplicationService::Install(const base::FilePath& path, std::string* id) {
     LOG(ERROR) << "Error during application installation: " << error;
     return false;
   }
+  if (!permission_policy_handler_->
+      InitApplicationPermission(application_data)) {
+    LOG(ERROR) << "Application permission data is invalid";
+    return false;
+  }
 
   if (application_storage_->Contains(application_data->ID())) {
     *id = application_data->ID();
@@ -625,6 +630,77 @@ Application* ApplicationService::Launch(
                     DidLaunchApplication(application));
 
   return application;
+}
+
+void ApplicationService::CheckAPIAccessControl(const std::string& app_id,
+    const std::string& extension_name,
+    const std::string& api_name, const PermissionCallback& callback) {
+  Application* app = GetApplicationByID(app_id);
+  if (!app) {
+    LOG(ERROR) << "No running application found with ID: "
+      << app_id;
+    callback.Run(UNDEFINED_RUNTIME_PERM);
+    return;
+  }
+  if (!app->UseExtension(extension_name)) {
+    LOG(ERROR) << "Can not find extension: "
+      << extension_name << " of Application with ID: "
+      << app_id;
+    callback.Run(UNDEFINED_RUNTIME_PERM);
+    return;
+  }
+  // Permission name should have been registered at extension initialization.
+  std::string permission_name =
+      app->GetRegisteredPermissionName(extension_name, api_name);
+  if (permission_name.empty()) {
+    LOG(ERROR) << "API: " << api_name << " of extension: "
+      << extension_name << " not registered!";
+    callback.Run(UNDEFINED_RUNTIME_PERM);
+    return;
+  }
+  // Okay, since we have the permission name, let's get down to the policies.
+  // First, find out whether the permission is stored for the current session.
+  StoredPermission perm = app->GetPermission(
+      SESSION_PERMISSION, permission_name);
+  if (perm != UNDEFINED_STORED_PERM) {
+    // "PROMPT" should not be in the session storage.
+    DCHECK(perm != PROMPT);
+    if (perm == ALLOW) {
+      callback.Run(ALLOW_SESSION);
+      return;
+    }
+    if (perm == DENY) {
+      callback.Run(DENY_SESSION);
+      return;
+    }
+    NOTREACHED();
+  }
+  // Then, query the persistent policy storage.
+  perm = app->GetPermission(PERSISTENT_PERMISSION, permission_name);
+  // Permission not found in persistent permission table, normally this should
+  // not happen because all the permission needed by the application should be
+  // contained in its manifest, so it also means that the application is asking
+  // for something wasn't allowed.
+  if (perm == UNDEFINED_STORED_PERM) {
+    callback.Run(UNDEFINED_RUNTIME_PERM);
+    return;
+  }
+  if (perm == PROMPT) {
+    // TODO(Bai): We needed to pop-up a dialog asking user to chose one from
+    // either allow/deny for session/one shot/forever. Then, we need to update
+    // the session and persistent policy accordingly.
+    callback.Run(UNDEFINED_RUNTIME_PERM);
+    return;
+  }
+  if (perm == ALLOW) {
+    callback.Run(ALLOW_ALWAYS);
+    return;
+  }
+  if (perm == DENY) {
+    callback.Run(DENY_ALWAYS);
+    return;
+  }
+  NOTREACHED();
 }
 
 }  // namespace application

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -71,6 +71,11 @@ class ApplicationService : public Application::Observer {
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
+  // Check whether application has permission to access API of extension.
+  void CheckAPIAccessControl(const std::string& app_id,
+      const std::string& extension_name,
+      const std::string& api_name, const PermissionCallback& callback);
+
  private:
   // Implementation of Application::Observer.
   virtual void OnApplicationTerminated(Application* app) OVERRIDE;

--- a/application/browser/application_storage_impl.cc
+++ b/application/browser/application_storage_impl.cc
@@ -40,14 +40,14 @@ const std::string StoredPermissionStr[] = {
 };
 
 std::string ToString(StoredPermission permission) {
-  if (permission == INVALID_STORED_PERM)
+  if (permission == UNDEFINED_STORED_PERM)
     return std::string("");
   return StoredPermissionStr[permission];
 }
 
 StoredPermission ToPermission(const std::string& str) {
   unsigned int i;
-  for (i = 0; i < INVALID_STORED_PERM; ++i) {
+  for (i = 0; i < UNDEFINED_STORED_PERM; ++i) {
     if (str == StoredPermissionStr[i])
       break;
   }

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -27,6 +27,8 @@
 #include "xwalk/application/common/manifest.h"
 #include "xwalk/application/common/manifest_handler.h"
 #include "xwalk/application/common/manifest_handlers/main_document_handler.h"
+#include "xwalk/application/common/manifest_handlers/permissions_handler.h"
+#include "xwalk/application/common/permission_policy_manager.h"
 #include "content/public/common/url_constants.h"
 #include "url/url_util.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -320,18 +322,32 @@ StoredPermission ApplicationData::GetPermission(
   StoredPermissionMap::const_iterator iter =
       permission_map_.find(permission_name);
   if (iter == permission_map_.end())
-    return INVALID_STORED_PERM;
+    return UNDEFINED_STORED_PERM;
   return iter->second;
 }
 
 bool ApplicationData::SetPermission(const std::string& permission_name,
                                     StoredPermission perm) {
-  if (perm != INVALID_STORED_PERM) {
+  if (perm != UNDEFINED_STORED_PERM) {
     permission_map_[permission_name] = perm;
     is_dirty_ = true;
     return true;
   }
   return false;
+}
+
+void ApplicationData::ClearPermissions() {
+  permission_map_.clear();
+}
+
+PermissionSet ApplicationData::GetManifestPermissions() const {
+  PermissionSet permissions;
+  if (manifest_->value()->HasKey(keys::kPermissionsKey)) {
+    const PermissionsInfo* perm_info = static_cast<PermissionsInfo*>(
+                           GetManifestData(keys::kPermissionsKey));
+    permissions = perm_info->GetAPIPermissions();
+  }
+  return permissions;
 }
 
 }   // namespace application

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -134,6 +134,8 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
       std::string& permission_name) const;
   bool SetPermission(const std::string& permission_name,
                      StoredPermission perm);
+  void ClearPermissions();
+  PermissionSet GetManifestPermissions() const;
 
   bool HasMainDocument() const;
 

--- a/application/common/manifest_handlers/permissions_handler.cc
+++ b/application/common/manifest_handlers/permissions_handler.cc
@@ -13,13 +13,6 @@ namespace keys = application_manifest_keys;
 
 namespace application {
 
-namespace {
-inline bool IsAPIPermission(const std::string& permission) {
-  // FIXME: Need to check from global API permissions set.
-  return true;
-}
-}  // namespace
-
 PermissionsInfo::PermissionsInfo() {
 }
 
@@ -47,7 +40,7 @@ bool PermissionsHandler::Parse(scoped_refptr<ApplicationData> application,
   }
 
   scoped_ptr<PermissionsInfo> permissions_info(new PermissionsInfo);
-  std::vector<std::string> api_permissions;
+  PermissionSet api_permissions;
   for (size_t i = 0; i < permissions->GetSize(); ++i) {
     std::string permission;
     if (!permissions->GetString(i, &permission)) {
@@ -55,9 +48,12 @@ bool PermissionsHandler::Parse(scoped_refptr<ApplicationData> application,
           "An error occurred when parsing permission string.");
       return false;
     }
-
-    if (IsAPIPermission(permission))
-      api_permissions.push_back(permission);
+    if (api_permissions.find(permission) != api_permissions.end()) {
+      *error = ASCIIToUTF16(
+          "Duplicated permission names found.");
+      return false;
+    }
+    api_permissions.insert(permission);
   }
   permissions_info->SetAPIPermissions(api_permissions);
   application->SetManifestData(keys::kPermissionsKey,

--- a/application/common/manifest_handlers/permissions_handler.h
+++ b/application/common/manifest_handlers/permissions_handler.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "xwalk/application/common/manifest_handler.h"
+#include "xwalk/application/common/permission_types.h"
 
 namespace xwalk {
 namespace application {
@@ -18,14 +19,14 @@ class PermissionsInfo: public ApplicationData::ManifestData {
   PermissionsInfo();
   virtual ~PermissionsInfo();
 
-  const std::vector<std::string>& GetAPIPermissions() const {
+  const PermissionSet& GetAPIPermissions() const {
     return api_permissions_;}
-  void SetAPIPermissions(const std::vector<std::string>& api_permissions) {
+  void SetAPIPermissions(const PermissionSet& api_permissions) {
     api_permissions_ = api_permissions;
   }
 
  private:
-  std::vector<std::string> api_permissions_;
+  PermissionSet api_permissions_;
   DISALLOW_COPY_AND_ASSIGN(PermissionsInfo);
 };
 

--- a/application/common/manifest_handlers/permissions_handler_unittest.cc
+++ b/application/common/manifest_handlers/permissions_handler_unittest.cc
@@ -15,7 +15,7 @@ namespace application {
 
 namespace {
 
-const std::vector<std::string>& GetAPIPermissionsInfo(
+const PermissionSet& GetAPIPermissionsInfo(
     scoped_refptr<const ApplicationData> application) {
   PermissionsInfo* info = static_cast<PermissionsInfo*>(
       application->GetManifestData(keys::kPermissionsKey));
@@ -75,10 +75,10 @@ TEST_F(PermissionsHandlerTest, DeviceAPIPermission) {
       "",
       &error);
   EXPECT_TRUE(application.get());
-  const std::vector<std::string>& permission_list =
+  const PermissionSet& permission_list =
       GetAPIPermissionsInfo(application);
   EXPECT_EQ(permission_list.size(), 1);
-  EXPECT_STREQ(permission_list[0].c_str(), "geolocation");
+  EXPECT_STREQ((*(permission_list.begin())).c_str(), "geolocation");
 }
 
 }  // namespace application

--- a/application/common/permission_policy_manager.cc
+++ b/application/common/permission_policy_manager.cc
@@ -21,5 +21,28 @@ StoredPermission PermissionPolicyManager::GetPermission(
   return ALLOW;
 }
 
+bool PermissionPolicyManager::InitApplicationPermission(
+    ApplicationData* app_data) {
+  app_data->ClearPermissions();
+  PermissionSet permissions = app_data->GetManifestPermissions();
+  if (permissions.empty())
+    return true;
+  // Convert manifest permissions to stored permissions.
+  StoredPermission perm = UNDEFINED_STORED_PERM;
+  for (PermissionSet::const_iterator iter = permissions.begin();
+      iter != permissions.end(); ++iter) {
+    perm = GetPermission(app_data->ID(), *iter);
+    if (perm == UNDEFINED_STORED_PERM) {
+      // If there are something added before we run into this undefined
+      // permission item, clear all the previous ones.
+      app_data->ClearPermissions();
+      LOG(ERROR) << "Invalid permission found: " << *iter;
+      return false;
+    }
+    app_data->SetPermission(*iter, perm);
+  }
+  return true;
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/permission_policy_manager.h
+++ b/application/common/permission_policy_manager.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "base/basictypes.h"
+#include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/permission_types.h"
 
 namespace xwalk {
@@ -26,10 +27,17 @@ class PermissionPolicyManager {
  public:
   PermissionPolicyManager();
   ~PermissionPolicyManager();
-  StoredPermission GetPermission(const std::string& app_id,
-                                 const std::string& permission_name) const;
+  // Permissions listed in manifest would be a little different from what
+  // stored in database. In manifest we have permissions stored in a JSON
+  // array, like ["bluetooth","contacts"], but in database, key-value pairs
+  // are used, like "bluetooth:ALLOW; contacts:PROMPT". A policy based
+  // conversion should be done during installation, and this also means that
+  // the function would only be used during installation.
+  bool InitApplicationPermission(ApplicationData* app_data);
 
  private:
+  StoredPermission GetPermission(const std::string& app_id,
+                                 const std::string& permission_name) const;
   DISALLOW_COPY_AND_ASSIGN(PermissionPolicyManager);
 };
 

--- a/application/common/permission_types.h
+++ b/application/common/permission_types.h
@@ -28,7 +28,7 @@ enum RuntimePermission {
   ALLOW_ALWAYS,
   DENY_ONCE,
   DENY_SESSION,
-  DENY_FOREVER,
+  DENY_ALWAYS,
   UNDEFINED_RUNTIME_PERM,
 };
 
@@ -38,7 +38,7 @@ enum StoredPermission {
   ALLOW = 0,
   DENY,
   PROMPT,
-  INVALID_STORED_PERM,
+  UNDEFINED_STORED_PERM,
 };
 
 typedef std::map<std::string, StoredPermission> StoredPermissionMap;


### PR DESCRIPTION
[Application] Added permission getter/setters in applicaiton …
Added session and persistent permission getter/setters. Also moved
permission policy manager into application system. Moved permission
initialization logic out of application data, i.e. the application
data won't initialize itself.

[Application] Add permission check logic in application …
This method is used to check API Control. It queries permissions
 actions from policy storage and tell the result to extension.
