### PR TITLE
[Android] Change targetSdkVersion from 17 to 19 for AndroidManifest.xml.

### DIFF
--- a/app/android/app_hello_world/AndroidManifest.xml
+++ b/app/android/app_hello_world/AndroidManifest.xml
@@ -23,7 +23,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/android/app_template/AndroidManifest.xml
+++ b/app/android/app_template/AndroidManifest.xml
@@ -24,7 +24,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/android/runtime_client_embedded_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_embedded_shell/AndroidManifest.xml
@@ -26,7 +26,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>

--- a/app/android/runtime_client_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_shell/AndroidManifest.xml
@@ -26,7 +26,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>

--- a/build/android/xwalkcore_library_template/AndroidManifest.xml
+++ b/build/android/xwalkcore_library_template/AndroidManifest.xml
@@ -5,5 +5,5 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="17" />
+        android:targetSdkVersion="19" />
 </manifest>

--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -29,7 +29,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>

--- a/runtime/android/runtime_lib/AndroidManifest.xml
+++ b/runtime/android/runtime_lib/AndroidManifest.xml
@@ -13,5 +13,5 @@
         android:label="XWalkRuntimeLib" android:hardwareAccelerated="true" android:icon="@drawable/crosswalk">
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
 </manifest>

--- a/runtime/android/runtime_shell/AndroidManifest.xml
+++ b/runtime/android/runtime_shell/AndroidManifest.xml
@@ -29,7 +29,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CAMERA"/>

--- a/test/android/core/javatests/AndroidManifest.xml
+++ b/test/android/core/javatests/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:authorities="org.xwalk.core.xwview.test.TestContentProvider" />
     </application>
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
     <instrumentation android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="org.xwalk.core.xwview.shell"
         android:label="Test for org.xwalk.core.xwview" />

--- a/test/android/runtime/javatests/AndroidManifest.xml
+++ b/test/android/runtime/javatests/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:authorities="org.xwalk.runtime.test.TestContentProvider" />
     </application>
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
     <instrumentation android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="org.xwalk.runtime.shell"
         android:label="Test for org.xwalk.runtime" />

--- a/test/android/runtime_client/javatests/AndroidManifest.xml
+++ b/test/android/runtime_client/javatests/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:authorities="org.xwalk.runtime.client.test.TestContentProvider" />
     </application>
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
     <instrumentation android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="org.xwalk.runtime.client.shell"
         android:label="Test for org.xwalk.runtime.client" />

--- a/test/android/runtime_client_embedded/javatests/AndroidManifest.xml
+++ b/test/android/runtime_client_embedded/javatests/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:authorities="org.xwalk.runtime.client.embedded.test.TestContentProvider" />
     </application>
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="17" />
+    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
     <instrumentation android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="org.xwalk.runtime.client.embedded.shell"
         android:label="Test for org.xwalk.runtime.client.embedded" />


### PR DESCRIPTION
AndroidManifest.xml of all Android projects should be changed to build
with Android 19 API and SDK.
