### PR TITLE
Introduce "--fullscreen" command line option for xwalk-launcher

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -101,6 +101,8 @@ bool Application::Launch(const LaunchParams& launch_params) {
   if (entry_point_used_ != AppMainKey) {
     NativeAppWindow::CreateParams params;
     params.net_wm_pid = launch_params.launcher_pid;
+    params.state = launch_params.window_state;
+
     main_runtime_->AttachWindow(params);
   }
 

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -14,6 +14,7 @@
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_vector.h"
 #include "base/observer_list.h"
+#include "ui/base/ui_base_types.h"
 #include "xwalk/application/browser/event_observer.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/runtime/browser/runtime.h"
@@ -63,13 +64,17 @@ class Application : public Runtime::Observer {
   struct LaunchParams {
     LaunchParams() :
         entry_points(Default),
-        launcher_pid(0) {}
+        launcher_pid(0),
+        window_state(ui::SHOW_STATE_DEFAULT) {}
 
     LaunchEntryPoints entry_points;
 
     // Used only when running as service. Specifies the PID of the launcher
     // process.
     int32 launcher_pid;
+
+    // Sets the initial state for the application windows.
+    ui::WindowShowState window_state;
   };
 
   // Closes all the application's runtimes (application pages).

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -50,17 +50,18 @@ class ApplicationService : public Application::Observer {
   bool Install(const base::FilePath& path, std::string* id);
   bool Uninstall(const std::string& id);
   bool Update(const std::string& id, const base::FilePath& path);
+
+  Application* Launch(scoped_refptr<ApplicationData> application_data,
+                      const Application::LaunchParams& launch_params);
   // Launch an installed application using application id.
   Application* Launch(
       const std::string& id,
       const Application::LaunchParams& params = Application::LaunchParams());
   // Launch an unpacked application using path to a local directory which
   // contains manifest file.
-  Application* Launch(const base::FilePath& path);
-  // Launch an application created from arbitrary url.
-  // FIXME: This application should have the same strict permissions
-  // as common browser apps.
-  Application* Launch(const GURL& url);
+  Application* Launch(
+      const base::FilePath& path,
+      const Application::LaunchParams& params = Application::LaunchParams());
 
   Application* GetApplicationByRenderHostID(int id) const;
   Application* GetApplicationByID(const std::string& app_id) const;
@@ -88,8 +89,6 @@ class ApplicationService : public Application::Observer {
   // Implementation of Application::Observer.
   virtual void OnApplicationTerminated(Application* app) OVERRIDE;
 
-  Application* Launch(scoped_refptr<ApplicationData> application_data,
-                      const Application::LaunchParams& launch_params);
 
   xwalk::RuntimeContext* runtime_context_;
   ApplicationStorage* application_storage_;

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -89,7 +89,7 @@ class ApplicationSystem {
 
  private:
   template <typename T>
-  bool LaunchWithCommandLineParam(const T& param);
+  bool LaunchWithCommandLineParam(const T& param, const CommandLine& cmd_line);
   // Note: initialization order matters.
   xwalk::RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationStorage> application_storage_;

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -72,9 +72,13 @@ void RunningApplicationsManager::OnLaunch(
 
   dbus::MessageReader reader(method_call);
   std::string app_id;
+  // We might want to pass key-value pairs if have more parameters in future.
   unsigned int launcher_pid;
+  bool fullscreen;
+
   if (!reader.PopString(&app_id) ||
-      !reader.PopUint32(&launcher_pid)) {
+      !reader.PopUint32(&launcher_pid) ||
+      !reader.PopBool(&fullscreen)) {
     scoped_ptr<dbus::Response> response =
         CreateError(method_call,
                     "Error parsing message. Missing arguments.");
@@ -84,6 +88,8 @@ void RunningApplicationsManager::OnLaunch(
 
   Application::LaunchParams params;
   params.launcher_pid = launcher_pid;
+  if (fullscreen)
+    params.window_state = ui::SHOW_STATE_FULLSCREEN;
 
   Application* application = application_service_->Launch(app_id, params);
   if (!application) {

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -366,13 +366,10 @@ void Runtime::ApplyWindowDefaultParams(NativeAppWindow::CreateParams* params) {
 
 void Runtime::ApplyFullScreenParam(NativeAppWindow::CreateParams* params) {
   DCHECK(params);
-  // TODO(cmarcelo): This is policy that probably should be moved to outside
-  // Runtime class.
-  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
-  if (cmd_line->HasSwitch(switches::kFullscreen)) {
-    params->state = ui::SHOW_STATE_FULLSCREEN;
+  if (params->state == ui::SHOW_STATE_FULLSCREEN)
     fullscreen_options_ |= FULLSCREEN_FOR_LAUNCH;
-  }
+  else
+    fullscreen_options_ &= ~FULLSCREEN_FOR_LAUNCH;
 }
 
 #if defined(OS_TIZEN_MOBILE)

--- a/runtime/browser/xwalk_runtime_browsertest.cc
+++ b/runtime/browser/xwalk_runtime_browsertest.cc
@@ -145,30 +145,16 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CloseNativeWindow) {
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LaunchWithFullscreenWindow) {
-  // At least one Runtime instance is created at startup.
-  size_t len = runtimes().size();
-  ASSERT_EQ(1, len);
-  // Original Runtime should has non fullscreen window.
-  EXPECT_TRUE(false == runtime()->window()->IsFullscreen());
-
-  // Add "--fullscreen" launch argument.
-  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
-  cmd_line->AppendSwitch("fullscreen");
-
-  // Create a new Runtime instance.
-  FullscreenNotificationObserver fullscreen_observer;
   GURL url(test_server()->GetURL("test.html"));
-  Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
-      runtime()->runtime_context(), url, runtime_registry());
-  content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len + 1, runtimes().size());
-  fullscreen_observer.Wait();
-  EXPECT_TRUE(true == new_runtime->window()->IsFullscreen());
+  Runtime* new_runtime = Runtime::Create(
+      runtime()->runtime_context(), runtime_registry());
 
-  // Close the newly created Runtime instance.
-  new_runtime->Close();
-  content::RunAllPendingInMessageLoop();
-  EXPECT_EQ(len, runtimes().size());
+  NativeAppWindow::CreateParams params;
+  params.state = ui::SHOW_STATE_FULLSCREEN;
+  new_runtime->AttachWindow(params);
+  xwalk_test_utils::NavigateToURL(new_runtime, url);
+
+  EXPECT_TRUE(new_runtime->window()->IsFullscreen());
 }
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, HTML5FullscreenAPI) {


### PR DESCRIPTION
Introduce "--fullscreen" command line option for xwalk-launcher
in order to allow launching applications in fullscreen mode
without necessity to re-start xwalk service process. Besides,
it allows simultaneous running applications in both fullscreen
and default modes.

This patch also moves the logic enabling fullscreen mode from the
Runtime class to more appropriate places: ApplicationSystem
and RunningApplicationsManager.

BUG=XWALK-1229
