### PR TITLE
[Extension] Make runtime variables available in extension constructor

### DIFF
--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -365,10 +365,9 @@ std::vector<std::string> RegisterExternalExtensionsInDirectory(
   for (base::FilePath extension_path = libraries.Next();
         !extension_path.empty(); extension_path = libraries.Next()) {
     scoped_ptr<XWalkExternalExtension> extension(
-        new XWalkExternalExtension(extension_path));
+        new XWalkExternalExtension(extension_path, runtime_variables));
     if (extension->is_valid()) {
       registered_extensions.push_back(extension->name());
-      extension->set_runtime_variables(runtime_variables);
       if (server->permissions_delegate())
         extension->set_permissions_delegate(server->permissions_delegate());
       server->RegisterExtension(extension.PassAs<XWalkExtension>());

--- a/extensions/common/xwalk_external_extension.cc
+++ b/extensions/common/xwalk_external_extension.cc
@@ -16,8 +16,10 @@
 namespace xwalk {
 namespace extensions {
 
-XWalkExternalExtension::XWalkExternalExtension(const base::FilePath& path)
-    : xw_extension_(0),
+XWalkExternalExtension::XWalkExternalExtension(
+    const base::FilePath& path, const base::ValueMap& runtime_variables)
+    : runtime_variables_(runtime_variables),
+      xw_extension_(0),
       created_instance_callback_(NULL),
       destroyed_instance_callback_(NULL),
       shutdown_callback_(NULL),

--- a/extensions/common/xwalk_external_extension.h
+++ b/extensions/common/xwalk_external_extension.h
@@ -31,15 +31,12 @@ class XWalkExternalInstance;
 // library.
 class XWalkExternalExtension : public XWalkExtension {
  public:
-  explicit XWalkExternalExtension(const base::FilePath& path);
+  XWalkExternalExtension(
+      const base::FilePath& path, const base::ValueMap& runtime_variables);
 
   virtual ~XWalkExternalExtension();
 
   bool is_valid();
-
-  void set_runtime_variables(const base::ValueMap& runtime_variables) {
-    runtime_variables_ = runtime_variables;
-  }
 
  private:
   friend class XWalkExternalAdapter;


### PR DESCRIPTION
External extension can't access runtime variables in "XW_Initialize", as it is set after extension created.
In order to solve this issue, the runtime variables will be passed as XWalkExternalExtension constructor parameter now.
