### PR TITLE
[Android] Fix that embedded shell can't read file from sdcard

### DIFF
--- a/app/android/runtime_client_embedded_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_embedded_shell/AndroidManifest.xml
@@ -39,5 +39,6 @@
   <uses-permission android:name="android.permission.SEND_SMS" />
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_SMS" /> 
 </manifest>


### PR DESCRIPTION
It's caused by missing permission for it.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1213
