### PR TITLE
Sync gyp_xwalk with the current contents of gyp_chromium.

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -9,8 +9,10 @@
 
 import glob
 import os
+import pipes
 import shlex
 import subprocess
+import string
 import sys
 
 xwalk_dir = os.path.dirname(os.path.realpath(__file__))
@@ -23,14 +25,23 @@ sys.path.insert(0, os.path.join(chrome_src, 'build'))
 import gyp_helper
 import landmine_utils
 
+# Assume this file is in a one-level-deep subdirectory of the source root.
+SRC_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 # Add paths so that pymod_do_main(...) can import files.
+sys.path.insert(1, os.path.join(chrome_src, 'tools'))
 sys.path.insert(1, os.path.join(chrome_src, 'tools', 'generate_shim_headers'))
 sys.path.insert(1, os.path.join(chrome_src, 'tools', 'grit'))
 sys.path.insert(1, os.path.join(chrome_src, 'chrome', 'tools', 'build'))
 sys.path.insert(1, os.path.join(chrome_src, 'native_client', 'build'))
+sys.path.insert(1, os.path.join(chrome_src, 'native_client_sdk', 'src',
+    'build_tools'))
 sys.path.insert(1, os.path.join(chrome_src, 'remoting', 'tools', 'build'))
+sys.path.insert(1, os.path.join(chrome_src, 'third_party', 'liblouis'))
 sys.path.insert(1, os.path.join(chrome_src, 'third_party', 'WebKit',
     'Source', 'build', 'scripts'))
+
+import find_depot_tools
 
 # On Windows, Psyco shortens warm runs of build/gyp_chromium by about
 # 20 seconds on a z600 machine with 12 GB of RAM, from 90 down to 70
@@ -51,10 +62,206 @@ if sys.platform == 'win32':
 else:
   psyco = None
 
