### PR TITLE
[Android] Fix the issue of package name in packaging tool.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -485,12 +485,13 @@ def Execution(options, sanitized_name):
   RunCommand(cmd)
 
   src_file = os.path.join('out', sanitized_name + '.apk')
+  package_name = options.name
   if options.app_version:
-    options.name += ('_' + options.app_version)
+    package_name += ('_' + options.app_version)
   if options.mode == 'shared':
-    dst_file = '%s.apk' % options.name
+    dst_file = '%s.apk' % package_name
   elif options.mode == 'embedded':
-    dst_file = '%s_%s.apk' % (options.name, options.arch)
+    dst_file = '%s_%s.apk' % (package_name, options.arch)
   shutil.copyfile(src_file, dst_file)
   CleanDir('out')
   if options.mode == 'embedded':


### PR DESCRIPTION
There is packaging name issue when packaging application for
more than one architecture, this fix is resolving this issue
by correcting the package name in packaging tool.
