### PR TITLE
[Tizen] Get rid of the crosswalk-emulator-support package.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -83,15 +83,6 @@ BuildRequires:  pkgconfig(scim)
 %description
 Crosswalk is an app runtime based on Chromium. It is an open source project started by the Intel Open Source Technology Center (http://www.01.org).
 
-%package emulator-support
-Summary:        Support files necessary for running Crosswalk on the Tizen emulator
-License:        (BSD-3-Clause and LGPL-2.1+)
-Group:          Web Framework/Web Run Time
-Url:            https://github.com/otcshare/crosswalk
-
-%description emulator-support
-This package contains additional support files that are needed for running Crosswalk on the Tizen emulator.
-
 %define _manifestdir /usr/share/packages
 %define _desktop_icondir /usr/share/icons/default/small
 %define _dbusservicedir /usr/share/dbus-1/services
@@ -232,7 +223,6 @@ install -m 06755 -p -D ${BUILDDIR_NAME}/out/Release/xwalk-pkg-helper %{buildroot
 # Supporting libraries and resources.
 install -p -D ${BUILDDIR_NAME}/out/Release/icudtl.dat %{buildroot}%{_libdir}/xwalk/icudtl.dat
 install -p -D ${BUILDDIR_NAME}/out/Release/libffmpegsumo.so %{buildroot}%{_libdir}/xwalk/libffmpegsumo.so
-install -p -D ${BUILDDIR_NAME}/out/Release/libosmesa.so %{buildroot}%{_libdir}/xwalk/libosmesa.so
 install -p -D ${BUILDDIR_NAME}/out/Release/xwalk.pak %{buildroot}%{_libdir}/xwalk/xwalk.pak
 
 # Register xwalk to the package manager.
@@ -254,6 +244,3 @@ install -p -D ../%{name}.png %{buildroot}%{_desktop_icondir}/%{name}.png
 %{_desktop_icondir}/%{name}.png
 %{_dbusservicedir}/org.crosswalkproject.Runtime1.service
 %{_systemduserservicedir}/xwalk.service
-
-%files emulator-support
-%{_libdir}/xwalk/libosmesa.so

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -35,9 +35,7 @@ void XWalkBrowserMainPartsTizen::PreMainMessageLoopStart() {
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
 
   const char* gl_name;
-  if (base::PathExists(base::FilePath("/usr/lib/xwalk/libosmesa.so")))
-    gl_name = gfx::kGLImplementationOSMesaName;
-  else if (base::PathExists(base::FilePath("/usr/lib/libGL.so")))
+  if (base::PathExists(base::FilePath("/usr/lib/libGL.so")))
     gl_name = gfx::kGLImplementationDesktopName;
   else
     gl_name = gfx::kGLImplementationEGLName;

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -491,11 +491,6 @@
           ],
         }],  # OS=="win"
         ['OS == "linux"', {
-          'dependencies': [
-            # Build osmesa to workaround egl backend issue on Tizen 2.1 emulator
-            # TODO: remove this once hardware backend works.
-            '../third_party/mesa/mesa.gyp:osmesa',
-          ],
           'copies': [
             {
               'destination': '<(PRODUCT_DIR)',


### PR DESCRIPTION
crosswalk-emulator-support was used during the Tizen 2.x times because the
Tizen emulator's GL implementation did not work as expected and we thus had to
fall back to libosmesa.

Now that Tizen 2.x is a thing of the past, we can get rid of it. If the Tizen
3 emulator still has problems, we are now in the position to try to fix it.
