### PR TITLE
[Tizen IVI] Make HTML5 full screen API work on IVI.

### DIFF
--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -127,6 +127,8 @@ void NativeAppWindowViews::Minimize() {
 }
 
 void NativeAppWindowViews::SetFullscreen(bool fullscreen) {
+  views::ViewsDelegate::views_delegate->SetShouldShowTitleBar(!fullscreen);
+
   if (is_fullscreen_ == fullscreen)
     return;
   is_fullscreen_ = fullscreen;


### PR DESCRIPTION
Currently, Crosswalk for Ozone-wayland shows the title bar by default on IVI.
As a result, when webapps enter fullscreen mode using HTML5 fullscreen API,
their title bar still exist.

This patch allows to hide the title bar in fullscreen mode.

It depends on the following patch in chromium-crosswalk:
https://github.com/joone/chromium-crosswalk/commit/42b71c5b1ce7b74e7f512f4be51e3fd8f5f3bbc3

Bug: XWALK-896
