### PR TITLE
[Android] Refine the callback function of compressor.

### DIFF
--- a/app/tools/android/compress_js_and_css.py
+++ b/app/tools/android/compress_js_and_css.py
@@ -4,9 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import fnmatch
 import os
-import stat
 import subprocess
 
 def GetJARFilename():
@@ -17,35 +15,18 @@ def GetJARFilename():
   cur_dir = os.path.realpath(os.path.dirname(__file__))
   return os.path.join(cur_dir, "libs", file_name)
 
-def GetFileList(path, ext, sub_dir = True):
-  if os.path.exists(path):
-    file_list = []
-    for name in os.listdir(path):
-      full_name = os.path.join(path, name)
-      st = os.lstat(full_name)
-      if stat.S_ISDIR(st.st_mode) and sub_dir:
-        file_list += GetFileList(full_name, ext)
-      elif os.path.isfile(full_name):
-        if fnmatch.fnmatch(full_name, ext):
-          file_list.append(full_name)
-    return file_list
-  else:
-    return []
 
-def ExecuteCmd(path, ext):
-  file_list = GetFileList(path, "*." + ext)
+def ExecuteCmd(file_list, ext):
   for file_full_path in file_list:
     if os.path.exists(file_full_path):
       cmd_args = ["java", "-jar", GetJARFilename(), "--type=" + ext,
           file_full_path, "-o", file_full_path]
       subprocess.call(cmd_args)
 
-class CompressJsAndCss(object):
-  def __init__(self, input_path):
-    self.input_path = input_path
 
-  def CompressJavaScript(self):
-    ExecuteCmd(self.input_path, "js")
+def CompressJavaScript(file_list):
+  ExecuteCmd(file_list, "js")
 
-  def CompressCss(self):
-    ExecuteCmd(self.input_path, "css")
+
+def CompressCss(file_list):
+  ExecuteCmd(file_list, "css")

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -25,6 +25,32 @@ def Clean(name, app_version):
       os.remove(name + '_' + app_version + '_arm.apk')
 
 
+def CompareSizeForCompressor(mode, original, ext, name, fun):
+  size = 0
+  compressed_size = 0
+  mode_list = ['all', 'js', 'css']
+
+  www_dir = os.path.join(name, 'assets', 'www')
+  if os.path.exists(www_dir):
+    size = GetFileSize(original)
+    compressed_file = os.path.join(www_dir, ext, 'test.' + ext)
+    compressed_size = GetFileSize(compressed_file)
+
+    if mode in mode_list:
+      fun(compressed_size < size)
+    else:
+      fun(size == compressed_size)
+  else:
+    print('Error: %s is not exist.' % www_dir)
+
+
+def GetFileSize(file_path):
+  size = 0
+  if os.path.exists(file_path):
+    size = os.path.getsize(file_path)
+  return size
+
+
 def RunCommand(command):
   """Runs the command list, return the output."""
   proc = subprocess.Popen(command, stdout=subprocess.PIPE,
@@ -716,7 +742,6 @@ class TestMakeApk(unittest.TestCase):
 
     self.executeCommandAndVerifyResult('customize.py')
 
-
   def testTargetDir(self):
     test_option = ['./', '../', '~/']
     for option in test_option:
@@ -735,6 +760,62 @@ class TestMakeApk(unittest.TestCase):
                                         % (option, arch))
           self.assertTrue(os.path.exists(apk_path))
           self.checkApk(apk_path, arch)
+
+  def testCompressor(self):
+    app_root = os.path.join('test_data', 'compressor')
+    css_folder = os.path.join('test_data', 'compressor', 'css')
+    css_file = os.path.join(css_folder, 'test.css')
+    js_folder = os.path.join('test_data', 'compressor', 'js')
+    js_file = os.path.join(js_folder, 'test.js')
+    fun = self.assertTrue
+    name = 'Example'
+
+    cmd = ['python', 'customize.py',
+           '--name=%s' % name,
+           '--compressor',
+           '--app-root=%s' % app_root]
+    RunCommand(cmd)
+    CompareSizeForCompressor('all', css_file, 'css', name, fun)
+    CompareSizeForCompressor('all', js_file, 'js', name, fun)
+
+    cmd = ['python', 'customize.py',
+           '--name=%s' % name,
+           '--app-root=%s' % app_root,
+           '--compressor']
+    RunCommand(cmd)
+    CompareSizeForCompressor('all', css_file, 'css', name, fun)
+    CompareSizeForCompressor('all', js_file, 'js', name, fun)
+
+    cmd = ['python', 'customize.py',
+           '--name=%s' % name,
+           '--compressor=js',
+           '--app-root=%s' % app_root]
+    RunCommand(cmd)
+    CompareSizeForCompressor('js', js_file, 'js', name, fun)
+
+    cmd = ['python', 'customize.py',
+           '--name=%s' % name,
+           '--compressor=css',
+           '--app-root=%s' % app_root]
+    RunCommand(cmd)
+    CompareSizeForCompressor('css', css_file, 'css', name, fun)
+
+    cmd = ['python', 'customize.py',
+           '--name=%s' % name,
+           '--app-root=%s' % app_root]
+    RunCommand(cmd)
+    CompareSizeForCompressor(None, css_file, 'css', name, fun)
+    CompareSizeForCompressor(None, js_file, 'js', name, fun)
+
+    cmd = ['python', 'customize.py',
+           '--name=%s' % name,
+           '--app-root=%s' % app_root,
+           '--compressor=other']
+    RunCommand(cmd)
+    CompareSizeForCompressor(None, css_file, 'css', name, fun)
+    CompareSizeForCompressor(None, js_file, 'js', name, fun)
+
+    Clean(name, '1.0.0')
 
 
 def SuiteWithModeOption():
@@ -771,6 +852,7 @@ def SuiteWithModeOption():
 def SuiteWithEmptyModeOption():
   # Gather all the tests for empty mode option.
   test_suite = unittest.TestSuite()
+  test_suite.addTest(TestMakeApk('testCompressor'))
   test_suite.addTest(TestMakeApk('testCustomizeFile'))
   test_suite.addTest(TestMakeApk('testEmptyMode'))
   test_suite.addTest(TestMakeApk('testToolVersion'))

--- a/app/tools/android/test_data/compressor/css/test.css
+++ b/app/tools/android/test_data/compressor/css/test.css
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2014, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+#body {
+    background-color: blue;
+}
+
+#div {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    text-align: center;
+}
+
+h1 {
+    color:orange;
+    text-align:center;
+}
+
+p {
+    font-family:"Times New Roman";
+    font-size:50px;
+}

--- a/app/tools/android/test_data/compressor/js/test.js
+++ b/app/tools/android/test_data/compressor/js/test.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2014, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+function multiplication(p1, p2) {
+  return p1 * p2; // return the product of p1 and p2.
+}
+
+function testAlert() {
+  alert("hello, world");
+}


### PR DESCRIPTION
This patch is to refine the feature of compressor.
optparse stores the converted value when we use '--compressor'
at the first time. Then we use '--compressor=css', optparse
does not consume the argument.
Add 'type' and 'nargs', they instruct optparse to consume the
argument and convert the parameter to related type.
Add test case for this feature.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1151
