### PR TITLE
"XWalkExtensionsIFrameTest.IFrameUsingDocumentWriteShouldNotCrash" test failure

### DIFF
--- a/test/base/xwalk_test_utils.cc
+++ b/test/base/xwalk_test_utils.cc
@@ -66,11 +66,8 @@ void NavigateToURL(xwalk::Runtime* runtime, const GURL& url) {
   if (runtime->web_contents()->IsLoading())
     content::WaitForLoadStop(runtime->web_contents());
 
-  TestNavigationObserver navigation_observer(runtime->web_contents(), 1);
   runtime->LoadURL(url);
-
-  base::RunLoop run_loop;
-  navigation_observer.Wait();
+  content::WaitForLoadStop(runtime->web_contents());
 }
 
 }  // namespace xwalk_test_utils


### PR DESCRIPTION
The "XWalkExtensionsIFrameTest.IFrameUsingDocumentWriteShouldNotCrash"
test failed on Linux due to some pending events left after
"xwalk_test_utils::NavigateToURL()". The pending events were
prosessed after the corresponding web contents had been
already destroyed causing the crash.
