### PR TITLE
[Tizen][Runtime] Fix session bus issue under service mode.

### DIFF
--- a/dbus/dbus_manager_tizen.cc
+++ b/dbus/dbus_manager_tizen.cc
@@ -31,12 +31,6 @@ scoped_refptr<dbus::Bus> DBusManager::session_bus() {
     dbus::Bus::Options options;
     options.dbus_task_runner = dbus_thread_->message_loop_proxy();
 
-    // On Tizen 2.x DBUS_SESSION_ADDRESS points to a wrong path, so we set
-    // the correct one here.
-    options.bus_type = dbus::Bus::CUSTOM_ADDRESS;
-    options.address = base::StringPrintf(
-        "unix:path=/run/user/%s/dbus/user_bus_socket", g_get_user_name());
-
     session_bus_ = new dbus::Bus(options);
   }
 


### PR DESCRIPTION
Tizen 3.x and Tizen 2.x have different DBUS_SESSION_ADDRESS values.
For Tizen 2.x, DBUS_SESSION_ADDRESS points to
'/run/user/$USERNAME/dbus/user_bus_socket',
while for Tizen 3.x, DBUS_SESSION_ADDRESS points to
'/run/user/$UID/dbus/user_bus_socket'.

Since Crosswalk switches to Tizen 3.x, we need to use the latter one.

BUG=XWALK-1112
