### PR TITLE
Fix multiple crashes of xwalk_browsertest in Debug mode

### DIFF
--- a/application/test/application_browsertest.cc
+++ b/application/test/application_browsertest.cc
@@ -38,6 +38,15 @@ void ApplicationBrowserTest::SetUp() {
   InProcessBrowserTest::SetUp();
 }
 
+void ApplicationBrowserTest::ProperMainThreadCleanup() {
+  const ScopedVector<Application>& apps =
+    application_sevice()->active_applications();
+
+  std::for_each(apps.begin(), apps.end(),
+    std::bind2nd(std::mem_fun(&Application::Terminate),
+                              Application::Immediate));
+}
+
 ApplicationService* ApplicationBrowserTest::application_sevice() const {
   return xwalk::XWalkRunner::GetInstance()->app_system()
       ->application_service();

--- a/application/test/application_browsertest.h
+++ b/application/test/application_browsertest.h
@@ -20,6 +20,8 @@ class ApplicationBrowserTest: public InProcessBrowserTest {
 
   virtual void SetUp() OVERRIDE;
 
+  virtual void ProperMainThreadCleanup() OVERRIDE;
+
   xwalk::application::ApplicationService* application_sevice() const;
 
   scoped_ptr<ApiTestRunner> test_runner_;

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -146,6 +146,12 @@ void Runtime::LoadURL(const GURL& url) {
 }
 
 void Runtime::Close() {
+  if (window_) {
+    window_->Close();
+    return;
+  }
+  // Runtime should not free itself on Close but be owned
+  // by Application.
   delete this;
 }
 
@@ -325,7 +331,9 @@ void Runtime::Observe(int type,
 }
 
 void Runtime::OnWindowDestroyed() {
-  Close();
+  // Runtime should not free itself on Close but be owned
+  // by Application.
+  delete this;
 }
 
 void Runtime::RequestMediaAccessPermission(

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -186,13 +186,6 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
 
   NativeAppWindow::Initialize();
 
-  application::ApplicationSystem* app_system = xwalk_runner_->app_system();
-  if (app_system->HandleApplicationManagementCommands(
-      *command_line, startup_url_,
-      run_default_message_loop_)) {
-    return;
-  }
-
   if (command_line->HasSwitch(switches::kListFeaturesFlags)) {
     XWalkRuntimeFeatures::GetInstance()->DumpFeaturesFlags();
     run_default_message_loop_ = false;
@@ -206,9 +199,11 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     return;
   }
 
-  if (app_system->LaunchFromCommandLine(*command_line, startup_url_,
-      run_default_message_loop_)) {
-    return;
+  application::ApplicationSystem* app_system = xwalk_runner_->app_system();
+  if (!app_system->HandleApplicationManagementCommands(*command_line,
+      startup_url_, run_default_message_loop_)) {
+    app_system->LaunchFromCommandLine(*command_line, startup_url_,
+                                      run_default_message_loop_);
   }
 
   // If the |ui_task| is specified in main function parameter, it indicates

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -56,8 +56,13 @@ RuntimeRegistry::~RuntimeRegistry() {
 }
 
 void RuntimeRegistry::CloseAll() {
+  if (runtimes_.empty())
+    return;
+
   RuntimeList cached(runtimes_);
   std::for_each(cached.begin(), cached.end(), std::mem_fun(&Runtime::Close));
+  // Wait until all windows are closed.
+  content::RunAllPendingInMessageLoop();
   DCHECK(runtimes_.empty()) << runtimes_.size();
 }
 
@@ -147,10 +152,7 @@ void InProcessBrowserTest::RunTestOnMainThreadLoop() {
 
   // Invoke cleanup and quit even if there are failures. This is similar to
   // gtest in that it invokes TearDown even if Setup fails.
-  CleanUpOnMainThread();
-  // Sometimes tests leave Quit tasks in the MessageLoop (for shame), so let's
-  // run all pending messages here to avoid preempting the QuitBrowsers tasks.
-  content::RunAllPendingInMessageLoop();
+  ProperMainThreadCleanup();
 
   runtime_registry_->CloseAll();
 }

--- a/test/base/in_process_browser_test.h
+++ b/test/base/in_process_browser_test.h
@@ -70,7 +70,7 @@ class InProcessBrowserTest : public content::BrowserTestBase {
 
   // Override this to add any custom cleanup code that needs to be done on the
   // main thread before the browser is torn down.
-  virtual void CleanUpOnMainThread() {}
+  virtual void ProperMainThreadCleanup() {}
 
   // BrowserTestBase:
   virtual void RunTestOnMainThreadLoop() OVERRIDE;


### PR DESCRIPTION
Runtime is responsible for creating and destroying the ui::Compositor through
NativeAppWindow. So, we should call window Close() before discarding the
Runtime and we should wait for the window is actually closed so that the
compositor is deleted normally (Credits to @nagineni for the preliminary
analysis).

Another problem which is fixed by this patch is the early return from the
"XWalkBrowserMainParts::PreMainMessageLoopRun" method if application system
managed to handle command line arguments as this did not take into account
the "parameters_.ui_task". This problem led to hanging of some browser tests
that were using command line arguments e.g. "ApplicationOnInstalledEventTest".

BUG=https://crosswalk-project.org/jira/browse/XWALK-1014
