### PR TITLE
Fix build for Mac.

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -410,8 +410,9 @@ if __name__ == '__main__':
   # option.  http://crbug.com/35878.
   # TODO(tc): Fix circular dependencies in ChromiumOS then add linux2 to the
   # list.
-  if sys.platform not in ('darwin',):
-    args.append('--no-circular-check')
+  # TODO(tmpsantos): Make runtime a proper module and enable the circular check
+  # back for Mac.
+  args.append('--no-circular-check')
 
   # Default to ninja on linux and windows, but only if no generator has
   # explicitly been set.


### PR DESCRIPTION
The sync of gyp_xwalk with gyp_chromium 34 disabled the circular dependency check for
all platforms but Mac. Upstream doesn't have circular problems on the Mac platform
but we do so we need to skip the circular check for now. I also put back the TODO as
it was.
