### PR TITLE
Fix the bug XWALK-956:Remote debugging not work in crosswalk/Tizen_IVI.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -176,11 +176,11 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     std::string port_str =
         command_line->GetSwitchValueASCII(switches::kRemoteDebuggingPort);
     int port;
-    const char* loopback_ip = "127.0.0.1";
+    const char* local_ip = "0.0.0.0";
     if (base::StringToInt(port_str, &port) && port > 0 && port < 65535) {
       remote_debugging_server_.reset(
           new RemoteDebuggingServer(runtime_context_,
-              loopback_ip, port, std::string()));
+              local_ip, port, std::string()));
     }
   }
 

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -81,8 +81,12 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   // External extensions will run in the BrowserProcess (in process mode).
   command_line->AppendSwitch(switches::kXWalkDisableExtensionProcess);
 
-  // Enable WebGL for Android.
+  // Only force to enable WebGL for Android for IA platforms because
+  // we've tested the WebGL conformance test. For other platforms, just
+  // follow up the behavior defined by Chromium upstream.
+#if defined(ARCH_CPU_X86)
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
+#endif
 
   // Disable HW encoding/decoding acceleration for WebRTC on Android.
   // FIXME: Remove these switches for Android when Android OS is removed from


### PR DESCRIPTION
Set this IP address to INADDR_ANY instead of "127.0.0.1". This allowed the server to receive packets destined to any of the interfaces.

BUG = https://crosswalk-project.org/jira/browse/XWALK-956
