### PR TITLE
[Android] Launch Screen full spec implementation

### DIFF
--- a/app/android/app_template/res/drawable/launchscreen_bg.xml
+++ b/app/android/app_template/res/drawable/launchscreen_bg.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright (c) 2014 Intel Corporation. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <!-- Background Color -->
+    <item>
+        <shape android:shape="rectangle" >
+            <solid android:color="#000000" />
+        </shape>
+    </item>
+    <!-- Background Image -->
+
+</layer-list>

--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+import shutil
+import sys
+
+from manifest_json_parser import ManifestJsonParser
+
+def CopyToPathWithName(root, name, final_path, rename):
+  if name == '':
+    return False
+  origin_path = os.path.join(root, name)
+  if not os.path.exists(origin_path):
+    print ('Error: \'' + origin_path + '\' not found.' )
+    sys.exit(6)
+  if not os.path.exists(final_path):
+    os.makedirs(final_path)
+  # Get the extension.
+  # Need to take care of special case, such as 'img.9.png'
+  name_components = name.split('.')
+  name_components[0] = rename
+  new_name = '.'.join(name_components)
+  final_path_with_name = os.path.join(final_path, new_name)
+  shutil.copyfile(origin_path, final_path_with_name)
+  return True
+
+
+def CopyDrawables(image_dict, orientation, sanitized_name, name, app_root):
+  drawable = os.path.join(sanitized_name, 'res', 'drawable')
+  if orientation == 'landscape':
+    drawable = drawable + '-land'
+  elif orientation == 'portrait':
+    drawable = drawable + '-port'
+  drawable_ldpi = drawable + '-ldpi'
+  drawable_mdpi = drawable + '-mdpi'
+  drawable_hdpi = drawable + '-hdpi'
+  drawable_xhdpi = drawable + '-xhdpi'
+
+  image_075x = image_dict.get('0.75x', '')
+  image_1x = image_dict.get('1x', '')
+  image_15x = image_dict.get('1.5x', '')
+  image_2x = image_dict.get('2x', '')
+
+  # Copy all supported images: 0.75x, 1x, 1.5x, 2x.
+  has_image = False
+  if image_075x:
+    if CopyToPathWithName(app_root, image_075x, drawable_ldpi, name):
+      has_image = True
+  if image_1x:
+    if CopyToPathWithName(app_root, image_1x, drawable_mdpi, name):
+      has_image = True
+  if image_15x:
+    if CopyToPathWithName(app_root, image_15x, drawable_hdpi, name):
+      has_image = True
+  if image_2x:
+    if CopyToPathWithName(app_root, image_2x, drawable_xhdpi, name):
+      has_image = True
+
+  # If no supported images found, find the closest one as 1x.
+  if not has_image:
+    closest = ''
+    delta = sys.maxint
+    for (k , v) in  image_dict.items():
+      items = k.split('x')
+      if len(items) == 2:
+        float_value = sys.maxint
+        try:
+          float_value = float(items[0])
+        except ValueError:
+          continue
+        if abs(float_value - 1) < delta:
+          closest = v
+          if CopyToPathWithName(app_root, closest, drawable_mdpi, name):
+            delta = float_value
+
+
+def CustomizeDrawable(image, orientation, sanitized_name, app_root, name):
+  # Parse the image.
+  # The format of image: 'image-1x.png [1x], image-75x.png 0.75x,
+  #                       image-15x.png 1.5x, image-2x.png 2x'
+  image_list = image.split(',')
+
+  # The first image: 'image-1x.png', the density is not provided.
+  image_pair_1 = image_list[0].strip()
+  items = image_pair_1.split(' ')
+  image_1x = ''
+  if len(items) == 1:
+    image_1x = items[0]
+    image_list.pop(0)
+  # The dictionary which contains the image pair.
+  image_dict = {'1x': image_1x}
+
+  for image_pair in image_list:
+    items = image_pair.strip().split(' ')
+    if len(items) >= 2:
+      x = items[len(items)-1]
+      image_item = items[0]
+      image_dict[x] = image_item
+
+  CopyDrawables(image_dict, orientation, sanitized_name, name, app_root)
+
+
+def CustomizeForeground(image, orientation, sanitized_name, app_root):
+  CustomizeDrawable(image, orientation, sanitized_name,
+                    app_root, "launchscreen_img")
+
+
+def CustomizeBackground(background_color,
+                        background_image,
+                        orientation,
+                        sanitized_name,
+                        app_root):
+  background_path = os.path.join(sanitized_name, 'res',
+                                 'drawable', 'launchscreen_bg.xml')
+  if not os.path.isfile(background_path):
+    print('Error: launchscreen_bg.xml is missing in the build tool.')
+    sys.exit(6)
+
+  has_background = False
+  background_file = open(background_path, 'r')
+  content = background_file.read()
+  background_file.close()
+  # Fill the background_color.
+  if background_color:
+    content = content.replace('#000000', background_color, 1)
+    has_background = True
+  # Fill the background_image.
+  if background_image:
+    CustomizeDrawable(background_image, orientation, sanitized_name,
+                      app_root, "launchscreen_bg_img")
+    # Only set Background Image once for each orientation.
+    tmp = '<item>\n' \
+          '  <bitmap\n' \
+          '    android:src=\"@drawable/launchscreen_bg_img\"\n' \
+          '    android:tileMode=\"repeat\" />\n' \
+          '</item>\n'
+    content = content.replace('<!-- Background Image -->', tmp, 1)
+    has_background = True
+  if has_background:
+    background_file = file(background_path,'w')
+    background_file.write(content)
+    background_file.close()
+  return has_background
+
+
+def CustomizeByOrientation(parser, orientation, sanitized_name, app_root):
+  background_color = parser.GetLaunchScreenBackgroundColor(orientation)
+  background_image = parser.GetLaunchScreenBackgroundImage(orientation)
+  image = parser.GetLaunchScreenImage(orientation)
+  # Customize background: background_color, background_image.
+  has_background = CustomizeBackground(background_color, background_image,
+                                       orientation, sanitized_name, app_root)
+  # Customize foreground: image.
+  CustomizeForeground(image, orientation, sanitized_name, app_root)
+  return has_background
+
+
+def CustomizeLaunchScreen(app_manifest, sanitized_name):
+  if not app_manifest:
+    return False
+  parser = ManifestJsonParser(os.path.expanduser(app_manifest))
+  app_root = os.path.dirname(app_manifest)
+  default = CustomizeByOrientation(parser, 'default',
+                                   sanitized_name, app_root)
+  portrait = CustomizeByOrientation(parser, 'portrait',
+                                    sanitized_name, app_root)
+  landscape = CustomizeByOrientation(parser, 'landscape',
+                                     sanitized_name, app_root)
+  return default or portrait or landscape

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -116,9 +116,6 @@ def ParseManifest(options):
     options.fullscreen = True
   elif parser.GetFullScreenFlag().lower() == 'false':
     options.fullscreen = False
