### PR TITLE
[Tizen] NativeAppWindowTizen should be used in Tizen IVI

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -21,9 +21,11 @@ namespace xwalk {
 NativeAppWindowTizen::NativeAppWindowTizen(
     const NativeAppWindow::CreateParams& create_params)
     : NativeAppWindowViews(create_params),
+#if defined(OS_TIZEN_MOBILE)
       indicator_widget_(new TizenSystemIndicatorWidget()),
+      indicator_container_(new WidgetContainerView(indicator_widget_)),
+#endif
       allowed_orientations_(ANY) {
-  indicator_container_.reset(new WidgetContainerView(indicator_widget_));
 }
 
 void NativeAppWindowTizen::Initialize() {
@@ -59,9 +61,11 @@ void NativeAppWindowTizen::ViewHierarchyChanged(
     const ViewHierarchyChangedDetails& details) {
   if (details.is_add && details.child == this) {
     NativeAppWindowViews::ViewHierarchyChanged(details);
+#if defined(OS_TIZEN_MOBILE)
     indicator_widget_->Initialize(GetNativeWindow());
     top_view_layout()->set_top_view(indicator_container_.get());
     AddChildView(indicator_container_.get());
+#endif
   }
 }
 
@@ -224,7 +228,10 @@ void NativeAppWindowTizen::ApplyDisplayRotation() {
   if (!root_window->IsVisible())
     return;
   UpdateTopViewOverlay();
+
+#if defined(OS_TIZEN_MOBILE)
   indicator_widget_->SetDisplay(display_);
+#endif
   root_window->SetTransform(GetRotationTransform());
 }
 

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -58,6 +58,7 @@ class NativeAppWindowTizen
   gfx::Display::Rotation GetClosestAllowedRotation(
       gfx::Display::Rotation) const;
 
+#if defined(OS_TIZEN_MOBILE)
   // The system indicator is implemented as a widget because it needs to
   // receive events and may also be an overlay on top of the rest of the
   // content, regular views do not support this. We add it to the container,
@@ -66,6 +67,8 @@ class NativeAppWindowTizen
   // The |indicator_widget_| is owned by the WidgetContainerView.
   TizenSystemIndicatorWidget* indicator_widget_;
   scoped_ptr<WidgetContainerView> indicator_container_;
+#endif
+
   gfx::Display display_;
   OrientationMask allowed_orientations_;
 

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -18,7 +18,7 @@
 #include "ui/views/window/native_frame_view.h"
 #endif
 
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
 #include "xwalk/runtime/browser/ui/native_app_window_tizen.h"
 #endif
 
@@ -294,7 +294,7 @@ void NativeAppWindowViews::OnWidgetBoundsChanged(views::Widget* widget,
 NativeAppWindow* NativeAppWindow::Create(
     const NativeAppWindow::CreateParams& create_params) {
   NativeAppWindowViews* window;
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   window = new NativeAppWindowTizen(create_params);
 #else
   window = new NativeAppWindowViews(create_params);


### PR DESCRIPTION
NativeAppWindowTizen should be used in Tizen IVI as it contains some
logic that is needed there, e.g. implementation of MultiOrientationScreen
interface (which is used by screen orientation extension).

Before the change an attempt to use screen orientation API caused an
xwalk daemon crash, this patch fixes the following bugs:

BUG=XWALK-1192
BUG=XWALK-1141
