### PR TITLE
[Android] Fix build error said: multiple definition of 'xwalk::XWalkRenderProcessObserver'.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -270,6 +270,10 @@
             'xwalk_core_jar_jni',
             'xwalk_core_native_jni',
           ],
+          'sources!':[
+            'runtime/renderer/xwalk_render_process_observer_generic.cc',
+            'runtime/renderer/xwalk_render_process_observer_generic.h',
+          ],
         }],
         ['OS=="win" and win_use_allocator_shim==1', {
           'dependencies': [


### PR DESCRIPTION
The PR#1711 defined another xwalk::XWalkRenderProcessObserver class
which has the same class name in Android port, so exclude the
xwalk_render_process_observer_generic.cc(h) files in Android port.