-  if parser.GetLaunchScreenImg():
-    options.launch_screen_img  = os.path.join(options.app_root,
-                                              parser.GetLaunchScreenImg())
 
 
 def ParseXPK(options, out_dir):
@@ -210,7 +207,7 @@ def Customize(options):
                options.permissions, options.app_url, app_root,
                options.app_local_path, remote_debugging,
                fullscreen_flag, options.keep_screen_on, options.extensions,
-               options.launch_screen_img, icon, package, name, app_version,
+               options.manifest, icon, package, name, app_version,
                orientation, options.xwalk_command_line)
 
 
@@ -687,10 +684,6 @@ def main(argv):
   if len(argv) == 1:
     parser.print_help()
     return 0
-
-  # This option will not export to users.
-  # Initialize here and will be read from manifest.json.
-  options.launch_screen_img = ''
 
   if options.version:
     if os.path.isfile('VERSION'):

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -138,17 +138,27 @@ class ManifestJsonParser(object):
       ret_dict['fullscreen'] = 'true'
     else:
       ret_dict['fullscreen'] = ''
-    ret_dict['launch_screen_img'] = ''
     if 'launch_screen' in self.data_src:
-      if 'default' not in self.data_src['launch_screen']:
-        print('Error: no \'default\' field for \'launch_screen\'.')
-        sys.exit(1)
-      default = self.data_src['launch_screen']['default']
-      if 'image' not in default:
-        print('Error: no \'image\' field for \'launch_screen.default\'.')
-        sys.exit(1)
-      ret_dict['launch_screen_img'] = default['image']
+      self.ParseLaunchScreen(ret_dict, 'default')
+      self.ParseLaunchScreen(ret_dict, 'portrait')
+      self.ParseLaunchScreen(ret_dict, 'landscape')
     return ret_dict
