### PR TITLE
[Tizen][Runtime] Enable CSP supporting for WGT package.

### DIFF
--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -146,6 +146,9 @@ static base::DictionaryValue* LoadManifestWgt(const base::FilePath& manifest_pat
     } else if (node_name == "application") {
       if (xml.NodeAttribute("package", &value))
         dv->SetString(keys::kTizenAppIdKey, value);
+    } else if (node_name == "content-security-policy") {
+      if (xml.ReadElementContent(&value))
+        dv->SetString(keys::kCSPKey, value);
 #endif
     }
   }


### PR DESCRIPTION
The xwalk runtime should support CSP for Tizen legacy apps when setting
it using tizen:content-security-policy tag in WGT config.xml.
