### PR TITLE
[application] The application termination via DBus 

### DIFF
--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -8,12 +8,11 @@
 #include <string>
 #include "base/memory/ref_counted.h"
 #include "dbus/bus.h"
+#include "xwalk/application/browser/application.h"
 #include "xwalk/dbus/object_manager_adaptor.h"
 
 namespace xwalk {
 namespace application {
-
-class Application;
 
 // Represents the running application inside D-Bus hierarchy of
 // RunningApplicationsManager.
@@ -31,13 +30,14 @@ class RunningApplicationObject : public dbus::ManagedObject {
   ~RunningApplicationObject();
 
  private:
-  void TerminateApplication();
+  void TerminateApplication(Application::TerminationMode mode);
 
   void OnExported(const std::string& interface_name,
                   const std::string& method_name,
                   bool success);
 
-  void OnTerminate(dbus::MethodCall* method_call,
+  void OnTerminate(Application::TerminationMode termination_mode,
+                   dbus::MethodCall* method_call,
                    dbus::ExportedObject::ResponseSender response_sender);
 
   void ListenForOwnerChange();

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -93,7 +93,7 @@ void RunningApplicationsManager::OnLaunch(
     response_sender.Run(response.Pass());
     return;
   }
-
+  CHECK(app_id == application->id());
   // FIXME(cmarcelo): ApplicationService will tell us when new applications
   // appear (with DidLaunchApplication()) and we create new managed objects
   // in D-Bus based on that.


### PR DESCRIPTION
The application DBus proxy should consider the fact that an
application might be still running even after its "Terminate"
method is called (if termination mode is 'Normal' and the app
contains 'OnSuspend' handlers) so it still should listen to
'owner' changes. Besides, the DBus client should be able to
enforce termination - might be needed for example if 'OnSuspend'
event takes too long time and the User wants to stop the app
immediately.
This patch exports a new "ForceTerminate" DBus method from
application proxy object and modifies its termination logic
accordingly to the requirements described above.
