### PR TITLE
[SysApps][Android] Handle security exception in Android messaging API.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/extension/api/messaging/MessagingSmsManager.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/api/messaging/MessagingSmsManager.java
@@ -97,7 +97,11 @@ public class MessagingSmsManager {
                                                                -promiseIdInt, 
                                                                intentSmsDelivered,
                                                                PendingIntent.FLAG_ONE_SHOT);
-        sms.sendTextMessage(phone, null, smsMessage, piSent, piDelivered);
+        try {
+            sms.sendTextMessage(phone, null, smsMessage, piSent, piDelivered);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to send SMS message.", e);
+        }
     }
 
     public void onSmsClear(int instanceID, JSONObject jsonMsg) {


### PR DESCRIPTION
Add try-catch block to handle sending SMS message exception.
