### PR TITLE
[Runtime] Fix some coding style issues reported by lint.py.

### DIFF
--- a/runtime/app/android/xwalk_main_delegate_android.cc
+++ b/runtime/app/android/xwalk_main_delegate_android.cc
@@ -57,7 +57,8 @@ void XWalkMainDelegateAndroid::InitResourceBundle() {
   int pak_fd =
       base::GlobalDescriptors::GetInstance()->MaybeGet(kXWalkPakDescriptor);
   if (pak_fd != base::kInvalidPlatformFileValue) {
-    ui::ResourceBundle::InitSharedInstanceWithPakFile(base::File(pak_fd), false);
+    ui::ResourceBundle::InitSharedInstanceWithPakFile(
+        base::File(pak_fd), false);
     ResourceBundle::GetSharedInstance().AddDataPackFromFile(
         base::File(pak_fd), ui::SCALE_FACTOR_100P);
     return;

--- a/runtime/renderer/android/xwalk_render_view_ext.cc
+++ b/runtime/renderer/android/xwalk_render_view_ext.cc
@@ -34,7 +34,8 @@ namespace xwalk {
 
 namespace {
 
-GURL GetAbsoluteUrl(const blink::WebNode& node, const base::string16& url_fragment) {
+GURL GetAbsoluteUrl(const blink::WebNode& node,
+                    const base::string16& url_fragment) {
   return GURL(node.document().completeURL(url_fragment));
 }
 


### PR DESCRIPTION
```
runtime/app/android/xwalk_main_delegate_android.cc:60:  Lines should be <= 80
characters long  [whitespace/line_length] [2]
runtime/renderer/android/xwalk_render_view_ext.cc:37:  Lines should be <= 80
characters long  [whitespace/line_length] [2]
```
