### PR TITLE
[Extensions] Removed Initialized() from the XWalkExtension class

### DIFF
--- a/extensions/common/xwalk_extension.cc
+++ b/extensions/common/xwalk_extension.cc
@@ -25,10 +25,6 @@ XWalkExtension::XWalkExtension() : permissions_delegate_(NULL) {}
 
 XWalkExtension::~XWalkExtension() {}
 
-bool XWalkExtension::Initialize() {
-  return false;
-}
-
 const base::ListValue& XWalkExtension::entry_points() const {
   return entry_points_;
 }

--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -46,8 +46,6 @@ class XWalkExtension {
 
   virtual ~XWalkExtension();
 
-  virtual bool Initialize();
-
   virtual XWalkExtensionInstance* CreateInstance() = 0;
 
   std::string name() const { return name_; }


### PR DESCRIPTION
This is only needed by XWalkExternalExtension.
