### PR TITLE
[IVI] Build fix for unit test

### DIFF
--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -36,7 +36,13 @@
 #endif
 
 using xwalk::Runtime;
+
+#if defined(OS_TIZEN)
+using xwalk::XWalkContentRendererClientTizen;
+#else
 using xwalk::XWalkContentRendererClient;
+#endif
+
 using xwalk::XWalkRunner;
 
 namespace {


### PR DESCRIPTION
I've got the following build error:

../../xwalk/test/base/in_process_browser_test.cc:46:20: error: ‘XWalkContentRendererClientTizen’ was not declared in this scope

This PR may fix this build error.