### PR TITLE
[Runtime] Should provide the application id exactly the same as the installed one.

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -343,7 +343,7 @@ bool ApplicationService::Update(const std::string& id,
     return false;
   }
 
-  if (id.empty() &&
+  if (id.empty() ||
       id.compare(app_id) != 0) {
     LOG(ERROR) << "The XPK/WGT file is not the same as expecting.";
     return false;


### PR DESCRIPTION
Current logic in Update() only check whether the provided id is not
empty, so change it to check if the expecting application id is the same
as the installed one.