+
+  def ParseLaunchScreen(self, ret_dict, orientation):
+    if orientation in self.data_src['launch_screen']:
+      sub_dict = self.data_src['launch_screen'][orientation]
+      if 'background_color' in sub_dict:
+        ret_dict['launch_screen_background_color_' + orientation] = (
+            sub_dict['background_color'])
+      if 'background_image' in sub_dict:
+        ret_dict['launch_screen_background_image_' + orientation] = (
+            sub_dict['background_image'])
+      if 'image' in sub_dict:
+        ret_dict['launch_screen_image_' + orientation] = (
+            sub_dict['image'])
+      if 'image_border' in sub_dict:
+        ret_dict['launch_screen_image_border_' + orientation] = (
+            sub_dict['image_border'])
 
   def ShowItems(self):
     """Show the processed results, it is used for command-line
@@ -164,7 +174,30 @@ class ManifestJsonParser(object):
     print("required_version: %s" % self.GetRequiredVersion())
     print("plugins: %s" % self.GetPlugins())
     print("fullscreen: %s" % self.GetFullScreenFlag())
-    print('launch_screen.default.image: %s' % self.GetLaunchScreenImg())
+    print('launch_screen.default.background_color: %s' %
+        self.GetLaunchScreenBackgroundColor('default'))
+    print('launch_screen.default.background_image: %s' %
+        self.GetLaunchScreenBackgroundImage('default'))
+    print('launch_screen.default.image: %s' %
+        self.GetLaunchScreenImage('default'))
+    print('launch_screen.default.image_border: %s' %
+        self.GetLaunchScreenImageBorder('default'))
+    print('launch_screen.portrait.background_color: %s' %
+        self.GetLaunchScreenBackgroundColor('portrait'))
+    print('launch_screen.portrait.background_image: %s' %
+        self.GetLaunchScreenBackgroundImage('portrait'))
+    print('launch_screen.portrait.image: %s' %
+        self.GetLaunchScreenImage('portrait'))
+    print('launch_screen.portrait.image_border: %s' %
+        self.GetLaunchScreenImageBorder('portrait'))
+    print('launch_screen.landscape.background_color: %s' %
+        self.GetLaunchScreenBackgroundColor('landscape'))
+    print('launch_screen.landscape.background_image: %s' %
+        self.GetLaunchScreenBackgroundImage('landscape'))
+    print('launch_screen.landscape.image: %s' %
+        self.GetLaunchScreenImage('landscape'))
+    print('launch_screen.landscape.image_border: %s' %
+        self.GetLaunchScreenImageBorder('landscape'))
 
 
   def GetAppName(self):
@@ -211,9 +244,33 @@ class ManifestJsonParser(object):
     """Return the set fullscreen flag of the application."""
     return self.ret_dict['fullscreen']
 
-  def GetLaunchScreenImg(self):
-    """Return the default img for launch_screen."""
-    return self.ret_dict['launch_screen_img']
+  def GetLaunchScreenBackgroundColor(self, orientation):
+    """Return the background color for launch_screen."""
+    if 'launch_screen_background_color_' + orientation in self.ret_dict:
+      return self.ret_dict['launch_screen_background_color_' + orientation]
+    else:
+      return ''
+
+  def GetLaunchScreenBackgroundImage(self, orientation):
+    """Return the background image for launch_screen."""
+    if 'launch_screen_background_image_' + orientation in self.ret_dict:
+      return self.ret_dict['launch_screen_background_image_' + orientation]
+    else:
+      return ''
+
+  def GetLaunchScreenImage(self, orientation):
+    """Return the image for launch_screen."""
+    if 'launch_screen_image_' + orientation in self.ret_dict:
+      return self.ret_dict['launch_screen_image_' + orientation]
+    else:
+      return ''
+
+  def GetLaunchScreenImageBorder(self, orientation):
+    """Return the image border for launch_screen."""
+    if 'launch_screen_image_border_' + orientation in self.ret_dict:
+      return self.ret_dict['launch_screen_image_border_' + orientation]
+    else:
+      return ''
 
 
 def main(argv):

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -16,6 +16,15 @@ const char kDescriptionKey[] = "description";
 const char kDisplay[] = "display";
 const char kLaunchLocalPathKey[] = "app.launch.local_path";
 const char kLaunchScreen[] = "launch_screen";
+const char kLaunchScreenDefault[] = "launch_screen.default";
+const char kLaunchScreenImageBorderDefault[] =
+    "launch_screen.default.image_border";
+const char kLaunchScreenImageBorderLandscape[] =
+    "launch_screen.landscape.image_border";
+const char kLaunchScreenImageBorderPortrait[] =
+    "launch_screen.portrait.image_border";
+const char kLaunchScreenLandscape[] = "launch_screen.landscape";
+const char kLaunchScreenPortrait[] = "launch_screen.portrait";
 const char kLaunchScreenReadyWhen[] = "launch_screen.ready_when";
 const char kLaunchWebURLKey[] = "app.launch.web_url";
 const char kManifestVersionKey[] = "manifest_version";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -18,6 +18,12 @@ namespace application_manifest_keys {
   extern const char kDisplay[];
   extern const char kLaunchLocalPathKey[];
   extern const char kLaunchScreen[];
+  extern const char kLaunchScreenDefault[];
+  extern const char kLaunchScreenImageBorderDefault[];
+  extern const char kLaunchScreenImageBorderLandscape[];
+  extern const char kLaunchScreenImageBorderPortrait[];
+  extern const char kLaunchScreenLandscape[];
+  extern const char kLaunchScreenPortrait[];
   extern const char kLaunchScreenReadyWhen[];
   extern const char kLaunchWebURLKey[];
   extern const char kManifestVersionKey[];

--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -126,6 +126,7 @@ def PrepareFromXwalk(src_dir, target_dir):
      os.path.join(target_dir, 'scripts/ant')),
     (os.path.join(tools_src_dir, 'compress_js_and_css.py'), target_dir),
     (os.path.join(tools_src_dir, 'customize.py'), target_dir),
+    (os.path.join(tools_src_dir, 'customize_launch_screen.py'), target_dir),
     (os.path.join(tools_src_dir, 'handle_permissions.py'), target_dir),
     (os.path.join(tools_src_dir, 'handle_xml.py'), target_dir),
     (os.path.join(tools_src_dir, 'make_apk.py'), target_dir),

--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -394,9 +394,9 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
     }
 
     @CalledByNative
-    public void onGetUrlAndLaunchScreenFromManifest(String url, String readyWhen) {
+    public void onGetUrlAndLaunchScreenFromManifest(String url, String readyWhen, String imageBorder) {
         if (url == null || url.isEmpty()) return;
-        mLaunchScreenManager.displayLaunchScreen(readyWhen);
+        mLaunchScreenManager.displayLaunchScreen(readyWhen, imageBorder);
         mContentsClientBridge.registerPageLoadListener(mLaunchScreenManager);
         loadUrl(url, null);
     }

--- a/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
@@ -5,6 +5,7 @@
 package org.xwalk.core;
 
 import java.lang.Runnable;
+import java.util.ArrayList;
 
 import android.app.Activity;
 import android.app.Dialog;
@@ -13,21 +14,32 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.Point;
 import android.graphics.Rect;
+import android.graphics.Shader.TileMode;
+import android.hardware.SensorManager;
 import android.os.Bundle;
+import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.TypedValue;
+import android.view.Display;
 import android.view.Gravity;
 import android.view.KeyEvent;
+import android.view.OrientationEventListener;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 
 import org.chromium.content.browser.ContentViewRenderView.FirstRenderedFrameListener;
 
@@ -36,10 +48,15 @@ import org.chromium.content.browser.ContentViewRenderView.FirstRenderedFrameList
  * @hide
  */
 public class XWalkLaunchScreenManager
-        implements FirstRenderedFrameListener, DialogInterface.OnShowListener, PageLoadListener {
+        implements FirstRenderedFrameListener, DialogInterface.OnShowListener,
+	           DialogInterface.OnDismissListener, PageLoadListener {
     // This string will be initialized before extension initialized,
     // and used by LaunchScreenExtension.
     private static String mIntentFilterStr;
+
+    private final static String BORDER_MODE_REPEAT = "repeat";
+    private final static String BORDER_MODE_STRETCH = "stretch";
+    private final static String BORDER_MODE_ROUND = "round";
 
     private XWalkView mXWalkView;
     private Activity mActivity;
@@ -50,12 +67,21 @@ public class XWalkLaunchScreenManager
     private boolean mFirstFrameReceived;
     private BroadcastReceiver mLaunchScreenReadyWhenReceiver;
     private boolean mCustomHideLaunchScreen;
+    private int mCurrentOrientation;
+    private OrientationEventListener mOrientationListener;
 
     private enum ReadyWhenType {
         FIRST_PAINT,
         USER_INTERACTIVE,
         COMPLETE,
         CUSTOM
+    }
+
+    private enum BorderModeType {
+        REPEAT,
+        STRETCH,
+        ROUND,
+        NONE
     }
 
     public XWalkLaunchScreenManager(Context context, XWalkView xwView) {
@@ -65,39 +91,63 @@ public class XWalkLaunchScreenManager
         mIntentFilterStr = mActivity.getPackageName() + ".hideLaunchScreen";
     }
 
-    public void displayLaunchScreen(String readyWhen) {
+    public void displayLaunchScreen(String readyWhen, final String imageBorderList) {
         if (mXWalkView == null) return;
         setReadyWhen(readyWhen);
 
         Runnable runnable = new Runnable() {
-           public void run(){
-                int resId = mActivity.getResources().getIdentifier(
-                        "launchscreen", "drawable", mActivity.getPackageName());
-                if (resId == 0) return;
+           public void run() {
+                int bgResId = mActivity.getResources().getIdentifier(
+                        "launchscreen_bg", "drawable", mActivity.getPackageName());
+                if (bgResId == 0) return;
+                Drawable bgDrawable = mActivity.getResources().getDrawable(bgResId);
+                if (bgDrawable == null) return;
 
-                // Can not use the drawable directly in shared mode, need to decode it and create a new drawable.
-                Bitmap bitmap = BitmapFactory.decodeResource(mActivity.getResources(), resId);
-                Drawable finalDrawable = new BitmapDrawable(mActivity.getResources(), bitmap);
-
-                mLaunchScreenDialog = new Dialog(mLibContext, android.R.style.Theme_Holo_Light_NoActionBar);
-                if ((mActivity.getWindow().getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
-                    mLaunchScreenDialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, 
+                mLaunchScreenDialog = new Dialog(mLibContext,
+                                                 android.R.style.Theme_Holo_Light_NoActionBar);
+                if ((mActivity.getWindow().getAttributes().flags &
+                     WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
+                    mLaunchScreenDialog.getWindow().setFlags(
+                            WindowManager.LayoutParams.FLAG_FULLSCREEN,
                             WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
-                mLaunchScreenDialog.getWindow().setBackgroundDrawable(finalDrawable);
                 mLaunchScreenDialog.setOnKeyListener(new Dialog.OnKeyListener() {
                     @Override
                     public boolean onKey(DialogInterface arg0, int keyCode,
                             KeyEvent event) {
                         if (keyCode == KeyEvent.KEYCODE_BACK) {
-                            mLaunchScreenDialog.dismiss();
+                            performHideLaunchScreen();
                             mActivity.onBackPressed();
                         }
                         return true;
                     }
                 });
                 mLaunchScreenDialog.setOnShowListener(XWalkLaunchScreenManager.this);
+                mLaunchScreenDialog.setOnDismissListener(XWalkLaunchScreenManager.this);
+                // Set background
+                mLaunchScreenDialog.getWindow().setBackgroundDrawable(bgDrawable);
+                // Set foreground image
+                RelativeLayout root = getLaunchScreenLayout(imageBorderList);
+                if (root == null) return;
+                mLaunchScreenDialog.setContentView(root);
                 mLaunchScreenDialog.show();
+
+                // Change the layout depends on the orientation change.
+                mOrientationListener = new OrientationEventListener(mActivity,
+                        SensorManager.SENSOR_DELAY_NORMAL) {
+                    public void onOrientationChanged(int ori) {
+                        if (mLaunchScreenDialog == null || !mLaunchScreenDialog.isShowing()) {
+                            return;
+                        }
+		        int orientation = getScreenOrientation();
+                        if (orientation != mCurrentOrientation) {
+                            RelativeLayout root = getLaunchScreenLayout(imageBorderList);
+                            if (root == null) return;
+                            mLaunchScreenDialog.setContentView(root);
+                        }
+                    }
+                };
+                mOrientationListener.enable();
                 if (mReadyWhen == ReadyWhenType.CUSTOM) registerBroadcastReceiver();
             }
         };
@@ -117,6 +167,12 @@ public class XWalkLaunchScreenManager
     }
 
     @Override
+    public void onDismiss(DialogInterface dialog) {
+        mOrientationListener.disable();
+        mOrientationListener = null;
+    }
+
+    @Override
     public void onPageFinished(String url) {
         mPageLoadFinished = true;
         hideLaunchScreenWhenReady();
@@ -124,6 +180,359 @@ public class XWalkLaunchScreenManager
 
     public static String getHideLaunchScreenFilterStr() {
         return mIntentFilterStr;
+    }
+
+    public int getScreenOrientation() {
+        // getResources().getConfiguration().orientation returns wrong value in some devices.
+        // Below is another way to calculate screen orientation.
+        Display display = mActivity.getWindowManager().getDefaultDisplay();
+        Point size = new Point();
+        display.getSize(size);
+        int orientation;
+        if (size.x < size.y) {
+            orientation = Configuration.ORIENTATION_PORTRAIT;
+        } else {
+            orientation = Configuration.ORIENTATION_LANDSCAPE;
+        }
+        return orientation;
+    }
+
+    private RelativeLayout getLaunchScreenLayout(String imageBorderList) {
+        // Parse the borders depends on orientation.
+        // imageBorderList format:"[default];[landscape];[portrait]"
+        String[] borders = imageBorderList.split(";");
+        // When there is no borders defined, display with no borders.
+        if (borders.length < 1) return parseImageBorder("");
+        int orientation = getScreenOrientation();
+        mCurrentOrientation = orientation;
+        if (borders.length >= 2 && orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            if (borders[1].equals("empty")) {
+                // Has launch_screen.landscape configured, but no image_border set.
+                // Display the iamge with no borders.
+                return parseImageBorder("");
+            } else if (borders[1].isEmpty()) {
+                // No launch_screen.landscape configured.
+                // Use launch_screen.default.
+                return parseImageBorder(borders[0]);
+            } else {
+                return parseImageBorder(borders[1]);
+            }
+        } else if (borders.length == 3 && orientation == Configuration.ORIENTATION_PORTRAIT) {
+            if (borders[2].equals("empty")) {
+                // Has launch_screen.portrait configured, but no image_border set.
+                // Display the iamge with no borders.
+                return parseImageBorder("");
+            } else if (borders[2].isEmpty()) {
+                // No launch_screen.portrait configured.
+                // Use launch_screen.default.
+                return parseImageBorder(borders[0]);
+            } else {
+                return parseImageBorder(borders[2]);
+            }
+        }
+
+        return parseImageBorder(borders[0]);
+    }
+
+    private int getSuitableSize(int maxSize, int divider) {
+        int finalSize = divider;
+        float minMod = divider;
+        for (; divider > 1; divider--) {
+            int mod = maxSize % divider;
+            // Found the suitable size.
+            if (mod == 0) {
+                finalSize = divider;
+                break;
+            }
+            // Record the best suitable one.
+            // If there is no mod==0 found, return the divider which min(mod).
+            if (mod < minMod) {
+                minMod = mod;
+                finalSize = divider;
+            }
+        }
+        return finalSize;
+    }
+
+    /**
+     * Get each section from 9-piece format image depends on the spec defined
+     * @param img The foreground image.
+     * @param x The position where the section start.
+     * @param y The position where the section start.
+     * @param width The width of the section.
+     * @param height The height of the section.
+     * @param mode The border type for this section.
+     * @param maxWidth When mode == ROUND, this will be used.
+     * @param maxHeight When mode == ROUND, this will be used.
+     * @return The ImageView for this section.
+     */
+    private ImageView getSubImageView(Bitmap img, int x, int y, int width, int height,
+                                      BorderModeType mode, int maxWidth, int maxHeight) {
+        if (img == null) return null;
+
+        if (width <= 0 || height <= 0) return null;
+
+        // Check whether the section is inside the foreground image.
+        Rect imgRect = new Rect(0, 0, img.getWidth(), img.getHeight());
+        Rect subRect = new Rect(x, y, x + width, y + height);
+        if (!imgRect.contains(subRect)) return null;
+
+        Bitmap subImage = Bitmap.createBitmap(img, x, y, width, height);
+        ImageView subImageView = new ImageView(mActivity);
+        BitmapDrawable drawable;
+        if (mode == BorderModeType.ROUND) {
+            int originW = subImage.getWidth();
+            int originH = subImage.getHeight();
+            int newW = originW;
+            int newH = originH;
+            // Scale down the sub image to let the last image not cropped when it's repeated.
+            if (maxWidth > 0) newW = getSuitableSize(maxWidth, originW);
+            if (maxHeight > 0) newH = getSuitableSize(maxHeight, originH);
+            // recreate the new scaled bitmap.
+            Bitmap resizedBitmap = Bitmap.createScaledBitmap(subImage, newW, newH, true);
+            // Treat as repeat mode.
+            subImage = resizedBitmap;
+            mode = BorderModeType.REPEAT;
+        }
+        if (mode == BorderModeType.REPEAT) {
+            drawable = new BitmapDrawable(mActivity.getResources(), subImage);
+            drawable.setTileModeXY(TileMode.REPEAT, TileMode.REPEAT);
+            subImageView.setImageDrawable(drawable);
+            subImageView.setScaleType(ScaleType.FIT_XY);
+        } else if (mode == BorderModeType.STRETCH) {
+            subImageView.setImageBitmap(subImage);
+            subImageView.setScaleType(ScaleType.FIT_XY);
+        } else {
+            subImageView.setImageBitmap(subImage);
+        }
+
+        return subImageView;
+    }
+
+    private int getStatusBarHeight() {
+        int resourceId = mActivity.getResources().getIdentifier(
+                "status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return mActivity.getResources().getDimensionPixelSize(resourceId);
+        }
+        // If not found, return default one.
+        return 25;
+    }
+
+    private RelativeLayout parseImageBorder(String imageBorder) {
+        int topBorder = 0;
+        int rightBorder = 0;
+        int leftBorder = 0;
+        int bottomBorder = 0;
+        BorderModeType horizontalMode = BorderModeType.STRETCH;
+        BorderModeType verticalMode = BorderModeType.STRETCH;
+
+        if (imageBorder.equals("empty")) imageBorder = "";
+
+        // Parse the value of image_border.
+        String[] items = imageBorder.split(" ");
+        ArrayList<String> borders = new ArrayList<String>();
+        ArrayList<BorderModeType> modes = new ArrayList<BorderModeType>();
+        for (int i = 0; i < items.length; i++) {
+            String item = items[i];
+            if (item.endsWith("px")) {
+                borders.add(item.replaceAll("px", ""));
+            } else if (item.equals(BORDER_MODE_REPEAT)) {
+                modes.add(BorderModeType.REPEAT);
+            } else if (item.equals(BORDER_MODE_STRETCH)) {
+                modes.add(BorderModeType.STRETCH);
+            } else if (item.equals(BORDER_MODE_ROUND)) {
+                modes.add(BorderModeType.ROUND);
+            }
+        }
+        // Parse borders as defined by the spec.
+        try {
+            if (borders.size() == 1) {
+                topBorder = rightBorder = leftBorder = bottomBorder =
+                        Integer.valueOf(borders.get(0));
+            } else if (borders.size() == 2) {
+                topBorder = bottomBorder = Integer.valueOf(borders.get(0));
+                rightBorder = leftBorder = Integer.valueOf(borders.get(1));
+            } else if (borders.size() == 3) {
+                rightBorder = leftBorder = Integer.valueOf(borders.get(1));
+                topBorder = Integer.valueOf(borders.get(0));
+                bottomBorder = Integer.valueOf(borders.get(2));
+            } else if (borders.size() == 4) {
+                topBorder = Integer.valueOf(borders.get(0));
+                rightBorder = Integer.valueOf(borders.get(1));
+                leftBorder = Integer.valueOf(borders.get(2));
+                bottomBorder = Integer.valueOf(borders.get(3));
+            }
+        } catch (NumberFormatException e) {
+            topBorder = rightBorder = leftBorder = bottomBorder = 0;
+        }
+
+        // The border values are dpi from manifest.json, need to translate to px.
+        DisplayMetrics matrix = mActivity.getResources().getDisplayMetrics();
+        topBorder = (int)TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, topBorder, matrix);
+        rightBorder = (int)TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, rightBorder, matrix);
+        leftBorder = (int)TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, leftBorder, matrix);
+        bottomBorder = (int)TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, bottomBorder, matrix);
+
+        // Parse border mode as spec defined.
+        if (modes.size() == 1) {
+            horizontalMode = verticalMode = modes.get(0);
+        } else if (modes.size() == 2) {
+            horizontalMode = modes.get(0);
+            verticalMode = modes.get(1);
+        }
+
+        // Get foreground image
+        int imgResId = mActivity.getResources().getIdentifier(
+                       "launchscreen_img", "drawable", mActivity.getPackageName());
+        if (imgResId == 0) return null;
+        Bitmap img = BitmapFactory.decodeResource(mActivity.getResources(), imgResId);
+        if (img == null) return null;
+
+        // Create the 9-piece layout as spec defined.
+        RelativeLayout root = new RelativeLayout(mActivity);
+        root.setLayoutParams(new RelativeLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT));
+        RelativeLayout.LayoutParams params;
+        ImageView subImageView;
+
+        // Get Screen width and height.
+        Display display = mActivity.getWindowManager().getDefaultDisplay();
+        Point size = new Point();
+        display.getSize(size);
+
+        // For non fullscreen, the height should substract status bar height
+        if ((mActivity.getWindow().getAttributes().flags &
+             WindowManager.LayoutParams.FLAG_FULLSCREEN) == 0) {
+            size.y -= getStatusBarHeight();
+        }
+
+        // Image section-1 top left
+        subImageView = getSubImageView(img, 0, 0, leftBorder, topBorder, BorderModeType.NONE, 0, 0);
+        if (subImageView != null) {
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.WRAP_CONTENT,
+                    RelativeLayout.LayoutParams.WRAP_CONTENT);
+            params.addRule(RelativeLayout.ALIGN_PARENT_LEFT, RelativeLayout.TRUE);
+            params.addRule(RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE);
+            root.addView(subImageView, params);
+        }
+
+        // Image section-2 top
+        subImageView = getSubImageView(img, leftBorder, 0, img.getWidth() - leftBorder
+                - rightBorder, topBorder, horizontalMode, size.x - leftBorder - rightBorder, 0);
+        if (subImageView != null) {
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.MATCH_PARENT,
+                    RelativeLayout.LayoutParams.WRAP_CONTENT);
+            params.addRule(RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE);
+            params.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
+            params.leftMargin = leftBorder;
+            params.rightMargin = rightBorder;
+            root.addView(subImageView, params);
+        }
+
+        // Image section-3 top right
+        subImageView = getSubImageView(img, img.getWidth() - rightBorder, 0,
+                rightBorder, topBorder, BorderModeType.NONE, 0, 0);
+        if (subImageView != null) {
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.WRAP_CONTENT,
+                    RelativeLayout.LayoutParams.WRAP_CONTENT);
+            params.addRule(RelativeLayout.ALIGN_PARENT_RIGHT, RelativeLayout.TRUE);
+            params.addRule(RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE);
+            root.addView(subImageView, params);
+        }
+
+        // Image section-4 left
+        subImageView = getSubImageView(img, 0, topBorder, leftBorder, img.getHeight()
+                - topBorder - bottomBorder, verticalMode, 0, size.y - topBorder - bottomBorder);
+        if (subImageView != null) {
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.WRAP_CONTENT,
+                    RelativeLayout.LayoutParams.MATCH_PARENT);
+            params.addRule(RelativeLayout.ALIGN_PARENT_LEFT, RelativeLayout.TRUE);
+            params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+            params.topMargin = topBorder;
+            params.bottomMargin = bottomBorder;
+            root.addView(subImageView, params);
+        }
+
+        // Image section-5 middle
+        subImageView = getSubImageView(img, leftBorder, topBorder, img.getWidth() - leftBorder - rightBorder,
+                img.getHeight() - topBorder - bottomBorder, BorderModeType.NONE, 0, 0);
+        if (subImageView != null) {
+            subImageView.setScaleType(ScaleType.FIT_XY);
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.MATCH_PARENT,
+                    RelativeLayout.LayoutParams.MATCH_PARENT);
+            params.leftMargin = leftBorder;
+            params.topMargin = topBorder;
+            params.rightMargin = rightBorder;
+            params.bottomMargin = bottomBorder;
+            root.addView(subImageView, params);
+        }
+
+        // Image section-6 right
+        subImageView = getSubImageView(img, img.getWidth() - rightBorder, topBorder, rightBorder,
+                img.getHeight() - topBorder - bottomBorder, verticalMode, 0,
+                size.y - topBorder - bottomBorder);
+        if (subImageView != null) {
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.WRAP_CONTENT,
+                    RelativeLayout.LayoutParams.MATCH_PARENT);
+            params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+            params.addRule(RelativeLayout.ALIGN_PARENT_RIGHT, RelativeLayout.TRUE);
+            params.topMargin = topBorder;
+            params.bottomMargin = bottomBorder;
+            root.addView(subImageView, params);
+        }
+
+        // Image section-7 bottom left
+        subImageView = getSubImageView(img, 0, img.getHeight() - bottomBorder,
+                leftBorder, bottomBorder, BorderModeType.NONE, 0, 0);
+        if (subImageView != null) {
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.WRAP_CONTENT,
+                    RelativeLayout.LayoutParams.WRAP_CONTENT);
+            params.addRule(RelativeLayout.ALIGN_PARENT_LEFT, RelativeLayout.TRUE);
+            params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
+            root.addView(subImageView, params);
+        }
+
+        // Image section-8 bottom
+        subImageView = getSubImageView(img, leftBorder, img.getHeight() - bottomBorder,
+                img.getWidth() - leftBorder - rightBorder, bottomBorder, horizontalMode,
+                size.x - leftBorder - rightBorder, 0);
+        if (subImageView != null) {
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.MATCH_PARENT,
+                    RelativeLayout.LayoutParams.WRAP_CONTENT);
+            params.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
+            params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
+            params.leftMargin = leftBorder;
+            params.rightMargin = rightBorder;
+            root.addView(subImageView, params);
+        }
+
+        // Image section-9 bottom right
+        subImageView = getSubImageView(img, img.getWidth() - rightBorder,
+                img.getHeight() - bottomBorder, rightBorder, bottomBorder,
+	        BorderModeType.NONE, 0, 0);
+        if (subImageView != null) {
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.WRAP_CONTENT,
+                    RelativeLayout.LayoutParams.WRAP_CONTENT);
+            params.addRule(RelativeLayout.ALIGN_PARENT_RIGHT, RelativeLayout.TRUE);
+            params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
+            root.addView(subImageView, params);
+        }
+        return root;
     }
 
     private void registerBroadcastReceiver() {


### PR DESCRIPTION
As the spec defined, the launch screen contains 3 layers:
1. background color
2. background image
3. foreground image
It's impossible to show all these layers together when an icon is tapped, because
of the limitation of 'Android drawable' mechanism.
The actual working flow is as below:
- Display the first 2 background layers.
- Display the 3rd foreground image layer with a Dialog.

Below is the description for the implementation in general:
Build script:
1. Parse manifest.json and customize launch screen.
2. Generate drawable:launchscreen_bg.xml depends on the configuration defined.
3. Copy background and foreground images to res folders.
Runtime:
1. Create a new layout to display 9-piece format foreground image.
2. Parse image-border from manifest.json, and customize the layout.
3. Display the 3 layers in a Dialog.

TODO:
One feature missed in this patch:
'ready_when' = 'user-interactive'

Spec=https://docs.google.com/a/intel.com/document/d/17PuNuHRTQuREUpaCvj-eEx7uYi2avd-VW-oaMXMpvwo/edit?pli=1#
BUG=XWALK-1198
