### PR TITLE
[Android] Fix the issue onPageFinished callback would be called twice

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkContentsClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkContentsClient.java
@@ -78,9 +78,12 @@ public abstract class XWalkContentsClient extends ContentViewClient {
 
         @Override
         public void didFinishLoad(long frameId, String validatedUrl, boolean isMainFrame) {
-            if (isMainFrame) {
-                onPageFinished(validatedUrl);
-            }
+            // Both didStopLoading and didFinishLoad will be called once a page is finished
+            // to load, but didStopLoading will also be called when user clicks "X" button
+            // on browser UI to stop loading page.
+            //
+            // So it is safe for Crosswalk to rely on didStopLoading to ensure onPageFinished
+            // can be called.
         }
     }
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
@@ -133,7 +133,7 @@ public class CookieManagerTest extends XWalkViewTestBase {
                 "document.cookie='" + name + "=" + value +
                         "; expires=' + expirationDate.toUTCString();" +
                 "})())";
-        loadUrlSync(jsCommand);
+        loadJavaScriptUrl(jsCommand);
     }
 
     private void waitForCookie(final String url) throws InterruptedException {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkClientOnPageFinishedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkClientOnPageFinishedTest.java
@@ -1,0 +1,144 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.MediumTest;
+
+import static org.chromium.base.test.util.ScalableTimeout.ScaleTimeout;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.content.browser.test.util.TestCallbackHelperContainer;
+import org.chromium.net.test.util.TestWebServer;
+
+import org.xwalk.core.XWalkClient;
+import org.xwalk.core.XWalkContent;
+import org.xwalk.core.XWalkView;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for the XWalkClient.onPageFinished() method.
+ */
+public class XWalkClientOnPageFinishedTest extends XWalkViewTestBase {
+    private static final long WAIT_TIMEOUT_MS = ScaleTimeout(2000);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        class TestXWalkClient extends XWalkClient {
+            @Override
+            public void onPageFinished(XWalkView view, String url) {
+                mTestContentsClient.didFinishLoad(url);
+            }
+        }
+
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkClient(new TestXWalkClient());
+            }
+        });
+    }
+
+    @MediumTest
+    @Feature({"XWalkClientOnPageFinishedTest"})
+    public void testOnPageFinishedPassesCorrectUrl() throws Throwable {
+        TestCallbackHelperContainer.OnPageFinishedHelper onPageFinishedHelper =
+                mTestContentsClient.getOnPageFinishedHelper();
+
+        String html = "<html><body>Simple page.</body></html>";
+        int currentCallCount = onPageFinishedHelper.getCallCount();
+        loadDataAsync(html, "text/html", false);
+
+        onPageFinishedHelper.waitForCallback(currentCallCount);
+        assertEquals("data:text/html," + html, onPageFinishedHelper.getUrl());
+    }
+
+    @MediumTest
+    @Feature({"XWalkClientOnPageFinishedTest"})
+    public void testOnPageFinishedCalledAfterError() throws Throwable {
+        TestCallbackHelperContainer.OnReceivedErrorHelper onReceivedErrorHelper =
+                mTestContentsClient.getOnReceivedErrorHelper();
+        TestCallbackHelperContainer.OnPageFinishedHelper onPageFinishedHelper =
+                mTestContentsClient.getOnPageFinishedHelper();
+
+        assertEquals(0, onReceivedErrorHelper.getCallCount());
+
+        String url = "http://localhost:7/non_existent";
+        int onReceivedErrorCallCount = onReceivedErrorHelper.getCallCount();
+        int onPageFinishedCallCount = onPageFinishedHelper.getCallCount();
+        loadUrlAsync(url);
+
+        onReceivedErrorHelper.waitForCallback(onReceivedErrorCallCount,
+                                              1 /* numberOfCallsToWaitFor */,
+                                              WAIT_TIMEOUT_MS,
+                                              TimeUnit.MILLISECONDS);
+        onPageFinishedHelper.waitForCallback(onPageFinishedCallCount,
+                                             1 /* numberOfCallsToWaitFor */,
+                                             WAIT_TIMEOUT_MS,
+                                             TimeUnit.MILLISECONDS);
+        assertEquals(1, onReceivedErrorHelper.getCallCount());
+    }
+
+    @MediumTest
+    @Feature({"XWalkClientOnPageFinishedTest"})
+    public void testOnPageFinishedNotCalledForValidSubresources() throws Throwable {
+        TestCallbackHelperContainer.OnPageFinishedHelper onPageFinishedHelper =
+                mTestContentsClient.getOnPageFinishedHelper();
+
+        TestWebServer webServer = null;
+        try {
+            webServer = new TestWebServer(false);
+
+            final String testHtml = "<html><head>Header</head><body>Body</body></html>";
+            final String testPath = "/test.html";
+            final String syncPath = "/sync.html";
+
+            final String testUrl = webServer.setResponse(testPath, testHtml, null);
+            final String syncUrl = webServer.setResponse(syncPath, testHtml, null);
+
+            assertEquals(0, onPageFinishedHelper.getCallCount());
+            final int pageWithSubresourcesCallCount = onPageFinishedHelper.getCallCount();
+            loadDataAsync("<html><iframe src=\"" + testUrl + "\" /></html>",
+                          "text/html",
+                          false);
+
+            onPageFinishedHelper.waitForCallback(pageWithSubresourcesCallCount);
+
+            // Rather than wait a fixed time to see that an onPageFinished callback isn't issued
+            // we load another valid page. Since callbacks arrive sequentially if the next callback
+            // we get is for the synchronizationUrl we know that the previous load did not schedule
+            // a callback for the iframe.
+            final int synchronizationPageCallCount = onPageFinishedHelper.getCallCount();
+            loadUrlAsync(syncUrl);
+
+            onPageFinishedHelper.waitForCallback(synchronizationPageCallCount);
+            assertEquals(syncUrl, onPageFinishedHelper.getUrl());
+            assertEquals(2, onPageFinishedHelper.getCallCount());
+        } finally {
+            if (webServer != null) webServer.shutdown();
+        }
+    }
+
+    @MediumTest
+    @Feature({"XWalkClientOnPageFinishedTest"})
+    public void testOnPageFinishedNotCalledForJavaScriptUrl() throws Throwable {
+        TestCallbackHelperContainer.OnPageFinishedHelper onPageFinishedHelper =
+                mTestContentsClient.getOnPageFinishedHelper();
+
+        String html = "<html><body>Simple page.</body></html>";
+        int currentCallCount = onPageFinishedHelper.getCallCount();
+        assertEquals(0, currentCallCount);
+
+        loadDataAsync(html, "text/html", false);
+        loadJavaScriptUrl("javascript: try { console.log('foo'); } catch(e) {};");
+
+        onPageFinishedHelper.waitForCallback(currentCallCount);
+        assertEquals("data:text/html," + html, onPageFinishedHelper.getUrl());
+        // onPageFinished won't be called for javascript: url.
+        assertEquals(1, onPageFinishedHelper.getCallCount());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -8,6 +8,7 @@ package org.xwalk.core.xwview.test;
 import android.app.Activity;
 import android.content.Context;
 import android.test.ActivityInstrumentationTestCase2;
+import android.util.Log;
 
 import java.io.InputStream;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import org.xwalk.core.XWalkWebChromeClient;
 public class XWalkViewTestBase
        extends ActivityInstrumentationTestCase2<XWalkViewTestRunnerActivity> {
     protected final static int WAIT_TIMEOUT_SECONDS = 15;
+    private final static String TAG = "XWalkViewTestBase";
     private XWalkView mXWalkView;
     final TestXWalkViewContentsClient mTestContentsClient = new TestXWalkViewContentsClient();
 
@@ -98,6 +100,14 @@ public class XWalkViewTestBase
                 }
             }
         });
+    }
+
+    protected void loadJavaScriptUrl(final String url) throws Exception {
+        if (!url.startsWith("javascript:")) {
+            Log.w(TAG, "loadJavascriptUrl only accepts javascript: url");
+            return;
+        }
+        loadUrlAsync(url);
     }
 
     protected void loadUrlSync(final String url) throws Exception {


### PR DESCRIPTION
The right behavior is onPageFinished callback of XWalkClient should only
be called one time when it completes to load the main frame. This commit
removes a duplicated invokation of onPageFinished, and also ports some
tests for onPageFinished callback from android_webview/.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1017
TEST=org.xwalk.core.xwview.test.XWalkClientOnPageFinishedTest
