### PR TITLE
[Android] Register JNI entries while libxwalkcore.so loaded

### DIFF
--- a/runtime/app/android/xwalk_entry_point.cc
+++ b/runtime/app/android/xwalk_entry_point.cc
@@ -13,6 +13,8 @@
 
 // This is called by the VM when the shared library is first loaded.
 JNI_EXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+  base::android::SetLibraryLoadedHook(&content::LibraryLoaded);
+
   base::android::InitVM(vm);
   JNIEnv* env = base::android::AttachCurrentThread();
   if (!base::android::RegisterLibraryLoaderEntryHook(env))


### PR DESCRIPTION
Upstream moves RegisterLibraryLoaderEntryHook from content
to base, but the real registration is still done at
content::LibraryLoaded, which is missed in xwalk.

Add the callback back to fix the issue.
