### PR TITLE
DEPS.xwalk: Roll blink-crosswalk (6f18c5b -> e8b6b99).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -8,7 +8,7 @@
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '34.0.1847.45'
 chromium_crosswalk_point = 'cb7bc58aa1239e2fa92d692e81ccd06fa6c82722'
-blink_crosswalk_point = '6f18c5b9b87216a3125e62573699115b9da852dd'
+blink_crosswalk_point = 'e8b6b995b38b422c2b4d58fa5201599f1e510537'
 v8_crosswalk_point = '702dcf9c6e58d90e85594fbe54579ade631fe3b5'
 
 deps_xwalk = {


### PR DESCRIPTION
e8b6b99 Merge pull request #12 from rakuco/backport-blink-r167638
901e77a [Backport r167638] Always initialize LayoutScope::m_block.
135bf8e Merge pull request #11 from rakuco/backport-blink-r167358
419801e [Backport r167358] fix may be used uninitialized warning on older
        compilers

This should fix the Tizen Generic build after we moved chromium-crosswalk to
34.0.1847.45.
