### PR TITLE
[Android] Update the package name handler in packaging tool.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -25,12 +25,14 @@ def ReplaceInvalidChars(value, mode='default'):
     mode: the target usage mode of original string.
   """
   if mode == 'default':
-    invalid_chars = '\/:*?"<>|- '
+    invalid_chars = '\/:*?"<>|-'
+  elif mode == 'packagename':
+    invalid_chars = '\/:~*?"<>|- '
   elif mode == 'apkname':
-    invalid_chars = '\/:.*?"<>|-'
+    invalid_chars = '\/:^.~`&@#$%{}[](),!*?"<>|- '
   for c in invalid_chars:
-    if mode == 'apkname' and c in value:
-      print("Illegal character: '%s' is replaced with '_'" % c)
+    if mode == 'default' or mode == 'apkname' and c in value:
+      print("Illegal character: '%s' is replaced with '_' in apk." % c)
     value = value.replace(c,'_')
   return value
 
@@ -371,8 +373,8 @@ def CustomizeAll(app_versionCode, description, icon, permissions, app_url,
                  app_root, app_local_path, enable_remote_debugging,
                  display_as_fullscreen, extensions, launch_screen_img,
                  package='org.xwalk.app.template', name='AppTemplate',
-                 app_version='1.0.0', orientation='unspecified') :
-  sanitized_name = ReplaceInvalidChars(name, 'apkname')
+                 sanitized_name = 'AppTemplate', app_version='1.0.0',
+                 orientation='unspecified'):
   try:
     Prepare(sanitized_name, package, app_root)
     CustomizeXML(sanitized_name, package, app_versionCode, app_version,
@@ -435,6 +437,8 @@ def main():
   parser.add_option('--launch-screen-img',
                     help='The fallback image for launch_screen')
   options, _ = parser.parse_args()
+  sanitized_name = ReplaceInvalidChars(options.name)
+  sanitized_name = ReplaceInvalidChars(sanitized_name, 'apkname')
   try:
     icon_dict = {144: 'icons/icon_144.png',
                  72: 'icons/icon_72.png',
@@ -455,7 +459,7 @@ def main():
                  options.app_local_path, options.enable_remote_debugging,
                  options.fullscreen, options.extensions,
                  options.launch_screen_img, options.package, options.name,
-                 options.app_version, options.orientation)
+                 sanitized_name, options.app_version, options.orientation)
   except SystemExit as ec:
     print('Exiting with error code: %d' % ec.code)
     return ec.code

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -166,7 +166,7 @@ class TestMakeApk(unittest.TestCase):
     # and the result of verification should be the same between shared mode
     # and embedded mode. So only do the verification in the shared mode.
     if self._mode.find('shared') != -1:
-      invalid_chars = '\/:.*?"<>|-'
+      invalid_chars = '\/:^.~`&@#$%{}[](),!*?"<>|- '
       for c in invalid_chars:
         invalid_name = '--name=Example' + c
         cmd = ['python', 'make_apk.py', invalid_name,
@@ -346,7 +346,8 @@ class TestMakeApk(unittest.TestCase):
 
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_app_launch_local_path.json')
-    cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path, self._mode]
+    cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
+           '--package=org.xwalk.example', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('Please make sure that the local path file') != -1)
     self.assertFalse(os.path.exists('Example.apk'))
@@ -394,7 +395,8 @@ class TestMakeApk(unittest.TestCase):
     Clean('Example', '1.0.0')
     manifest_path = os.path.join('test_data', 'manifest', 'manifest.json')
     cmd = ['python', 'make_apk.py', '--enable-remote-debugging',
-           '--manifest=%s' % manifest_path, self._mode]
+           '--manifest=%s' % manifest_path,
+           '--package=org.xwalk.example', self._mode]
     RunCommand(cmd)
     activity = 'Example/src/org/xwalk/example/ExampleActivity.java'
     with open(activity, 'r') as content_file:
@@ -424,7 +426,8 @@ class TestMakeApk(unittest.TestCase):
 
   def testManifest(self):
     manifest_path = os.path.join('test_data', 'manifest', 'manifest.json')
-    cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path, self._mode]
+    cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
+           '--package=org.xwalk.example', self._mode]
     RunCommand(cmd)
     manifest = 'Example/AndroidManifest.xml'
     with open(manifest, 'r') as content_file:
@@ -452,7 +455,8 @@ class TestMakeApk(unittest.TestCase):
   def testManifestWithSpecificValue(self):
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_app_launch_local_path.json')
-    cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path, self._mode]
+    cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
+           '--package=org.xwalk.example', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('no app launch path') == -1)
     self.checkApks('Example', '1.0.0')
@@ -462,37 +466,37 @@ class TestMakeApk(unittest.TestCase):
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_no_app_launch_path.json')
     cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
-           '--verbose', self._mode]
+           '--package=org.xwalk.example', '--verbose', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('no app launch path') != -1)
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_no_name.json')
     cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
-           '--verbose', self._mode]
+           '--package=org.xwalk.example', '--verbose', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('no \'name\' field') != -1)
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_no_version.json')
     cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
-           '--verbose', self._mode]
+           '--package=org.xwalk.example', '--verbose', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('no \'version\' field') != -1)
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_permissions_format_error.json')
     cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
-           '--verbose', self._mode]
+           '--package=org.xwalk.example', '--verbose', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('\'Permissions\' field error') != -1)
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_permissions_field_error.json')
     cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
-           '--verbose', self._mode]
+           '--package=org.xwalk.example', '--verbose', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('\'Permissions\' field error') != -1)
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_not_supported_permission.json')
     cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path,
-           '--verbose', self._mode]
+           '--package=org.xwalk.example', '--verbose', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(
         out.find('\'Telephony\' related API is not supported') != -1)
@@ -550,7 +554,8 @@ class TestMakeApk(unittest.TestCase):
 
   def testXPK(self):
     xpk_file = os.path.join('test_data', 'xpk', 'example.xpk')
-    cmd = ['python', 'make_apk.py', '--xpk=%s' % xpk_file, self._mode]
+    cmd = ['python', 'make_apk.py', '--xpk=%s' % xpk_file,
+           '--package=org.xwalk.example', self._mode]
     RunCommand(cmd)
     self.assertTrue(os.path.exists('Example'))
     self.checkApks('Example', '1.0.0')
@@ -558,7 +563,8 @@ class TestMakeApk(unittest.TestCase):
 
   def testXPKWithError(self):
     xpk_file = os.path.join('test_data', 'xpk', 'error.xpk')
-    cmd = ['python', 'make_apk.py', '--xpk=%s' % xpk_file, self._mode]
+    cmd = ['python', 'make_apk.py', '--xpk=%s' % xpk_file,
+           '--package=org.xwalk.example', self._mode]
     out = RunCommand(cmd)
     error_msg = 'XPK doesn\'t contain manifest file'
     self.assertTrue(out.find(error_msg) != -1)


### PR DESCRIPTION
In packaging tool, if the option of package name is not set or
the the wrong package name is set, there is no information prompt.
in addition, when there is space in activity name or package path,
the produced package cannot be launched, this is because the Dex
used in packaging tool cannot work with package path including space,
there is a launching related file is lost. And also javac.py cannot
work with the specific illegal characters. This fix resolves these
issues by updating the handler of package name.

BUG=XWALK-1210
