### PR TITLE
[Android] Fix build fail for XWalkCoreShell

### DIFF
--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewSectionFragment.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewSectionFragment.java
@@ -5,7 +5,7 @@
 package org.xwalk.core.xwview.shell;
 
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.client.XWalkDefaultWebChromeClient;
+import org.xwalk.core.XWalkDefaultWebChromeClient;
 
 import android.app.Activity;
 import android.os.Bundle;


### PR DESCRIPTION
Package name for XWalkDefaultWebChromeClient has been changed.
