### PR TITLE
Xwalk can not be launched with empty url.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -44,7 +44,7 @@ GURL GetURLFromCommandLine(const CommandLine& command_line) {
   const CommandLine::StringVector& args = command_line.GetArgs();
 
   if (args.empty())
-    return GURL();
+    return GURL(content::kAboutBlankURL);
 
   GURL url(args[0]);
   if (url.is_valid() && url.has_scheme())


### PR DESCRIPTION
The constructor "GURL()" will create an invalid Url rather than "about:blank".
That causes xwalk failed to be launched with empty url, for example:
command "./xwalk" will be failed.

BUG=https://crosswalk-project.org/jira/browse/XWALK-958
