### PR TITLE
[Android] Remove unnecessary pak file loading for sandboxed process.

### DIFF
--- a/runtime/app/android/xwalk_main_delegate_android.cc
+++ b/runtime/app/android/xwalk_main_delegate_android.cc
@@ -54,15 +54,6 @@ int XWalkMainDelegateAndroid::RunProcess(
 }
 
 void XWalkMainDelegateAndroid::InitResourceBundle() {
-  int pak_fd =
-      base::GlobalDescriptors::GetInstance()->MaybeGet(kXWalkPakDescriptor);
-  if (pak_fd != base::kInvalidPlatformFileValue) {
-    ui::ResourceBundle::InitSharedInstanceWithPakFile(
-        base::File(pak_fd), false);
-    ResourceBundle::GetSharedInstance().AddDataPackFromFile(
-        base::File(pak_fd), ui::SCALE_FACTOR_100P);
-    return;
-  }
   base::FilePath pak_file;
   base::FilePath pak_dir;
   bool got_path = PathService::Get(base::DIR_ANDROID_APP_DATA, &pak_dir);

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -237,28 +237,6 @@ void XWalkContentBrowserClient::CancelDesktopNotification(
 }
 
 #if defined(OS_ANDROID)
-void XWalkContentBrowserClient::GetAdditionalMappedFilesForChildProcess(
-    const CommandLine& command_line,
-    int child_process_id,
-    std::vector<content::FileDescriptorInfo>* mappings) {
-  int flags = base::PLATFORM_FILE_OPEN | base::PLATFORM_FILE_READ;
-  base::FilePath pak_file;
-  bool r = PathService::Get(base::DIR_ANDROID_APP_DATA, &pak_file);
-  CHECK(r);
-  pak_file = pak_file.Append(FILE_PATH_LITERAL("paks"));
-  pak_file = pak_file.Append(FILE_PATH_LITERAL(kXWalkPakFilePath));
-
-  base::PlatformFile f =
-      base::CreatePlatformFile(pak_file, flags, NULL, NULL);
-  if (f == base::kInvalidPlatformFileValue) {
-    NOTREACHED() << "Failed to open file when creating renderer process: "
-                 << "xwalk.pak";
-  }
-  mappings->push_back(
-      content::FileDescriptorInfo(kXWalkPakDescriptor,
-                                  base::FileDescriptor(f, true)));
-}
-
 void XWalkContentBrowserClient::ResourceDispatcherHostCreated() {
   RuntimeResourceDispatcherHostDelegateAndroid::
   ResourceDispatcherHostCreated();

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -98,10 +98,6 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
       int notification_id) OVERRIDE;
 
 #if defined(OS_ANDROID)
-  virtual void GetAdditionalMappedFilesForChildProcess(
-      const CommandLine& command_line,
-      int child_process_id,
-      std::vector<content::FileDescriptorInfo>* mappings) OVERRIDE;
   virtual void ResourceDispatcherHostCreated();
 #endif
   XWalkBrowserMainParts* main_parts() { return main_parts_; }


### PR DESCRIPTION
Since XWalk is ALWAYS running in single process mode, the pak file loading
for sandboxed process is never be used.

BUG=
