### PR TITLE
[Tizen][Runtime] Enable WGT CSP support.

### DIFF
--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -273,8 +273,9 @@ ApplicationProtocolHandler::MaybeCreateJob(
   if (application) {
     directory_path = application->Path();
 
+    const char* csp_key = GetCSPKey(application->GetPackageType());
     const CSPInfo* csp_info = static_cast<CSPInfo*>(
-      application->GetManifestData(keys::kCSPKey));
+          application->GetManifestData(csp_key));
     if (csp_info) {
       const std::map<std::string, std::vector<std::string> >& policies =
           csp_info->GetDirectives();

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -47,6 +47,7 @@ const char kAuthorHrefKey[] = "widget.author.@href";
 const char kHeightKey[] = "widget.@height";
 const char kWidthKey[] = "widget.@width";
 const char kPreferencesKey[] = "widget.preference";
+const char kCSPKey[] = "widget.content-security-policy.#text";
 
 // Child keys inside 'kPreferencesKey'.
 const char kPreferencesNameKey[] = "@name";
@@ -109,6 +110,14 @@ const char* GetLaunchLocalPathKey(Manifest::PackageType package_type) {
 
   return application_manifest_keys::kLaunchLocalPathKey;
 }
+
+const char* GetCSPKey(Manifest::PackageType package_type) {
+  if (package_type == Manifest::TYPE_WGT)
+    return application_widget_keys::kCSPKey;
+
+  return application_manifest_keys::kCSPKey;
+}
+
 #if defined(OS_TIZEN)
 const char* GetTizenAppIdKey(Manifest::PackageType package_type) {
   if (package_type == Manifest::TYPE_WGT)

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -38,6 +38,7 @@ namespace application_widget_keys {
   extern const char kWebURLsKey[];
   extern const char kWidgetKey[];
   extern const char kVersionKey[];
+  extern const char kCSPKey[];
   extern const char kAuthorKey[];
   extern const char kDescriptionKey[];
   extern const char kShortNameKey[];
@@ -74,6 +75,7 @@ const char* GetNameKey(Manifest::PackageType type);
 const char* GetVersionKey(Manifest::PackageType type);
 const char* GetWebURLsKey(Manifest::PackageType type);
 const char* GetLaunchLocalPathKey(Manifest::PackageType type);
+const char* GetCSPKey(Manifest::PackageType type);
 #if defined(OS_TIZEN)
 const char* GetTizenAppIdKey(Manifest::PackageType type);
 const char* GetIcon128Key(Manifest::PackageType type);

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -67,6 +67,9 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   std::vector<ManifestHandler*> handlers;
   // We can put WGT specific manifest handlers here.
   handlers.push_back(new WidgetHandler);
+#if defined(OS_TIZEN)
+  handlers.push_back(new CSPHandler(Manifest::TYPE_WGT));
+#endif
   widget_registry_ = new ManifestHandlerRegistry(handlers);
   return widget_registry_;
 }
@@ -79,7 +82,7 @@ ManifestHandlerRegistry::GetInstanceForXPK() {
   std::vector<ManifestHandler*> handlers;
   // FIXME: Add manifest handlers here like this:
   // handlers.push_back(new xxxHandler);
-  handlers.push_back(new CSPHandler);
+  handlers.push_back(new CSPHandler(Manifest::TYPE_XPK));
   handlers.push_back(new MainDocumentHandler);
   handlers.push_back(new PermissionsHandler);
   xpk_registry_ = new ManifestHandlerRegistry(handlers);

--- a/application/common/manifest_handlers/csp_handler.h
+++ b/application/common/manifest_handlers/csp_handler.h
@@ -32,7 +32,7 @@ class CSPInfo : public ApplicationData::ManifestData {
 
 class CSPHandler : public ManifestHandler {
  public:
-  CSPHandler();
+  explicit CSPHandler(Manifest::PackageType type);
   virtual ~CSPHandler();
 
   virtual bool Parse(scoped_refptr<ApplicationData> application,
@@ -41,6 +41,8 @@ class CSPHandler : public ManifestHandler {
   virtual std::vector<std::string> Keys() const OVERRIDE;
 
  private:
+  Manifest::PackageType package_type_;
+
   DISALLOW_COPY_AND_ASSIGN(CSPHandler);
 };
 


### PR DESCRIPTION
The WGT CSP support is disabled by the PR#1593: Separate WGT
applications manifest handling from XPK applications. And this should be
enabled again by adding a CSP handler into the WGT manifest parser.
