### PR TITLE
[Android] CSS doesn't apply on Crosswalk-based Cordova app.

### DIFF
--- a/runtime/browser/android/net/android_stream_reader_url_request_job.cc
+++ b/runtime/browser/android/net/android_stream_reader_url_request_job.cc
@@ -102,7 +102,6 @@ AndroidStreamReaderURLRequestJob::AndroidStreamReaderURLRequestJob(
     const std::string& content_security_policy)
     : URLRequestJob(request, network_delegate),
       delegate_(delegate.Pass()),
-      mime_type_("text/html"),
       relative_path_(relative_path),
       content_security_policy_(content_security_policy),
       weak_factory_(this) {
@@ -382,8 +381,10 @@ int AndroidStreamReaderURLRequestJob::GetResponseCode() const {
 void AndroidStreamReaderURLRequestJob::GetResponseInfo(
     net::HttpResponseInfo* info) {
   if (response_info_) {
+    std::string mime_type;
+    GetMimeType(&mime_type);
     response_info_->headers = xwalk::application::BuildHttpHeaders(
-        content_security_policy_, mime_type_, "GET", relative_path_,
+        content_security_policy_, mime_type, "GET", relative_path_,
         relative_path_, true);
     *info = *response_info_;
   }

--- a/runtime/browser/android/net/android_stream_reader_url_request_job.h
+++ b/runtime/browser/android/net/android_stream_reader_url_request_job.h
@@ -118,7 +118,6 @@ class AndroidStreamReaderURLRequestJob : public net::URLRequestJob {
   net::HttpByteRange byte_range_;
   scoped_ptr<net::HttpResponseInfo> response_info_;
   scoped_ptr<Delegate> delegate_;
-  const std::string mime_type_;
   base::FilePath relative_path_;
   std::string content_security_policy_;
   scoped_refptr<InputStreamReaderWrapper> input_stream_reader_wrapper_;


### PR DESCRIPTION
Because all of the mime-types are replaced by "text/html"
when appending headers for CSP support, even for css file and
image file. These is incorrect. XWalk should use their respective
mime-types for http request. Such as: "image/png" for image file,
"text/css" for css file.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1027
