### PR TITLE
[Runtime] Add Widget Access Request Policy (WARP) parsing handler for WGT package.

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -48,11 +48,16 @@ const char kHeightKey[] = "widget.@height";
 const char kWidthKey[] = "widget.@width";
 const char kPreferencesKey[] = "widget.preference";
 const char kCSPKey[] = "widget.content-security-policy.#text";
+const char kAccessKey[] = "widget.access";
 
 // Child keys inside 'kPreferencesKey'.
 const char kPreferencesNameKey[] = "@name";
 const char kPreferencesValueKey[] = "@value";
 const char kPreferencesReadonlyKey[] = "@readonly";
+
+// Child keys inside 'kAccessKey'.
+const char kAccessOriginKey[] = "@origin";
+const char kAccessSubdomainsKey[] = "@subdomains";
 
 #if defined(OS_TIZEN)
 const char kIcon128Key[] = "widget.icon.@src";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -38,6 +38,9 @@ namespace application_widget_keys {
   extern const char kWebURLsKey[];
   extern const char kWidgetKey[];
   extern const char kVersionKey[];
+  extern const char kAccessKey[];
+  extern const char kAccessOriginKey[];
+  extern const char kAccessSubdomainsKey[];
   extern const char kCSPKey[];
   extern const char kAuthorKey[];
   extern const char kDescriptionKey[];

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -10,6 +10,7 @@
 #include "xwalk/application/common/manifest_handlers/csp_handler.h"
 #include "xwalk/application/common/manifest_handlers/main_document_handler.h"
 #include "xwalk/application/common/manifest_handlers/permissions_handler.h"
+#include "xwalk/application/common/manifest_handlers/warp_handler.h"
 #include "xwalk/application/common/manifest_handlers/widget_handler.h"
 
 namespace xwalk {
@@ -67,6 +68,7 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   std::vector<ManifestHandler*> handlers;
   // We can put WGT specific manifest handlers here.
   handlers.push_back(new WidgetHandler);
+  handlers.push_back(new WARPHandler);
 #if defined(OS_TIZEN)
   handlers.push_back(new CSPHandler(Manifest::TYPE_WGT));
 #endif

--- a/application/common/manifest_handlers/warp_handler.cc
+++ b/application/common/manifest_handlers/warp_handler.cc
@@ -1,0 +1,68 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/warp_handler.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+namespace application {
+
+WARPInfo::WARPInfo() {
+}
+
+WARPInfo::~WARPInfo() {
+}
+
+WARPHandler::WARPHandler() {
+}
+
+WARPHandler::~WARPHandler() {
+}
+
+bool WARPHandler::Parse(scoped_refptr<ApplicationData> application,
+                       base::string16* error) {
+  base::Value* value;
+  if (!application->GetManifest()->HasPath(keys::kAccessKey))
+    return true;
+  if (!application->GetManifest()->Get(keys::kAccessKey, &value)) {
+    *error = base::ASCIIToUTF16(
+        "Invalid value of Widget Access Request Policy(WARP).");
+    return false;
+  }
+
+  scoped_ptr<base::ListValue> warp_list;
+  if (value->IsType(base::Value::TYPE_DICTIONARY)) {
+    warp_list.reset(new base::ListValue);
+    warp_list->Append(value->DeepCopy());
+  } else {
+    base::ListValue* list;
+    value->GetAsList(&list);
+    if (list)
+      warp_list.reset(list->DeepCopy());
+  }
+
+  if (!warp_list) {
+    *error = base::ASCIIToUTF16(
+        "Invalid Widget Access Request Policy(WARP) list.");
+    return false;
+  }
+
+  scoped_ptr<WARPInfo> warp_info(new WARPInfo);
+  warp_info->SetWARP(warp_list.release());
+  application->SetManifestData(keys::kAccessKey, warp_info.release());
+
+  return true;
+}
+
+std::vector<std::string> WARPHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kAccessKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/warp_handler.h
+++ b/application/common/manifest_handlers/warp_handler.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_WARP_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_WARP_HANDLER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest_handler.h"
+
+namespace xwalk {
+namespace application {
+
+class WARPInfo : public ApplicationData::ManifestData {
+ public:
+  WARPInfo();
+  virtual ~WARPInfo();
+
+  void SetWARP(const base::ListValue* warp) {
+    warp_.reset(warp);
+  }
+  const base::ListValue* GetWARP() const { return warp_.get(); }
+
+ private:
+  scoped_ptr<const base::ListValue> warp_;
+};
+
+class WARPHandler : public ManifestHandler {
+ public:
+  WARPHandler();
+  virtual ~WARPHandler();
+
+  virtual bool Parse(scoped_refptr<ApplicationData> application,
+                     base::string16* error) OVERRIDE;
+  virtual std::vector<std::string> Keys() const OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(WARPHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_WARP_HANDLER_H_

--- a/application/common/manifest_handlers/warp_handler_unittest.cc
+++ b/application/common/manifest_handlers/warp_handler_unittest.cc
@@ -1,0 +1,98 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/warp_handler.h"
+
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+namespace application {
+
+class WARPHandlerTest: public testing::Test {
+ public:
+  virtual void SetUp() OVERRIDE {
+    manifest.SetString(keys::kNameKey, "no name");
+    manifest.SetString(keys::kVersionKey, "0");
+  }
+
+  scoped_refptr<ApplicationData> CreateApplication() {
+    std::string error;
+    scoped_refptr<ApplicationData> application = ApplicationData::Create(
+        base::FilePath(), Manifest::INVALID_TYPE, manifest, "", &error);
+    return application;
+  }
+
+  const WARPInfo* GetWARPInfo(
+      scoped_refptr<ApplicationData> application) {
+    const WARPInfo* info = static_cast<WARPInfo*>(
+        application->GetManifestData(keys::kAccessKey));
+    return info;
+  }
+
+  base::DictionaryValue manifest;
+};
+
+// FIXME: the default WARP policy settings in WARP manifest handler
+// are temporally removed, since they had affected some tests and legacy apps.
+TEST_F(WARPHandlerTest, NoWARP) {
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  EXPECT_FALSE(GetWARPInfo(application));
+}
+
+TEST_F(WARPHandlerTest, OneWARP) {
+  base::DictionaryValue* warp = new base::DictionaryValue;
+  warp->SetString(keys::kAccessOriginKey, "http://www.sample.com");
+  warp->SetBoolean(keys::kAccessSubdomainsKey, true);
+  manifest.Set(keys::kAccessKey, warp);
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  const WARPInfo* info = GetWARPInfo(application);
+  EXPECT_TRUE(info);
+  scoped_ptr<base::ListValue> list(info->GetWARP()->DeepCopy());
+  base::DictionaryValue* new_warp;
+  list->GetDictionary(0, &new_warp);
+  EXPECT_TRUE(new_warp);
+  EXPECT_TRUE(warp->Equals(new_warp));
+}
+
+TEST_F(WARPHandlerTest, WARPs) {
+  base::DictionaryValue* warp1 = new base::DictionaryValue;
+  warp1->SetString(keys::kAccessOriginKey, "http://www.sample1.com");
+  warp1->SetBoolean(keys::kAccessSubdomainsKey, true);
+  base::DictionaryValue* warp2 = new base::DictionaryValue;
+  warp2->SetString(keys::kAccessOriginKey, "http://www.sample2.com");
+  warp2->SetBoolean(keys::kAccessSubdomainsKey, false);
+  base::ListValue* warp_list = new base::ListValue;
+  warp_list->Append(warp1);
+  warp_list->Append(warp2);
+  manifest.Set(keys::kAccessKey, warp_list);
+
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+
+  const WARPInfo* info = GetWARPInfo(application);
+  EXPECT_TRUE(info);
+
+  scoped_ptr<base::ListValue> list(info->GetWARP()->DeepCopy());
+
+  base::DictionaryValue* new_warp1;
+  list->GetDictionary(0, &new_warp1);
+  EXPECT_TRUE(new_warp1);
+  base::DictionaryValue* new_warp2;
+  list->GetDictionary(1, &new_warp2);
+  EXPECT_TRUE(new_warp2);
+
+  EXPECT_TRUE(warp1->Equals(new_warp1));
+  EXPECT_TRUE(warp2->Equals(new_warp2));
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -69,6 +69,8 @@
         'common/manifest_handlers/main_document_handler.h',
         'common/manifest_handlers/permissions_handler.cc',
         'common/manifest_handlers/permissions_handler.h',
+        'common/manifest_handlers/warp_handler.cc',
+        'common/manifest_handlers/warp_handler.h',
         'common/manifest_handlers/widget_handler.cc',
         'common/manifest_handlers/widget_handler.h',
         'common/permission_policy_manager.cc',

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -42,6 +42,7 @@
         'application/common/manifest_handlers/csp_handler_unittest.cc',
         'application/common/manifest_handlers/main_document_handler_unittest.cc',
         'application/common/manifest_handlers/permissions_handler_unittest.cc',
+        'application/common/manifest_handlers/warp_handler_unittest.cc',
         'application/common/manifest_handler_unittest.cc',
         'application/common/manifest_unittest.cc',
         'runtime/common/xwalk_content_client_unittest.cc',


### PR DESCRIPTION
Add a WARP handler into the WGT package parser. The WARP spec reference
link is: http://www.w3.org/TR/widgets-access
