### PR TITLE
Remove runtime context from 'XWalkBrowserMainParts' class

### DIFF
--- a/runtime/browser/android/intercepted_request_data_impl.cc
+++ b/runtime/browser/android/intercepted_request_data_impl.cc
@@ -15,8 +15,7 @@
 #include "xwalk/runtime/browser/android/net/android_stream_reader_url_request_job.h"
 #include "xwalk/runtime/browser/android/net/input_stream_impl.h"
 #include "xwalk/runtime/browser/runtime_context.h"
-#include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
-#include "xwalk/runtime/browser/xwalk_content_browser_client.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 using base::android::ScopedJavaLocalRef;
 
@@ -122,9 +121,8 @@ net::URLRequestJob* InterceptedRequestDataImpl::CreateJobFor(
   scoped_ptr<AndroidStreamReaderURLRequestJob::Delegate>
       stream_reader_job_delegate_impl(new StreamReaderJobDelegateImpl(this));
 
-  xwalk::XWalkBrowserMainParts* main_parts =
-          xwalk::XWalkContentBrowserClient::Get()->main_parts();
-  xwalk::RuntimeContext* runtime_context = main_parts->runtime_context();
+  RuntimeContext* runtime_context =
+      XWalkRunner::GetInstance()->runtime_context();
   std::string content_security_policy = runtime_context->GetCSPString();
 
   return new AndroidStreamReaderURLRequestJob(

--- a/runtime/browser/android/net/android_protocol_handler.cc
+++ b/runtime/browser/android/net/android_protocol_handler.cc
@@ -24,8 +24,7 @@
 #include "xwalk/runtime/browser/android/net/input_stream_impl.h"
 #include "xwalk/runtime/browser/android/net/url_constants.h"
 #include "xwalk/runtime/browser/runtime_context.h"
-#include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
-#include "xwalk/runtime/browser/xwalk_content_browser_client.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 using base::android::AttachCurrentThread;
 using base::android::ClearException;
@@ -249,9 +248,8 @@ net::URLRequestJob* AndroidProtocolHandlerBase::MaybeCreateJob(
   scoped_ptr<AndroidStreamReaderURLRequestJobDelegateImpl> reader_delegate(
       new AndroidStreamReaderURLRequestJobDelegateImpl());
 
-  xwalk::XWalkBrowserMainParts* main_parts =
-          xwalk::XWalkContentBrowserClient::Get()->main_parts();
-  xwalk::RuntimeContext* runtime_context = main_parts->runtime_context();
+  xwalk::RuntimeContext* runtime_context =
+      xwalk::XWalkRunner::GetInstance()->runtime_context();
   std::string content_security_policy = runtime_context->GetCSPString();
 
   return new AndroidStreamReaderURLRequestJob(

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -35,8 +35,7 @@
 #include "xwalk/runtime/browser/android/xwalk_web_contents_delegate.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_resource_dispatcher_host_delegate_android.h"
-#include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
-#include "xwalk/runtime/browser/xwalk_content_browser_client.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "jni/XWalkContent_jni.h"
 
 using base::android::AttachCurrentThread;
@@ -120,11 +119,8 @@ content::WebContents* XWalkContent::CreateWebContents(
     JNIEnv* env, jobject io_thread_client,
     jobject intercept_navigation_delegate) {
 
-  XWalkBrowserMainParts* main_parts =
-          XWalkContentBrowserClient::Get()->main_parts();
-  CHECK(main_parts);
-  // FIXME : need a better way to get context.
-  RuntimeContext* runtime_context = main_parts->runtime_context();
+  RuntimeContext* runtime_context =
+      XWalkRunner::GetInstance()->runtime_context();
   CHECK(runtime_context);
 
   content::WebContents* web_contents = content::WebContents::Create(
@@ -235,10 +231,8 @@ jboolean XWalkContent::SetManifest(JNIEnv* env,
   std::string csp;
   manifest.GetString(
       xwalk::application_manifest_keys::kCSPKey, &csp);
-  XWalkBrowserMainParts* main_parts =
-          XWalkContentBrowserClient::Get()->main_parts();
-  CHECK(main_parts);
-  RuntimeContext* runtime_context = main_parts->runtime_context();
+  RuntimeContext* runtime_context =
+      XWalkRunner::GetInstance()->runtime_context();
   CHECK(runtime_context);
   runtime_context->SetCSPString(csp);
 

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -165,7 +165,6 @@ void XWalkBrowserMainParts::RegisterExternalExtensions() {
 void XWalkBrowserMainParts::PreMainMessageLoopRun() {
   xwalk_runner_->PreMainMessageLoopRun();
 
-  runtime_context_ = xwalk_runner_->runtime_context();
   extension_service_ = xwalk_runner_->extension_service();
 
   if (extension_service_)
@@ -179,7 +178,7 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     const char* local_ip = "0.0.0.0";
     if (base::StringToInt(port_str, &port) && port > 0 && port < 65535) {
       remote_debugging_server_.reset(
-          new RemoteDebuggingServer(runtime_context_,
+          new RemoteDebuggingServer(xwalk_runner_->runtime_context(),
               local_ip, port, std::string()));
     }
   }

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -22,7 +22,6 @@ class RenderProcessHost;
 
 namespace xwalk {
 
-class RuntimeContext;
 class RemoteDebuggingServer;
 class XWalkRunner;
 
@@ -57,8 +56,6 @@ class XWalkBrowserMainParts : public content::BrowserMainParts {
       extensions::XWalkExtensionVector* extensions);
 
 #if defined(OS_ANDROID)
-  RuntimeContext* runtime_context() { return runtime_context_; }
-
   // XWalkExtensionAndroid needs to register its extensions on
   // XWalkBrowserMainParts so they get correctly registered on-demand
   // by XWalkExtensionService each time a in_process Server is created.
@@ -70,8 +67,6 @@ class XWalkBrowserMainParts : public content::BrowserMainParts {
   void RegisterExternalExtensions();
 
   XWalkRunner* xwalk_runner_;
-
-  RuntimeContext* runtime_context_;
 
   extensions::XWalkExtensionService* extension_service_;
 

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -122,7 +122,6 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopRun() {
 
   xwalk_runner_->PreMainMessageLoopRun();
 
-  runtime_context_ = xwalk_runner_->runtime_context();
   extension_service_ = xwalk_runner_->extension_service();
 
   // Prepare the cookie store.


### PR DESCRIPTION
SSIA. Runtime context should be obtained from 'XWalkRunner' - there is
no need to store it in "main parts" and have a runtime context getter
there.
