### PR TITLE
[Android] Fix the issue of unsupported app.launch.local_path 'http.html'...

### DIFF
--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -103,7 +103,7 @@ class ManifestJsonParser(object):
       app_url = self.data_src['app']['launch']['local_path']
     else:
       app_url = ''
-    if app_url.lower().startswith(('http', 'https')):
+    if app_url.lower().startswith(('http://', 'https://')):
       app_local_path = ''
     else:
       app_local_path = app_url

--- a/app/tools/android/test_data/manifest/manifest_app_launch_local_path.json
+++ b/app/tools/android/test_data/manifest/manifest_app_launch_local_path.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "app": {
       "launch": {
-          "local_path": "abc.html"
+          "local_path": "http.html"
       }
   },
   "description": "a sample description",


### PR DESCRIPTION
....

There is issue if the app.launch.local_path is defined as the specific
'http.html', in the manifest parser, it is differentiating the web url
from local_path via 'http', this fix is resovling this issue by using
'http:' as the differentating keyword.

BUG=https://crosswalk-project.org/jira/browse/XWALK-985
