### PR TITLE
[Android] Add a new flag for universal file access

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -34,6 +34,8 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
 
     private boolean mRemoteDebugging = false;
 
+    private boolean mAllowUniversalAccessFromFileURLs = false;
+
     private AlertDialog mLibraryNotFoundDialog = null;
 
     private XWalkMixedResources mMixedResources = null;
@@ -135,6 +137,10 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
                 String result = mRuntimeView.enableRemoteDebugging("", mPackageName);
             } else {
                 mRuntimeView.disableRemoteDebugging();
+            }
+
+            if (mAllowUniversalAccessFromFileURLs) {
+                mRuntimeView.setSettingEnabled("AllowUniversalAccessFromFileURLs", true);
             }
 
             didTryLoadRuntimeView(mRuntimeView.get());
@@ -265,6 +271,10 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
 
     public void setRemoteDebugging(boolean value) {
         mRemoteDebugging = value;
+    }
+
+    public void setAllowUniversalAccessFromFileURLs(boolean value) {
+        mAllowUniversalAccessFromFileURLs = value;
     }
 
 }

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
@@ -38,6 +38,7 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
     private Method mEnableRemoteDebugging;
     private Method mDisableRemoteDebugging;
     private Method mOnKeyUp;
+    private Method mSetSettingEnabled;
 
     // For instrumentation test.
     private Method mGetTitleForTest;
@@ -68,6 +69,7 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
         mEnableRemoteDebugging = lookupMethod("enableRemoteDebugging", String.class, String.class);
         mDisableRemoteDebugging = lookupMethod("disableRemoteDebugging");
         mOnKeyUp = lookupMethod("onKeyUp", int.class, KeyEvent.class);
+        mSetSettingEnabled = lookupMethod("setSettingEnabled", String.class, boolean.class);
     }
 
     /**
@@ -269,6 +271,13 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
         Boolean handled = (Boolean) invokeMethod(mOnKeyUp, mInstance, keyCode, event);
         if (handled != null) return handled;
         return false;
+    }
+
+    /**
+     * Evaluate the setting via the pair of name and value.
+     */
+    public void setSettingEnabled(String name, boolean value) {
+        invokeMethod(mSetSettingEnabled, mInstance, name, value);
     }
 
     // The following functions just for instrumentation test.

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -195,6 +195,9 @@ def Customize(options):
   name = 'AppTemplate'
   if options.name:
     name = options.name
+  universal_file_access = ''
+  if options.allow_universal_access_from_file_urls:
+    universal_file_access = '--allow-universal-access-from-file-urls'
   app_version = '1.0.0'
   if options.app_version:
     app_version = options.app_version
@@ -219,7 +222,7 @@ def Customize(options):
                options.app_local_path, remote_debugging,
                fullscreen_flag, options.extensions,
                options.launch_screen_img, package, name, app_version,
-               orientation)
+               orientation, universal_file_access)
 
 
 def Execution(options, sanitized_name):
@@ -602,6 +605,11 @@ def main(argv):
   group = optparse.OptionGroup(parser, 'Optional arguments',
       'They are used for various settings for applications through '
       'command line options.')
+  info = ('Allow JavaScript running in the context of a file scheme '
+          'URL to access content from any origin.')
+  group.add_option('--allow-universal-access-from-file-urls',
+                   dest='allow_universal_access_from_file_urls',
+                   action='store_true', default=False, help = info)
   info = ('The version name of the application. '
           'For example, --app-version=1.0.0')
   group.add_option('--app-version', help=info)

--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -281,6 +281,13 @@ public class XWalkContent extends FrameLayout {
         return nativeDevToolsAgentId(mXWalkContent);
     }
 
+    public void setSettingEnabled(String name, boolean value) {
+        // Expose more setttings here if needed.
+        if (name.equals("AllowUniversalAccessFromFileURLs")) {
+            mSettings.setAllowUniversalAccessFromFileURLs(value);
+        }
+    }
+
     public XWalkSettings getSettings() {
         return mSettings;
     }

--- a/runtime/android/core/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkView.java
@@ -181,6 +181,11 @@ public class XWalkView extends FrameLayout {
         super.setLayoutParams(params);
     }
 
+    public void setSettingEnabled(String name, boolean value) {
+        checkThreadSafety();
+        mContent.setSettingEnabled(name, value);
+    }
+
     public XWalkSettings getSettings() {
         checkThreadSafety();
         return mContent.getSettings();

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -103,6 +103,11 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
         return mXwalkView;
     }
 
+    @Override
+    public void setSettingEnabled(String name, boolean value) {
+        mXwalkView.setSettingEnabled(name, value);
+    }
+
     // For instrumentation test.
     @Override
     public String getTitleForTest() {

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeView.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeView.java
@@ -180,6 +180,10 @@ public class XWalkRuntimeView extends FrameLayout {
         return super.onKeyUp(keyCode, event);
     }
 
+    public void setSettingEnabled(String name, boolean value) {
+        mProvider.setSettingEnabled(name, value);
+    }
+
     // For instrumentation test.
     public String getTitleForTest() {
         return mProvider.getTitleForTest();

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -32,6 +32,7 @@ interface XWalkRuntimeViewProvider {
     public String enableRemoteDebugging(String frontEndUrl, String socketName);
     public void disableRemoteDebugging();
     public boolean onKeyUp(int KeyCode, KeyEvent event);
+    public void setSettingEnabled(String name, boolean value);
 
     // For instrumentation test.
     public String getTitleForTest();


### PR DESCRIPTION
Add a new general API for settings, with the format:
    void setSettingEnabled(String name, boolean value);

Add a new command line of "--allow-universal-access-from-file-urls"
in make_apk.py, by which JavaScript running in the context of a
file scheme URL could access content from any origin.

Change back to use file scheme temporarily to package apps due to
app scheme is not recognized as a local one in blink.

BUG=XWALK-1256
