### PR TITLE
[Android] Change the class modifier for the core library.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/AndroidProtocolHandler.java
+++ b/runtime/android/core/src/org/xwalk/core/AndroidProtocolHandler.java
@@ -25,7 +25,7 @@ import org.chromium.base.JNINamespace;
  * See android_protocol_handler.cc.
  */
 @JNINamespace("xwalk")
-public class AndroidProtocolHandler {
+class AndroidProtocolHandler {
     private static final String TAG = "AndroidProtocolHandler";
 
     // Supported URL schemes. This needs to be kept in sync with

--- a/runtime/android/core/src/org/xwalk/core/DownloadListener.java
+++ b/runtime/android/core/src/org/xwalk/core/DownloadListener.java
@@ -4,7 +4,7 @@
 
 package org.xwalk.core;
 
-public interface DownloadListener {
+interface DownloadListener {
 
     public abstract void onDownloadStart(String url, String userAgent,
             String contentDisposition, String mimetype, long contentLength);

--- a/runtime/android/core/src/org/xwalk/core/HttpAuthDatabase.java
+++ b/runtime/android/core/src/org/xwalk/core/HttpAuthDatabase.java
@@ -26,7 +26,7 @@ import android.util.Log;
  * if triggered early on (e.g. as a side effect of CookieSyncManager.createInstance() call),
  * sufficiently in advance of the first blocking usage of the API.
  */
-public class HttpAuthDatabase {
+class HttpAuthDatabase {
 
     private static final String LOGTAG = HttpAuthDatabase.class.getName();
 

--- a/runtime/android/core/src/org/xwalk/core/InMemorySharedPreferences.java
+++ b/runtime/android/core/src/org/xwalk/core/InMemorySharedPreferences.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * <p/>
  * It keeps all state in memory, and there is no difference between apply() and commit().
  */
-public class InMemorySharedPreferences implements SharedPreferences {
+class InMemorySharedPreferences implements SharedPreferences {
 
     // Guarded on its own monitor.
     private final Map<String, Object> mData;

--- a/runtime/android/core/src/org/xwalk/core/InterceptedRequestData.java
+++ b/runtime/android/core/src/org/xwalk/core/InterceptedRequestData.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
  * The response information that is to be returned for a particular resource fetch.
  */
 @JNINamespace("xwalk")
-public class InterceptedRequestData {
+class InterceptedRequestData {
     private String mMimeType;
     private String mCharset;
     private InputStream mData;

--- a/runtime/android/core/src/org/xwalk/core/PageLoadListener.java
+++ b/runtime/android/core/src/org/xwalk/core/PageLoadListener.java
@@ -4,7 +4,7 @@
 
 package org.xwalk.core;
 
-public interface PageLoadListener {
+interface PageLoadListener {
 
     public void onPageFinished(String url);
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentVideoViewClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentVideoViewClient.java
@@ -12,7 +12,7 @@ import android.view.WindowManager;
 import org.chromium.content.browser.ContentVideoViewClient;
 import org.xwalk.core.XWalkWebChromeClient.CustomViewCallback;
 
-public class XWalkContentVideoViewClient implements ContentVideoViewClient {
+class XWalkContentVideoViewClient implements ContentVideoViewClient {
     private XWalkContentsClient mContentsClient;
     private Activity mActivity;
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClient.java
@@ -35,6 +35,7 @@ import org.chromium.net.NetError;
  * new abstract methods that the our own client must implement.
  * i.e.: all methods in this class should either be final, or abstract.
  */
+// TODO(yongsheng): remove public modifier.
 public abstract class XWalkContentsClient extends ContentViewClient {
 
     private static final String TAG = "XWalkContentsClient";

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -30,7 +30,7 @@ import org.chromium.content.browser.DownloadInfo;
 // Help bridge callback in XWalkContentsClient to XWalkViewClient and
 // WebChromeClient; Also handle the JNI conmmunication logic.
 @JNINamespace("xwalk")
-public class XWalkContentsClientBridge extends XWalkContentsClient
+class XWalkContentsClientBridge extends XWalkContentsClient
         implements ContentViewDownloadDelegate {
 
     private XWalkView mXWalkView;

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsIoThreadClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsIoThreadClient.java
@@ -11,7 +11,7 @@ import org.chromium.base.JNINamespace;
  * Delegate for handling callbacks. All methods are called on the IO thread.
  */
 @JNINamespace("xwalk")
-public interface XWalkContentsIoThreadClient {
+interface XWalkContentsIoThreadClient {
     @CalledByNative
     public int getCacheMode();
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkCookieManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkCookieManager.java
@@ -12,6 +12,7 @@ import org.chromium.base.JNINamespace;
  * Methods in this class are thread safe.
  */
 @JNINamespace("xwalk")
+// TODO(yongsheng): remove public modifier.
 public final class XWalkCookieManager {
     /**
      * Control whether cookie is enabled or disabled

--- a/runtime/android/core/src/org/xwalk/core/XWalkDefaultClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDefaultClient.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package org.xwalk.core.client;
+package org.xwalk.core;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -26,6 +26,7 @@ import org.xwalk.core.SslErrorHandler;
 import org.xwalk.core.XWalkClient;
 import org.xwalk.core.XWalkView;
 
+// TODO(yongsheng): remove public modifier.
 public class XWalkDefaultClient extends XWalkClient {
 
     // Strings for displaying Dialog.

--- a/runtime/android/core/src/org/xwalk/core/XWalkDefaultDownloadListener.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDefaultDownloadListener.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package org.xwalk.core.client;
+package org.xwalk.core;
 
 import android.app.DownloadManager;
 import android.app.DownloadManager.Request;
@@ -26,7 +26,7 @@ import org.xwalk.core.AndroidProtocolHandler;
 import org.xwalk.core.DownloadListener;
 import org.xwalk.core.R;
 
-public class XWalkDefaultDownloadListener implements DownloadListener {
+class XWalkDefaultDownloadListener implements DownloadListener {
     private static String DOWNLOAD_START_TOAST;
     private static String DOWNLOAD_NO_PERMISSION_TOAST;
     private static String DOWNLOAD_ALREADY_EXISTS_TOAST;

--- a/runtime/android/core/src/org/xwalk/core/XWalkDefaultNavigationHandler.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDefaultNavigationHandler.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package org.xwalk.core.client;
+package org.xwalk.core;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -15,6 +15,7 @@ import org.chromium.components.navigation_interception.NavigationParams;
 
 import org.xwalk.core.XWalkNavigationHandler;
 
+// TODO(yongsheng): remove public modifier.
 public class XWalkDefaultNavigationHandler implements XWalkNavigationHandler {
     private static final String TAG = "XWalkDefaultNavigationHandler";
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkDefaultNotificationService.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDefaultNotificationService.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package org.xwalk.core.client;
+package org.xwalk.core;
 
 import java.util.HashMap;
 
@@ -23,6 +23,7 @@ import org.xwalk.core.XWalkContentsClientBridge;
 import org.xwalk.core.XWalkNotificationService;
 import org.xwalk.core.XWalkView;
 
+// TODO(yongsheng): remove public modifier.
 public class XWalkDefaultNotificationService implements XWalkNotificationService {
     private static final String TAG = "XWalkDefaultNotificationService";
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkDefaultWebChromeClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDefaultWebChromeClient.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package org.xwalk.core.client;
+package org.xwalk.core;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -31,6 +31,8 @@ import org.xwalk.core.XWalkGeolocationPermissions;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkWebChromeClient;
 
+// Provisionally set it as public.
+// TODO(yongsheng): remove public modifier.
 public class XWalkDefaultWebChromeClient extends XWalkWebChromeClient {
 
     // Strings for displaying Dialog.

--- a/runtime/android/core/src/org/xwalk/core/XWalkDevToolsServer.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDevToolsServer.java
@@ -10,7 +10,7 @@ import org.chromium.base.JNINamespace;
  * Controller for Remote Web Debugging (Developer Tools).
  */
 @JNINamespace("xwalk")
-public class XWalkDevToolsServer {
+class XWalkDevToolsServer {
 
     private int mNativeDevToolsServer = 0;
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkGeolocationPermissions.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkGeolocationPermissions.java
@@ -17,6 +17,7 @@ import org.chromium.net.GURLUtils;
  * This class is used to manage permissions for the WebView's Geolocation JavaScript API.
  *
  * Callbacks are posted on the UI thread.
+ * TODO(yongsheng): remove public modifier.
  */
 public final class XWalkGeolocationPermissions {
     /**

--- a/runtime/android/core/src/org/xwalk/core/XWalkHttpAuthHandler.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkHttpAuthHandler.java
@@ -8,6 +8,7 @@ import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
 
 @JNINamespace("xwalk")
+// TODO(yongsheng): remove public modifier.
 public class XWalkHttpAuthHandler {
 
     private int mNativeXWalkHttpAuthHandler;

--- a/runtime/android/core/src/org/xwalk/core/XWalkInternalResources.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkInternalResources.java
@@ -10,9 +10,9 @@ import android.util.Log;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-public class XWalkInternalResources {
+class XWalkInternalResources {
     private static final String TAG = "XWalkInternalResources";
-    
+
     private static boolean loaded = false;
     private final static String INTERNAL_RESOURCE_CLASSES[] = {
         "org.chromium.content.R",
@@ -49,10 +49,10 @@ public class XWalkInternalResources {
                             Log.w(TAG, generatedInnerClazz.getName() + "." +
                                     field.getName() + " is not accessable.");
                         } catch (IllegalArgumentException e) {
-                            Log.w(TAG, generatedInnerClazz.getName() + "." + 
+                            Log.w(TAG, generatedInnerClazz.getName() + "." +
                                     field.getName() + " is not int.");
                         } catch (NoSuchFieldException e) {
-                            Log.w(TAG, generatedInnerClazz.getName() + "." + 
+                            Log.w(TAG, generatedInnerClazz.getName() + "." +
                                     field.getName() + " is not found.");
                         }
                     }

--- a/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
@@ -31,6 +31,8 @@ import android.widget.LinearLayout;
 
 import org.chromium.content.browser.ContentViewRenderView.FirstRenderedFrameListener;
 
+// Provisionally set it as public due to the use of launch screen extension.
+// TODO(yongsheng): remove public modifier.
 public class XWalkLaunchScreenManager
         implements FirstRenderedFrameListener, DialogInterface.OnShowListener, PageLoadListener {
     // This string will be initialized before extension initialized,

--- a/runtime/android/core/src/org/xwalk/core/XWalkMediaPlayerResourceLoadingFilter.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkMediaPlayerResourceLoadingFilter.java
@@ -20,7 +20,7 @@ import java.util.List;
  * customize the resource loading process in xwalk.
  */
 
-public class XWalkMediaPlayerResourceLoadingFilter extends
+class XWalkMediaPlayerResourceLoadingFilter extends
         MediaPlayerBridge.ResourceLoadingFilter {
     @Override
     public boolean shouldOverrideResourceLoading(MediaPlayer mediaPlayer,

--- a/runtime/android/core/src/org/xwalk/core/XWalkNavigationHandler.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNavigationHandler.java
@@ -6,7 +6,7 @@ package org.xwalk.core;
 
 import org.chromium.components.navigation_interception.NavigationParams;
 
-public interface XWalkNavigationHandler {
+interface XWalkNavigationHandler {
 
     /**
      * Handles the navigation request.

--- a/runtime/android/core/src/org/xwalk/core/XWalkNotificationService.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNotificationService.java
@@ -7,7 +7,7 @@ package org.xwalk.core;
 import android.content.Intent;
 import android.graphics.Bitmap;
 
-public interface XWalkNotificationService {
+interface XWalkNotificationService {
     public void setBridge(XWalkContentsClientBridge bridge);
     public void showNotification(
             String title, String message, int notificationId, int processId, int routeId);

--- a/runtime/android/core/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkView.java
@@ -16,11 +16,11 @@ import android.view.ViewGroup;
 import android.webkit.WebSettings;
 import android.widget.FrameLayout;
 
-import org.xwalk.core.client.XWalkDefaultClient;
-import org.xwalk.core.client.XWalkDefaultDownloadListener;
-import org.xwalk.core.client.XWalkDefaultNavigationHandler;
-import org.xwalk.core.client.XWalkDefaultNotificationService;
-import org.xwalk.core.client.XWalkDefaultWebChromeClient;
+import org.xwalk.core.XWalkDefaultClient;
+import org.xwalk.core.XWalkDefaultDownloadListener;
+import org.xwalk.core.XWalkDefaultNavigationHandler;
+import org.xwalk.core.XWalkDefaultNotificationService;
+import org.xwalk.core.XWalkDefaultWebChromeClient;
 import org.xwalk.core.extension.XWalkExtensionManager;
 
 public class XWalkView extends FrameLayout {

--- a/runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java
@@ -74,11 +74,11 @@ class XWalkViewDelegate {
         ResourceExtractor.setMandatoryPaksToExtract(MANDATORY_PAKS);
         final int resourcesListResId = context.getResources().getIdentifier(
                 XWALK_RESOURCES_LIST_RES_NAME, "array", context.getPackageName());
-        if (resourcesListResId != 0) {    
+        if (resourcesListResId != 0) {
             ResourceExtractor.setResourceIntercepter(new ResourceIntercepter() {
 
                 @Override
-                public Set<String> getInterceptableResourceList() {        
+                public Set<String> getInterceptableResourceList() {
                     try {
                         Set<String> resourcesList = new HashSet<String>();
                         String[] resources = context.getResources().getStringArray(resourcesListResId);
@@ -100,10 +100,10 @@ class XWalkViewDelegate {
                     try {
                         if (resId != 0) return context.getResources().openRawResource(resId);
                     } catch (NotFoundException e) {
-                        Log.w(TAG, "R.raw." + resourceName + " can't be found.");                        
+                        Log.w(TAG, "R.raw." + resourceName + " can't be found.");
                     }
                     return null;
-                }                
+                }
             });
         }
         ResourceExtractor.setExtractImplicitLocaleForTesting(false);

--- a/runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegate.java
@@ -9,7 +9,7 @@ import org.chromium.base.JNINamespace;
 import org.chromium.components.web_contents_delegate_android.WebContentsDelegateAndroid;
 
 @JNINamespace("xwalk")
-public abstract class XWalkWebContentsDelegate extends WebContentsDelegateAndroid {
+abstract class XWalkWebContentsDelegate extends WebContentsDelegateAndroid {
     @CalledByNative
     public abstract boolean addNewContents(boolean isDialog, boolean isUserGesture);
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegateAdapter.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegateAdapter.java
@@ -6,7 +6,7 @@ package org.xwalk.core;
 
 import android.util.Log;
 
-public class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
+class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
 
     private XWalkContentsClient mXWalkContentsClient;
 

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionBridge.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionBridge.java
@@ -9,7 +9,7 @@ import android.content.Intent;
 /**
  * Interface for bridging XWalkExtension functionalities to its backend implementation.
  */
-public interface XWalkExtensionBridge {
+interface XWalkExtensionBridge {
     /**
      * Post a message from native to a specific receiver on JavaScript side.
      *

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionClientImpl.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionClientImpl.java
@@ -16,7 +16,7 @@ import java.lang.reflect.Method;
  * runtime to runtime client. The objects of class 'XWalkExtensionClient' in runtime
  * client side will be passed into this class because we need to call its methods.
  */
-public class XWalkExtensionClientImpl extends XWalkExtension {
+class XWalkExtensionClientImpl extends XWalkExtension {
 
     private static final String TAG = XWalkExtensionClientImpl.class.getName();
     private Object mExtensionClient;

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionContextWrapper.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionContextWrapper.java
@@ -11,7 +11,7 @@ import android.content.Context;
  * This is a public class to provide context for extensions.
  * It'll be shared by all external extensions.
  */
-public class XWalkExtensionContextWrapper implements XWalkExtensionContext {
+class XWalkExtensionContextWrapper implements XWalkExtensionContext {
     private XWalkExtensionContext mOriginContext;
 
     public XWalkExtensionContextWrapper(XWalkExtensionContext context) {

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -30,7 +30,7 @@ import org.chromium.base.BaseSwitches;
 import org.chromium.base.CommandLine;
 import org.chromium.content.app.LibraryLoader;
 import org.chromium.content.browser.TracingControllerAndroid;
-import org.xwalk.core.client.XWalkDefaultWebChromeClient;
+import org.xwalk.core.XWalkDefaultWebChromeClient;
 import org.xwalk.core.XWalkView;
 
 public class XWalkViewShellActivity extends Activity {

--- a/runtime/android/runtime/src/org/xwalk/runtime/MixedContext.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/MixedContext.java
@@ -17,7 +17,7 @@ import android.content.ServiceConnection;
  * get both the application's context and the library itself's context.
  *
  */
-public class MixedContext extends ContextWrapper {
+class MixedContext extends ContextWrapper {
     private Context mActivityCtx;
 
     public MixedContext(Context base, Context activity) {

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkClientForTest.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkClientForTest.java
@@ -10,12 +10,11 @@ import android.net.http.SslError;
 
 import java.lang.reflect.Method;
 
-import org.xwalk.core.client.XWalkDefaultClient;
+import org.xwalk.core.XWalkDefaultClient;
 import org.xwalk.core.SslErrorHandler;
-import org.xwalk.core.XWalkHttpAuthHandler;
 import org.xwalk.core.XWalkView;
 
-public class XWalkClientForTest extends XWalkDefaultClient {
+class XWalkClientForTest extends XWalkDefaultClient {
     private Object mCallbackForTest;
 
     public XWalkClientForTest(Context context, XWalkView view) {

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkManifestReader.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkManifestReader.java
@@ -16,7 +16,7 @@ import java.net.URISyntaxException;
 /**
  * This internal class parses manifest.json of current app.
  */
-public class XWalkManifestReader {
+class XWalkManifestReader {
     private final static String TAG = "XWalkManifestReader";
     private final static String ASSETS_FILE_PATH = "file:///android_asset/";
     private final static String WWW_FOLDER = "www";

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -15,7 +15,7 @@ import android.view.View;
  * real implementation like runtime core.
  *
  */
-public interface XWalkRuntimeViewProvider {
+interface XWalkRuntimeViewProvider {
     // For handling life cycle and activity result.
     public void onCreate();
     public void onResume();

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkWebChromeClientForTest.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkWebChromeClientForTest.java
@@ -8,10 +8,10 @@ import android.content.Context;
 
 import java.lang.reflect.Method;
 
-import org.xwalk.core.client.XWalkDefaultWebChromeClient;
+import org.xwalk.core.XWalkDefaultWebChromeClient;
 import org.xwalk.core.XWalkView;
 
-public class XWalkWebChromeClientForTest extends XWalkDefaultWebChromeClient{
+class XWalkWebChromeClientForTest extends XWalkDefaultWebChromeClient{
     private Object mCallbackForTest;
 
     public XWalkWebChromeClientForTest(Context context, XWalkView view) {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/HandleActionUriTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/HandleActionUriTest.java
@@ -13,7 +13,7 @@ import android.test.suitebuilder.annotation.SmallTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkClient;
-import org.xwalk.core.client.XWalkDefaultNavigationHandler;
+import org.xwalk.core.XWalkDefaultNavigationHandler;
 
 /**
  * Test suite for handling ActionUri.

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/WebNotificationTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/WebNotificationTest.java
@@ -19,7 +19,7 @@ import org.chromium.base.test.util.Feature;
 import org.xwalk.core.XWalkClient;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkWebChromeClient;
-import org.xwalk.core.client.XWalkDefaultNotificationService;
+import org.xwalk.core.XWalkDefaultNotificationService;
 
 /**
  * Test suite for web notification API.


### PR DESCRIPTION
Set the classes defined in the core library with correct modifiers.
Previously lots of them are public which are not appropriate. Only
expose classes which will be for API. Some of them are still public
due to the usage of Cordova and Test Shell. Will do them.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1041
