### PR TITLE
[Android] Customize the resource loading of MediaPlayer

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '32.0.1700.14'
-chromium_crosswalk_point = '438a2ac36c659f06e175326586b6a1690c61a496'
+chromium_crosswalk_point = '09f40d1962ea6b4b036fa31e950cb9c335d4bbbe'
 blink_crosswalk_point = '2cb175435ece6896eabf6fe2ff9f1bf6ea8969e3'
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,

--- a/runtime/android/java/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContent.java
@@ -28,6 +28,7 @@ import org.chromium.content.browser.ContentViewRenderView;
 import org.chromium.content.browser.ContentViewStatics;
 import org.chromium.content.browser.LoadUrlParams;
 import org.chromium.content.browser.NavigationHistory;
+import org.chromium.media.MediaPlayerBridge;
 import org.chromium.ui.WindowAndroid;
 
 @JNINamespace("xwalk")
@@ -112,6 +113,9 @@ public class XWalkContent extends FrameLayout {
 
         SharedPreferences sharedPreferences = new InMemorySharedPreferences();
         mGeolocationPermissions = new XWalkGeolocationPermissions(sharedPreferences);
+
+        MediaPlayerBridge.setResourceLoadingFilter(
+                new XWalkMediaPlayerResourceLoadingFilter());
     }
 
     void doLoadUrl(String url) {

--- a/runtime/android/java/src/org/xwalk/core/XWalkMediaPlayerResourceLoadingFilter.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkMediaPlayerResourceLoadingFilter.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.content.Context;
+import android.content.res.AssetFileDescriptor;
+import android.media.MediaPlayer;
+import android.net.Uri;
+
+import org.chromium.media.MediaPlayerBridge;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * This class inherits from MediaPlayerBridge.ResourceLoadingFilter to
+ * customize the resource loading process in xwalk.
+ */
+
+public class XWalkMediaPlayerResourceLoadingFilter extends
+        MediaPlayerBridge.ResourceLoadingFilter {
+    @Override
+    public boolean shouldOverrideResourceLoading(MediaPlayer mediaPlayer,
+            Context context, Uri uri) {
+        if (uri.getScheme().equals(AndroidProtocolHandler.APP_SCHEME)) {
+            uri = AndroidProtocolHandler.appUriToFileUri(uri);
+        }
+
+        String scheme = uri.getScheme();
+
+        if (!scheme.equals(AndroidProtocolHandler.FILE_SCHEME)) return false;
+
+        try {
+            AssetFileDescriptor afd =
+                    context.getAssets().openFd(AndroidProtocolHandler.getAssetPath(uri));
+            mediaPlayer.setDataSource(
+                    afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Add XWalkMediaPlayerResourceLoadingFilter which inherits
MediaPlayerBridge.ResourceLoadingFilter. Then we can customize
the MediaPlayer in xwalk. Now we have two customized items:
    Support app scheme in the resource loading of MediaPlayer.
    Support file://android_asset/ url in MediaPlayer.

BUG=https://crosswalk-project.org/jira/browse/XWALK-880

It's cherry-picked from 15b5b9479.
