### PR TITLE
DEPS.xwalk: Bring in v8-crosswalk.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -9,9 +9,12 @@
 chromium_version = '34.0.1809.2'
 chromium_crosswalk_point = '15cca626e89f5bf95ed8b188611c9e3391072a97'
 blink_crosswalk_point = '23bf1559a940e70973171b227f281a70387eb09d'
+v8_crosswalk_point = 'fa1156fbdad63372079f9c14bd52e96159ada37f'
+
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,
   'src/third_party/WebKit': 'https://github.com/crosswalk-project/blink-crosswalk.git@%s' % blink_crosswalk_point,
+  'src/v8': 'https://github.com/crosswalk-project/v8-crosswalk.git@%s' % v8_crosswalk_point,
 
   # Ozone-Wayland is required for Wayland support in Chromium.
   'src/ozone': 'https://github.com/01org/ozone-wayland.git@aea2c94041dd0fbf386182e66fd173b87a7862e6',


### PR DESCRIPTION
Start tracking v8-crosswalk in src/v8. v8-crosswalk is a V8 fork along the
lines of chromium-crosswalk and blink-crosswalk. For now its main purpose is
to have all the SIMD.js optimizations some folks have been working on. Other
than that, it should be the usual V8 we all know.
