### PR TITLE
[Extension] Added application id for permission checking calls.

### DIFF
--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -91,7 +91,9 @@ class ExtensionSandboxedProcessLauncherDelegate
 #endif
 
 bool XWalkExtensionProcessHost::Delegate::OnRegisterPermissions(
-    const std::string& extension_name, const std::string& perm_table) {
+    int render_process_id,
+    const std::string& extension_name,
+    const std::string& perm_table) {
   return false;
 }
 
@@ -246,7 +248,8 @@ void XWalkExtensionProcessHost::OnCheckAPIAccessControl(
     const std::string& extension_name,
     const std::string& api_name, IPC::Message* reply_msg) {
   CHECK(delegate_);
-  delegate_->OnCheckAPIAccessControl(extension_name, api_name,
+  delegate_->OnCheckAPIAccessControl(render_process_host_->GetID(),
+                                     extension_name, api_name,
       base::Bind(&XWalkExtensionProcessHost::ReplyAccessControlToExtension,
                  base::Unretained(this),
                  reply_msg));
@@ -256,7 +259,8 @@ void XWalkExtensionProcessHost::OnRegisterPermissions(
     const std::string& extension_name,
     const std::string& perm_table, bool* result) {
   CHECK(delegate_);
-  *result = delegate_->OnRegisterPermissions(extension_name, perm_table);
+  *result = delegate_->OnRegisterPermissions(
+      render_process_host_->GetID(), extension_name, perm_table);
 }
 
 bool XWalkExtensionProcessHost::Send(IPC::Message* msg) {

--- a/extensions/browser/xwalk_extension_process_host.h
+++ b/extensions/browser/xwalk_extension_process_host.h
@@ -36,10 +36,13 @@ class XWalkExtensionProcessHost
    public:
     virtual void OnExtensionProcessDied(XWalkExtensionProcessHost* eph,
         int render_process_id) {}
-    virtual void OnCheckAPIAccessControl(const std::string& extension_name,
-        const std::string& api_name, const PermissionCallback& callback) {}
-    virtual bool OnRegisterPermissions(const std::string& extension_name,
-        const std::string& perm_table);
+    virtual void OnCheckAPIAccessControl(int render_process_id,
+                                         const std::string& extension_name,
+                                         const std::string& api_name,
+                                         const PermissionCallback& callback) {}
+    virtual bool OnRegisterPermissions(int render_process_id,
+                                       const std::string& extension_name,
+                                       const std::string& perm_table);
 
    protected:
     ~Delegate() {}

--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -201,7 +201,9 @@ class ExtensionServerMessageFilter : public IPC::ChannelProxy::MessageFilter,
 };
 
 bool XWalkExtensionService::Delegate::RegisterPermissions(
-    const std::string& extension_name, const std::string& perm_table) {
+    int render_process_id,
+    const std::string& extension_name,
+    const std::string& perm_table) {
   return false;
 }
 
@@ -451,18 +453,22 @@ void XWalkExtensionService::OnRenderProcessDied(
 }
 
 void XWalkExtensionService::OnCheckAPIAccessControl(
+    int render_process_id,
     const std::string& extension_name,
     const std::string& api_name,
     const PermissionCallback& callback) {
   CHECK(delegate_);
-  delegate_->CheckAPIAccessControl(extension_name, api_name, callback);
+  delegate_->CheckAPIAccessControl(render_process_id, extension_name,
+                                   api_name, callback);
 }
 
 bool XWalkExtensionService::OnRegisterPermissions(
+    int render_process_id,
     const std::string& extension_name,
     const std::string& perm_table) {
   CHECK(delegate_);
-  return delegate_->RegisterPermissions(extension_name, perm_table);
+  return delegate_->RegisterPermissions(render_process_id,
+                                        extension_name, perm_table);
 }
 
 }  // namespace extensions

--- a/extensions/browser/xwalk_extension_service.h
+++ b/extensions/browser/xwalk_extension_service.h
@@ -39,9 +39,14 @@ class XWalkExtensionService : public content::NotificationObserver,
  public:
   class Delegate {
    public:
-    virtual void CheckAPIAccessControl(const std::string& extension_name,
-        const std::string& api_name, const PermissionCallback& callback) {}
-    virtual bool RegisterPermissions(const std::string& extension_name,
+    virtual void CheckAPIAccessControl(
+        int render_process_id,
+        const std::string& extension_name,
+        const std::string& api_name,
+        const PermissionCallback& callback) {}
+    virtual bool RegisterPermissions(
+        int render_process_id,
+        const std::string& extension_name,
         const std::string& perm_table);
 
    protected:
@@ -92,10 +97,14 @@ class XWalkExtensionService : public content::NotificationObserver,
   virtual void OnExtensionProcessDied(XWalkExtensionProcessHost* eph,
       int render_process_id) OVERRIDE;
 
-  virtual void OnCheckAPIAccessControl(const std::string& extension_name,
-      const std::string& api_name, const PermissionCallback& callback) OVERRIDE;
-  virtual bool OnRegisterPermissions(const std::string& extension_name,
-      const std::string& perm_table) OVERRIDE;
+  virtual void OnCheckAPIAccessControl(
+      int render_process_id,
+      const std::string& extension_name,
+      const std::string& api_name,
+      const PermissionCallback& callback) OVERRIDE;
+  virtual bool OnRegisterPermissions(int render_process_id,
+                                     const std::string& extension_name,
+                                     const std::string& perm_table) OVERRIDE;
 
   // NotificationObserver implementation.
   virtual void Observe(int type, const content::NotificationSource& source,

--- a/runtime/browser/xwalk_app_extension_bridge.cc
+++ b/runtime/browser/xwalk_app_extension_bridge.cc
@@ -19,40 +19,39 @@ XWalkAppExtensionBridge::XWalkAppExtensionBridge()
 XWalkAppExtensionBridge::~XWalkAppExtensionBridge() {}
 
 void XWalkAppExtensionBridge::CheckAPIAccessControl(
+    int render_process_id,
     const std::string& extension_name,
     const std::string& api_name,
     const extensions::PermissionCallback& callback) {
   CHECK(app_system_);
-  xwalk::application::ApplicationService* service =
+  application::ApplicationService *service =
       app_system_->application_service();
-  // TODO(Bai): The extension system should be aware where the request is
-  // comming from, i.e. the request origin application ID. So, apart from
-  // the rp-ep mapping, we need an additional mapping for AppID-rp.
-  const ScopedVector<xwalk::application::Application> &apps =
-      service->active_applications();
-  if (apps.empty()) {
+
+  application::Application *app =
+      service->GetApplicationByRenderHostID(render_process_id);
+  if (!app) {
     callback.Run(extensions::UNDEFINED_RUNTIME_PERM);
     return;
   }
-  std::string app_id = (apps.front())->id();
-  service->CheckAPIAccessControl(app_id, extension_name, api_name,
+
+  service->CheckAPIAccessControl(app->id(), extension_name, api_name,
       *(reinterpret_cast<const xwalk::application::PermissionCallback*>
       (&callback)));
 }
 
 bool XWalkAppExtensionBridge::RegisterPermissions(
+    int render_process_id,
     const std::string& extension_name,
     const std::string& perm_table) {
   CHECK(app_system_);
-  xwalk::application::ApplicationService* service =
+  application::ApplicationService *service =
       app_system_->application_service();
-  const ScopedVector<xwalk::application::Application> &apps =
-      service->active_applications();
-  if (apps.empty()) {
+  application::Application *app =
+      service->GetApplicationByRenderHostID(render_process_id);
+  if (!app)
     return false;
-  }
-  std::string app_id = (apps.front())->id();
-  return service->RegisterPermissions(app_id, extension_name, perm_table);
+
+  return service->RegisterPermissions(app->id(), extension_name, perm_table);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_app_extension_bridge.h
+++ b/runtime/browser/xwalk_app_extension_bridge.h
@@ -30,10 +30,14 @@ class XWalkAppExtensionBridge
     app_system_ = app_system;
   }
   // XWalkExtensionService::Delegate implementation
-  virtual void CheckAPIAccessControl(const std::string& extension_name,
+  virtual void CheckAPIAccessControl(
+      int render_process_id,
+      const std::string& extension_name,
       const std::string& api_name,
       const extensions::PermissionCallback& callback) OVERRIDE;
-  virtual bool RegisterPermissions(const std::string& extension_name,
+  virtual bool RegisterPermissions(
+      int render_process_id,
+      const std::string& extension_name,
       const std::string& perm_table) OVERRIDE;
 
  private:


### PR DESCRIPTION
The permission checking/registering was issued from extension process
but we don't know where it comes from, i.e. from which application.
In the beginning, we take the app id from the running app list
(simply pick the first one) which is just not right when we're going
to support multiple apps.
So the right way is to bind each extension process with its
corresponding app id, and then whenever there is a permission check
we know where it comes from.
