### PR TITLE
Revert "Xwalk can not be launched with empty url."

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -44,7 +44,7 @@ GURL GetURLFromCommandLine(const CommandLine& command_line) {
   const CommandLine::StringVector& args = command_line.GetArgs();
 
   if (args.empty())
-    return GURL(content::kAboutBlankURL);
+    return GURL();
 
   GURL url(args[0]);
   if (url.is_valid() && url.has_scheme())


### PR DESCRIPTION
This has caused 6 tests to fail on Linux:

xwalk_browsertest:
       LoadGeolocationPage
       LoadURLAndClose
       TestMultiApp

xwalk_extensions_browsertest:
       CreateNewRuntimeAndNewRP
       OpenLinkInNewRuntimeAndNewRP
       OpenLinkInNewRuntimeAndSameRP

This reverts commit 723ccbedc0e0111e3da212b3b2831f59ac6ad5a9.
