### PR TITLE
[Tizen][Runtime] Add "allow-navigation" handler for Tizen legacy WGT package.

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -62,6 +62,7 @@ const char kAccessSubdomainsKey[] = "@subdomains";
 #if defined(OS_TIZEN)
 const char kIcon128Key[] = "widget.icon.@src";
 const char kTizenAppIdKey[] = "widget.application.@package";
+const char kAllowNavigationKey[] = "widget.allow-navigation.#text";
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -57,6 +57,7 @@ namespace application_widget_keys {
 #if defined(OS_TIZEN)
   extern const char kTizenAppIdKey[];
   extern const char kIcon128Key[];
+  extern const char kAllowNavigationKey[];
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -9,6 +9,9 @@
 #include "base/stl_util.h"
 #include "xwalk/application/common/manifest_handlers/csp_handler.h"
 #include "xwalk/application/common/manifest_handlers/main_document_handler.h"
+#if defined(OS_TIZEN)
+#include "xwalk/application/common/manifest_handlers/navigation_handler.h"
+#endif
 #include "xwalk/application/common/manifest_handlers/permissions_handler.h"
 #include "xwalk/application/common/manifest_handlers/warp_handler.h"
 #include "xwalk/application/common/manifest_handlers/widget_handler.h"
@@ -71,6 +74,7 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   handlers.push_back(new WARPHandler);
 #if defined(OS_TIZEN)
   handlers.push_back(new CSPHandler(Manifest::TYPE_WGT));
+  handlers.push_back(new NavigationHandler);
 #endif
   widget_registry_ = new ManifestHandlerRegistry(handlers);
   return widget_registry_;

--- a/application/common/manifest_handlers/navigation_handler.cc
+++ b/application/common/manifest_handlers/navigation_handler.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/navigation_handler.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+namespace application {
+namespace {
+const char navigation_separator = ' ';
+}
+
+NavigationInfo::NavigationInfo(const std::string& allowed_domains) {
+  base::SplitString(allowed_domains, navigation_separator, &allowed_domains_);
+}
+
+NavigationInfo::~NavigationInfo() {
+}
+
+NavigationHandler::NavigationHandler() {
+}
+
+NavigationHandler::~NavigationHandler() {
+}
+
+bool NavigationHandler::Parse(scoped_refptr<ApplicationData> application_data,
+                              base::string16* error) {
+  if (!application_data->GetManifest()->HasPath(keys::kAllowNavigationKey))
+    return true;
+  std::string allowed_domains;
+  if (!application_data->GetManifest()->GetString(keys::kAllowNavigationKey,
+                                                  &allowed_domains)) {
+    *error = base::ASCIIToUTF16("Invalid value of allow-navigation.");
+    return false;
+  }
+  if (allowed_domains.empty())
+    return true;
+
+  application_data->SetManifestData(keys::kAllowNavigationKey,
+                                    new NavigationInfo(allowed_domains));
+
+  return true;
+}
+
+std::vector<std::string> NavigationHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kAllowNavigationKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/navigation_handler.h
+++ b/application/common/manifest_handlers/navigation_handler.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_NAVIGATION_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_NAVIGATION_HANDLER_H_
+
+#include <string>
+#include <vector>
+
+#include "base/strings/string_split.h"
+#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest_handler.h"
+
+namespace xwalk {
+namespace application {
+
+class NavigationInfo : public ApplicationData::ManifestData {
+ public:
+  explicit NavigationInfo(const std::string& allowed_domains);
+  virtual ~NavigationInfo();
+
+  const std::vector<std::string>& GetAllowedDomains() const {
+    return allowed_domains_; }
+
+ private:
+  std::vector<std::string> allowed_domains_;
+};
+
+class NavigationHandler : public ManifestHandler {
+ public:
+  NavigationHandler();
+  virtual ~NavigationHandler();
+
+  virtual bool Parse(scoped_refptr<ApplicationData> application_data,
+                     base::string16* error) OVERRIDE;
+  virtual std::vector<std::string> Keys() const OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(NavigationHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_NAVIGATION_HANDLER_H_

--- a/application/common/manifest_handlers/navigation_handler_unittest.cc
+++ b/application/common/manifest_handlers/navigation_handler_unittest.cc
@@ -1,0 +1,74 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/navigation_handler.h"
+
+#include <string>
+#include <vector>
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+namespace application {
+
+class NavigationHandlerTest: public testing::Test {
+ public:
+  virtual void SetUp() OVERRIDE {
+    manifest.SetString(keys::kNameKey, "no name");
+    manifest.SetString(keys::kVersionKey, "0");
+  }
+
+  scoped_refptr<ApplicationData> CreateApplication() {
+    std::string error;
+    scoped_refptr<ApplicationData> application = ApplicationData::Create(
+        base::FilePath(), Manifest::INVALID_TYPE, manifest, "", &error);
+    return application;
+  }
+
+  const NavigationInfo* GetNavigationInfo(
+      scoped_refptr<ApplicationData> application) {
+    const NavigationInfo* info = static_cast<NavigationInfo*>(
+        application->GetManifestData(keys::kAllowNavigationKey));
+    return info;
+  }
+
+  base::DictionaryValue manifest;
+};
+
+TEST_F(NavigationHandlerTest, NoNavigation) {
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  EXPECT_FALSE(GetNavigationInfo(application));
+}
+
+TEST_F(NavigationHandlerTest, OneNavigation) {
+  manifest.SetString(keys::kAllowNavigationKey, "http://www.sample.com");
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  const NavigationInfo* info = GetNavigationInfo(application);
+  EXPECT_TRUE(info);
+  const std::vector<std::string>& list = info->GetAllowedDomains();
+  EXPECT_TRUE(list.size() == 1 && list[0] == "http://www.sample.com");
+}
+
+TEST_F(NavigationHandlerTest, Navigations) {
+  manifest.SetString(keys::kAllowNavigationKey,
+                     "http://www.sample1.com www.sample2.com");
+  scoped_refptr<ApplicationData> application = CreateApplication();
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  const NavigationInfo* info = GetNavigationInfo(application);
+  EXPECT_TRUE(info);
+  const std::vector<std::string>& list = info->GetAllowedDomains();
+  EXPECT_TRUE(list.size() == 2 &&
+              list[0] == "http://www.sample1.com" &&
+              list[1] == "www.sample2.com");
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -119,6 +119,8 @@
             'browser/installer/tizen/packageinfo_constants.h',
             'browser/installer/tizen/service_package_installer.cc',
             'browser/installer/tizen/service_package_installer.h',
+            'common/manifest_handlers/navigation_handler.cc',
+            'common/manifest_handlers/navigation_handler.h',
           ],
         }],
       ],

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -57,6 +57,11 @@
             '../skia/skia.gyp:skia',
           ],
         }],
+        ['tizen == 1 or tizen_mobile == 1', {
+          'sources': [
+            'application/common/manifest_handlers/navigation_handler_unittest.cc',
+          ],
+        }],
       ],
     },
     {


### PR DESCRIPTION
This element defines a list of URL domains that are allowed to be navigated in the Web
Application window for Tizen legacy WGT.

Please refer to
https://source.tizen.org/sites/default/files/page/tizen-2.2-wrt-core-spec.pdf
for more details.