-def additional_include_files(args=[]):
+
+def GetSupplementalFiles():
+  """Returns a list of the supplemental files that are included in all GYP
+  sources."""
+  return glob.glob(os.path.join(chrome_src, '*', 'supplement.gypi'))
+
+
+def FormatKeyForGN(key):
+  """Returns the given GYP key reformatted for GN.
+
+  GYP dictionary keys can be almost anything, but in GN they are identifiers
+  and must follow the same rules. This reformats such keys to be valid GN
+  identifiers."""
+  return ''.join([c if c in string.ascii_letters else '_' for c in key])
+
+
+def EscapeStringForGN(s):
+  """Converts a string to a GN string literal."""
+  # Escape $ characters which have special meaning to GN.
+  return '"' + s.replace('$', '\\$').replace('"', '\\"') + '"'
+
+
+def ProcessGypDefinesItems(items):
+  """Converts a list of strings to a list of key-value pairs."""
+  result = []
+  for item in items:
+    tokens = item.split('=', 1)
+    # Some GYP variables have hyphens, which we don't support.
+    key = FormatKeyForGN(tokens[0])
+    if len(tokens) == 2:
+      result += [(key, tokens[1])]
+    else:
+      # No value supplied, treat it as a boolean and set it. Note that we
+      # use the string '1' here so we have a consistent definition whether
+      # you do 'foo=1' or 'foo'.
+      result += [(key, '1')]
+  return result
+
+def GetGypVarsForGN(supplemental_files):
+  """Returns a dictionary of all GYP vars that we will be passing to GN."""
+
+  # GYP defines from the supplemental.gypi files.
+  supp_items = []
+  for supplement in supplemental_files:
+    with open(supplement, 'r') as f:
+      try:
+        file_data = eval(f.read(), {'__builtins__': None}, None)
+      except SyntaxError, e:
+        e.filename = os.path.abspath(supplement)
+        raise
+      variables = file_data.get('variables', [])
+      for v in variables:
+        supp_items += [(FormatKeyForGN(v), str(variables[v]))]
+
+  # GYP defines from the environment.
+  env_items = ProcessGypDefinesItems(
+      shlex.split(os.environ.get('GYP_DEFINES', '')))
+
+  # GYP defines from the command line. We can't use optparse since we want
+  # to ignore all arguments other than "-D".
+  cmdline_input_items = []
+  for i in range(len(sys.argv))[1:]:
+    if sys.argv[i].startswith('-D'):
+      if sys.argv[i] == '-D' and i + 1 < len(sys.argv):
+        cmdline_input_items += [sys.argv[i + 1]]
+      elif len(sys.argv[i]) > 2:
+        cmdline_input_items += [sys.argv[i][2:]]
+  cmdline_items = ProcessGypDefinesItems(cmdline_input_items)
+
+  return dict(supp_items + env_items + cmdline_items)
+
+def GetOutputDirectory():
+  """Returns the output directory that GYP will use."""
+  # GYP generator flags from the command line. We can't use optparse since we
+  # want to ignore all arguments other than "-G".
+  needle = '-Goutput_dir='
+  cmdline_input_items = []
+  for item in sys.argv[1:]:
+    if item.startswith(needle):
+      return item[len(needle):]
+
+  env_items = shlex.split(os.environ.get('GYP_GENERATOR_FLAGS', ''))
+  needle = 'output_dir='
+  for item in env_items:
+    if item.startswith(needle):
+      return item[len(needle):]
+
+  return "out"
+
+def GetArgsStringForGN(supplemental_files):
+  """Returns the args to pass to GN.
+  Based on a subset of the GYP variables that have been rewritten a bit."""
+
+  # Find the .gyp directory in the user's home directory.
+  home_dot_gyp = os.environ.get('GYP_CONFIG_DIR', None)
+  if home_dot_gyp:
+    home_dot_gyp = os.path.expanduser(home_dot_gyp)
+  if not home_dot_gyp:
+    home_vars = ['HOME']
+    if sys.platform in ('cygwin', 'win32'):
+      home_vars.append('USERPROFILE')
+    for home_var in home_vars:
+      home = os.getenv(home_var)
+      if home != None:
+        home_dot_gyp = os.path.join(home, '.gyp')
+        if not os.path.exists(home_dot_gyp):
+          home_dot_gyp = None
+        else:
+          break
+
+  if home_dot_gyp:
+    include_gypi = os.path.join(home_dot_gyp, "include.gypi")
+    if os.path.exists(include_gypi):
+      supplemental_files += [include_gypi]
+
+  vars_dict = GetGypVarsForGN(supplemental_files)
+  gn_args = ''
+
+  # Note: These are the additional flags passed to various builds by builders
+  # on the main waterfall. We'll probably need to add these at some point:
+  #   mac_strip_release=1         http://crbug.com/330301
+  #   linux_dump_symbols=0        http://crbug.com/330300
+  #   host_os=linux  Probably can skip, GN knows the host OS.
+  #   order_text_section=<path>   http://crbug.com/330299
+  #   chromium_win_pch=0          http://crbug.com/297678
+  #   chromium_ios_signing=0      http://crbug.com/330302
+  #   linux_use_tcmalloc=0        http://crbug.com/330303
+  #   release_extra_flags=...     http://crbug.com/330305
+
+  # These tuples of (key, value, gn_arg_string) use the gn_arg_string for
+  # gn when the key is set to the given value in the GYP arguments.
+  remap_cases = [
+      ('android_webview_build', '1', 'is_android_webview_build=true'),
+      ('branding', 'Chrome', 'is_chrome_branded=true'),
+      ('build_for_tool', 'drmemory', 'disable_iterator_debugging=true'),
+      ('build_for_tool', 'tsan', 'disable_iterator_debugging=true'),
+      ('buildtype', 'Official', 'is_official_build=true'),
+      ('component', 'shared_library', 'is_component_build=true'),
+      ('clang', '1', 'is_clang=true'),
+      ('clang_use_chrome_plugins', '0', 'clang_use_chrome_plugins=false'),
+      ('disable_glibcxx_debug', '1', 'disable_iterator_debugging=true'),
+      ('target_arch', 'ia32', 'cpu_arch="x86"'),
+      ('target_arch', 'x64', 'cpu_arch="x64" force_win64=true'),
+      ('target_arch', 'arm', 'cpu_arch="arm"'),
+      ('target_arch', 'mipsel', 'cpu_arch="mipsel"'),
+      ('fastbuild', '0', 'symbol_level=2'),
+      ('fastbuild', '1', 'symbol_level=1'),
+      ('fastbuild', '2', 'symbol_level=0'),
+      ('OS', 'ios', 'os="ios"'),
+      ('OS', 'android', 'os="android"'),
+      ('chromeos', '1', 'os="chromeos"'),
+      ('use_aura', '1', 'use_aura=true'),
+      ('use_goma', '1', 'use_goma=true'),
+      ('asan', '1', 'is_asan=true'),
+      ('lsan', '1', 'is_lsan=true'),
+      ('msan', '1', 'is_msan=true'),
+      ('tsan', '1', 'is_tsan=true'),
+  ]
+  for i in remap_cases:
+    if i[0] in vars_dict and vars_dict[i[0]] == i[1]:
+      gn_args += ' ' + i[2]
+
+  # These string arguments get passed directly as GN strings.
+  for v in ['android_src', 'windows_sdk_path', 'arm_float_abi']:
+    if v in vars_dict:
+      gn_args += ' ' + v + '=' + EscapeStringForGN(vars_dict[v])
+
+  # gomadir is renamed goma_dir in the GN build.
+  if 'gomadir' in vars_dict:
+    gn_args += ' goma_dir=%s' % EscapeStringForGN(vars_dict['gomadir'])
+
+  # These arguments get passed directly as integers (avoiding the quoting and
+  # escaping of the string ones above).
+  for v in ['arm_version']:
+    if v in vars_dict:
+      gn_args += ' %s=%s' % (v, vars_dict[v])
+
+  # Some other flags come from GYP environment variables.
+  gyp_msvs_version = os.environ.get('GYP_MSVS_VERSION', '')
+  if gyp_msvs_version:
+    gn_args += ' visual_studio_version=' + EscapeStringForGN(gyp_msvs_version)
+  gyp_msvs_override_path = os.environ.get('GYP_MSVS_OVERRIDE_PATH', '')
+  if gyp_msvs_override_path:
+    gn_args += ' visual_studio_path=' + \
+        EscapeStringForGN(gyp_msvs_override_path)
+
+  # Set the GYP flag so BUILD files know they're being invoked in GYP mode.
+  gn_args += ' is_gyp=true'
+
+  gyp_outdir = GetOutputDirectory()
+  gn_args += ' gyp_output_dir=\"%s\"' % gyp_outdir
+
+  return gn_args.strip()
+
+
+def additional_include_files(supplemental_files, args=[]):
   """
-  Returns a list of additional (.gypi) files to include, without
-  duplicating ones that are already specified on the command line.
+  Returns a list of additional (.gypi) files to include, without duplicating
+  ones that are already specified on the command line. The list of supplemental
+  include files is passed in as an argument.
   """
   # Determine the include files specified on the command line.
   # This doesn't cover all the different option formats you can use,
