### PR TITLE
[Tizen] Pure wayland build fix

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -1,3 +1,6 @@
+%bcond_with x
+%bcond_with wayland
+
 Name:           crosswalk
 Version:        5.34.93.0
 Release:        0
@@ -57,6 +60,7 @@ BuildRequires:  pkgconfig(nspr)
 BuildRequires:  pkgconfig(nss)
 BuildRequires:  pkgconfig(sensor)
 BuildRequires:  pkgconfig(vconf)
+%if %{with x}
 BuildRequires:  pkgconfig(x11)
 BuildRequires:  pkgconfig(xcomposite)
 BuildRequires:  pkgconfig(xcursor)
@@ -69,13 +73,7 @@ BuildRequires:  pkgconfig(xrender)
 BuildRequires:  pkgconfig(xscrnsaver)
 BuildRequires:  pkgconfig(xt)
 BuildRequires:  pkgconfig(xtst)
-
-# Depending on the Tizen version and profile we are building for, we have
-# different dependencies, patches and gyp options to pass. Checking for
-# specific profiles is not very future-proof. We therefore try to check for
-# either specific features that may be enabled in the current profile (such as
-# Wayland support).
-%bcond_with wayland
+%endif
 
 %if %{with wayland}
 BuildRequires:  pkgconfig(wayland-client)


### PR DESCRIPTION
Pure wayland build need to avoid the BuildRequire for all X11 libraries.
This commit depends on the integration of another one.

Depends-on: 96ca0581561fcef26b7d9f7d2425c1403589ea8d

Please refer to GitHub pull-request:
https://github.com/crosswalk-project/chromium-crosswalk/pull/120

Signed-off-by: Yannick GICQUEL yannick.gicquel@open.eurogiciel.org
