### PR TITLE
[Tizen][Runtime] Implement widget preference attribute.

### DIFF
--- a/application/application_resources.grd
+++ b/application/application_resources.grd
@@ -13,6 +13,7 @@
       <include name="IDR_XWALK_APPLICATION_EVENT_API" file="extension/application_event_api.js" type="BINDATA" />
       <include name="IDR_XWALK_APPLICATION_RUNTIME_API" file="extension/application_runtime_api.js" type="BINDATA" />
       <include name="IDR_XWALK_APPLICATION_WIDGET_API" file="extension/application_widget_api.js" type="BINDATA" />
+      <include name="IDR_XWALK_APPLICATION_WIDGET_COMMON_API" file="extension/application_widget_common_api.js" type="BINDATA" />
       <include name="IDR_XWALK_APPLICATION_TEST_API" file="test/application_testapi.js" type="BINDATA" />
     </includes>
   </release>

--- a/application/common/manifest_handlers/widget_handler.cc
+++ b/application/common/manifest_handlers/widget_handler.cc
@@ -71,8 +71,9 @@ void ParsePreferenceItem(const base::DictionaryValue* in_value,
   if (in_value->GetString(keys::kPreferencesValueKey, &pref_value))
     out_value->SetString(kPreferencesValue, pref_value);
 
-  if (in_value->GetString(keys::kPreferencesReadonlyKey, &pref_readonly))
-    out_value->SetString(kPreferencesReadonly, pref_readonly);
+  if (in_value->GetString(keys::kPreferencesReadonlyKey, &pref_readonly)) {
+      out_value->SetBoolean(kPreferencesReadonly, pref_readonly == "true");
+  }
 }
 
 }  // namespace

--- a/application/extension/application_widget_api.js
+++ b/application/extension/application_widget_api.js
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 var application = requireNative('application');
+var common = requireNative('widget_common');
 
 var empty = "";
 var zero = 0;