@@ -77,14 +284,50 @@ def additional_include_files(args=[]):
   AddInclude(os.path.join(chrome_src, 'build', 'common.gypi'))
 
   # Optionally add supplemental .gypi files if present.
-  supplements = glob.glob(os.path.join(chrome_src, '*', 'supplement.gypi'))
-  for supplement in supplements:
+  for supplement in supplemental_files:
     AddInclude(supplement)
 
   return result
 
+
+def RunGN(supplemental_includes):
+  """Runs GN, returning True if it succeeded, printing an error and returning
+  false if not."""
+
+  # The binaries in platform-specific subdirectories in src/tools/gn/bin.
+  gnpath = SRC_DIR + '/tools/gn/bin/'
+  if sys.platform in ('cygwin', 'win32'):
+    gnpath += 'win/gn.exe'
+  elif sys.platform.startswith('linux'):
+    # On Linux we have 32-bit and 64-bit versions.
+    if subprocess.check_output(["getconf", "LONG_BIT"]).find("64") >= 0:
+      gnpath += 'linux/gn'
+    else:
+      gnpath += 'linux/gn32'
+  elif sys.platform == 'darwin':
+    gnpath += 'mac/gn'
+  else:
+    print 'Unknown platform for GN: ', sys.platform
+    return False
+
+  print 'Generating gyp files from GN...'
+
+  # Need to pass both the source root (the bots don't run this command from
+  # within the source tree) as well as set the is_gyp value so the BUILD files
+  # to know they're being run under GYP.
+  args = [gnpath, 'gyp', '-q',
+          '--root=' + chrome_src,
+          '--args=' + GetArgsStringForGN(supplemental_includes),
+          '--output=//' + GetOutputDirectory() + '/gn_build/']
+  return subprocess.call(args) == 0
+
+
 if __name__ == '__main__':
   args = sys.argv[1:]
+
+  if int(os.environ.get('GYP_CHROMIUM_NO_ACTION', 0)):
+    print 'Skipping gyp_chromium due to GYP_CHROMIUM_NO_ACTION env var.'
+    sys.exit(0)
 
   # Support external media types capability such as MP4/MP3.
   args = list(set(args))
@@ -122,7 +365,9 @@ if __name__ == '__main__':
   # TODO(bradnelson): take this out once this issue is fixed:
   #    http://code.google.com/p/gyp/issues/detail?id=177
   if sys.platform == 'cygwin':
