### PR TITLE
[Android] Check accessability before dynamically setting resource ids

### DIFF
--- a/runtime/android/java/src/org/xwalk/core/XWalkInternalResources.java
+++ b/runtime/android/java/src/org/xwalk/core/XWalkInternalResources.java
@@ -39,6 +39,8 @@ public class XWalkInternalResources {
                     }
                     Field[] fields = innerClazz.getFields();
                     for (Field field : fields) {
+                        // It's final means we are probably not used as library project.
+                        if (!field.isAccessible()) continue;
                         try {
                             int value = generatedInnerClazz.getField(field.getName()).getInt(null);
                             field.setInt(null, value);


### PR DESCRIPTION
When not used as Android Library, the resource ids in R.java will
be final. To avoid a lot of warning messages in such case, check
accessability before trying to set values.
