### PR TITLE
[Android] Support package file name including space character.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -27,7 +27,7 @@ def ReplaceInvalidChars(value, mode='default'):
   if mode == 'default':
     invalid_chars = '\/:*?"<>|- '
   elif mode == 'apkname':
-    invalid_chars = '\/:.*?"<>|- '
+    invalid_chars = '\/:.*?"<>|-'
   for c in invalid_chars:
     if mode == 'apkname' and c in value:
       print("Illegal character: '%s' is replaced with '_'" % c)
@@ -339,7 +339,7 @@ def main():
   info = ('The package name. Such as: '
           '--package=com.example.YourPackage')
   parser.add_option('--package', help=info)
-  info = ('The apk name. Such as: --name=YourApplicationName')
+  info = ('The apk name. Such as: --name="Your Application Name"')
   parser.add_option('--name', help=info)
   info = ('The version of the app. Such as: --app-version=TheVersionNumber')
   parser.add_option('--app-version', help=info)

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -599,7 +599,7 @@ def main(argv):
   group = optparse.OptionGroup(parser, 'Mandatory arguments',
       'They are used for describing the APK information through '
       'command line options.')
-  info = ('The apk name. For example, --name=YourApplicationName')
+  info = ('The apk name. For example, --name="Your Application Name"')
   group.add_option('--name', help=info)
   info = ('The package name. For example, '
           '--package=com.example.YourPackage')
@@ -720,7 +720,7 @@ def main(argv):
 
   options.name = ReplaceInvalidChars(options.name, 'apkname')
   options.package = ReplaceInvalidChars(options.package)
-  sanitized_name = ReplaceInvalidChars(options.name)
+  sanitized_name = ReplaceInvalidChars(options.name, 'apkname')
 
   try:
     compress = compress_js_and_css.CompressJsAndCss(options.app_root)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -156,16 +156,17 @@ class TestMakeApk(unittest.TestCase):
     out = RunCommand(cmd)
     self.assertTrue(out.find('The APK name is required!') != -1)
     Clean('Example', '1.0.0')
-    cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+    cmd = ['python', 'make_apk.py', '--name="Test Example"',
+           '--app-version=1.0.0',
            '--package=org.xwalk.example', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('The APK name is required!') == -1)
-    Clean('Example', '1.0.0')
+    Clean('Test Example', '1.0.0')
     # The following invalid chars verification is too heavy for embedded mode,
     # and the result of verification should be the same between shared mode
     # and embedded mode. So only do the verification in the shared mode.
     if self._mode.find('shared') != -1:
-      invalid_chars = '\/:.*?"<>|- '
+      invalid_chars = '\/:.*?"<>|-'
       for c in invalid_chars:
         invalid_name = '--name=Example' + c
         cmd = ['python', 'make_apk.py', invalid_name,


### PR DESCRIPTION
If package file name includes space character, this character
will be replaced with '_', according to the new user requirement,
blank character should be supported, this fix resolves this issue
by removing the space from the invalid characters.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1006
