### PR TITLE
Update DEPS.xwalk to include new patch in Chromium

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '32.0.1700.102'
-chromium_crosswalk_point = '2071e32149e7911bc378a20ef5a5363f382d6999'
+chromium_crosswalk_point = '5d18596e85a4bb96531c0290c95887ca24129939'
 blink_crosswalk_point = 'b00d5cd307239b282e959838c1ed4d239c80ad90'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
https://github.com/crosswalk-project/crosswalk/pull/1539
This PR depends on the patch in Chromium, with PR
https://github.com/crosswalk-project/chromium-crosswalk/pull/115
Need to update the deps to avoid compile failure.
BUG=https://crosswalk-project.org/jira/browse/XWALK-880
