### PR TITLE
[Tools] Pass --delete_unversioned_trees to gclient sync.

### DIFF
--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -54,7 +54,8 @@ class DepsFetcher(object):
 
   def DoGclientSyncForChromium(self):
     gclient_cmd = ['gclient', 'sync', '--verbose', '--reset',
-                   '--force', '--with_branch_heads']
+                   '--force', '--with_branch_heads',
+                   '--delete_unversioned_trees']
     gclient_cmd.append('--gclientfile=%s' %
                        os.path.basename(self._new_gclient_file))
     gclient_utils.CheckCallAndFilterAndHeader(gclient_cmd,


### PR DESCRIPTION
Change fetch_deps.py so that we remove repositories that are no longer used; 
especially when we move to different Chromium versions and the repositories we
track change.
