### PR TITLE
[Tizen] [Runtime] Fix the issue that widget apps fails to install without version attribute.

### DIFF
--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -137,7 +137,10 @@ const std::string& ApplicationData::ID() const {
 }
 
 const std::string ApplicationData::VersionString() const {
-  return Version()->GetString();
+  if (!version_->components().empty())
+    return Version()->GetString();
+
+  return "";
 }
 
 bool ApplicationData::IsPlatformApp() const {


### PR DESCRIPTION
[Tizen] [Runtime] Fix the issue that widget apps fails to install without version attribute.

It reports installation crash if a widget app doesn't contains
widget 'version' attribute in the config.xml file. The root cause is
Version::GetString() always assumes a Version instance is valid, in
other words, not an empty string.

Due to the 'version' attribute could be optional for widget app, a
solution to fix this issue is we add check in
ApplicationData::VersionString().

BUG=XWALK-1226
