### PR TITLE
[Android] Temporarily disable CSP support and related test.

### DIFF
--- a/runtime/browser/android/net/android_stream_reader_url_request_job.cc
+++ b/runtime/browser/android/net/android_stream_reader_url_request_job.cc
@@ -382,9 +382,8 @@ int AndroidStreamReaderURLRequestJob::GetResponseCode() const {
 void AndroidStreamReaderURLRequestJob::GetResponseInfo(
     net::HttpResponseInfo* info) {
   if (response_info_) {
-    response_info_->headers = xwalk::application::BuildHttpHeaders(
-        content_security_policy_, mime_type_, "GET", relative_path_,
-        relative_path_, true);
+    // TODO(gaochun): Enable CSP when http status code issue was fixed.
+    // Bug: https://crosswalk-project.org/jira/browse/XWALK-1022
     *info = *response_info_;
   }
 }

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/CSPTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/CSPTest.java
@@ -6,6 +6,7 @@
 package org.xwalk.runtime.client.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.shell.XWalkRuntimeClientShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -15,8 +16,11 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class CSPTest extends XWalkRuntimeClientTestBase {
 
-    @SmallTest
-    @Feature({"CSP"})
+    // TODO(gaochun): Enable the test when the issue was fixed:
+    // Bug: https://crosswalk-project.org/jira/browse/XWALK-1022
+    // @SmallTest
+    // @Feature({"CSP"})
+    @DisabledTest
     public void testCSP() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/CSPTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/CSPTest.java
@@ -6,6 +6,7 @@
 package org.xwalk.runtime.client.embedded.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.embedded.shell.XWalkRuntimeClientEmbeddedShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -15,8 +16,11 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class CSPTest extends XWalkRuntimeClientTestBase {
 
-    @SmallTest
-    @Feature({"CSP"})
+    // TODO(gaochun): Enable the test when the issue was fixed:
+    // Bug: https://crosswalk-project.org/jira/browse/XWALK-1022
+    // @SmallTest
+    // @Feature({"CSP"})
+    @DisabledTest
     public void testCSP() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(


### PR DESCRIPTION
A known issue was found in the common code of csp implementation
both for Android and Tizen, so disable the bridge code in android
until the issue was fixed.

bug=https://crosswalk-project.org/jira/browse/XWALK-1022
