### PR TITLE
[Android] Check the local path file in packaging tool.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -702,9 +702,9 @@ def main(argv):
     if options.permissions:
       permission_list = options.permissions.split(':')
     else:
-      print ('Warning: all supported permissions on Android port are added. '
-             'Refer to https://github.com/crosswalk-project/'
-             'crosswalk-website/wiki/Crosswalk-manifest')
+      print('Warning: all supported permissions on Android port are added. '
+            'Refer to https://github.com/crosswalk-project/'
+            'crosswalk-website/wiki/Crosswalk-manifest')
       permission_list = permission_mapping_table.keys()
     options.permissions = HandlePermissionList(permission_list)
 
@@ -713,6 +713,12 @@ def main(argv):
       ParseManifest(options)
     except SystemExit as ec:
       return ec.code
+
+  if (options.app_root and options.app_local_path and not
+      os.path.isfile(os.path.join(options.app_root, options.app_local_path))):
+    print('Please make sure that the local path file of launching app '
+          'does exist.')
+    sys.exit(7)
 
   options.name = ReplaceInvalidChars(options.name, 'apkname')
   options.package = ReplaceInvalidChars(options.package)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -331,6 +331,13 @@ class TestMakeApk(unittest.TestCase):
     self.assertFalse(os.path.exists('Example.apk'))
     Clean('Example', '1.0.0')
 
+    manifest_path = os.path.join('test_data', 'manifest', 'manifest.json')
+    cmd = ['python', 'make_apk.py', '--manifest=%s' % manifest_path, self._mode]
+    RunCommand(cmd)
+    self.assertTrue(out.find('Please make sure the local path file') != -1)
+    self.assertFalse(os.path.exists('Example.apk'))
+    Clean('Example', '1.0.0')
+
   def testIcon(self):
     icon_path = './app_src/res/drawable-xhdpi/crosswalk.png'
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',


### PR DESCRIPTION
The webapp can be created successfully when the local path file
of launching application doesn't exist. This fix resolves this
issue by checking whether this file exists, when it doesn't exist,
related information is prompted and packaging is stopped.

BUG=XWALK-1212
