### PR TITLE
[Android] Enable CSP support and related test.

### DIFF
--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -44,6 +44,8 @@ namespace keys = application_manifest_keys;
 
 namespace application {
 
+namespace {
+
 net::HttpResponseHeaders* BuildHttpHeaders(
     const std::string& content_security_policy,
     const std::string& mime_type, const std::string& method,
@@ -81,8 +83,6 @@ net::HttpResponseHeaders* BuildHttpHeaders(
   raw_headers.append(2, '\0');
   return new net::HttpResponseHeaders(raw_headers);
 }
-
-namespace {
 
 class GeneratedMainDocumentJob: public net::URLRequestSimpleJob {
  public:

--- a/application/browser/application_protocols.h
+++ b/application/browser/application_protocols.h
@@ -5,26 +5,14 @@
 #ifndef XWALK_APPLICATION_BROWSER_APPLICATION_PROTOCOLS_H_
 #define XWALK_APPLICATION_BROWSER_APPLICATION_PROTOCOLS_H_
 
-#include <string>
-
-#include "base/files/file_path.h"
 #include "base/memory/linked_ptr.h"
 #include "net/url_request/url_request_job_factory.h"
 #include "xwalk/application/browser/application_system.h"
-
-namespace net {
-class HttpResponseHeaders;
-}
 
 namespace xwalk {
 namespace application {
 
 class ApplicationService;
-net::HttpResponseHeaders* BuildHttpHeaders(
-    const std::string& content_security_policy,
-    const std::string& mime_type, const std::string& method,
-    const base::FilePath& file_path, const base::FilePath& relative_path,
-    bool is_authority_match);
 
 // Creates the handlers for the app:// scheme.
 linked_ptr<net::URLRequestJobFactory::ProtocolHandler>

--- a/runtime/browser/android/intercepted_request_data_impl.cc
+++ b/runtime/browser/android/intercepted_request_data_impl.cc
@@ -9,7 +9,6 @@
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
 #include "jni/InterceptedRequestData_jni.h"
-#include "net/base/escape.h"
 #include "net/url_request/url_request.h"
 #include "net/url_request/url_request_job.h"
 #include "xwalk/runtime/browser/android/net/android_protocol_handler.h"
@@ -123,10 +122,6 @@ net::URLRequestJob* InterceptedRequestDataImpl::CreateJobFor(
   scoped_ptr<AndroidStreamReaderURLRequestJob::Delegate>
       stream_reader_job_delegate_impl(new StreamReaderJobDelegateImpl(this));
 
-  base::FilePath relative_path = base::FilePath(
-      net::UnescapeURLComponent(request->url().path(),
-          net::UnescapeRule::SPACES | net::UnescapeRule::URL_SPECIAL_CHARS));
-
   xwalk::XWalkBrowserMainParts* main_parts =
           xwalk::XWalkContentBrowserClient::Get()->main_parts();
   xwalk::RuntimeContext* runtime_context = main_parts->runtime_context();
@@ -134,7 +129,7 @@ net::URLRequestJob* InterceptedRequestDataImpl::CreateJobFor(
 
   return new AndroidStreamReaderURLRequestJob(
       request, network_delegate, stream_reader_job_delegate_impl.Pass(),
-      relative_path, content_security_policy);
+      content_security_policy);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/android/net/android_protocol_handler.cc
+++ b/runtime/browser/android/net/android_protocol_handler.cc
@@ -249,10 +249,6 @@ net::URLRequestJob* AndroidProtocolHandlerBase::MaybeCreateJob(
   scoped_ptr<AndroidStreamReaderURLRequestJobDelegateImpl> reader_delegate(
       new AndroidStreamReaderURLRequestJobDelegateImpl());
 
-  base::FilePath relative_path = base::FilePath(
-      net::UnescapeURLComponent(request->url().path(),
-          net::UnescapeRule::SPACES | net::UnescapeRule::URL_SPECIAL_CHARS));
-
   xwalk::XWalkBrowserMainParts* main_parts =
           xwalk::XWalkContentBrowserClient::Get()->main_parts();
   xwalk::RuntimeContext* runtime_context = main_parts->runtime_context();
@@ -262,7 +258,6 @@ net::URLRequestJob* AndroidProtocolHandlerBase::MaybeCreateJob(
       request,
       network_delegate,
       reader_delegate.PassAs<AndroidStreamReaderURLRequestJob::Delegate>(),
-      relative_path,
       content_security_policy);
 }
 

--- a/runtime/browser/android/net/android_stream_reader_url_request_job.h
+++ b/runtime/browser/android/net/android_stream_reader_url_request_job.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/android/scoped_java_ref.h"
-#include "base/files/file_path.h"
 #include "base/location.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_ptr.h"
@@ -78,7 +77,6 @@ class AndroidStreamReaderURLRequestJob : public net::URLRequestJob {
       net::URLRequest* request,
       net::NetworkDelegate* network_delegate,
       scoped_ptr<Delegate> delegate,
-      const base::FilePath& relative_path,
       const std::string& content_security_policy);
 
   // URLRequestJob:
@@ -118,8 +116,6 @@ class AndroidStreamReaderURLRequestJob : public net::URLRequestJob {
   net::HttpByteRange byte_range_;
   scoped_ptr<net::HttpResponseInfo> response_info_;
   scoped_ptr<Delegate> delegate_;
-  const std::string mime_type_;
-  base::FilePath relative_path_;
   std::string content_security_policy_;
   scoped_refptr<InputStreamReaderWrapper> input_stream_reader_wrapper_;
   base::WeakPtrFactory<AndroidStreamReaderURLRequestJob> weak_factory_;

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkClientShouldInterceptRequestTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkClientShouldInterceptRequestTest.java
@@ -318,10 +318,8 @@ public class XWalkClientShouldInterceptRequestTest extends XWalkViewTestBase {
         }
     }
 
-    //@SmallTest
-    //@Feature({"XWalkClientShouldInterceptRequest"})
-    // TODO(gaochun): Enable it once the issue XWALK-1022 gets resolved.
-    @DisabledTest
+    @SmallTest
+    @Feature({"XWalkClientShouldInterceptRequest"})
     public void testHttpStatusField() throws Throwable {
         final String syncGetUrl = mWebServer.getResponseUrl("/intercept_me");
         final String syncGetJs =

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/CSPTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/CSPTest.java
@@ -6,7 +6,6 @@
 package org.xwalk.runtime.client.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.shell.XWalkRuntimeClientShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -16,11 +15,8 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class CSPTest extends XWalkRuntimeClientTestBase {
 
-    // TODO(gaochun): Enable the test when the issue was fixed:
-    // Bug: https://crosswalk-project.org/jira/browse/XWALK-1022
-    // @SmallTest
-    // @Feature({"CSP"})
-    @DisabledTest
+    @SmallTest
+    @Feature({"CSP"})
     public void testCSP() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/CSPTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/CSPTest.java
@@ -6,7 +6,6 @@
 package org.xwalk.runtime.client.embedded.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.embedded.shell.XWalkRuntimeClientEmbeddedShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -16,11 +15,8 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class CSPTest extends XWalkRuntimeClientTestBase {
 
-    // TODO(gaochun): Enable the test when the issue was fixed:
-    // Bug: https://crosswalk-project.org/jira/browse/XWALK-1022
-    // @SmallTest
-    // @Feature({"CSP"})
-    @DisabledTest
+    @SmallTest
+    @Feature({"CSP"})
     public void testCSP() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(


### PR DESCRIPTION
Insert CSP content to http response header with android specific
method: AndroidStreamReaderURLRequestJob::HeadersComplete(), rather
than reuse the header created by Tizen code.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1022
