### PR TITLE
[Tizen IVI] Run XWalk with title bar in windowed mode by default.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -234,7 +234,7 @@ void Application::OnRuntimeRemoved(Runtime* runtime) {
   runtimes_.erase(runtime);
 
   if (runtimes_.empty()) {
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
     runtime->CloseRootWindow();
 #endif
     base::MessageLoop::current()->PostTask(FROM_HERE,

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -60,7 +60,7 @@ Runtime* Runtime::Create(
   WebContents* web_contents = WebContents::Create(params);
 
   Runtime* runtime = new Runtime(web_contents, observer);
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   runtime->InitRootWindow();
 #endif
 
@@ -80,7 +80,7 @@ Runtime::Runtime(content::WebContents* web_contents, Observer* observer)
        xwalk::NOTIFICATION_RUNTIME_OPENED,
        content::Source<Runtime>(this),
        content::NotificationService::NoDetails());
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   root_window_ = NULL;
 #endif
   if (observer_)
@@ -129,7 +129,7 @@ void Runtime::AttachWindow(const NativeAppWindow::CreateParams& params) {
   if (!app_icon_.IsEmpty())
     window_->UpdateIcon(app_icon_);
   window_->Show();
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   if (root_window_)
     root_window_->Show();
 #endif
@@ -231,7 +231,7 @@ void Runtime::WebContentsCreated(
     const GURL& target_url,
     content::WebContents* new_contents) {
   Runtime* new_runtime = new Runtime(new_contents, observer_);
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   new_runtime->SetRootWindow(root_window_);
 #endif
   new_runtime->AttachDefaultWindow();
@@ -357,7 +357,7 @@ void Runtime::ApplyWindowDefaultParams(NativeAppWindow::CreateParams* params) {
     params->web_contents = web_contents_.get();
   if (params->bounds.IsEmpty())
     params->bounds = gfx::Rect(0, 0, kDefaultWidth, kDefaultHeight);
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   if (root_window_)
     params->parent = root_window_->GetNativeWindow();
 #endif
@@ -375,7 +375,7 @@ void Runtime::ApplyFullScreenParam(NativeAppWindow::CreateParams* params) {
   }
 }
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
 void Runtime::CloseRootWindow() {
   if (root_window_) {
     root_window_->Close();

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -74,7 +74,7 @@ class Runtime : public content::WebContentsDelegate,
   RuntimeContext* runtime_context() const { return runtime_context_; }
   gfx::Image app_icon() const { return app_icon_; }
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   void CloseRootWindow();
 #endif
 
@@ -152,7 +152,7 @@ class Runtime : public content::WebContentsDelegate,
   void ApplyWindowDefaultParams(NativeAppWindow::CreateParams* params);
   void ApplyFullScreenParam(NativeAppWindow::CreateParams* params);
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   void ApplyRootWindowParams(NativeAppWindow::CreateParams* params);
   void SetRootWindow(NativeAppWindow* window);
   void InitRootWindow();
@@ -169,7 +169,7 @@ class Runtime : public content::WebContentsDelegate,
 
   NativeAppWindow* window_;
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   NativeAppWindow* root_window_;
 #endif
 

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -52,7 +52,7 @@ void NativeAppWindowViews::Initialize() {
   params.top_level = true;
   params.show_state = create_params_.state;
   params.parent = create_params_.parent;
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   params.type = views::Widget::InitParams::TYPE_WINDOW_FRAMELESS;
   // On Tizen apps are sized to the work area.
   gfx::Rect bounds =
@@ -66,7 +66,7 @@ void NativeAppWindowViews::Initialize() {
 
   window_->Init(params);
 
-#if defined(OS_TIZEN)
+#if defined(OS_TIZEN_MOBILE)
   // Set the bounds manually to avoid inset.
   window_->SetBounds(bounds);
 #elif !defined(USE_OZONE)


### PR DESCRIPTION
The following commit makes XWalk run in full screen mode by default
because many parts of the code guarded by OS_TIZEN_MOBILE macro
were included in Tizen IVI, but some code seem to be specific for
Tizen Mobile such as creating the root window and frameless window,
which should be excluded from Tizen IVI.

https://github.com/crosswalk-project/crosswalk/commit/459efb92ed7d39f7b9be0ee99235f9b7f9c28b0b
