### PR TITLE
[Runtime] Enable to update an XPK/WGT package in service mode.

### DIFF
--- a/application/browser/linux/installed_applications_manager.cc
+++ b/application/browser/linux/installed_applications_manager.cc
@@ -130,10 +130,12 @@ void InstalledApplicationsManager::OnInstall(
   }
 
   std::string app_id;
-  if (!application_service_->Install(file_path, &app_id)) {
+  if (!application_service_->Install(file_path, &app_id) &&
+      (app_id.empty() || !application_service_->Update(app_id, file_path))) {
     scoped_ptr<dbus::Response> response =
         CreateError(method_call,
-                    "Error installing application with path: " + file_path_str);
+                    "Error installing/updating application with path: "
+                    + file_path_str);
     response_sender.Run(response.Pass());
     return;
   }

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -25,7 +25,7 @@ static GDBusConnection* g_connection;
 
 static GOptionEntry entries[] = {
   { "install", 'i', 0, G_OPTION_ARG_STRING, &install_path,
-    "Path of the application to be installed", "PATH" },
+    "Path of the application to be installed/updated", "PATH" },
   { "uninstall", 'u', 0, G_OPTION_ARG_STRING, &uninstall_appid,
     "Uninstall the application with this appid", "APPID" },
   { NULL }
@@ -63,7 +63,7 @@ static bool install_application(const char* path) {
   const char* object_path;
 
   g_variant_get(result, "(o)", &object_path);
-  g_print("Application installed with path '%s'\n", object_path);
+  g_print("Application installed/updated with path '%s'\n", object_path);
   g_variant_unref(result);
 
   ret = true;


### PR DESCRIPTION
When running xwalk under service mode, the updating function should take
place when installing an installed application, the same behavior as
single application mode.
