### PR TITLE
Flaky crashes of XWalkExtensionsIFrameTest tests

### DIFF
--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -115,7 +115,7 @@ class ExtensionServerMessageFilter : public IPC::ChannelProxy::MessageFilter,
 
     base::Closure closure = base::Bind(
         base::IgnoreResult(&XWalkExtensionServer::OnMessageReceived),
-        base::Unretained(server), message);
+        server->AsWeakPtr(), message);
 
     task_runner->PostTask(FROM_HERE, closure);
   }
@@ -138,7 +138,7 @@ class ExtensionServerMessageFilter : public IPC::ChannelProxy::MessageFilter,
 
     base::Closure closure = base::Bind(
         base::IgnoreResult(&XWalkExtensionServer::OnCreateInstance),
-        base::Unretained(server), instance_id, name);
+        server->AsWeakPtr(), instance_id, name);
 
     task_runner->PostTask(FROM_HERE, closure);
   }

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/weak_ptr.h"
 #include "base/synchronization/lock.h"
 #include "base/values.h"
 #include "ipc/ipc_channel_proxy.h"
@@ -42,7 +43,8 @@ class XWalkExtensionInstance;
 //
 // This class is used both by in-process extensions running in the Browser
 // Process, and by the external extensions running in the Extension Process.
-class XWalkExtensionServer : public IPC::Listener {
+class XWalkExtensionServer : public IPC::Listener,
+    public base::SupportsWeakPtr<XWalkExtensionServer> {
  public:
   XWalkExtensionServer();
   virtual ~XWalkExtensionServer();


### PR DESCRIPTION
The problem here was due to a race condition with
XWalkExtensionServer. The XWalkExtensionServer methods
are invoked via task runner (on message loop), on the
other hand XWalkExtensionServer is deleted on message
loop, so the crashes turned up when the deferred calls
were processed after the object deletion.

Fixed now using WeakPtrs.