-    python_dir = os.path.join(chrome_src, 'third_party', 'python_26')
+    depot_tools_path = find_depot_tools.add_depot_tools_to_path()
+    python_dir = sorted(glob.glob(os.path.join(depot_tools_path,
+                                               'python2*_bin')))[-1]
     env = os.environ.copy()
     env['PATH'] = python_dir + os.pathsep + env.get('PATH', '')
     p = subprocess.Popen(
@@ -152,23 +397,76 @@ if __name__ == '__main__':
     else:
       args.append(os.path.join(xwalk_dir, 'xwalk.gyp'))
 
-  args.extend(['-I' + i for i in additional_include_files(args)])
-
   # There shouldn't be a circular dependency relationship between .gyp files,
-  # but in Chromium's .gyp files, circular relationships currently exist.
+  # but in Chromium's .gyp files, on non-Mac platforms, circular relationships
+  # currently exist.  The check for circular dependencies is currently
+  # bypassed on other platforms, but is left enabled on the Mac, where a
+  # violation of the rule causes Xcode to misbehave badly.
   # TODO(mark): Find and kill remaining circular dependencies, and remove this
   # option.  http://crbug.com/35878.
   # TODO(tc): Fix circular dependencies in ChromiumOS then add linux2 to the
   # list.
-  # TODO(tmpsantos): Make runtime a proper module and enable the circular check
-  # back for Mac.
-  args.append('--no-circular-check')
+  if sys.platform not in ('darwin',):
+    args.append('--no-circular-check')
+
+  # Default to ninja on linux and windows, but only if no generator has
+  # explicitly been set.
+  # Also default to ninja on mac, but only when not building chrome/ios.
+  # . -f / --format has precedence over the env var, no need to check for it
+  # . set the env var only if it hasn't been set yet
+  # . chromium.gyp_env has been applied to os.environ at this point already
+  if sys.platform.startswith('linux') and not os.environ.get('GYP_GENERATORS'):
+    os.environ['GYP_GENERATORS'] = 'ninja'
+  if sys.platform.startswith('win') and not os.environ.get('GYP_GENERATORS'):
+    os.environ['GYP_GENERATORS'] = 'ninja'
+  elif sys.platform == 'darwin' and not os.environ.get('GYP_GENERATORS') and \
+      not 'OS=ios' in os.environ.get('GYP_DEFINES', []):
+    os.environ['GYP_GENERATORS'] = 'ninja'
+
+  # If using ninja on windows, and the automatic toolchain has been installed
+  # by depot_tools, then use it.
+  if (sys.platform in ('win32', 'cygwin') and
+      os.environ.get('GYP_GENERATORS') == 'ninja'):
+    depot_tools_path = find_depot_tools.add_depot_tools_to_path()
+    toolchain = os.path.normpath(os.path.join(
+        depot_tools_path, 'win_toolchain', 'vs2013_files'))
+    if os.path.isdir(toolchain):
+      os.environ['GYP_MSVS_OVERRIDE_PATH'] = toolchain
+      os.environ['GYP_MSVS_VERSION'] = '2013'
+      # We need to make sure windows_sdk_path is set to the automated
+      # toolchain values in GYP_DEFINES, but don't want to override any other
+      # values there.
+      gyp_defines_dict = gyp.NameValueListToDict(gyp.ShlexEnv('GYP_DEFINES'))
+      win8sdk = os.path.join(toolchain, 'win8sdk')
+      gyp_defines_dict['windows_sdk_path'] = win8sdk
+      os.environ['WINDOWSSDKDIR'] = win8sdk
+      os.environ['GYP_DEFINES'] = ' '.join('%s=%s' % (k, pipes.quote(str(v)))
+          for k, v in gyp_defines_dict.iteritems())
+      # Include the VS runtime in the PATH in case it's not machine-installed.
+      runtime_path = ';'.join(os.path.normpath(os.path.join(toolchain, s))
+                              for s in ('sys64', 'sys32'))
+      os.environ['PATH'] = runtime_path + ';' + os.environ['PATH']
+      print('Using automatic toolchain in %s.' % toolchain)
 
   # If CHROMIUM_GYP_SYNTAX_CHECK is set to 1, it will invoke gyp with --check
   # to enfore syntax checking.
   syntax_check = os.environ.get('CHROMIUM_GYP_SYNTAX_CHECK')
   if syntax_check and int(syntax_check):
     args.append('--check')
+
+  supplemental_includes = GetSupplementalFiles()
+
+  # FIXME(rakuco,joone): This is a workaround to allow the Tizen build to
+  # proceed, as we use make there and GN isn't involved in this case (otherwise
+  # we run into problems like GN always looking for GTK+ dependencies).
+  if os.environ.get('GYP_GENERATORS') != 'make':
+    if not RunGN(supplemental_includes):
+      sys.exit(1)
+
+  args.extend(
+      ['-I' + i for i in additional_include_files(supplemental_includes, args)])
+
+  args.extend(['-D', 'gyp_output_dir=' + GetOutputDirectory()])
 
   print 'Updating projects from gyp files...'
   sys.stdout.flush()


### PR DESCRIPTION
gyp_chromium underwent a large amount of changes since M32 due to the work on
GN upstream. This broke the Android build (gyp_xwalk did not even detect it
was supposed to set up an Android build in the first place).

I have basically copied gyp_chromium on top of gyp_xwalk and applied the 
relevant changes after comparing gyp_xwalk with M32's gyp_chromium, with the 
addition of a change that does not run GN when using the make generator (as a
temporary measure to keep the Tizen build working while we find a better 
solution).
