### PR TITLE
[Android] Fix resId setting for internal resources failed

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkInternalResources.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkInternalResources.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.util.Log;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 public class XWalkInternalResources {
     private static final String TAG = "XWalkInternalResources";
@@ -40,7 +41,7 @@ public class XWalkInternalResources {
                     Field[] fields = innerClazz.getFields();
                     for (Field field : fields) {
                         // It's final means we are probably not used as library project.
-                        if (!field.isAccessible()) continue;
+                        if (Modifier.isFinal(field.getModifiers())) continue;
                         try {
                             int value = generatedInnerClazz.getField(field.getName()).getInt(null);
                             field.setInt(null, value);


### PR DESCRIPTION
It's because the code was justify whether a field is final
by read its isAccessible(). It's wrong in java reflection.
Fix it by using Modifier.isFinal(getModifers()) instead.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1115
