### PR TITLE
[Application][Runtime][Extension] Merge xwalk-launcher with extension process for service mode

### DIFF
--- a/application/browser/application_service_provider_linux.cc
+++ b/application/browser/application_service_provider_linux.cc
@@ -11,6 +11,7 @@
 #include "dbus/message.h"
 #include "xwalk/dbus/xwalk_service_name.h"
 #include "xwalk/application/browser/linux/installed_applications_manager.h"
+#include "xwalk/application/browser/linux/running_application_object.h"
 #include "xwalk/application/browser/linux/running_applications_manager.h"
 
 namespace xwalk {
@@ -41,6 +42,12 @@ ApplicationServiceProviderLinux::ApplicationServiceProviderLinux(
 }
 
 ApplicationServiceProviderLinux::~ApplicationServiceProviderLinux() {}
+
+RunningApplicationObject*
+ApplicationServiceProviderLinux::GetRunningApplicationObject(
+    const Application* app) {
+  return running_apps_->GetRunningApp(app->id());
+}
 
 void ApplicationServiceProviderLinux::OnServiceNameExported(
     const std::string& service_name, bool success) {

--- a/application/browser/application_service_provider_linux.h
+++ b/application/browser/application_service_provider_linux.h
@@ -16,9 +16,11 @@ class Bus;
 namespace xwalk {
 namespace application {
 
+class Application;
 class ApplicationService;
 class ApplicationStorage;
 class InstalledApplicationsManager;
+class RunningApplicationObject;
 class RunningApplicationsManager;
 
 // Uses a D-Bus service named "org.crosswalkproject.Runtime1" to expose
@@ -29,6 +31,8 @@ class ApplicationServiceProviderLinux {
                                   ApplicationStorage* app_storage,
                                   scoped_refptr<dbus::Bus> session_bus);
   virtual ~ApplicationServiceProviderLinux();
+
+  RunningApplicationObject* GetRunningApplicationObject(const Application* app);
 
  private:
   void OnServiceNameExported(const std::string& service_name, bool success);

--- a/application/browser/application_system_linux.cc
+++ b/application/browser/application_system_linux.cc
@@ -30,5 +30,9 @@ DBusManager& ApplicationSystemLinux::dbus_manager() {
   return *dbus_manager_.get();
 }
 
+ApplicationServiceProviderLinux* ApplicationSystemLinux::service_provider() {
+  return service_provider_.get();
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/browser/application_system_linux.h
+++ b/application/browser/application_system_linux.h
@@ -22,6 +22,7 @@ class ApplicationSystemLinux : public ApplicationSystem {
   virtual ~ApplicationSystemLinux();
 
   DBusManager& dbus_manager();
+  ApplicationServiceProviderLinux* service_provider();
 
  private:
   scoped_ptr<DBusManager> dbus_manager_;

--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -8,6 +8,7 @@
 #include <string>
 #include "base/memory/ref_counted.h"
 #include "dbus/bus.h"
+#include "ipc/ipc_channel_handle.h"
 #include "xwalk/application/browser/application.h"
 #include "xwalk/dbus/object_manager_adaptor.h"
 
@@ -29,6 +30,8 @@ class RunningApplicationObject : public dbus::ManagedObject {
 
   virtual ~RunningApplicationObject();
 
+  void ExtensionProcessCreated(const IPC::ChannelHandle& handle);
+
  private:
   void TerminateApplication(Application::TerminationMode mode);
 
@@ -40,6 +43,10 @@ class RunningApplicationObject : public dbus::ManagedObject {
                    dbus::MethodCall* method_call,
                    dbus::ExportedObject::ResponseSender response_sender);
 
+  void OnGetExtensionProcessChannel(
+      dbus::MethodCall* method_call,
+      dbus::ExportedObject::ResponseSender response_sender);
+
   void ListenForOwnerChange();
   void UnlistenForOwnerChange();
   void OnNameOwnerChanged(const std::string& service_owner);
@@ -50,6 +57,8 @@ class RunningApplicationObject : public dbus::ManagedObject {
   std::string launcher_name_;
   dbus::Bus::GetServiceOwnerCallback owner_change_callback_;
   Application* application_;
+
+  IPC::ChannelHandle ep_bp_channel_;
 };
 
 }  // namespace application

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -54,6 +54,14 @@ RunningApplicationsManager::RunningApplicationsManager(
 
 RunningApplicationsManager::~RunningApplicationsManager() {}
 
+RunningApplicationObject* RunningApplicationsManager::GetRunningApp(
+    const std::string& app_id) {
+  dbus::ManagedObject* managed_object =
+      adaptor_.GetManagedObject(GetRunningPathForAppID(app_id));
+  DCHECK(managed_object);
+  return static_cast<RunningApplicationObject*>(managed_object);
+}
+
 namespace {
 
 scoped_ptr<dbus::Response> CreateError(dbus::MethodCall* method_call,

--- a/application/browser/linux/running_applications_manager.h
+++ b/application/browser/linux/running_applications_manager.h
@@ -33,6 +33,8 @@ class RunningApplicationsManager : public ApplicationService::Observer {
                              ApplicationService* service);
   virtual ~RunningApplicationsManager();
 
+  RunningApplicationObject* GetRunningApp(const std::string& app_id);
+
  private:
   // org.crosswalkproject.Running.Manager1 interface.
   void OnLaunch(dbus::MethodCall* method_call,

--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -4,7 +4,7 @@
       'target_name': 'gio',
       'type': 'none',
       'variables': {
-        'glib_packages': 'glib-2.0 gio-2.0',
+        'glib_packages': 'glib-2.0 gio-unix-2.0',
       },
       'direct_dependent_settings': {
         'cflags': [
@@ -44,6 +44,9 @@
       'product_name': 'xwalk-launcher',
       'include_dirs': [
         '../../../..',
+      ],
+      'dependencies': [
+        '../../../extensions/extensions.gyp:xwalk_extensions',
       ],
       'sources': [
         'dbus_connection.h',

--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -22,6 +22,7 @@
 #include "ipc/ipc_switches.h"
 #include "xwalk/extensions/common/xwalk_extension_messages.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 using content::BrowserThread;
 
@@ -137,58 +138,82 @@ void ToListValue(base::ValueMap* vm, base::ListValue* lv) {
 
 void XWalkExtensionProcessHost::StartProcess() {
   CHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
-  CHECK(!process_);
+  CHECK(!process_ || !channel_);
 
-  process_.reset(content::BrowserChildProcessHost::Create(
-      content::PROCESS_TYPE_CONTENT_END, this));
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kXWalkRunAsService)) {
+#if defined(OS_LINUX)
+    std::string channel_id =
+        IPC::Channel::GenerateVerifiedChannelID(std::string());
+    channel_.reset(new IPC::Channel(
+          channel_id, IPC::Channel::MODE_SERVER, this));
+    if (!channel_->Connect())
+      NOTREACHED();
+    IPC::ChannelHandle channel_handle(channel_id,
+        base::FileDescriptor(channel_->TakeClientFileDescriptor(), true));
+    BrowserThread::PostTask(
+        BrowserThread::UI, FROM_HERE,
+        base::Bind(
+            &XWalkExtensionProcessHost::Delegate::OnExtensionProcessCreated,
+            base::Unretained(delegate_), render_process_host_->GetID(),
+            channel_handle));
+#else
+    NOTIMPLEMENTED();
+#endif
+  } else {
+    process_.reset(content::BrowserChildProcessHost::Create(
+        content::PROCESS_TYPE_CONTENT_END, this));
 
-  std::string channel_id = process_->GetHost()->CreateChannel();
-  CHECK(!channel_id.empty());
+    std::string channel_id = process_->GetHost()->CreateChannel();
+    CHECK(!channel_id.empty());
 
-  CommandLine::StringType extension_cmd_prefix;
+    CommandLine::StringType extension_cmd_prefix;
 #if defined(OS_POSIX)
-  const CommandLine &browser_command_line = *CommandLine::ForCurrentProcess();
-  extension_cmd_prefix = browser_command_line.GetSwitchValueNative(
-      switches::kXWalkExtensionCmdPrefix);
+    const CommandLine &browser_command_line = *CommandLine::ForCurrentProcess();
+    extension_cmd_prefix = browser_command_line.GetSwitchValueNative(
+        switches::kXWalkExtensionCmdPrefix);
 #endif
 
 #if defined(OS_LINUX)
-  int flags = extension_cmd_prefix.empty() ?
-      content::ChildProcessHost::CHILD_ALLOW_SELF :
-      content::ChildProcessHost::CHILD_NORMAL;
+    int flags = extension_cmd_prefix.empty() ?
+        content::ChildProcessHost::CHILD_ALLOW_SELF :
+        content::ChildProcessHost::CHILD_NORMAL;
 #else
-  int flags = content::ChildProcessHost::CHILD_NORMAL;
+    int flags = content::ChildProcessHost::CHILD_NORMAL;
 #endif
 
-  base::FilePath exe_path = content::ChildProcessHost::GetChildPath(flags);
-  if (exe_path.empty())
-    return;
+    base::FilePath exe_path = content::ChildProcessHost::GetChildPath(flags);
+    if (exe_path.empty())
+      return;
 
-  scoped_ptr<CommandLine> cmd_line(new CommandLine(exe_path));
-  cmd_line->AppendSwitchASCII(switches::kProcessType,
-                              switches::kXWalkExtensionProcess);
-  cmd_line->AppendSwitchASCII(switches::kProcessChannelID, channel_id);
-  if (!extension_cmd_prefix.empty())
-    cmd_line->PrependWrapper(extension_cmd_prefix);
+    scoped_ptr<CommandLine> cmd_line(new CommandLine(exe_path));
+    cmd_line->AppendSwitchASCII(switches::kProcessType,
+                                switches::kXWalkExtensionProcess);
+    cmd_line->AppendSwitchASCII(switches::kProcessChannelID, channel_id);
+    if (!extension_cmd_prefix.empty())
+      cmd_line->PrependWrapper(extension_cmd_prefix);
 
-  process_->Launch(
+    process_->Launch(
 #if defined(OS_WIN)
-      new ExtensionSandboxedProcessLauncherDelegate(),
+        new ExtensionSandboxedProcessLauncherDelegate(),
 #elif defined(OS_POSIX)
-    false, base::EnvironmentMap(),
+        false, base::EnvironmentMap(),
 #endif
-    cmd_line.release());
+        cmd_line.release());
+  }
 
   base::ListValue runtime_variables_lv;
   ToListValue(&const_cast<base::ValueMap&>(runtime_variables_),
       &runtime_variables_lv);
-  process_->GetHost()->Send(new XWalkExtensionProcessMsg_RegisterExtensions(
-      external_extensions_path_, runtime_variables_lv));
+  Send(new XWalkExtensionProcessMsg_RegisterExtensions(
+        external_extensions_path_, runtime_variables_lv));
 }
 
 void XWalkExtensionProcessHost::StopProcess() {
-  DCHECK(process_);
-  process_.reset();
+  if (process_);
+    process_.reset();
+  if (channel_)
+    channel_.reset();
 }
 
 void XWalkExtensionProcessHost::OnGetExtensionProcessChannel(
@@ -284,7 +309,11 @@ void XWalkExtensionProcessHost::OnRegisterPermissions(
 }
 
 bool XWalkExtensionProcessHost::Send(IPC::Message* msg) {
-  return process_->GetHost()->Send(msg);
+  if (process_)
+    return process_->GetHost()->Send(msg);
+  if (channel_)
+    return channel_->Send(msg);
+  return false;
 }
 
 }  // namespace extensions

--- a/extensions/browser/xwalk_extension_process_host.h
+++ b/extensions/browser/xwalk_extension_process_host.h
@@ -36,6 +36,8 @@ class XWalkExtensionProcessHost
    public:
     virtual void OnExtensionProcessDied(XWalkExtensionProcessHost* eph,
         int render_process_id) {}
+    virtual void OnExtensionProcessCreated(int render_process_id,
+                                           const IPC::ChannelHandle handle) {}
     virtual void OnCheckAPIAccessControl(int render_process_id,
                                          const std::string& extension_name,
                                          const std::string& api_name,
@@ -43,7 +45,6 @@ class XWalkExtensionProcessHost
     virtual bool OnRegisterPermissions(int render_process_id,
                                        const std::string& extension_name,
                                        const std::string& perm_table);
-
    protected:
     ~Delegate() {}
   };
@@ -104,6 +105,9 @@ class XWalkExtensionProcessHost
   XWalkExtensionProcessHost::Delegate* delegate_;
 
   base::ValueMap runtime_variables_;
+
+  // IPC channel for launcher to communicate with BP in service mode.
+  scoped_ptr<IPC::Channel> channel_;
 };
 
 }  // namespace extensions

--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -452,6 +452,13 @@ void XWalkExtensionService::OnRenderProcessDied(
   delete data;
 }
 
+void XWalkExtensionService::OnExtensionProcessCreated(
+      int render_process_id,
+      const IPC::ChannelHandle channel_handle) {
+  CHECK(delegate_);
+  delegate_->ExtensionProcessCreated(render_process_id, channel_handle);
+}
+
 void XWalkExtensionService::OnCheckAPIAccessControl(
     int render_process_id,
     const std::string& extension_name,

--- a/extensions/browser/xwalk_extension_service.h
+++ b/extensions/browser/xwalk_extension_service.h
@@ -48,6 +48,9 @@ class XWalkExtensionService : public content::NotificationObserver,
         int render_process_id,
         const std::string& extension_name,
         const std::string& perm_table);
+    virtual void ExtensionProcessCreated(
+        int render_process_id,
+        const IPC::ChannelHandle& channel_handle) {}
 
    protected:
     ~Delegate() {}
@@ -96,6 +99,10 @@ class XWalkExtensionService : public content::NotificationObserver,
   // XWalkExtensionProcessHost::Delegate implementation.
   virtual void OnExtensionProcessDied(XWalkExtensionProcessHost* eph,
       int render_process_id) OVERRIDE;
+
+  virtual void OnExtensionProcessCreated(
+      int render_process_id,
+      const IPC::ChannelHandle handle) OVERRIDE;
 
   virtual void OnCheckAPIAccessControl(
       int render_process_id,

--- a/extensions/extension_process/xwalk_extension_process.h
+++ b/extensions/extension_process/xwalk_extension_process.h
@@ -40,7 +40,9 @@ class XWalkExtensionRunner;
 class XWalkExtensionProcess : public IPC::Listener,
                               public XWalkExtension::PermissionsDelegate {
  public:
-  XWalkExtensionProcess();
+  XWalkExtensionProcess(
+      const IPC::ChannelHandle& channel_handle = IPC::ChannelHandle());
+
   virtual ~XWalkExtensionProcess();
   virtual bool CheckAPIAccessControl(const std::string& extension_name,
       const std::string& api_name) OVERRIDE;
@@ -55,7 +57,8 @@ class XWalkExtensionProcess : public IPC::Listener,
   void OnRegisterExtensions(const base::FilePath& extension_path,
                             const base::ListValue& browser_variables);
 
-  void CreateBrowserProcessChannel();
+  void CreateBrowserProcessChannel(const IPC::ChannelHandle& channel_handle);
+
   void CreateRenderProcessChannel();
 
   base::WaitableEvent shutdown_event_;

--- a/runtime/browser/xwalk_app_extension_bridge.cc
+++ b/runtime/browser/xwalk_app_extension_bridge.cc
@@ -10,6 +10,12 @@
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
 
+#if defined(OS_LINUX)
+#include "xwalk/application/browser/application_system_linux.h"
+#include "xwalk/application/browser/application_service_provider_linux.h"
+#include "xwalk/application/browser/linux/running_application_object.h"
+#endif
+
 namespace xwalk {
 
 XWalkAppExtensionBridge::XWalkAppExtensionBridge()
@@ -52,6 +58,25 @@ bool XWalkAppExtensionBridge::RegisterPermissions(
     return false;
 
   return service->RegisterPermissions(app->id(), extension_name, perm_table);
+}
+
+void XWalkAppExtensionBridge::ExtensionProcessCreated(
+    int render_process_id,
+    const IPC::ChannelHandle& channel_handle) {
+#if defined(OS_LINUX)
+  CHECK(app_system_);
+  application::ApplicationService* service = app_system_->application_service();
+  application::Application* app =
+      service->GetApplicationByRenderHostID(render_process_id);
+  CHECK(app);
+
+  application::ApplicationSystemLinux* app_system =
+      static_cast<application::ApplicationSystemLinux*>(app_system_);
+  application::RunningApplicationObject* running_app_object =
+      app_system->service_provider()->GetRunningApplicationObject(app);
+  CHECK(running_app_object);
+  running_app_object->ExtensionProcessCreated(channel_handle);
+#endif
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_app_extension_bridge.h
+++ b/runtime/browser/xwalk_app_extension_bridge.h
@@ -39,6 +39,9 @@ class XWalkAppExtensionBridge
       int render_process_id,
       const std::string& extension_name,
       const std::string& perm_table) OVERRIDE;
+  virtual void ExtensionProcessCreated(
+      int render_process_id,
+      const IPC::ChannelHandle& channel_handle) OVERRIDE;
 
  private:
   application::ApplicationSystem* app_system_;

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -154,7 +154,7 @@ void XWalkBrowserMainParts::RegisterExternalExtensions() {
 
   if (!cmd_line->HasSwitch(
           switches::kXWalkAllowExternalExtensionsForRemoteSources) &&
-      !startup_url_.SchemeIsFile()) {
+      (!startup_url_.is_empty() && !startup_url_.SchemeIsFile())) {
     VLOG(0) << "Unsupported scheme for external extensions: " <<
           startup_url_.scheme();
     return;

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -302,6 +302,7 @@
         ['OS=="linux"', {
           'dependencies': [
             '../build/linux/system.gyp:fontconfig',
+            '../build/linux/system.gyp:dbus',
           ],
         }],  # OS=="linux"
         ['os_posix==1 and OS != "mac" and linux_use_tcmalloc==1', {


### PR DESCRIPTION
With this update when running in service mode, XWalkExtensionProcess will be
bootstrapped by launcher instead of runtime daemon.

This improvement has several advantages:
1. Some Tizen Device APIs binding with AUL can be directly called in launcher,
instead of passing request through IPC.
2. Less process number for an application, the system footprint will be smaller.

Implementation details:
Once a XWalkExtensionProcessHost is created, it will notify corresponding running
application's DBus object to send a signal to its launcher. The launcher will
retrieve the created IPC channel and instantiate a XWalkExtensionProcess.
