### PR TITLE
[Android] Use render frame to retrieve web contents.

### DIFF
--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -40,7 +40,7 @@ void RunUpdateNotificationIconOnUIThread(
     int route_id,
     const SkBitmap& icon) {
   XWalkContentsClientBridgeBase* bridge =
-      XWalkContentsClientBridgeBase::FromID(process_id, route_id);
+      XWalkContentsClientBridgeBase::FromRenderViewID(process_id, route_id);
   if (bridge)
     bridge->UpdateNotificationIcon(notification_id, icon);
 }

--- a/runtime/browser/android/xwalk_contents_client_bridge_base.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge_base.cc
@@ -6,6 +6,7 @@
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge_base.h"
 
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_contents.h"
 
@@ -55,7 +56,7 @@ XWalkContentsClientBridgeBase* XWalkContentsClientBridgeBase::FromWebContents(
 }
 
 // static
-XWalkContentsClientBridgeBase* XWalkContentsClientBridgeBase::FromID(
+XWalkContentsClientBridgeBase* XWalkContentsClientBridgeBase::FromRenderViewID(
     int render_process_id,
     int render_view_id) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
@@ -64,6 +65,19 @@ XWalkContentsClientBridgeBase* XWalkContentsClientBridgeBase::FromID(
   if (!rvh) return NULL;
   content::WebContents* web_contents =
       content::WebContents::FromRenderViewHost(rvh);
+  return UserData::GetContents(web_contents);
+}
+
+// static
+XWalkContentsClientBridgeBase* XWalkContentsClientBridgeBase::FromRenderFrameID(
+    int render_process_id,
+    int render_frame_id) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  content::RenderFrameHost* rfh =
+      content::RenderFrameHost::FromID(render_process_id, render_frame_id);
+  if (!rfh) return NULL;
+  content::WebContents* web_contents =
+      content::WebContents::FromRenderFrameHost(rfh);
   return UserData::GetContents(web_contents);
 }
 

--- a/runtime/browser/android/xwalk_contents_client_bridge_base.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge_base.h
@@ -35,8 +35,10 @@ class XWalkContentsClientBridgeBase {
                         XWalkContentsClientBridgeBase* handler);
   static XWalkContentsClientBridgeBase* FromWebContents(
       content::WebContents* web_contents);
-  static XWalkContentsClientBridgeBase* FromID(int render_process_id,
+  static XWalkContentsClientBridgeBase* FromRenderViewID(int render_process_id,
                                             int render_view_id);
+  static XWalkContentsClientBridgeBase* FromRenderFrameID(int render_process_id,
+                                            int render_frame_id);
 
   virtual ~XWalkContentsClientBridgeBase();
 

--- a/runtime/browser/android/xwalk_cookie_access_policy.cc
+++ b/runtime/browser/android/xwalk_cookie_access_policy.cc
@@ -57,7 +57,7 @@ bool XWalkCookieAccessPolicy::AllowGetCookie(
     const net::CookieList& cookie_list,
     content::ResourceContext* context,
     int render_process_id,
-    int render_view_id) {
+    int render_frame_id) {
   return GetGlobalAllowAccess();
 }
 
@@ -67,7 +67,7 @@ bool XWalkCookieAccessPolicy::AllowSetCookie(
     const std::string& cookie_line,
     content::ResourceContext* context,
     int render_process_id,
-    int render_view_id,
+    int render_frame_id,
     net::CookieOptions* options) {
   return GetGlobalAllowAccess();
 }

--- a/runtime/browser/android/xwalk_cookie_access_policy.h
+++ b/runtime/browser/android/xwalk_cookie_access_policy.h
@@ -50,13 +50,13 @@ class XWalkCookieAccessPolicy {
                       const net::CookieList& cookie_list,
                       content::ResourceContext* context,
                       int render_process_id,
-                      int render_view_id);
+                      int render_frame_id);
   bool AllowSetCookie(const GURL& url,
                       const GURL& first_party,
                       const std::string& cookie_line,
                       content::ResourceContext* context,
                       int render_process_id,
-                      int render_view_id,
+                      int render_frame_id,
                       net::CookieOptions* options);
 
  private:

--- a/runtime/browser/android/xwalk_request_interceptor.cc
+++ b/runtime/browser/android/xwalk_request_interceptor.cc
@@ -59,13 +59,13 @@ XWalkRequestInterceptor::QueryForInterceptedRequestData(
     const GURL& location,
     net::URLRequest* request) const {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
-  int render_process_id, render_view_id;
+  int render_process_id, render_frame_id;
   if (!ResourceRequestInfo::GetRenderFrameForRequest(
-      request, &render_process_id, &render_view_id))
+      request, &render_process_id, &render_frame_id))
     return scoped_ptr<InterceptedRequestData>();
 
   scoped_ptr<XWalkContentsIoThreadClient> io_thread_client =
-    XWalkContentsIoThreadClient::FromID(render_process_id, render_view_id);
+    XWalkContentsIoThreadClient::FromID(render_process_id, render_frame_id);
 
   if (!io_thread_client.get())
     return scoped_ptr<InterceptedRequestData>();

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -16,6 +16,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/main_function_params.h"
 #include "content/public/common/show_desktop_notification_params.h"
+#include "net/ssl/ssl_info.h"
 #include "net/url_request/url_request_context_getter.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
@@ -157,7 +158,7 @@ bool XWalkContentBrowserClient::AllowGetCookie(
     const net::CookieList& cookie_list,
     content::ResourceContext* context,
     int render_process_id,
-    int render_view_id) {
+    int render_frame_id) {
 #if defined(OS_ANDROID)
   return XWalkCookieAccessPolicy::GetInstance()->AllowGetCookie(
       url,
@@ -165,7 +166,7 @@ bool XWalkContentBrowserClient::AllowGetCookie(
       cookie_list,
       context,
       render_process_id,
-      render_view_id);
+      render_frame_id);
 #else
   return true;
 #endif
@@ -177,7 +178,7 @@ bool XWalkContentBrowserClient::AllowSetCookie(
     const std::string& cookie_line,
     content::ResourceContext* context,
     int render_process_id,
-    int render_view_id,
+    int render_frame_id,
     net::CookieOptions* options) {
 #if defined(OS_ANDROID)
   return XWalkCookieAccessPolicy::GetInstance()->AllowSetCookie(
@@ -186,7 +187,7 @@ bool XWalkContentBrowserClient::AllowSetCookie(
       cookie_line,
       context,
       render_process_id,
-      render_view_id,
+      render_frame_id,
       options);
 #else
   return true;
@@ -219,7 +220,8 @@ void XWalkContentBrowserClient::ShowDesktopNotification(
     bool worker) {
 #if defined(OS_ANDROID)
   XWalkContentsClientBridgeBase* bridge =
-      XWalkContentsClientBridgeBase::FromID(render_process_id, render_view_id);
+      XWalkContentsClientBridgeBase::FromRenderViewID(render_process_id,
+          render_view_id);
   bridge->ShowNotification(params, worker, render_process_id, render_view_id);
 #endif
 }
@@ -230,7 +232,8 @@ void XWalkContentBrowserClient::CancelDesktopNotification(
     int notification_id) {
 #if defined(OS_ANDROID)
   XWalkContentsClientBridgeBase* bridge =
-      XWalkContentsClientBridgeBase::FromID(render_process_id, render_view_id);
+      XWalkContentsClientBridgeBase::FromRenderViewID(render_process_id,
+          render_view_id);
   bridge->CancelNotification(
       notification_id, render_process_id, render_view_id);
 #endif

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -65,13 +65,13 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
                               const net::CookieList& cookie_list,
                               content::ResourceContext* context,
                               int render_process_id,
-                              int render_view_id) OVERRIDE;
+                              int render_frame_id) OVERRIDE;
   virtual bool AllowSetCookie(const GURL& url,
                               const GURL& first_party,
                               const std::string& cookie_line,
                               content::ResourceContext* context,
                               int render_process_id,
-                              int render_view_id,
+                              int render_frame_id,
                               net::CookieOptions* options) OVERRIDE;
 
   virtual content::SpeechRecognitionManagerDelegate*


### PR DESCRIPTION
Chromium uses render frame for some cases instead of render view. This
change tries to follow up the behaviors defined by upstream.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1252
