### PR TITLE
[Android] Change the default version to empty in packaging tool.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -195,7 +195,7 @@ def Customize(options):
   name = 'AppTemplate'
   if options.name:
     name = options.name
-  app_version = '1.0.0'
+  app_version = ''
   if options.app_version:
     app_version = options.app_version
   app_versionCode = MakeVersionCode(options)


### PR DESCRIPTION
When the manifest.json version value is empty,
the webapp could be packed and installed successfully,
but shouldn't be show version in Apps.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1146
