### PR TITLE
[Android] Make the uid that can connect to the devtools server configurable

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkDevToolsServer.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkDevToolsServer.java
@@ -31,8 +31,13 @@ public class XWalkDevToolsServer {
         nativeSetRemoteDebuggingEnabled(mNativeDevToolsServer, enabled);
     }
 
+    public void allowConnectionFromUid(int uid) {
+        nativeAllowConnectionFromUid(mNativeDevToolsServer, uid);
+    }
+
     private native int nativeInitRemoteDebugging(String socketName);
     private native void nativeDestroyRemoteDebugging(int devToolsServer);
     private native boolean nativeIsRemoteDebuggingEnabled(int devToolsServer);
     private native void nativeSetRemoteDebuggingEnabled(int devToolsServer, boolean enabled);
+    private native void nativeAllowConnectionFromUid(int devToolsServer, int uid);
 }

--- a/runtime/android/java/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkView.java
@@ -223,18 +223,26 @@ public class XWalkView extends FrameLayout {
     }
 
     // Enables remote debugging and returns the URL at which the dev tools server is listening
-    // for commands.
-    public String enableRemoteDebugging() {
+    // for commands. The allowedUid argument can be used to specify the uid of the process that is
+    // permitted to connect.
+    public String enableRemoteDebugging(int allowedUid) {
         checkThreadSafety();
         // Chrome looks for "devtools_remote" pattern in the name of a unix domain socket
         // to identify a debugging page
         final String socketName = getContext().getApplicationContext().getPackageName() + "_devtools_remote";
         if (mDevToolsServer == null) {
             mDevToolsServer = new XWalkDevToolsServer(socketName);
+            mDevToolsServer.allowConnectionFromUid(allowedUid);
             mDevToolsServer.setRemoteDebuggingEnabled(true);
         }
         // devtools/page is hardcoded in devtools_http_handler_impl.cc (kPageUrlPrefix)
         return "ws://" + socketName + "/devtools/page/" + mContent.devToolsAgentId();
+    }
+
+    // Enables remote debugging and returns the URL at which the dev tools server is listening
+    // for commands. Only the current process is allowed to connect to the server.
+    public String enableRemoteDebugging() {
+        return enableRemoteDebugging(mContext.getApplicationInfo().uid);
     }
 
     public void disableRemoteDebugging() {

--- a/runtime/browser/android/xwalk_dev_tools_server.h
+++ b/runtime/browser/android/xwalk_dev_tools_server.h
@@ -29,9 +29,14 @@ class XWalkDevToolsServer {
 
   bool IsStarted() const;
 
+  void AllowConnectionFromUid(uid_t uid);
+
  private:
+  bool CanUserConnectToDevTools(uid_t uid, gid_t gid);
+
   std::string socket_name_;
   content::DevToolsHttpHandler* protocol_handler_;
+  uid_t allowed_uid_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkDevToolsServer);
 };


### PR DESCRIPTION
...ble

Currently, the devtools server allows only code running in the same process
to connect. This change allows specifying the process that can connect to
devtools server.

This code is being modified since the XDK architecture for remote debugging
has changed. Previously, App Analyzer had a websocket proxy that used to run
in the same process as xwalk. In the next version of XDK, the websocket proxy
is being moved to be part of another application (App Preview) and will run
in a process that is different from xwalk. With the addition of this API,
App Preview service will instruct App Analyzer to allow connections from
the service.
