### PR TITLE
[TIZEN] WebApp are installed with wrong application Type

### DIFF
--- a/application/common/installer/package_installer_tizen.cc
+++ b/application/common/installer/package_installer_tizen.cc
@@ -125,7 +125,7 @@ bool GeneratePkgInfoXml(xwalk::application::ApplicationData* application,
   xml_writer.AddAttribute("appid",
       xwalk::application::RawAppIdToAppIdForTizenPkgmgrDB(tizen_app_id));
   xml_writer.AddAttribute("exec", execute_path.MaybeAsASCII());
-  xml_writer.AddAttribute("type", "c++app");
+  xml_writer.AddAttribute("type", "webapp");
   xml_writer.AddAttribute("taskmanage", "true");
   xml_writer.WriteElement("label", application->Name());
 


### PR DESCRIPTION
Currently Webapp are installed as Native App.
So Application Framework interpret them as native app

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
