### PR TITLE
[Runtime] Fix onLaunch event is not fired under service mode.

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -515,6 +515,7 @@ Application* ApplicationService::Launch(
 
 Application* ApplicationService::Launch(
     const std::string& id, const Application::LaunchParams& params) {
+  Application* application = NULL;
   scoped_refptr<ApplicationData> application_data =
     application_storage_->GetApplicationData(id);
   if (!application_data) {
@@ -522,7 +523,12 @@ Application* ApplicationService::Launch(
     return NULL;
   }
 
-  return Launch(application_data, params);
+  if (application = Launch(application_data, params)) {
+    scoped_refptr<Event> event = Event::CreateEvent(
+        kOnLaunched, scoped_ptr<base::ListValue>(new base::ListValue));
+    event_manager_->SendEvent(application->id(), event);
+  }
+  return application;
 }
 
 Application* ApplicationService::Launch(

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -126,9 +126,7 @@ bool ApplicationSystem::LaunchWithCommandLineParam(
   if (cmd_line.HasSwitch(switches::kFullscreen))
     launch_params.window_state = ui::SHOW_STATE_FULLSCREEN;
 
-  if (Application* application =
-      application_service_->Launch(param, launch_params)) {
-    event_manager_->SendEvent(application->id(), event);
+  if (application_service_->Launch(param, launch_params)) {
     return true;
   }
 


### PR DESCRIPTION
Bug reports 'webapi-runtime-xwalk-tests' cases are failed to launch.
Root cause is onLaunched event is not sent under run-as-service mode.
The patch fixed above issue.

BUG=XWALK-1228
