### PR TITLE
[SysApps][Android] Fix Issue: Error callback isn't triggered without SIM card.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/extension/api/messaging/MessagingSmsManager.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/api/messaging/MessagingSmsManager.java
@@ -61,7 +61,6 @@ public class MessagingSmsManager {
     public void onSmsSend(int instanceID, JSONObject jsonMsg) {
         if (!checkService(DEFAULT_SERVICE_ID)) {
             Log.e(TAG, "No Sim Card");
-            return;
         }
         String promise_id = null;
         JSONObject eventBody = null;
@@ -232,7 +231,7 @@ public class MessagingSmsManager {
                     jsSentMsg.put("to", to);
                     jsSentMsg.put("body", smsMessage);
                     jsSentMsg.put("messageClass", "class1");
-                    jsSentMsg.put("state", "sending");
+                    jsSentMsg.put("state", error ? "failed" : "sending");
                     jsSentMsg.put("deliveryStatus", error ? "error" : "pending");
 
                     JSONObject jsonMsgPromise = new JSONObject();


### PR DESCRIPTION
When there is no SIM card, the onSmsSend put a error message and return. Thus, the JS error callback won't be invoked. Simply removing the return will resolve the issue, the error will be handled in MessagingReceiver and send back to JS end.

BUG=XWALK-940
