### PR TITLE
[Android] Bump the build SDK version from 18 to 19.

### DIFF
--- a/build/android/xwalkcore_library_template/project.properties
+++ b/build/android/xwalkcore_library_template/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-18
+target=android-19


### PR DESCRIPTION
Crosswalk has to be built with Android SDK and API 19 to avoid
compile errors.
