### PR TITLE
[Android] Fix some Java compiling warnings for Crosswalk.

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkWebChromeClient.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkWebChromeClient.java
@@ -239,6 +239,12 @@ public class XWalkWebChromeClient {
     */
     // Note that the callback must always be executed at some point to ensure
     // that the sleeping WebCore thread is woken up.
+    // Since the parameter type WebStorage.QuotaUpdater and this API are
+    // deprecated in Android 4.4, while this parameter type and this API
+    // are still used before Android 4.4, no other API and parameter are
+    // to replace them, suppress the compiling warnings for Android 4.4
+    // due to deprecation.
+    @SuppressWarnings("deprecation")
     public void onExceededDatabaseQuota(String url, String databaseIdentifier,
             long quota, long estimatedDatabaseSize, long totalQuota,
             WebStorage.QuotaUpdater quotaUpdater) {
@@ -264,6 +270,12 @@ public class XWalkWebChromeClient {
     */
     // Note that the callback must always be executed at some point to ensure
     // that the sleeping WebCore thread is woken up.
+    // Since the parameter type WebStorage.QuotaUpdater and this API are
+    // deprecated in Android 4.4, while this parameter type and this API
+    // are still used before Android 4.4, no other API and parameter are
+    // to replace them, suppress the compiling warnings for Android 4.4
+    // due to deprecation.
+    @SuppressWarnings("deprecation")
     public void onReachedMaxAppCacheSize(long requiredStorage, long quota,
             WebStorage.QuotaUpdater quotaUpdater) {
         quotaUpdater.updateQuota(quota);

--- a/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultNotificationService.java
+++ b/runtime/android/java/src/org/xwalk/core/client/XWalkDefaultNotificationService.java
@@ -143,9 +143,9 @@ public class XWalkDefaultNotificationService implements XWalkNotificationService
             }
             builder.setLargeIcon(
                     Bitmap.createScaledBitmap(icon, targetWidth, targetHeight, true));
-            Notification notification = builder.getNotification();
+            Notification notification = builder.build();
             doShowNotification(notificationId, notification);
-            mExistNotificationIds.put(notificationId, builder);            
+            mExistNotificationIds.put(notificationId, builder);
         }
     }
 
@@ -181,13 +181,13 @@ public class XWalkDefaultNotificationService implements XWalkNotificationService
                          .setContentTitle(title)
                          .setSmallIcon(iconRes)
                          .setAutoCancel(true);
-        Notification notification = builder.getNotification();
+        Notification notification = builder.build();
         doShowNotification(notificationId, notification);
         mExistNotificationIds.put(notificationId, builder);
         notificationChanged();
         onNotificationShown(notificationId, processId, routeId);
     }
-    
+
     @Override
     public void cancelNotification(int notificationId, int processId, int routeId) {
         mNotificationManager.cancel(notificationId);
@@ -210,7 +210,7 @@ public class XWalkDefaultNotificationService implements XWalkNotificationService
             notificationChanged();
             if (mBridge != null) {
                 mBridge.notificationClicked(notificationId, processId, routeId);
-            } 
+            }
         }
     }
 

--- a/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesStorage.java
+++ b/runtime/android/java/src/org/xwalk/runtime/extension/api/device_capabilities/DeviceCapabilitiesStorage.java
@@ -86,9 +86,9 @@ class DeviceCapabilitiesStorage {
             StatFs stat = new StatFs(mPath);
             // FIXME(halton): After API level 18, use getTotalBytes() and
             // getAvailableBytes() instead
-            long blockSize = stat.getBlockSize();
-            mCapacity = blockSize * stat.getBlockCount();
-            mAvailCapacity = blockSize * stat.getAvailableBlocks();
+            long blockSize = stat.getBlockSizeLong();
+            mCapacity = blockSize * stat.getBlockCountLong();
+            mAvailCapacity = blockSize * stat.getAvailableBlocksLong();
         }
 
         public JSONObject convertToJSON() {


### PR DESCRIPTION
Since some webkit APIs and Android OS APIs are deprecated as the
updated Android OS version, there are compiling warnings in Crosswalk.
This fix resolves these issues by using specific modes. For deprecated
parameter type in API, we suppress the warnings, for example, in
XWalkWebChromeClient::onExceededDatabaseQuota(), the parameter type of
WebStorage.QuotaUpdater is deprecated in Android 4.4, while it is still
used before Android 4.4, no other parameter is to replace it. For the
deprecated APIs, the compatible APIs are used to replace them accordingly.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1064
