### PR TITLE
[Android] Fix that window.close is not working

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkSettings.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkSettings.java
@@ -30,6 +30,7 @@ public class XWalkSettings {
 
     private final Context mContext;
 
+    private boolean mAllowScriptsToCloseWindows = true;
     private boolean mLoadsImagesAutomatically = true;
     private boolean mImagesEnabled = true;
     private boolean mJavaScriptEnabled = true;
@@ -172,6 +173,20 @@ public class XWalkSettings {
     private void nativeXWalkSettingsGone(int nativeXWalkSettings) {
         assert mNativeXWalkSettings != 0 && mNativeXWalkSettings == nativeXWalkSettings;
         mNativeXWalkSettings = 0;
+    }
+
+    public void setAllowScriptsToCloseWindows(boolean allow) {
+        synchronized (mXWalkSettingsLock) {
+            if (mAllowScriptsToCloseWindows != allow) {
+                mAllowScriptsToCloseWindows = allow;
+            }
+        }
+    }
+
+    public boolean getAllowScriptsToCloseWindows() {
+        synchronized (mXWalkSettingsLock) {
+            return mAllowScriptsToCloseWindows;
+        }
     }
 
     /**

--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultClient.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultClient.java
@@ -156,4 +156,11 @@ public class XWalkDefaultClient extends XWalkClient {
             showHttpAuthDialog(handler, host, realm);
         }
     }
+
+    @Override
+    public void onCloseWindow(XWalkView view) {
+        if (view != null && view.getActivity() != null) {
+            view.getActivity().finish();
+        }
+    }
 }

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -44,6 +44,8 @@ struct XWalkSettings::FieldIds {
     // FIXME: we should be using a new GetFieldIDFromClassName() with caching.
     ScopedJavaLocalRef<jclass> clazz(
         GetClass(env, "org/xwalk/core/XWalkSettings"));
+    allow_scripts_to_close_windows =
+        GetFieldID(env, clazz, "mAllowScriptsToCloseWindows", "Z");
     load_images_automatically =
         GetFieldID(env, clazz, "mLoadsImagesAutomatically", "Z");
     images_enabled =
@@ -71,6 +73,7 @@ struct XWalkSettings::FieldIds {
   }
 
   // Field ids
+  jfieldID allow_scripts_to_close_windows;
   jfieldID load_images_automatically;
   jfieldID images_enabled;
   jfieldID java_script_enabled;
@@ -156,6 +159,9 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
       web_contents()->GetRenderViewHost();
   if (!render_view_host) return;
   WebPreferences prefs = render_view_host->GetWebkitPreferences();
+
+  prefs.allow_scripts_to_close_windows =
+      env->GetBooleanField(obj, field_ids_->allow_scripts_to_close_windows);
 
   prefs.loads_images_automatically =
       env->GetBooleanField(obj, field_ids_->load_images_automatically);


### PR DESCRIPTION
Webapp might use window.close() to exit app.
This commit turns on the setting to allow this
usage and finish the activity when calling
window.close().

BUG=https://crosswalk-project.org/jira/browse/XWALK-939
