### PR TITLE
[Android] Fix the regression issue of http authentication on chromium 34...

### DIFF
--- a/runtime/browser/android/xwalk_login_delegate.cc
+++ b/runtime/browser/android/xwalk_login_delegate.cc
@@ -8,7 +8,7 @@
 #include "base/logging.h"
 #include "base/supports_user_data.h"
 #include "content/public/browser/browser_thread.h"
-#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/resource_dispatcher_host.h"
 #include "content/public/browser/resource_request_info.h"
 #include "content/public/browser/web_contents.h"
@@ -16,7 +16,7 @@
 #include "net/url_request/url_request.h"
 
 using content::BrowserThread;
-using content::RenderViewHost;
+using content::RenderFrameHost;
 using content::ResourceDispatcherHost;
 using content::ResourceRequestInfo;
 using content::WebContents;
@@ -39,9 +39,9 @@ XWalkLoginDelegate::XWalkLoginDelegate(net::AuthChallengeInfo* auth_info,
     : auth_info_(auth_info),
       request_(request),
       render_process_id_(0),
-      render_view_id_(0) {
+      render_frame_id_(0) {
     ResourceRequestInfo::GetRenderFrameForRequest(
-        request, &render_process_id_, &render_view_id_);
+        request, &render_process_id_, &render_frame_id_);
 
     UrlRequestAuthAttemptsData* count =
         static_cast<UrlRequestAuthAttemptsData*>(
@@ -85,15 +85,15 @@ void XWalkLoginDelegate::HandleHttpAuthRequestOnUIThread(
   xwalk_http_auth_handler_.reset(XWalkHttpAuthHandlerBase::Create(
       this, auth_info_.get(), first_auth_attempt));
 
-  RenderViewHost* render_view_host = RenderViewHost::FromID(
-      render_process_id_, render_view_id_);
-  if (!render_view_host) {
+  RenderFrameHost* render_frame_host = RenderFrameHost::FromID(
+      render_process_id_, render_frame_id_);
+  if (!render_frame_host) {
     Cancel();
     return;
   }
 
-  WebContents* web_contents = WebContents::FromRenderViewHost(
-      render_view_host);
+  WebContents* web_contents = WebContents::FromRenderFrameHost(
+      render_frame_host);
   if (!xwalk_http_auth_handler_->HandleOnUIThread(web_contents)) {
     Cancel();
     return;

--- a/runtime/browser/android/xwalk_login_delegate.h
+++ b/runtime/browser/android/xwalk_login_delegate.h
@@ -24,7 +24,8 @@ class XWalkLoginDelegate
   XWalkLoginDelegate(net::AuthChallengeInfo* auth_info,
                      net::URLRequest* request);
 
-  virtual void Proceed(const base::string16& user, const base::string16& password);
+  virtual void Proceed(const base::string16& user,
+                       const base::string16& password);
   virtual void Cancel();
 
   // from ResourceDispatcherHostLoginDelegate
@@ -34,14 +35,15 @@ class XWalkLoginDelegate
   virtual ~XWalkLoginDelegate();
   void HandleHttpAuthRequestOnUIThread(bool first_auth_attempt);
   void CancelOnIOThread();
-  void ProceedOnIOThread(const base::string16& user, const base::string16& password);
+  void ProceedOnIOThread(const base::string16& user,
+                         const base::string16& password);
   void DeleteAuthHandlerSoon();
 
   scoped_ptr<XWalkHttpAuthHandlerBase> xwalk_http_auth_handler_;
   scoped_refptr<net::AuthChallengeInfo> auth_info_;
   net::URLRequest* request_;
   int render_process_id_;
-  int render_view_id_;
+  int render_frame_id_;
 };
 
 }  // namespace xwalk


### PR DESCRIPTION
....

Based on chromium 34, the http authentication cannot work, while
it works on chromium 32, this is because Chromium 34 starts to
support the out-of-process iframe, RenderViewHost is replaced by
RenderFrameHost, while in XwalkLoginDelegate, webcontents is still
gotten via the RenderViewHost, which causes the corresponding UI
thread for http authentication not to work. This fix resolves this
issue by replacing RenderView with RenderFrame for http authentication.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1088
