### PR TITLE
[Android] Fix binaries size regression

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -362,6 +362,7 @@ if __name__ == '__main__':
 
   if landmine_utils.platform() == 'android':
     args.append('-Dnotifications=1')
+    args.append('-Drelease_unwind_tables=0')
 
   # Use the Psyco JIT if available.
   if psyco:


### PR DESCRIPTION
It's introduced by M34 chromium, which include
unwind table for debug trace even for release build.
For chromium case, the debug info will only be
excluded for official build.

Fix this by explicitly disable unwind table for
release build.

TODO: Revert this patch after crosswalk supports
official build also.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1057
