### PR TITLE
[Runtime][IVI] Fix Tizen IVI build error by PR#1593.

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -40,7 +40,7 @@ const char kLaunchLocalPathKey[] = "widget.content.@src";
 const char kWebURLsKey[] = "widget.@id";
 
 #if defined(OS_TIZEN)
-const char kIcon128Key = "widget.icon.@src";
+const char kIcon128Key[] = "widget.icon.@src";
 const char kTizenAppIdKey[] = "widget.application.@package";
 #endif
 }  // namespace application_widget_keys


### PR DESCRIPTION
IVI buildbot reports error:
'xwalk::application_widget_keys::kIcon128Key' has a previous declaration
as 'const char xwalk::application_widget_keys::kIcon128Key []'

This PR fix above error.
