### PR TITLE
[Extension] Enabled registering permissions in XW_Initialize.

### DIFF
--- a/extensions/common/xwalk_extension.cc
+++ b/extensions/common/xwalk_extension.cc
@@ -25,6 +25,10 @@ XWalkExtension::XWalkExtension() : permissions_delegate_(NULL) {}
 
 XWalkExtension::~XWalkExtension() {}
 
+bool XWalkExtension::Initialize() {
+  return false;
+}
+
 const base::ListValue& XWalkExtension::entry_points() const {
   return entry_points_;
 }

--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -46,6 +46,8 @@ class XWalkExtension {
 
   virtual ~XWalkExtension();
 
+  virtual bool Initialize();
+
   virtual XWalkExtensionInstance* CreateInstance() = 0;
 
   std::string name() const { return name_; }

--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -366,12 +366,15 @@ std::vector<std::string> RegisterExternalExtensionsInDirectory(
         !extension_path.empty(); extension_path = libraries.Next()) {
     scoped_ptr<XWalkExternalExtension> extension(
         new XWalkExternalExtension(extension_path));
-    if (extension->is_valid()) {
+    extension->set_runtime_variables(runtime_variables);
+    if (server->permissions_delegate())
+      extension->set_permissions_delegate(server->permissions_delegate());
+    if (extension->Initialize()) {
       registered_extensions.push_back(extension->name());
-      extension->set_runtime_variables(runtime_variables);
-      if (server->permissions_delegate())
-        extension->set_permissions_delegate(server->permissions_delegate());
       server->RegisterExtension(extension.PassAs<XWalkExtension>());
+    } else {
+      LOG(WARNING) << "Failed to initialize extension: "
+                   << extension_path.AsUTF8Unsafe();
     }
   }
 

--- a/extensions/common/xwalk_external_extension.h
+++ b/extensions/common/xwalk_external_extension.h
@@ -6,6 +6,7 @@
 #define XWALK_EXTENSIONS_COMMON_XWALK_EXTERNAL_EXTENSION_H_
 
 #include <string>
+#include "base/files/file_path.h"
 #include "base/values.h"
 #include "base/scoped_native_library.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
@@ -35,7 +36,7 @@ class XWalkExternalExtension : public XWalkExtension {
 
   virtual ~XWalkExternalExtension();
 
-  bool is_valid();
+  bool Initialize();
 
   void set_runtime_variables(const base::ValueMap& runtime_variables) {
     runtime_variables_ = runtime_variables;
@@ -70,6 +71,7 @@ class XWalkExternalExtension : public XWalkExtension {
   // XW_Internal_BrowserInterface_1 (from XW_Browser.h) implementation.
   void RuntimeGetStringVariable(const char* key, char* value, size_t value_len);
 
+  base::FilePath library_path_;
   base::ScopedNativeLibrary library_;
   XW_Extension xw_extension_;
 


### PR DESCRIPTION
There was a dependency loop in registering the permissions during
extension initialization. The permission delegate used by registering
permissions was initialized after constructor, so that we cannot
use the delegate to register permissions in there.
The patch moved the delegate initialization into constructor and
removed the 'set_permissions_delegate' function.
