### PR TITLE
Roll the DEPS to involve new patches in Chromium

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '34.0.1809.2'
-chromium_crosswalk_point = 'f25efe5364e190490fdb90deebe53baf46e0688d'
+chromium_crosswalk_point = '224b7311bdfeccfc9df5bf19ab4e878853efd8ee'
 blink_crosswalk_point = '26982f43d2966dcb4e070dc63364b568f16829a3'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
Patches of PR #115 in Chromium were missed during rebase.
It causes the crash in xwalk.
