### PR TITLE
[Android] Display 'Paste' option when long click on the input box

### DIFF
--- a/runtime/browser/android/xwalk_web_contents_view_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_view_delegate.cc
@@ -1,0 +1,42 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/android/xwalk_web_contents_view_delegate.h"
+
+#include "base/command_line.h"
+#include "content/public/browser/android/content_view_core.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_view.h"
+#include "content/public/common/context_menu_params.h"
+
+namespace xwalk {
+
+XWalkWebContentsViewDelegate::XWalkWebContentsViewDelegate(
+    content::WebContents* web_contents)
+    : web_contents_(web_contents) {
+}
+
+XWalkWebContentsViewDelegate::~XWalkWebContentsViewDelegate() {
+}
+
+void XWalkWebContentsViewDelegate::ShowContextMenu(
+    content::RenderFrameHost* render_frame_host,
+    const content::ContextMenuParams& params) {
+  if (params.is_editable && params.selection_text.empty()) {
+    content::ContentViewCore* content_view_core =
+        content::ContentViewCore::FromWebContents(web_contents_);
+    if (content_view_core) {
+      content_view_core->ShowPastePopup(params.selection_start.x(),
+                                        params.selection_start.y());
+    }
+  }
+}
+
+content::WebDragDestDelegate*
+    XWalkWebContentsViewDelegate::GetDragDestDelegate() {
+  return NULL;
+}
+
+}  // namespace xwalk

--- a/runtime/browser/android/xwalk_web_contents_view_delegate.h
+++ b/runtime/browser/android/xwalk_web_contents_view_delegate.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_ANDROID_XWALK_WEB_CONTENTS_VIEW_DELEGATE_H_
+#define XWALK_RUNTIME_BROWSER_ANDROID_XWALK_WEB_CONTENTS_VIEW_DELEGATE_H_
+
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_view_delegate.h"
+#include "content/public/common/context_menu_params.h"
+
+namespace xwalk {
+
+class XWalkWebContentsViewDelegate : public content::WebContentsViewDelegate {
+ public:
+  explicit XWalkWebContentsViewDelegate(content::WebContents* web_contents);
+  virtual ~XWalkWebContentsViewDelegate();
+
+  // Overridden from WebContentsViewDelegate:
+  virtual void ShowContextMenu(content::RenderFrameHost* render_frame_host,
+      const content::ContextMenuParams& params) OVERRIDE;
+  virtual content::WebDragDestDelegate* GetDragDestDelegate() OVERRIDE;
+
+ private:
+  content::WebContents* web_contents_;
+  content::ContextMenuParams params_;
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkWebContentsViewDelegate);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_ANDROID_XWALK_WEB_CONTENTS_VIEW_DELEGATE_H_

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -31,6 +31,7 @@
 #include "base/base_paths_android.h"
 #include "xwalk/runtime/browser/android/xwalk_cookie_access_policy.h"
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
+#include "xwalk/runtime/browser/android/xwalk_web_contents_view_delegate.h"
 #include "xwalk/runtime/browser/runtime_resource_dispatcher_host_delegate_android.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_android.h"
 #include "xwalk/runtime/common/android/xwalk_globals_android.h"
@@ -134,7 +135,11 @@ content::AccessTokenStore* XWalkContentBrowserClient::CreateAccessTokenStore() {
 content::WebContentsViewDelegate*
 XWalkContentBrowserClient::GetWebContentsViewDelegate(
     content::WebContents* web_contents) {
+#if defined(OS_ANDROID)
+  return new XWalkWebContentsViewDelegate(web_contents);
+#else
   return NULL;
+#endif
 }
 
 void XWalkContentBrowserClient::RenderProcessWillLaunch(

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -116,6 +116,8 @@
         'runtime/browser/android/xwalk_settings.cc',
         'runtime/browser/android/xwalk_web_contents_delegate.cc',
         'runtime/browser/android/xwalk_web_contents_delegate.h',
+        'runtime/browser/android/xwalk_web_contents_view_delegate.cc',
+        'runtime/browser/android/xwalk_web_contents_view_delegate.h',
         'runtime/browser/application_component.cc',
         'runtime/browser/application_component.h',
         'runtime/browser/devtools/remote_debugging_server.cc',


### PR DESCRIPTION
Add a new XWalkWebContentsViewDelegate to show the context menu.
Previously there is no delegate for Android port.

BUG=XWALK-1087
