### PR TITLE
[Runtime] Separate WGT applications manifest handling from XPK applications.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -28,6 +28,7 @@
 namespace xwalk {
 
 namespace keys = application_manifest_keys;
+namespace widget_keys = application_widget_keys;
 
 namespace application {
 
@@ -137,7 +138,10 @@ GURL Application::GetURLFromAppMainKey() {
 GURL Application::GetURLFromLocalPathKey() {
   const Manifest* manifest = application_data_->GetManifest();
   std::string entry_page;
-  if (!manifest->GetString(keys::kLaunchLocalPathKey, &entry_page)
+  std::string key(GetLaunchLocalPathKey(
+      application_data_->GetPackageType()));
+
+  if (!manifest->GetString(key, &entry_page)
       || entry_page.empty())
     return GURL();
 

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -138,6 +138,7 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   PermissionSet GetManifestPermissions() const;
 
   bool HasMainDocument() const;
+  Manifest::PackageType GetPackageType() const;
 
  private:
   friend class base::RefCountedThreadSafe<ApplicationData>;

--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -4,9 +4,11 @@
 
 #include "xwalk/application/common/application_file_util.h"
 
+#include <algorithm>
 #include <map>
 #include <vector>
 
+#include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/file_util.h"
@@ -19,7 +21,7 @@
 #include "base/threading/thread_restrictions.h"
 #include "net/base/escape.h"
 #include "net/base/file_stream.h"
-#include "third_party/libxml/chromium/libxml_utils.h"
+#include "third_party/libxml/src/include/libxml/tree.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/application_manifest_constants.h"
@@ -30,9 +32,126 @@
 
 namespace errors = xwalk::application_manifest_errors;
 namespace keys = xwalk::application_manifest_keys;
+namespace widget_keys = xwalk::application_widget_keys;
+
+namespace {
+const char kAttributePrefix[] = "@";
+const char kNamespaceKey[] = "@namespace";
+const char kTextKey[] = "#text";
+}
 
 namespace xwalk {
 namespace application {
+
+inline char* ToCharPointer(void* ptr) {
+  return reinterpret_cast<char *>(ptr);
+}
+
+inline const char* ToConstCharPointer(const void* ptr) {
+  return reinterpret_cast<const char*>(ptr);
+}
+
+// Load XML node into Dictionary structure.
+// The keys for the XML node to Dictionary mapping are described below:
+// XML                                 Dictionary
+// <e></e>                             "e":{"#text": ""}
+// <e>textA</e>                        "e":{"#text":"textA"}
+// <e attr="val">textA</e>             "e":{ "@attr":"val", "#text": "textA"}
+// <e> <a>textA</a> <b>textB</b> </e>  "e":{
+//                                       "a":{"#text":"textA"}
+//                                       "b":{"#text":"textB"}
+//                                     }
+// <e> <a>textX</a> <a>textY</a> </e>  "e":{
+//                                       "a":[ {"#text":"textX"},
+//                                             {"#text":"textY"}]
+//                                     }
+// <e> textX <a>textY</a> </e>         "e":{ "#text":"textX",
+//                                           "a":{"#text":"textY"}
+//                                     }
+//
+// For elements that are specified under a namespace, the dictionary
+// will add '@namespace' key for them, e.g.,
+// XML:
+// <e xmln="linkA" xmlns:N="LinkB">
+//   <sub-e1> text1 </sub-e>
+//   <N:sub-e2 text2 />
+// </e>
+// will be saved in Dictionary as,
+// "e":{
+//   "#text": "",
+//   "@namespace": "linkA"
+//   "sub-e1": {
+//     "#text": "text1",
+//     "@namespace": "linkA"
+//   },
+//   "sub-e2": {
+//     "#text":"text2"
+//     "@namespace": "linkB"
+//   }
+// }
+base::DictionaryValue* LoadXMLNode(xmlNode* root) {
+  scoped_ptr<base::DictionaryValue> value(new base::DictionaryValue);
+  if (root->type != XML_ELEMENT_NODE)
+    return NULL;
+
+  xmlAttr* prop = NULL;
+  for (prop = root->properties; prop; prop = prop->next) {
+    char* prop_value = ToCharPointer(xmlNodeListGetString(
+        root->doc, prop->children, 1));
+    value->SetString(
+        std::string(kAttributePrefix) + ToConstCharPointer(prop->name),
+        prop_value);
+    xmlFree(prop_value);
+  }
+
+  if (root->ns)
+    value->SetString(kNamespaceKey, ToConstCharPointer(root->ns->href));
+
+  for (xmlNode* node = root->children; node; node = node->next) {
+    std::string sub_node_name(ToConstCharPointer(node->name));
+    base::DictionaryValue* sub_value = LoadXMLNode(node);
+    if (!sub_value)
+      continue;
+
+    if (!value->HasKey(sub_node_name)) {
+      value->Set(sub_node_name, sub_value);
+      continue;
+    }
+
+    base::Value* temp;
+    value->Get(sub_node_name, &temp);
+    DCHECK(temp);
+
+    if (temp->IsType(base::Value::TYPE_LIST)) {
+      base::ListValue* list;
+      temp->GetAsList(&list);
+      list->Append(sub_value);
+      value->Set(sub_node_name, list);
+    } else {
+      DCHECK(temp->IsType(base::Value::TYPE_DICTIONARY));
+      base::DictionaryValue* dict;
+      temp->GetAsDictionary(&dict);
+      base::DictionaryValue* prev_value(new base::DictionaryValue());
+      prev_value = dict->DeepCopy();
+
+      base::ListValue* list = new base::ListValue();
+      list->Append(prev_value);
+      list->Append(sub_value);
+      value->Set(sub_node_name, list);
+    }
+  }
+
+  char* text = ToCharPointer(
+      xmlNodeListGetString(root->doc, root->children, 1));
+  if (!text) {
+    value->SetString(kTextKey, std::string());
+  } else {
+    value->SetString(kTextKey, text);
+  }
+  xmlFree(text);
+
+  return value.release();
+}
 
 scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_path,
@@ -47,7 +166,8 @@ scoped_refptr<ApplicationData> LoadApplication(
     const std::string& application_id,
     Manifest::SourceType source_type,
     std::string* error) {
-  scoped_ptr<base::DictionaryValue> manifest(LoadManifest(application_path, error));
+  scoped_ptr<base::DictionaryValue> manifest(
+      LoadManifest(application_path, error));
   if (!manifest.get())
     return NULL;
 
@@ -61,9 +181,14 @@ scoped_refptr<ApplicationData> LoadApplication(
     return NULL;
 
   std::vector<InstallWarning> warnings;
-  if (!ManifestHandlerRegistry::GetInstance()->ValidateAppManifest(
-          application, error, &warnings))
+  ManifestHandlerRegistry* registry =
+      manifest->HasKey(widget_keys::kWidgetKey)
+      ? ManifestHandlerRegistry::GetInstance(Manifest::TYPE_WGT)
+      : ManifestHandlerRegistry::GetInstance(Manifest::TYPE_XPK);
+
+  if (!registry->ValidateAppManifest(application, error, &warnings))
     return NULL;
+
   if (!warnings.empty()) {
     LOG(WARNING) << "There are some warnings when validating the application "
                  << application->ID();
@@ -72,8 +197,9 @@ scoped_refptr<ApplicationData> LoadApplication(
   return application;
 }
 
-static base::DictionaryValue* LoadManifestXpk(const base::FilePath& manifest_path,
-      std::string* error) {
+static base::DictionaryValue* LoadManifestXpk(
+    const base::FilePath& manifest_path,
+    std::string* error) {
   JSONFileValueSerializer serializer(manifest_path);
   scoped_ptr<base::Value> root(serializer.Deserialize(NULL, error));
   if (!root.get()) {
@@ -96,7 +222,8 @@ static base::DictionaryValue* LoadManifestXpk(const base::FilePath& manifest_pat
     return NULL;
   }
 
-  base::DictionaryValue* dv = static_cast<base::DictionaryValue*>(root.release());
+  base::DictionaryValue* dv =
+      static_cast<base::DictionaryValue*>(root.release());
 #if defined(OS_TIZEN)
   // Ignore any Tizen application ID, as this is automatically generated.
   dv->Remove(keys::kTizenAppIdKey, NULL);
@@ -105,55 +232,23 @@ static base::DictionaryValue* LoadManifestXpk(const base::FilePath& manifest_pat
   return dv;
 }
 
-static base::DictionaryValue* LoadManifestWgt(const base::FilePath& manifest_path,
-      std::string* error) {
-  XmlReader xml;
-
-  if (!xml.LoadFile(manifest_path.MaybeAsASCII())) {
+static base::DictionaryValue* LoadManifestWgt(
+    const base::FilePath& manifest_path,
+    std::string* error) {
+  xmlDoc * doc = NULL;
+  xmlNode* root_node = NULL;
+  doc = xmlReadFile(manifest_path.MaybeAsASCII().c_str(), NULL, 0);
+  if (doc == NULL) {
     *error = base::StringPrintf("%s", errors::kManifestUnreadable);
     return NULL;
   }
+  root_node = xmlDocGetRootElement(doc);
+  base::DictionaryValue* dv = LoadXMLNode(root_node);
+  scoped_ptr<base::DictionaryValue> result(new base::DictionaryValue);
+  if (dv)
+    result->Set(ToConstCharPointer(root_node->name), dv);
 
-  while (!xml.SkipToElement()) {
-    if (!xml.Read()) {
-      *error = base::StringPrintf("%s", errors::kManifestUnreadable);
-      return NULL;
-    }
-  }
-
-  scoped_ptr<base::DictionaryValue> dv(new base::DictionaryValue);
-  std::string value;
-  while (xml.Read()) {
-    std::string node_name = xml.NodeName();
-
-    if (node_name == "widget") {
-      if (xml.NodeAttribute("version", &value))
-        dv->SetString(keys::kVersionKey, value);
-      else if (xml.NodeAttribute("id", &value))
-        dv->SetString(keys::kWebURLsKey, value);
-    } else if (node_name == "content") {
-      if (xml.NodeAttribute("src", &value))
-        dv->SetString(keys::kLaunchLocalPathKey, value);
-    } else if (node_name == "name") {
-      value = "";  // ReadElementContent() will concatenate the value.
-
-      if (xml.ReadElementContent(&value))
-        dv->SetString(keys::kNameKey, value);
-#if defined(OS_TIZEN)
-    } else if (node_name == "icon") {
-      if (xml.NodeAttribute("src", &value))
-        dv->SetString(keys::kIcon128Key, value);
-    } else if (node_name == "application") {
-      if (xml.NodeAttribute("package", &value))
-        dv->SetString(keys::kTizenAppIdKey, value);
-    } else if (node_name == "content-security-policy") {
-      if (xml.ReadElementContent(&value))
-        dv->SetString(keys::kCSPKey, value);
-#endif
-    }
-  }
-
-  return dv.release();
+  return result.release();
 }
 
 base::DictionaryValue* LoadManifest(const base::FilePath& application_path,

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -31,6 +31,20 @@ const char kIcon128Key[] = "icons.128";
 
 }  // namespace application_manifest_keys
 
+// manifest keys for widget applications.
+namespace application_widget_keys {
+const char kNameKey[] = "widget.name.#text";
+const char kVersionKey[] = "widget.@version";
+const char kWidgetKey[] = "widget";
+const char kLaunchLocalPathKey[] = "widget.content.@src";
+const char kWebURLsKey[] = "widget.@id";
+
+#if defined(OS_TIZEN)
+const char kIcon128Key = "widget.icon.@src";
+const char kTizenAppIdKey[] = "widget.application.@package";
+#endif
+}  // namespace application_widget_keys
+
 namespace application_manifest_errors {
 const char kInvalidDescription[] =
     "Invalid value for 'description'.";
@@ -52,4 +66,49 @@ const char kPlatformAppNeedsManifestVersion2[] =
     "Packaged apps need manifest_version set to >= 2";
 }  // namespace application_manifest_errors
 
+namespace application {
+
+const char* GetNameKey(Manifest::PackageType package_type) {
+  if (package_type == Manifest::TYPE_WGT)
+    return application_widget_keys::kNameKey;
+
+  return application_manifest_keys::kNameKey;
+}
+
+const char* GetVersionKey(Manifest::PackageType package_type) {
+  if (package_type == Manifest::TYPE_WGT)
+    return application_widget_keys::kVersionKey;
+
+  return application_manifest_keys::kVersionKey;
+}
+
+const char* GetWebURLsKey(Manifest::PackageType package_type) {
+  if (package_type == Manifest::TYPE_WGT)
+    return application_widget_keys::kWebURLsKey;
+
+  return application_manifest_keys::kWebURLsKey;
+}
+
+const char* GetLaunchLocalPathKey(Manifest::PackageType package_type) {
+  if (package_type == Manifest::TYPE_WGT)
+    return application_widget_keys::kLaunchLocalPathKey;
+
+  return application_manifest_keys::kLaunchLocalPathKey;
+}
+#if defined(OS_TIZEN)
+const char* GetTizenAppIdKey(Manifest::PackageType package_type) {
+  if (package_type == Manifest::TYPE_WGT)
+    return application_widget_keys::kTizenAppIdKey;
+
+  return application_manifest_keys::kTizenAppIdKey;
+}
+
+const char* GetIcon128Key(Manifest::PackageType package_type) {
+  if (package_type == Manifest::TYPE_WGT)
+    return application_widget_keys::kIcon128Key;
+
+  return application_manifest_keys::kIcon128Key;
+}
+#endif
+}  // namespace application
 }  // namespace xwalk

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -5,6 +5,7 @@
 #ifndef XWALK_APPLICATION_COMMON_APPLICATION_MANIFEST_CONSTANTS_H_
 #define XWALK_APPLICATION_COMMON_APPLICATION_MANIFEST_CONSTANTS_H_
 
+#include "xwalk/application/common/manifest.h"
 // Keys used in JSON representation of applications.
 namespace xwalk {
 namespace application_manifest_keys {
@@ -31,6 +32,18 @@ namespace application_manifest_keys {
 #endif
 }  // namespace application_manifest_keys
 
+namespace application_widget_keys {
+  extern const char kNameKey[];
+  extern const char kLaunchLocalPathKey[];
+  extern const char kWebURLsKey[];
+  extern const char kWidgetKey[];
+  extern const char kVersionKey[];
+#if defined(OS_TIZEN)
+  extern const char kTizenAppIdKey[];
+  extern const char kIcon128Key[];
+#endif
+}  // namespace application_widget_keys
+
 namespace application_manifest_errors {
   extern const char kInvalidDescription[];
   extern const char kInvalidKey[];
@@ -41,6 +54,19 @@ namespace application_manifest_errors {
   extern const char kManifestUnreadable[];
   extern const char kPlatformAppNeedsManifestVersion2[];
 }  // namespace application_manifest_errors
+
+namespace application {
+
+typedef application::Manifest Manifest;
+const char* GetNameKey(Manifest::PackageType type);
+const char* GetVersionKey(Manifest::PackageType type);
+const char* GetWebURLsKey(Manifest::PackageType type);
+const char* GetLaunchLocalPathKey(Manifest::PackageType type);
+#if defined(OS_TIZEN)
+const char* GetTizenAppIdKey(Manifest::PackageType type);
+const char* GetIcon128Key(Manifest::PackageType type);
+#endif
+}  // namespace application
 }  // namespace xwalk
 
 #endif  // XWALK_APPLICATION_COMMON_APPLICATION_MANIFEST_CONSTANTS_H_

--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -14,6 +14,7 @@
 
 namespace errors = xwalk::application_manifest_errors;
 namespace keys   = xwalk::application_manifest_keys;
+namespace widget_keys = xwalk::application_widget_keys;
 
 namespace xwalk {
 namespace application {
@@ -32,6 +33,12 @@ Manifest::Manifest(SourceType source_type,
       type_ = TYPE_PACKAGED_APP;
     }
   }
+
+  if (data_->HasKey(widget_keys::kWidgetKey) &&
+      data_->Get(widget_keys::kWidgetKey, NULL))
+    package_type_ = TYPE_WGT;
+  else
+    package_type_ = TYPE_XPK;
 }
 
 Manifest::~Manifest() {

--- a/application/common/manifest.h
+++ b/application/common/manifest.h
@@ -38,6 +38,12 @@ class Manifest {
     TYPE_PACKAGED_APP
   };
 
+  enum PackageType {
+    TYPE_WGT = 0,
+    TYPE_XPK
+  };
+
+
   Manifest(SourceType source_type, scoped_ptr<base::DictionaryValue> value);
   virtual ~Manifest();
 
@@ -63,6 +69,8 @@ class Manifest {
 
   bool IsPackaged() const { return type_ == TYPE_PACKAGED_APP; }
   bool IsHosted() const { return type_ == TYPE_HOSTED_APP; }
+
+  PackageType GetPackageType() const { return package_type_; }
 
   // These access the wrapped manifest value, returning false when the property
   // does not exist or if the manifest type can't access it.
@@ -107,6 +115,8 @@ class Manifest {
   scoped_ptr<base::DictionaryValue> data_;
 
   Type type_;
+
+  PackageType package_type_;
 
   DISALLOW_COPY_AND_ASSIGN(Manifest);
 };

--- a/application/common/manifest_handler.h
+++ b/application/common/manifest_handler.h
@@ -12,6 +12,7 @@
 #include "base/memory/linked_ptr.h"
 #include "base/strings/string16.h"
 #include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest.h"
 
 namespace xwalk {
 namespace application {
@@ -54,7 +55,8 @@ class ManifestHandlerRegistry {
  public:
   ~ManifestHandlerRegistry();
 
-  static ManifestHandlerRegistry* GetInstance();
+  static ManifestHandlerRegistry* GetInstance(
+      Manifest::PackageType package_type);
 
   bool ParseAppManifest(
        scoped_refptr<ApplicationData> application, base::string16* error);
@@ -74,7 +76,11 @@ class ManifestHandlerRegistry {
   void ReorderHandlersGivenDependencies();
 
   // Sets a new global registry, for testing purposes.
-  static void SetInstanceForTesting(ManifestHandlerRegistry* registry);
+  static void SetInstanceForTesting(ManifestHandlerRegistry* registry,
+                                    Manifest::PackageType package_type);
+
+  static ManifestHandlerRegistry* GetInstanceForWGT();
+  static ManifestHandlerRegistry* GetInstanceForXPK();
 
   typedef std::map<std::string, ManifestHandler*> ManifestHandlerMap;
   typedef std::map<ManifestHandler*, int> ManifestHandlerOrderMap;
@@ -84,7 +90,8 @@ class ManifestHandlerRegistry {
   // Handlers are executed in order; lowest order first.
   ManifestHandlerOrderMap order_map_;
 
-  static ManifestHandlerRegistry* registry_;
+  static ManifestHandlerRegistry* xpk_registry_;
+  static ManifestHandlerRegistry* widget_registry_;
 };
 
 }  // namespace application

--- a/application/common/manifest_handler_unittest.cc
+++ b/application/common/manifest_handler_unittest.cc
@@ -31,12 +31,15 @@ class ScopedTestingManifestHandlerRegistry {
       const std::vector<ManifestHandler*>& handlers)
       : registry_(
           new ManifestHandlerRegistry(handlers)),
-        prev_registry_(ManifestHandlerRegistry::GetInstance()) {
-    ManifestHandlerRegistry::SetInstanceForTesting(registry_.get());
+        prev_registry_(
+          ManifestHandlerRegistry::GetInstance(Manifest::TYPE_XPK)) {
+    ManifestHandlerRegistry::SetInstanceForTesting(
+        registry_.get(), Manifest::TYPE_XPK);
   }
 
   ~ScopedTestingManifestHandlerRegistry() {
-    ManifestHandlerRegistry::SetInstanceForTesting(prev_registry_);
+    ManifestHandlerRegistry::SetInstanceForTesting(
+        prev_registry_, Manifest::TYPE_XPK);
   }
 
   scoped_ptr<ManifestHandlerRegistry> registry_;
@@ -91,7 +94,8 @@ class ManifestHandlerTest : public testing::Test {
     virtual ~TestManifestHandler() {}
 
     virtual bool Parse(
-        scoped_refptr<ApplicationData> application, base::string16* error) OVERRIDE {
+        scoped_refptr<ApplicationData> application,
+        base::string16* error) OVERRIDE {
       watcher_->Record(name_);
       return true;
     }
@@ -120,7 +124,8 @@ class ManifestHandlerTest : public testing::Test {
         : TestManifestHandler(name, keys, prereqs, watcher) {
     }
     virtual bool Parse(
-        scoped_refptr<ApplicationData> application, base::string16* error) OVERRIDE {
+        scoped_refptr<ApplicationData> application,
+        base::string16* error) OVERRIDE {
       *error = base::ASCIIToUTF16(name_);
       return false;
     }
@@ -151,7 +156,8 @@ class ManifestHandlerTest : public testing::Test {
     }
 
     virtual bool Parse(
-        scoped_refptr<ApplicationData> application, base::string16* error) OVERRIDE {
+        scoped_refptr<ApplicationData> application,
+        base::string16* error) OVERRIDE {
       return true;
     }
 


### PR DESCRIPTION
When loading WGT manifest file, current Crosswalk maps XML Widget
elements to manifest keys under namespace 'application_manifest_keys' by
hard code. Consequently, WGT app and XPK app share the same manifest
keys and manifest handlers. As with more manifest keys and handlers are
introduced for WGT app, this causes a mix up of WGT specific keys and
XPK specific keys, due to WGT and XPK app have different manifest formats
and keys, especially put Tizen Extending Configuration Elements into
consideration.

A solution to fix above issue is to separate WGT manifest keys and handlers
from XPK apps. In detail, when loading WGT manifest, we introduce a
mechanism to save XML configuration information into manifest Dictionary
structure(note that this is not hard code mapping), keys are different
from those of XPK apps. WGT keys are put under 'application_widget_keys'
namespace, while XPK keys are put under 'application_manifest_keys'.
Then we could add WGT specific handlers for WGT keys.
