### PR TITLE
[Tizen] Make better split between Tizen and Tizen mobile codebase

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -199,7 +199,7 @@ void Application::OnRuntimeRemoved(Runtime* runtime) {
   runtimes_.erase(runtime);
 
   if (runtimes_.empty()) {
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
     runtime->CloseRootWindow();
 #endif
     base::MessageLoop::current()->PostTask(FROM_HERE,

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -29,7 +29,7 @@
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 #include "xwalk/application/browser/installer/tizen/package_installer.h"
 #include "xwalk/application/browser/installer/tizen/service_package_installer.h"
 #endif
@@ -149,7 +149,7 @@ void SaveSystemEventsInfo(
   }
 }
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 bool InstallPackageOnTizen(xwalk::application::ApplicationService* service,
                            xwalk::application::ApplicationStorage* storage,
                            xwalk::application::ApplicationData* application,
@@ -185,7 +185,7 @@ bool UninstallPackageOnTizen(xwalk::application::ApplicationService* service,
   }
   return true;
 }
-#endif  // OS_TIZEN_MOBILE
+#endif  // OS_TIZEN
 
 bool CopyDirectoryContents(const base::FilePath& from,
     const base::FilePath& to) {
@@ -293,7 +293,7 @@ bool ApplicationService::Install(const base::FilePath& path, std::string* id) {
     return false;
   }
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   if (!InstallPackageOnTizen(this, application_storage_,
                              application_data.get(),
                              runtime_context_->GetPath())) {
@@ -399,7 +399,7 @@ bool ApplicationService::Update(const std::string& id,
     return false;
   }
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   if (!UninstallPackageOnTizen(this, application_storage_,
                                old_application.get(),
                                runtime_context_->GetPath())) {
@@ -413,14 +413,14 @@ bool ApplicationService::Update(const std::string& id,
     LOG(ERROR) << "An Error occurred when updating the application.";
     base::DeleteFile(app_dir, true);
     base::Move(tmp_dir, app_dir);
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
     InstallPackageOnTizen(this, application_storage_,
                           old_application.get(),
                           runtime_context_->GetPath());
 #endif
     return false;
   }
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   if (!InstallPackageOnTizen(this, application_storage_,
                              new_application.get(),
                              runtime_context_->GetPath()))
@@ -447,7 +447,7 @@ bool ApplicationService::Uninstall(const std::string& id) {
     return false;
   }
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   if (!UninstallPackageOnTizen(this, application_storage_, application.get(),
                                runtime_context_->GetPath()))
     result = false;

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -135,7 +135,7 @@ bool ApplicationSystem::LaunchFromCommandLine(
   // On Tizen, applications are launched by a symbolic link named like the
   // application ID.
   // FIXME(cmarcelo): Remove when we move to a separate launcher on Tizen.
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   std::string command_name = cmd_line.GetProgram().BaseName().MaybeAsASCII();
   if (ApplicationData::IsIDValid(command_name)) {
     run_default_message_loop = LaunchWithCommandLineParam(command_name);

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -33,7 +33,7 @@
 #include "url/url_util.h"
 #include "ui/base/l10n/l10n_util.h"
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 #include "xwalk/tizen/appcore_context.h"
 #endif
 
@@ -247,7 +247,7 @@ bool ApplicationData::Init(base::string16* error) {
     return false;
 
   finished_parsing_manifest_ = true;
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   appcore_context_ = tizen::AppcoreContext::Create();
 #endif
   return true;

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -32,7 +32,7 @@ class ListValue;
 class Version;
 }
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 namespace tizen {
 class AppcoreContext;
 }
@@ -223,7 +223,7 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   // Application's persistent permissions.
   StoredPermissionMap permission_map_;
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   scoped_ptr<tizen::AppcoreContext> appcore_context_;
 #endif
 

--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -58,7 +58,7 @@
             'gio',
           ],
         }],
-        ['tizen_mobile==1', {
+        ['tizen==1 or tizen_mobile==1', {
           'dependencies': [
             'gio',
             '../../../build/system.gyp:tizen_appcore_common'

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
 
   mainloop = g_main_loop_new(NULL, FALSE);
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   char name[128];
   snprintf(name, sizeof(name), "xwalk-%s", appid);
 

--- a/application/tools/linux/xwalk_launcher_tizen.cc
+++ b/application/tools/linux/xwalk_launcher_tizen.cc
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 #include <appcore/appcore-common.h>
 #endif
 #include "xwalk/application/tools/linux/xwalk_launcher_tizen.h"

--- a/application/tools/linux/xwalk_tizen_user.cc
+++ b/application/tools/linux/xwalk_tizen_user.cc
@@ -12,7 +12,7 @@
 #include <pwd.h>
 
 int xwalk_tizen_set_home_for_user_app(void) {
-#if !defined(OS_TIZEN_MOBILE)
+#if !defined(OS_TIZEN)
   return 0;
 #endif
 

--- a/application/tools/tizen/xwalk_pkg_helper.cc
+++ b/application/tools/tizen/xwalk_pkg_helper.cc
@@ -9,7 +9,7 @@
 // that required 'root' access are done by a small code base.
 
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 #include <pkgmgr/pkgmgr_parser.h>
 #else
 // So we can compile this on Linux Desktop

--- a/application/tools/tizen/xwalk_tizen_helper.gyp
+++ b/application/tools/tizen/xwalk_tizen_helper.gyp
@@ -5,7 +5,7 @@
       'type': 'executable',
       'product_name': 'xwalk-pkg-helper',
       'conditions': [
-        ['tizen_mobile==1', {
+        ['tizen==1 or tizen_mobile==1', {
           'dependencies': [
             '../../../build/system.gyp:tizen',
             '../../../../base/base.gyp:base',

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -102,7 +102,7 @@
             'browser/linux/running_applications_manager.h',
           ],
         }],
-        [ 'tizen_mobile == 1', {
+        [ 'tizen == 1 or tizen_mobile == 1', {
           'dependencies': [
             'build/system.gyp:tizen',
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -4,8 +4,30 @@
 
 {
   'conditions': [
-    [ 'tizen_mobile == 1', {
+    [ 'tizen == 1 or tizen_mobile == 1', {
       'targets': [
+        {
+          'target_name': 'tizen_geolocation',
+          'type': 'none',
+          'variables': {
+            'packages': [
+              'capi-location-manager',
+            ],
+          },
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags <@(packages))',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(pkg-config --libs-only-L --libs-only-other <@(packages))',
+            ],
+            'libraries': [
+              '<!@(pkg-config --libs-only-l <@(packages))',
+            ],
+          },
+        },
         {
           'target_name': 'tizen',
           'type': 'none',
@@ -61,28 +83,6 @@
           'variables': {
             'packages': [
               'vconf',
-            ],
-          },
-          'direct_dependent_settings': {
-            'cflags': [
-              '<!@(pkg-config --cflags <@(packages))',
-            ],
-          },
-          'link_settings': {
-            'ldflags': [
-              '<!@(pkg-config --libs-only-L --libs-only-other <@(packages))',
-            ],
-            'libraries': [
-              '<!@(pkg-config --libs-only-l <@(packages))',
-            ],
-          },
-        },
-        {
-          'target_name': 'tizen_geolocation',
-          'type': 'none',
-          'variables': {
-            'packages': [
-              'capi-location-manager',
             ],
           },
           'direct_dependent_settings': {

--- a/dbus/xwalk_dbus.gyp
+++ b/dbus/xwalk_dbus.gyp
@@ -18,11 +18,11 @@
         'xwalk_service_name.h',
       ],
       'conditions': [
-        [ 'tizen_mobile == 1', {
+        [ 'tizen == 1 or tizen_mobile == 1', {
           'sources': [
             'dbus_manager_tizen.cc',
           ],
-        }, { # tizen_mobile == 0
+        }, { # tizen == 0
           'sources': [
             'dbus_manager.cc',
           ],

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -185,6 +185,7 @@ export GYP_GENERATORS='make'
 ${GYP_EXTRA_FLAGS} \
 -Dchromeos=0 \
 -Ddisable_nacl=1 \
+-Dtizen=1 \
 -Dpython_ver=2.7 \
 -Duse_aura=1 \
 -Duse_cups=0 \

--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -19,7 +19,7 @@
 #include "xwalk/runtime/common/xwalk_paths.h"
 #include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 #include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
 #endif
 
@@ -90,7 +90,7 @@ content::ContentBrowserClient* XWalkMainDelegate::CreateContentBrowserClient() {
 
 content::ContentRendererClient*
     XWalkMainDelegate::CreateContentRendererClient() {
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   renderer_client_.reset(new XWalkContentRendererClientTizen());
 #else
   renderer_client_.reset(new XWalkContentRendererClient());

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -60,7 +60,7 @@ Runtime* Runtime::Create(
   WebContents* web_contents = WebContents::Create(params);
 
   Runtime* runtime = new Runtime(web_contents, observer);
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   runtime->InitRootWindow();
 #endif
 
@@ -80,7 +80,7 @@ Runtime::Runtime(content::WebContents* web_contents, Observer* observer)
        xwalk::NOTIFICATION_RUNTIME_OPENED,
        content::Source<Runtime>(this),
        content::NotificationService::NoDetails());
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   root_window_ = NULL;
 #endif
   if (observer_)
@@ -129,7 +129,7 @@ void Runtime::AttachWindow(const NativeAppWindow::CreateParams& params) {
   if (!app_icon_.IsEmpty())
     window_->UpdateIcon(app_icon_);
   window_->Show();
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   if (root_window_)
     root_window_->Show();
 #endif
@@ -225,7 +225,7 @@ void Runtime::WebContentsCreated(
     const GURL& target_url,
     content::WebContents* new_contents) {
   Runtime* new_runtime = new Runtime(new_contents, observer_);
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   new_runtime->SetRootWindow(root_window_);
 #endif
   new_runtime->AttachDefaultWindow();
@@ -349,7 +349,7 @@ void Runtime::ApplyWindowDefaultParams(NativeAppWindow::CreateParams* params) {
     params->web_contents = web_contents_.get();
   if (params->bounds.IsEmpty())
     params->bounds = gfx::Rect(0, 0, kDefaultWidth, kDefaultHeight);
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   if (root_window_)
     params->parent = root_window_->GetNativeWindow();
 #endif
@@ -367,7 +367,7 @@ void Runtime::ApplyFullScreenParam(NativeAppWindow::CreateParams* params) {
   }
 }
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 void Runtime::CloseRootWindow() {
   if (root_window_) {
     root_window_->Close();

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -74,7 +74,7 @@ class Runtime : public content::WebContentsDelegate,
   RuntimeContext* runtime_context() const { return runtime_context_; }
   gfx::Image app_icon() const { return app_icon_; }
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   void CloseRootWindow();
 #endif
 
@@ -152,7 +152,7 @@ class Runtime : public content::WebContentsDelegate,
   void ApplyWindowDefaultParams(NativeAppWindow::CreateParams* params);
   void ApplyFullScreenParam(NativeAppWindow::CreateParams* params);
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   void ApplyRootWindowParams(NativeAppWindow::CreateParams* params);
   void SetRootWindow(NativeAppWindow* window);
   void InitRootWindow();
@@ -169,7 +169,7 @@ class Runtime : public content::WebContentsDelegate,
 
   NativeAppWindow* window_;
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   NativeAppWindow* root_window_;
 #endif
 

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -147,7 +147,7 @@ content::ResourceContext* RuntimeContext::GetResourceContext()  {
 
 content::GeolocationPermissionContext*
     RuntimeContext::GetGeolocationPermissionContext()  {
-#if defined(OS_ANDROID) || defined(OS_TIZEN_MOBILE)
+#if defined(OS_ANDROID) || defined(OS_TIZEN)
   if (!geolocation_permission_context_) {
     geolocation_permission_context_ =
         RuntimeGeolocationPermissionContext::Create(this);

--- a/runtime/browser/runtime_geolocation_permission_context.cc
+++ b/runtime/browser/runtime_geolocation_permission_context.cc
@@ -36,7 +36,7 @@ RuntimeGeolocationPermissionContext::RequestGeolocationPermissionOnUIThread(
   }
 
   xwalk_content->ShowGeolocationPrompt(requesting_frame, callback);
-#elif defined(OS_TIZEN_MOBILE)
+#elif defined(OS_TIZEN)
   // TODO(shalamov): Implement geolocation permission UI for Tizen.
   callback.Run(true);
 #endif

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -52,7 +52,7 @@ void NativeAppWindowViews::Initialize() {
   params.top_level = true;
   params.show_state = create_params_.state;
   params.parent = create_params_.parent;
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   params.type = views::Widget::InitParams::TYPE_WINDOW_FRAMELESS;
   // On Tizen apps are sized to the work area.
   gfx::Rect bounds =
@@ -66,7 +66,7 @@ void NativeAppWindowViews::Initialize() {
 
   window_->Init(params);
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   // Set the bounds manually to avoid inset.
   window_->SetBounds(bounds);
 #elif !defined(USE_OZONE)

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -46,10 +46,6 @@ void XWalkBrowserMainPartsTizen::PreMainMessageLoopStart() {
     gl_name = gfx::kGLImplementationEGLName;
   command_line->AppendSwitchASCII(switches::kUseGL, gl_name);
 
-  // Workaround to provide viewport meta tag proper behavior on Tizen.
-  // FIXME: Must be removed when Chromium r235967 is in place.
-  command_line->AppendSwitchASCII(switches::kForceDeviceScaleFactor, "2.0");
-
   XWalkBrowserMainParts::PreMainMessageLoopStart();
 }
 

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -37,7 +37,7 @@
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_mac.h"
 #endif
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 #endif
 
@@ -75,7 +75,7 @@ content::BrowserMainParts* XWalkContentBrowserClient::CreateBrowserMainParts(
   main_parts_ = new XWalkBrowserMainPartsMac(parameters);
 #elif defined(OS_ANDROID)
   main_parts_ = new XWalkBrowserMainPartsAndroid(parameters);
-#elif defined(OS_TIZEN_MOBILE)
+#elif defined(OS_TIZEN)
   main_parts_ = new XWalkBrowserMainPartsTizen(parameters);
 #else
   main_parts_ = new XWalkBrowserMainParts(parameters);

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -24,7 +24,7 @@
 
 #if defined(OS_ANDROID)
 #include "xwalk/runtime/browser/xwalk_runner_android.h"
-#elif defined(OS_TIZEN_MOBILE)
+#elif defined(OS_TIZEN)
 #include "xwalk/runtime/browser/xwalk_runner_tizen.h"
 #endif
 
@@ -169,7 +169,7 @@ scoped_ptr<XWalkRunner> XWalkRunner::Create() {
   XWalkRunner* runner = NULL;
 #if defined(OS_ANDROID)
   runner = new XWalkRunnerAndroid;
-#elif defined(OS_TIZEN_MOBILE)
+#elif defined(OS_TIZEN)
   runner = new XWalkRunnerTizen;
 #else
   runner = new XWalkRunner;

--- a/runtime/browser/xwalk_runtime_browsertest.cc
+++ b/runtime/browser/xwalk_runtime_browsertest.cc
@@ -232,7 +232,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, OpenLinkInNewRuntime) {
   EXPECT_EQ(len + 1, runtimes().size());
 }
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LoadTizenWebUiFwFile) {
   GURL url = xwalk_test_utils::GetTestURL(
       base::FilePath(), base::FilePath().AppendASCII("tizenwebuifw.html"));

--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -27,7 +27,7 @@ std::string XWalkContentClient::GetProduct() const {
 
 std::string XWalkContentClient::GetUserAgent() const {
   std::string product = "Chrome/" CHROME_VERSION;
-#if (defined(OS_TIZEN_MOBILE) || defined(OS_ANDROID))
+#if (defined(OS_TIZEN) || defined(OS_ANDROID))
   product += " Mobile Crosswalk/" XWALK_VERSION;
 #else
   product += " Crosswalk/" XWALK_VERSION;

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -42,7 +42,7 @@ bool GetXWalkDataPath(base::FilePath* path) {
   CHECK(PathService::Get(base::DIR_LOCAL_APP_DATA, &cur));
   cur = cur.Append(xwalk_suffix);
 
-#elif defined(OS_TIZEN_MOBILE)
+#elif defined(OS_TIZEN)
   if (XWalkRunner::GetInstance()->is_running_as_service())
     cur = GetConfigPath().Append(xwalk_suffix);
   else

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -31,7 +31,7 @@
 #include "xwalk/test/base/xwalk_test_suite.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 #include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
 #endif
 
@@ -42,7 +42,7 @@ using xwalk::XWalkRunner;
 namespace {
 
 // Used when running in single-process mode.
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 base::LazyInstance<XWalkContentRendererClientTizen>::Leaky
         g_xwalk_content_renderer_client = LAZY_INSTANCE_INITIALIZER;
 #else

--- a/tizen/xwalk_tizen.gypi
+++ b/tizen/xwalk_tizen.gypi
@@ -5,7 +5,6 @@
     'type': 'static_library',
     'dependencies': [
       '../../skia/skia.gyp:skia',
-      '../../ui/ui.gyp:ui',
       '../build/system.gyp:tizen_appcore',
       '../build/system.gyp:tizen_vibration',
     ],
@@ -15,16 +14,6 @@
     'sources': [
       'appcore_context.cc',
       'appcore_context.h',
-      'mobile/ui/tizen_plug_message_writer.cc',
-      'mobile/ui/tizen_plug_message_writer.h',
-      'mobile/ui/tizen_system_indicator.cc',
-      'mobile/ui/tizen_system_indicator.h',
-      'mobile/ui/tizen_system_indicator_watcher.cc',
-      'mobile/ui/tizen_system_indicator_watcher.h',
-      'mobile/ui/tizen_system_indicator_widget.cc',
-      'mobile/ui/tizen_system_indicator_widget.h',
-      'mobile/ui/widget_container_view.cc',
-      'mobile/ui/widget_container_view.h',
       'mobile/sensor/sensor_provider.cc',
       'mobile/sensor/sensor_provider.h',
       'mobile/sensor/tizen_data_fetcher_shared_memory.cc',
@@ -33,6 +22,25 @@
       'mobile/sensor/tizen_platform_sensor.h',
       'browser/vibration/vibration_provider_tizen.cc',
       'browser/vibration/vibration_provider_tizen.h',
+    ],
+    'conditions': [
+      [ 'tizen_mobile == 1', {
+        'dependencies': [
+          '../../ui/ui.gyp:ui',
+        ],
+        'sources': [
+          'mobile/ui/tizen_plug_message_writer.cc',
+          'mobile/ui/tizen_plug_message_writer.h',
+          'mobile/ui/tizen_system_indicator.cc',
+          'mobile/ui/tizen_system_indicator.h',
+          'mobile/ui/tizen_system_indicator_watcher.cc',
+          'mobile/ui/tizen_system_indicator_watcher.h',
+          'mobile/ui/tizen_system_indicator_widget.cc',
+          'mobile/ui/tizen_system_indicator_widget.h',
+          'mobile/ui/widget_container_view.cc',
+          'mobile/ui/widget_container_view.h',
+        ],
+      }],
     ],
   }],
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -243,7 +243,7 @@
         },
       },
       'conditions': [
-        [ 'tizen_mobile == 1', {
+        [ 'tizen == 1 or tizen_mobile == 1', {
           'dependencies': [
             'build/system.gyp:tizen_geolocation',
             'sysapps/sysapps_resources.gyp:xwalk_sysapps_resources',


### PR DESCRIPTION
There are generic and mobile specific parts of the code that could
be split or shared. This patch enables -Dtizen=1 by default and moves
mobile specific code under tizen_mobile and OS_TIZEN_MOBILE flags.
