### PR TITLE
[Runtime] Generate the WGT package id by settings in config.xml.

### DIFF
--- a/application/browser/installer/package.cc
+++ b/application/browser/installer/package.cc
@@ -17,7 +17,8 @@ namespace xwalk {
 namespace application {
 
 Package::Package(const base::FilePath& source_path)
-  : source_path_(source_path) {
+    : source_path_(source_path),
+      is_extracted_(false) {
 }
 
 Package::~Package() {
@@ -40,6 +41,11 @@ scoped_ptr<Package> Package::Create(const base::FilePath& source_path) {
 }
 
 bool Package::Extract(base::FilePath* target_path) {
+  if (is_extracted_) {
+    *target_path = temp_dir_.path();
+    return true;
+  }
+
   if (!IsValid()) {
     LOG(ERROR) << "XPK/WGT file is not valid.";
     return false;
@@ -55,6 +61,8 @@ bool Package::Extract(base::FilePath* target_path) {
     LOG(ERROR) << "An error occurred during package extraction";
     return false;
   }
+
+  is_extracted_ = true;
 
   *target_path = temp_dir_.path();
   return true;

--- a/application/browser/installer/package.h
+++ b/application/browser/installer/package.h
@@ -40,6 +40,8 @@ class Package {
   base::FilePath source_path_;
   // Temporary directory for unpacking.
   base::ScopedTempDir temp_dir_;
+  // Represent if the package has been extracted.
+  bool is_extracted_;
 };
 
 }  // namespace application


### PR DESCRIPTION
For WGT package, the package id in Crosswalk runtime should be generated
from the settings (id attribute in widget (W3C widget) or
application (Tizen widget) element) in config.xml, instead of generating
from a randomly temporary directory path, so that one package should be
identified by its id.
