### PR TITLE
[IVI][Runtime] Fix for installing application on Tizen IVI 3.0 image.

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -29,7 +29,7 @@
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
 #include "xwalk/application/browser/installer/tizen/package_installer.h"
 #include "xwalk/application/browser/installer/tizen/service_package_installer.h"
 #endif
@@ -149,7 +149,7 @@ void SaveSystemEventsInfo(
   }
 }
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
 bool InstallPackageOnTizen(xwalk::application::ApplicationService* service,
                            xwalk::application::ApplicationStorage* storage,
                            xwalk::application::ApplicationData* application,
@@ -185,7 +185,7 @@ bool UninstallPackageOnTizen(xwalk::application::ApplicationService* service,
   }
   return true;
 }
-#endif  // OS_TIZEN
+#endif  // OS_TIZEN_MOBILE
 
 bool CopyDirectoryContents(const base::FilePath& from,
     const base::FilePath& to) {
@@ -293,7 +293,7 @@ bool ApplicationService::Install(const base::FilePath& path, std::string* id) {
     return false;
   }
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   if (!InstallPackageOnTizen(this, application_storage_,
                              application_data.get(),
                              runtime_context_->GetPath())) {
@@ -402,7 +402,7 @@ bool ApplicationService::Update(const std::string& id,
     return false;
   }
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   if (!UninstallPackageOnTizen(this, application_storage_,
                                old_application.get(),
                                runtime_context_->GetPath())) {
@@ -416,14 +416,14 @@ bool ApplicationService::Update(const std::string& id,
     LOG(ERROR) << "An Error occurred when updating the application.";
     base::DeleteFile(app_dir, true);
     base::Move(tmp_dir, app_dir);
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
     InstallPackageOnTizen(this, application_storage_,
                           old_application.get(),
                           runtime_context_->GetPath());
 #endif
     return false;
   }
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   if (!InstallPackageOnTizen(this, application_storage_,
                              new_application.get(),
                              runtime_context_->GetPath()))
@@ -455,7 +455,7 @@ bool ApplicationService::Uninstall(const std::string& id) {
     app->Terminate(Application::Immediate);
   }
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   if (!UninstallPackageOnTizen(this, application_storage_, application.get(),
                                runtime_context_->GetPath()))
     result = false;

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -42,7 +42,7 @@ bool GetXWalkDataPath(base::FilePath* path) {
   CHECK(PathService::Get(base::DIR_LOCAL_APP_DATA, &cur));
   cur = cur.Append(xwalk_suffix);
 
-#elif defined(OS_TIZEN)
+#elif defined(OS_TIZEN_MOBILE)
   if (XWalkRunner::GetInstance()->is_running_as_service())
     cur = GetConfigPath().Append(xwalk_suffix);
   else


### PR DESCRIPTION
The integrations are not compatible with Tizen IVI 3.0, due to they are
designed for Tizen mobile 2.x, so revert the flag from OS_TIZEN to
OS_TIZEN_MOBILE temporary.

BUG=XWALK-1074
