### PR TITLE
[Android] Add the test cases related to wrong permissions in packaging t...

### DIFF
--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -270,6 +270,19 @@ class TestMakeApk(unittest.TestCase):
     self.checkApks('Example', '1.0.0')
     Clean('Example', '1.0.0')
 
+  def testPermissionsWithError(self):
+    cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+           '--package=org.xwalk.example', '--permissions=UndefinedPermission',
+           '--app-url=http://www.intel.com', self._mode]
+    out = RunCommand(cmd)
+    self.assertTrue(out.find('related API is not supported.') != -1)
+    cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+           '--package=org.xwalk.example',
+           '--permissions=Contacts.Geolocation.Messaging',
+           '--app-url=http://www.intel.com', self._mode]
+    out = RunCommand(cmd)
+    self.assertTrue(out.find('related API is not supported.') != -1)
+
   def testPackage(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            self._mode]
@@ -730,6 +743,7 @@ def SuiteWithModeOption():
   test_suite.addTest(TestMakeApk('testOrientation'))
   test_suite.addTest(TestMakeApk('testPackage'))
   test_suite.addTest(TestMakeApk('testPermissions'))
+  test_suite.addTest(TestMakeApk('testPermissionsWithError'))
   test_suite.addTest(TestMakeApk('testXPK'))
   test_suite.addTest(TestMakeApk('testXPKWithError'))
   test_suite.addTest(TestMakeApk('testTargetDir'))


### PR DESCRIPTION
...ool.

Since there is no negative permission test case in packaging tool for
command-line mode, this pull request adds the test cases of setting
wrong permissions in packaging tool.

BUG=XWALK-1249