+
 var widgetStringInfo = {
   "author"      : empty,
   "description" : empty,
@@ -29,7 +31,8 @@ function defineReadOnlyProperty(object, key, value) {
       } else if (key == "height") {
         value = window.innerHeight;
       } else if (value == empty) {
-        value = extension.internal.sendSyncMessage(key);
+        value = extension.internal.sendSyncMessage(
+            { cmd: 'GetWidgetInfo', widgetKey: key });
       }
 
       return value;
@@ -41,3 +44,94 @@ for (var key in widgetStringInfo) {
   defineReadOnlyProperty(exports, key, widgetStringInfo[key]);
 }
 
+var WidgetStorage = function() {
+  var _keyList = new Array();
+
+  this.init = function() {
+    var result = extension.internal.sendSyncMessage(
+        { cmd: 'GetAllItems' });
+    for (var itemKey in result) {
+      var itemValue = result[itemKey];
+      this[itemKey] = itemValue;
+      _keyList.push(itemKey);
+    }
+  }
+
+  this.__defineGetter__('length', function() {
+    return _keyList.length;
+  });
+
+  this.key = function(index) {
+    return _keyList[index];
+  }
+
+  this.getItem = function(itemKey) {
+    return this[String(itemKey)];
+  } 
+
+  this.setItem = function(itemKey, itemValue) {
+    var result = extension.internal.sendSyncMessage({
+        cmd: 'SetPreferencesItem',
+        preferencesItemKey: String(itemKey),
+        preferencesItemValue: String(itemValue) });
+
+    if (result) {
+      this[String(itemKey)] = String(itemValue);
+      _keyList.push(String(itemKey));
+    } else {
+      throw new common.CustomDOMException(
+          common.CustomDOMException.NO_MODIFICATION_ALLOWED_ERR,
+          'The object can not be modified.');
+    }
+  };
+  
+  this.removeItem = function(itemKey) {
+    var result = extension.internal.sendSyncMessage({
+        cmd: 'RemovePreferencesItem',
+        preferencesItemKey: String(itemKey) });
+
+    if (result) {
+      delete this[itemKey];
+      delete _keyList[_keyList.indexOf(String(itemKey))];
+    } else {
+      throw new common.CustomDOMException(
+          common.CustomDOMException.NO_MODIFICATION_ALLOWED_ERR,
+          'The object can not be modified.');
+    }
+  }
+
+  this.clear = function() {
+    var itemKey;
+    var result = extension.internal.sendSyncMessage({
+        cmd: 'ClearAllItems' });
+
+    if (!result)
+      return;
+
+    for (var i = _keyList.length-1; i >= 0; --i) {
+      // if the itemKey is still in DB(e.g. readonly),
+      // we should keep it in JS side.
+      var exists = extension.internal.sendSyncMessage({
+          cmd: 'KeyExists',
+          preferencesItemKey: _keyList[i] });
+
+      if (!exists) {
+        delete this[_keyList[i]];
+        _keyList.splice(i, 1);
+      }
+    }
+  }
+
+  this.init();
+};
+
+var widgetStorage = new WidgetStorage();
+exports.preferences = widgetStorage;
+
+Object.defineProperty(exports, 'preferences', {
+  configurable: false,
+  enumerable: false,
+  get: function() {
+    return widgetStorage;
+  }
+});

--- a/application/extension/application_widget_common_api.js
+++ b/application/extension/application_widget_common_api.js
@@ -1,0 +1,82 @@
+var errors = {
+  '1': { type: 'INDEX_SIZE_ERR', name: 'IndexSizeError', message: '' },
+  '2': { type: 'DOMSTRING_SIZE_ERR', name: 'DOMStringSizeError', message: '' },
+  '3': { type: 'HIERARCHY_REQUEST_ERR', name: 'HierarchyRequestError', message: '' },
+  '4': { type: 'WRONG_DOCUMENT_ERR', name: 'WrongDocumentError', message: '' },
+  '5': { type: 'INVALID_CHARACTER_ERR', name: 'InvalidCharacterError', message: '' },
+  '6': { type: 'NO_DATA_ALLOWED_ERR', name: 'NoDataAllowedError', message: '' },
+  '7': { type: 'NO_MODIFICATION_ALLOWED_ERR', name: 'NoModificationAllowedError', message: '' },
+  '8': { type: 'NOT_FOUND_ERR', name: 'NotFoundError', message: '' },
+  '9': { type: 'NOT_SUPPORTED_ERR', name: 'Not_supportedError', message: '' },
+  '10': { type: 'INUSE_ATTRIBUTE_ERR', name: 'InuseAttributeError', message: '' },
+  '11': { type: 'INVALID_STATE_ERR', name: 'InvalidStateError', message: '' },
+  '12': { type: 'SYNTAX_ERR', name: 'SyntaxError', message: '' },
+  '13': { type: 'INVALID_MODIFICATION_ERR', name: 'InvalidModificationError', message: '' },
+  '14': { type: 'NAMESPACE_ERR', name: 'NamespaceError', message: '' },
+  '15': { type: 'INVALID_ACCESS_ERR', name: 'InvalidAccessError', message: '' },
+  '16': { type: 'VALIDATION_ERR', name: 'ValidationError', message: '' },
+  '17': { type: 'TYPE_MISMATCH_ERR', name: 'TypeMismatchError', message: '' },
+  '18': { type: 'SECURITY_ERR', name: 'SecurityError', message: '' },
+  '19': { type: 'NETWORK_ERR', name: 'NetworkError', message: '' },
+  '20': { type: 'ABORT_ERR', name: 'AbortError', message: '' },
+  '21': { type: 'URL_MISMATCH_ERR', name: 'UrlMismatchError', message: '' },
+  '22': { type: 'QUOTA_EXCEEDED_ERR', name: 'QuotaExceededError', message: '' },
+  '23': { type: 'TIMEOUT_ERR', name: 'TimeoutError', message: '' },
+  '24': { type: 'INVALID_NODE_TYPE_ERR', name: 'InvalidNodeTypeError', message: '' },
+  '25': { type: 'DATA_CLONE_ERR', name: 'DataCloneError', message: '' },
+};
+
+var CustomDOMException = function(code, message) {
+  var _code, _message, _name;
+
+  if (typeof code !== 'number') {
+    throw TypeError('Wrong argument type for Exception.');
+  } else if ((code in errors) === false) {
+    throw TypeError('Unknown exception code: ' + code);
+  } else {
+    _code = code;
+    _name = errors[_code].name;
+    if (typeof message === 'string') {
+      _message = message;
+    } else {
+      _message = errors[_code].message;
+    }
+  }
+
+  var props = {};
+  var newException;
+
+  try {
+    document.removeChild({})
+  } catch (e) {
+    newException = Object.create(e)
+  }
+
+  var proto = newException.__proto__;
+
+  props = Object.getOwnPropertyDescriptor(proto, "name");
+  props.value = _name;
+  Object.defineProperty(newException, "name", props);
+
+  props = Object.getOwnPropertyDescriptor(proto, "code");
+  props.value = _code;
+  Object.defineProperty(newException, "code", props);
+
+  props = Object.getOwnPropertyDescriptor(proto, "message");
+  props.value = _message;
+  Object.defineProperty(newException, "message", props);
+
+  props.value = function() {
+    return _name + ": " + _message;
+  }
+  Object.defineProperty(newException, "toString", props);
+
+  return newException;
+}
+
+for (var value in errors) {
+  Object.defineProperty(CustomDOMException, errors[value].type,
+      { value: parseInt(value) });
+}
+
+exports.CustomDOMException = CustomDOMException;

--- a/application/extension/application_widget_extension.cc
+++ b/application/extension/application_widget_extension.cc
@@ -5,6 +5,8 @@
 #include "xwalk/application/extension/application_widget_extension.h"
 
 #include "base/bind.h"
+#include "base/path_service.h"
+#include "base/strings/string_util.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/web_contents.h"
 #include "ipc/ipc_message.h"
@@ -14,9 +16,20 @@
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/manifest_handlers/widget_handler.h"
+#include "xwalk/application/extension/application_widget_storage.h"
 #include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/runtime/browser/runtime_context.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
+#include "xwalk/runtime/common/xwalk_paths.h"
 
 using content::BrowserThread;
+
+namespace {
+const char kCommandKey[] = "cmd";
+const char kWidgetAttributeKey[] = "widgetKey";
+const char kPreferencesItemKey[] = "preferencesItemKey";
+const char kPreferencesItemValue[] = "preferencesItemValue";
+}
 
 namespace xwalk {
 namespace application {
@@ -37,36 +50,152 @@ XWalkExtensionInstance* ApplicationWidgetExtension::CreateInstance() {
 
 AppWidgetExtensionInstance::AppWidgetExtensionInstance(
     Application* application)
-  : application_(application) {
+  : application_(application),
+    handler_(this) {
   DCHECK(application_);
+  base::ThreadRestrictions::SetIOAllowed(true);
+
+  base::FilePath path;
+  xwalk::RegisterPathProvider();
+  PathService::Get(xwalk::DIR_WGT_STORAGE_PATH, &path);
+  widget_storage_.reset(new AppWidgetStorage(application_, path));
 }
 
 void AppWidgetExtensionInstance::HandleMessage(scoped_ptr<base::Value> msg) {
+  handler_.HandleMessage(msg.Pass());
 }
 
 void AppWidgetExtensionInstance::HandleSyncMessage(
     scoped_ptr<base::Value> msg) {
-  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
-  std::string key;
-  base::Value* result;
-  base::StringValue* ret_val = base::Value::CreateStringValue("");
+  base::DictionaryValue* dict;
+  std::string command;
+  msg->GetAsDictionary(&dict);
 
-  if (!msg->GetAsString(&key)) {
-    LOG(ERROR) << "Fail to get sync message as manifest widget key.";
-    SendSyncReplyToJS(scoped_ptr<base::Value>(ret_val));
+  if (!msg->GetAsDictionary(&dict) || !dict->GetString(kCommandKey, &command)) {
+    LOG(ERROR) << "Fail to handle command sync message.";
+    SendSyncReplyToJS(scoped_ptr<base::Value>(
+        base::Value::CreateStringValue("")));
     return;
+  }
+
+  scoped_ptr<base::Value> result(base::Value::CreateStringValue(""));
+  if (command == "GetWidgetInfo") {
+    result = GetWidgetInfo(msg.Pass());
+  } else if (command == "SetPreferencesItem") {
+    result = SetPreferencesItem(msg.Pass());
+  } else if (command == "RemovePreferencesItem") {
+    result = RemovePreferencesItem(msg.Pass());
+  } else if (command == "ClearAllItems") {
+    result = ClearAllItems(msg.Pass());
+  } else if (command == "GetAllItems") {
+    result = GetAllItems(msg.Pass());
+  } else if (command == "KeyExists") {
+    result = KeyExists(msg.Pass());
+  } else {
+    LOG(ERROR) << command << " ASSERT NOT REACHED.";
+  }
+
+  SendSyncReplyToJS(result.Pass());
+}
+
+scoped_ptr<base::StringValue> AppWidgetExtensionInstance::GetWidgetInfo(
+    scoped_ptr<base::Value> msg) {
+  scoped_ptr<base::StringValue> result(base::Value::CreateStringValue(""));
+  std::string key;
+  std::string value;
+  base::DictionaryValue* dict;
+
+  if (!msg->GetAsDictionary(&dict) ||
+      !dict->GetString(kWidgetAttributeKey, &key)) {
+    LOG(ERROR) << "Fail to get widget attribute key.";
+    return result.Pass();
   }
 
   WidgetInfo* info =
       static_cast<WidgetInfo*>(
       application_->data()->GetManifestData(widget_keys::kWidgetKey));
-  base::DictionaryValue* value = info->GetWidgetInfo();
-  if (!value->Get(key, &result)) {
-    LOG(ERROR) << "Fail to get value for key: " << key;
-    SendSyncReplyToJS(scoped_ptr<base::Value>(ret_val));
-  } else {
-    SendSyncReplyToJS(scoped_ptr<base::Value>(result));
+  base::DictionaryValue* widget_info = info->GetWidgetInfo();
+  widget_info->GetString(key, &value);
+  result.reset(base::Value::CreateStringValue(value));
+  return result.Pass();
+}
+
+scoped_ptr<base::FundamentalValue>
+AppWidgetExtensionInstance::SetPreferencesItem(scoped_ptr<base::Value> msg) {
+  scoped_ptr<base::FundamentalValue> result(
+      base::Value::CreateBooleanValue(false));
+  std::string key;
+  std::string value;
+  base::DictionaryValue* dict;
+
+  if (!msg->GetAsDictionary(&dict) ||
+      !dict->GetString(kPreferencesItemKey, &key) ||
+      !dict->GetString(kPreferencesItemValue, &value)) {
+    LOG(ERROR) << "Fail to set preferences item.";
+    return result.Pass();
   }
+
+  if (widget_storage_->AddEntry(key, value, false))
+    result.reset(base::Value::CreateBooleanValue(true));
+
+  return result.Pass();
+}
+
+scoped_ptr<base::FundamentalValue>
+AppWidgetExtensionInstance::RemovePreferencesItem(scoped_ptr<base::Value> msg) {
+  scoped_ptr<base::FundamentalValue> result(
+      base::Value::CreateBooleanValue(false));
+  std::string key;
+  base::DictionaryValue* dict;
+
+  if (!msg->GetAsDictionary(&dict) ||
+      !dict->GetString(kPreferencesItemKey, &key)) {
+    LOG(ERROR) << "Fail to remove preferences item.";
+    return result.Pass();
+  }
+
+  if (widget_storage_->RemoveEntry(key))
+    result.reset(base::Value::CreateBooleanValue(true));
+
+  return result.Pass();
+}
+
+scoped_ptr<base::FundamentalValue> AppWidgetExtensionInstance::ClearAllItems(
+    scoped_ptr<base::Value> msg) {
+  scoped_ptr<base::FundamentalValue> result(
+      base::Value::CreateBooleanValue(false));
+
+  if (widget_storage_->Clear())
+    result.reset(base::Value::CreateBooleanValue(true));
+
+  return result.Pass();
+}
+
+scoped_ptr<base::DictionaryValue> AppWidgetExtensionInstance::GetAllItems(
+    scoped_ptr<base::Value> msg) {
+  scoped_ptr<base::DictionaryValue> result(new base::DictionaryValue());
+  widget_storage_->GetAllEntries(result.get());
+
+  return result.Pass();
+}
+
+scoped_ptr<base::FundamentalValue> AppWidgetExtensionInstance::KeyExists(
+    scoped_ptr<base::Value> msg) const {
+  scoped_ptr<base::FundamentalValue> result(
+      base::Value::CreateBooleanValue(false));
+  std::string key;
+  base::DictionaryValue* dict;
+
+  if (!msg->GetAsDictionary(&dict) ||
+      !dict->GetString(kPreferencesItemKey, &key)) {
+    LOG(ERROR) << "Fail to remove preferences item.";
+    return result.Pass();
+  }
+
+  if (widget_storage_->EntryExists(key))
+    result.reset(base::Value::CreateBooleanValue(true));
+
+  return result.Pass();
 }
 
 }  // namespace application

--- a/application/extension/application_widget_extension.h
+++ b/application/extension/application_widget_extension.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "xwalk/extensions/browser/xwalk_extension_function_handler.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
 
 namespace xwalk {
@@ -14,6 +15,8 @@ namespace application {
 class Application;
 
 using extensions::XWalkExtension;
+using extensions::XWalkExtensionFunctionHandler;
+using extensions::XWalkExtensionFunctionInfo;
 using extensions::XWalkExtensionInstance;
 
 class ApplicationWidgetExtension : public XWalkExtension {
@@ -35,7 +38,19 @@ class AppWidgetExtensionInstance : public XWalkExtensionInstance {
   virtual void HandleSyncMessage(scoped_ptr<base::Value> msg) OVERRIDE;
 
  private:
+  scoped_ptr<base::StringValue> GetWidgetInfo(scoped_ptr<base::Value> msg);
+  scoped_ptr<base::FundamentalValue> SetPreferencesItem(
+      scoped_ptr<base::Value> mgs);
+  scoped_ptr<base::FundamentalValue> RemovePreferencesItem(
+      scoped_ptr<base::Value> mgs);
+  scoped_ptr<base::FundamentalValue> ClearAllItems(scoped_ptr<base::Value> mgs);
+  scoped_ptr<base::DictionaryValue> GetAllItems(scoped_ptr<base::Value> mgs);
+  scoped_ptr<base::FundamentalValue> KeyExists(
+      scoped_ptr<base::Value> mgs) const;
+
   Application* application_;
+  scoped_ptr<class AppWidgetStorage> widget_storage_;
+  XWalkExtensionFunctionHandler handler_;
 };
 
 }  // namespace application

--- a/application/extension/application_widget_storage.cc
+++ b/application/extension/application_widget_storage.cc
@@ -1,0 +1,306 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/extension/application_widget_storage.h"
+
+#include <string>
+
+#include "base/file_util.h"
+#include "sql/statement.h"
+#include "sql/transaction.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/manifest_handlers/widget_handler.h"
+
+namespace {
+
+namespace widget_keys = xwalk::application_widget_keys;
+
+const char kPreferences[] = "preferences";
+const char kPreferencesName[] = "name";
+const char kPreferencesValue[] = "value";
+const char kPreferencesReadonly[] = "readonly";
+
+const base::FilePath::CharType kWidgetStorageExtension[] =
+    FILE_PATH_LITERAL(".widgetStorage");
+
+const char kStorageTableName[] = "widget_storage";
+
+const char kCreateStorageTableOp[] =
+    "CREATE TABLE widget_storage ("
+    "key TEXT NOT NULL UNIQUE PRIMARY KEY,"
+    "value TEXT NOT NULL,"
+    "read_only INTEGER )";
+
+const char kClearStorageTableWithBindOp[] =
+    "DELETE FROM widget_storage WHERE read_only = ? ";
+
+const char kInsertItemWithBindOp[] =
+    "INSERT INTO widget_storage (value, read_only, key) "
+    "VALUES(?,?,?)";
+
+const char kUpdateItemWithBindOp[] =
+    "UPDATE widget_storage SET value = ? , read_only = ? "
+    "WHERE key = ?";
+
+const char kRemoveItemWithBindOp[] =
+    "DELETE FROM widget_storage WHERE key = ?";
+
+const char kSelectTableLength[] =
+    "SELECT count(*) FROM widget_storage ";
+
+const char kSelectCountWithBindOp[] =
+    "SELECT count(*) FROM widget_storage "
+    "WHERE key = ?";
+
+const char kSelectAllItem[] =
+    "SELECT key, value FROM widget_storage ";
+
+const char kSelectReadOnlyWithBindOp[] =
+    "SELECT read_only FROM widget_storage "
+    "WHERE key = ?";
+}  // namespace
+
+namespace xwalk {
+namespace application {
+
+AppWidgetStorage::AppWidgetStorage(Application* application,
+                                   const base::FilePath& data_dir)
+    : application_(application),
+      db_initialized_(false) {
+  sqlite_db_.reset(new sql::Connection);
+
+  base::FilePath name(application_->id());
+  base::FilePath::StringType storage_name =
+      name.value() + kWidgetStorageExtension;
+  data_path_ = data_dir.Append(storage_name);
+
+  if (!base::PathExists(data_dir) && !base::CreateDirectory(data_dir)) {
+    LOG(ERROR) << "Could not create widget storage path.";
+    return;
+  }
+
+  if (!Init()) {
+    LOG(ERROR) << "Initialize widget storage failed.";
+    return;
+  }
+}
+
+AppWidgetStorage::~AppWidgetStorage() {
+}
+
+bool AppWidgetStorage::Init() {
+  if (!sqlite_db_->Open(data_path_)) {
+    LOG(ERROR) << "Unable to open widget storage DB.";
+    return false;
+  }
+  sqlite_db_->Preload();
+
+  if (!InitStorageTable()) {
+     LOG(ERROR) << "Unable to init widget storage table.";
+     return false;
+  }
+  return db_initialized_;
+}
+
+bool AppWidgetStorage::SaveConfigInfoItem(base::DictionaryValue* dict) {
+  DCHECK(dict);
+  std::string key;
+  std::string value;
+  bool read_only = false;
+  dict->GetString(kPreferencesName, &key);
+  dict->GetString(kPreferencesValue, &value);
+  dict->GetBoolean(kPreferencesReadonly, &read_only);
+  return AddEntry(key, value, read_only);
+}
+
+bool AppWidgetStorage::SaveConfigInfoInDB() {
+  WidgetInfo* info =
+      static_cast<WidgetInfo*>(
+      application_->data()->GetManifestData(widget_keys::kWidgetKey));
+  base::DictionaryValue* widget_info = info->GetWidgetInfo();
+  if (!widget_info) {
+    LOG(ERROR) << "Fail to get parsed widget information.";
+    return false;
+  }
+
+  base::Value* pref_value;
+  widget_info->Get(kPreferences, &pref_value);
+
+  if (pref_value && pref_value->IsType(base::Value::TYPE_DICTIONARY)) {
+    base::DictionaryValue* dict;
+    pref_value->GetAsDictionary(&dict);
+    return SaveConfigInfoItem(dict);
+  } else if (pref_value && pref_value->IsType(base::Value::TYPE_LIST)) {
+    base::ListValue* list;
+    pref_value->GetAsList(&list);
+
+    for (base::ListValue::iterator it = list->begin();
+         it != list->end(); ++it) {
+      base::DictionaryValue* dict;
+      (*it)->GetAsDictionary(&dict);
+      if (!SaveConfigInfoItem(dict))
+        return false;
+    }
+  } else {
+    LOG(INFO) << "No widget preferences or preference type is not supported.";
+  }
+
+  return true;
+}
+
+bool AppWidgetStorage::InitStorageTable() {
+  if (sqlite_db_->DoesTableExist(kStorageTableName)) {
+    db_initialized_ = (sqlite_db_ && sqlite_db_->is_open());
+    return true;
+  }
+
+  sql::Transaction transaction(sqlite_db_.get());
+  transaction.Begin();
+  if (!sqlite_db_->Execute(kCreateStorageTableOp))
+    return false;
+  if (!transaction.Commit())
+    return false;
+
+  db_initialized_ = (sqlite_db_ && sqlite_db_->is_open());
+  SaveConfigInfoInDB();
+
+  return true;
+}
+
+bool AppWidgetStorage::EntryExists(const std::string& key) const {
+  sql::Transaction transaction(sqlite_db_.get());
+  if (!transaction.Begin())
+    return false;
+
+  sql::Statement stmt(sqlite_db_->GetUniqueStatement(
+      kSelectCountWithBindOp));
+  stmt.BindString(0, key);
+  if (!stmt.Step()) {
+    LOG(ERROR) << "An error occured when selecting count from DB.";
+    return false;
+  }
+
+  if (!transaction.Commit())
+    return false;
+
+  int exist = stmt.ColumnInt(0);
+  return exist > 0;
+}
+
+bool AppWidgetStorage::IsReadOnly(const std::string& key) {
+  sql::Transaction transaction(sqlite_db_.get());
+  if (!transaction.Begin())
+    return true;
+
+  sql::Statement stmt(sqlite_db_->GetUniqueStatement(
+      kSelectReadOnlyWithBindOp));
+  stmt.BindString(0, key);
+  if (!stmt.Step()) {
+    LOG(ERROR) << "An error occured when selecting count from DB.";
+    return true;
+  }
+
+  if (!transaction.Commit())
+    return true;
+
+  return stmt.ColumnBool(0);
+}
+
+bool AppWidgetStorage::AddEntry(const std::string& key,
+                               const std::string& value,
+                               bool read_only) {
+  if (!db_initialized_ && !Init())
+    return false;
+
+  std::string operation;
+  if (!EntryExists(key)) {
+    operation = kInsertItemWithBindOp;
+  } else if (!IsReadOnly(key)) {
+    operation = kUpdateItemWithBindOp;
+  } else {
+    LOG(ERROR) << "Could not set read only item " << key;
+    return false;
+  }
+
+  sql::Transaction transaction(sqlite_db_.get());
+  if (!transaction.Begin())
+    return false;
+
+  sql::Statement stmt(sqlite_db_->GetUniqueStatement(
+    operation.c_str()));
+  stmt.BindString(0, value);
+  stmt.BindBool(1, read_only);
+  stmt.BindString(2, key);
+  if (!stmt.Run()) {
+    LOG(ERROR) << "An error occured when set item into DB.";
+    return false;
+  }
+
+  return transaction.Commit();
+}
+
+bool AppWidgetStorage::RemoveEntry(const std::string& key) {
+  if (!db_initialized_ && !Init())
+    return false;
+
+  if (IsReadOnly(key)) {
+    LOG(ERROR) << "Could not remove read only item " << key;
+    return false;
+  }
+
+  sql::Transaction transaction(sqlite_db_.get());
+  if (!transaction.Begin())
+    return false;
+
+  sql::Statement stmt(sqlite_db_->GetUniqueStatement(
+      kRemoveItemWithBindOp));
+  stmt.BindString(0, key);
+
+  if (!stmt.Run()) {
+    LOG(ERROR) << "An error occured when removing item into DB.";
+    return false;
+  }
+
+  return transaction.Commit();
+}
+
+bool AppWidgetStorage::Clear() {
+  if (!db_initialized_ && !Init())
+    return false;
+
+  sql::Transaction transaction(sqlite_db_.get());
+  transaction.Begin();
+
+  sql::Statement stmt(sqlite_db_->GetUniqueStatement(
+      kClearStorageTableWithBindOp));
+  stmt.BindBool(0, false);
+
+  if (!stmt.Run()) {
+    LOG(ERROR) << "An error occured when removing item into DB.";
+    return false;
+  }
+
+  return transaction.Commit();
+}
+
+bool AppWidgetStorage::GetAllEntries(base::DictionaryValue* result) {
+  std::string key;
+  std::string value;
+  DCHECK(result);
+
+  if (!db_initialized_ && !Init())
+    return false;
+
+  sql::Statement stmt(sqlite_db_->GetUniqueStatement(kSelectAllItem));
+  while (stmt.Step()) {
+    key = stmt.ColumnString(0);
+    value = stmt.ColumnString(1);
+    result->SetString(key, value);
+  }
+
+  return true;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/extension/application_widget_storage.h
+++ b/application/extension/application_widget_storage.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_EXTENSION_APPLICATION_WIDGET_STORAGE_H_
+#define XWALK_APPLICATION_EXTENSION_APPLICATION_WIDGET_STORAGE_H_
+
+#include <map>
+#include <string>
+
+#include "base/values.h"
+#include "base/files/file_path.h"
+#include "sql/connection.h"
+#include "xwalk/application/browser/application.h"
+
+namespace xwalk {
+namespace application {
+
+class AppWidgetStorage {
+ public:
+  AppWidgetStorage(Application* application,
+                   const base::FilePath& data_dir);
+  ~AppWidgetStorage();
+
+  // Adds or replaces entry (if not readonly);
+  // returns true on success.
+  bool AddEntry(const std::string& key,
+               const std::string& value,
+               bool read_only);
+  bool RemoveEntry(const std::string& key);
+  bool Clear();
+  bool GetAllEntries(base::DictionaryValue* result);
+  bool EntryExists(const std::string& key) const;
+
+ private:
+  bool Init();
+  bool IsReadOnly(const std::string& key);
+  bool InitStorageTable();
+  bool SaveConfigInfoInDB();
+  bool SaveConfigInfoItem(base::DictionaryValue* dict);
+
+  Application* application_;
+  scoped_ptr<sql::Connection> sqlite_db_;
+  base::FilePath data_path_;
+  bool db_initialized_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+#endif  // XWALK_APPLICATION_EXTENSION_APPLICATION_WIDGET_STORAGE_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -83,6 +83,8 @@
         'extension/application_runtime_extension.h',
         'extension/application_widget_extension.cc',
         'extension/application_widget_extension.h',
+        'extension/application_widget_storage.cc',
+        'extension/application_widget_storage.h',
 
         'renderer/application_native_module.cc',
         'renderer/application_native_module.h',

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -78,6 +78,11 @@ bool PathProvider(int key, base::FilePath* path) {
       cur = cur.Append(FILE_PATH_LITERAL("test"));
       cur = cur.Append(FILE_PATH_LITERAL("data"));
       break;
+    case xwalk::DIR_WGT_STORAGE_PATH:
+      if (!GetXWalkDataPath(&cur))
+        return false;
+      cur = cur.Append(FILE_PATH_LITERAL("Widget Storage"));
+      break;
     default:
       return false;
   }

--- a/runtime/common/xwalk_paths.h
+++ b/runtime/common/xwalk_paths.h
@@ -15,6 +15,7 @@ enum {
   DIR_DATA_PATH = PATH_START,  // Directory where the cache and local storage
                                // data resides.
   DIR_TEST_DATA,               // Directory where unit test data resides.
+  DIR_WGT_STORAGE_PATH,        // Directory where widget storage data resides.
   PATH_END
 };
 

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -6,6 +6,7 @@
 
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/renderer/render_thread.h"
+#include "grit/xwalk_application_resources.h"
 #include "grit/xwalk_sysapps_resources.h"
 #include "third_party/WebKit/public/platform/WebString.h"
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
@@ -93,6 +94,9 @@ void XWalkContentRendererClient::DidCreateModuleSystem(
   module_system->RegisterNativeModule("sysapps_promise",
       extensions::CreateJSModuleFromResource(
           IDR_XWALK_SYSAPPS_COMMON_PROMISE_API));
+  module_system->RegisterNativeModule("widget_common",
+      extensions::CreateJSModuleFromResource(
+          IDR_XWALK_APPLICATION_WIDGET_COMMON_API));
 }
 
 }  // namespace xwalk


### PR DESCRIPTION
The 'preferences' attribute allows authors to manipulate a widget
storage area that is unique for the instance of a widget. It does this
by implementing the Storage interface specified in
http://www.w3.org/TR/webstorage/

Spec:
http://www.w3.org/TR/widgets-apis/#the-preferences-attribute

This CL implements the below features,
1. Web Storage functions and attributes, includes,
   length, getItem(), setItem(), removeItem(), clear().
2. 'readonly' field support for the key/value pairs.
3. Remove the widget database file when uninstallation app.
4. Load Manifest configuration when creating widget DB.

BUG=XWALK-1075
