### PR TITLE
[Android] Add the information prompt when failed to package app with wro...

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -701,6 +701,11 @@ def main(argv):
                    '"--app-local-path" options together!')
     if options.permissions:
       permission_list = options.permissions.split(':')
+      for permission in permission_list:
+        if permission.lower() not in list(permission_mapping_table.keys()):
+          print('Error: permission \'%s\' related API is not supported.'
+                % permission)
+          sys.exit(13)
     else:
       print ('Warning: all supported permissions on Android port are added. '
              'Refer to https://github.com/crosswalk-project/'

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -270,6 +270,19 @@ class TestMakeApk(unittest.TestCase):
     self.checkApks('Example', '1.0.0')
     Clean('Example', '1.0.0')
 
+  def testPermissionsWithError(self):
+    cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+           '--package=org.xwalk.example', '--permissions=UndefinedPermission',
+           '--app-url=http://www.intel.com', self._mode]
+    out = RunCommand(cmd)
+    self.assertTrue(out.find('related API is not supported.') != -1)
+    cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+           '--package=org.xwalk.example',
+           '--permissions=Contacts.Geolocation.Messaging',
+           '--app-url=http://www.intel.com', self._mode]
+    out = RunCommand(cmd)
+    self.assertTrue(out.find('related API is not supported.') != -1)
+
   def testPackage(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            self._mode]
@@ -730,6 +743,7 @@ def SuiteWithModeOption():
   test_suite.addTest(TestMakeApk('testOrientation'))
   test_suite.addTest(TestMakeApk('testPackage'))
   test_suite.addTest(TestMakeApk('testPermissions'))
+  test_suite.addTest(TestMakeApk('testPermissionsWithError'))
   test_suite.addTest(TestMakeApk('testXPK'))
   test_suite.addTest(TestMakeApk('testXPKWithError'))
   test_suite.addTest(TestMakeApk('testTargetDir'))


### PR DESCRIPTION
...ng permission.

When packaging application with wrong permission, the packaging is failed,
while there is no information prompt, this fix resolves this issue by adding
information prompt in packaging tool.

BUG=XWALK-1205, XWALK-1206
