### PR TITLE
[Android] Support package file name including space character.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -27,7 +27,7 @@ def ReplaceInvalidChars(value, mode='default'):
   if mode == 'default':
     invalid_chars = '\/:*?"<>|- '
   elif mode == 'apkname':
-    invalid_chars = '\/:.*?"<>|- '
+    invalid_chars = '\/:.*?"<>|-'
   for c in invalid_chars:
     if mode == 'apkname' and c in value:
       print("Illegal character: '%s' is replaced with '_'" % c)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -156,16 +156,16 @@ class TestMakeApk(unittest.TestCase):
     out = RunCommand(cmd)
     self.assertTrue(out.find('The APK name is required!') != -1)
     Clean('Example', '1.0.0')
-    cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+    cmd = ['python', 'make_apk.py', '--name=An Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('The APK name is required!') == -1)
-    Clean('Example', '1.0.0')
+    Clean('An Example', '1.0.0')
     # The following invalid chars verification is too heavy for embedded mode,
     # and the result of verification should be the same between shared mode
     # and embedded mode. So only do the verification in the shared mode.
     if self._mode.find('shared') != -1:
-      invalid_chars = '\/:.*?"<>|- '
+      invalid_chars = '\/:.*?"<>|-'
       for c in invalid_chars:
         invalid_name = '--name=Example' + c
         cmd = ['python', 'make_apk.py', invalid_name,


### PR DESCRIPTION
If package file name includes space character, this character
will be replaced with '_', according to the new user requirement,
blank character should be supported, this fix resolves this issue
by removing the space from the invalid characters.

BUG=https://crosswalk-project/jira/browse/XWALK-1006
