### PR TITLE
[Android] Allow extension manager to load extension js from res/raw

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -157,8 +157,8 @@ def CopyJSBindingFiles(project_source, out_directory):
   print 'Copying js binding files...'
   jsapi_directory = os.path.join(out_directory,
                                  LIBRARY_PROJECT_NAME,
-                                 'assets',
-                                 'jsapi')
+                                 'res',
+                                 'raw')
   if not os.path.exists(jsapi_directory):
     os.makedirs(jsapi_directory)
 


### PR DESCRIPTION
This is step one of getting rid of assets for xwalk_core_library.
Because assets are not supported well for android library project.

Now XWalkExtensionManager will load extension js files from res/raw
first for internal extensions, then from assets if not found.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1084
