### PR TITLE
Enable 'hidpi' build option for Tizen.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -196,7 +196,8 @@ ${GYP_EXTRA_FLAGS} \
 -Duse_system_libxml=1 \
 -Duse_system_nspr=1 \
 -Denable_xi21_mt=1 \
--Duse_xi2_mt=0
+-Duse_xi2_mt=0 \
+-Denable_hidpi=1
 
 make %{?_smp_mflags} -C "${BUILDDIR_NAME}" BUILDTYPE=Release xwalk xwalkctl xwalk_launcher xwalk-pkg-helper
 


### PR DESCRIPTION
SSIA. This is necessary to include the value '2.0'
to the supported scale factors list on Linux.
The command line hack enforcing scale factor value
for Tizen shall be removed with
https://github.com/crosswalk-project/crosswalk/pull/1605.
