### PR TITLE
[Runtime] Fix WGT config.xml parsing error if one type of tag has more than three instances.

### DIFF
--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -126,7 +126,6 @@ base::DictionaryValue* LoadXMLNode(xmlNode* root) {
       base::ListValue* list;
       temp->GetAsList(&list);
       list->Append(sub_value);
-      value->Set(sub_node_name, list);
     } else {
       DCHECK(temp->IsType(base::Value::TYPE_DICTIONARY));
       base::DictionaryValue* dict;


### PR DESCRIPTION
When parsing config.xml, if one type of element has more than three
instances, the ListValue will be destroyed by excess invoking Value::Set
method, this will cause the crash when visiting the list.

BUG=XWALK-1142
