### PR TITLE
DEPS.xwalk: Roll v8-crosswalk (702dcf9 -> ffe72f9)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -9,7 +9,7 @@
 chromium_version = '34.0.1847.45'
 chromium_crosswalk_point = 'cb7bc58aa1239e2fa92d692e81ccd06fa6c82722'
 blink_crosswalk_point = 'e8b6b995b38b422c2b4d58fa5201599f1e510537'
-v8_crosswalk_point = '702dcf9c6e58d90e85594fbe54579ade631fe3b5'
+v8_crosswalk_point = 'ffe72f9229923611866423ced472b1dff97abdfe'
 
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
```
ffe72f9 Merge pull request #12 from dp7/master
9c52a1b Merge branch 'xdkcpuprofiler'
c4235bb Fixed a limit for static initializers
e5ca80d Updated a comment about increasing number of the static initializers
70eae13 Fixed a limit for static initializers
b571343 Merge pull request #11 from huningxin/fix_x4_typed_array
1d446c3 Merge pull request #10 from dp7/master
3f182b6 [SIMD] Fix d8 crashes when constructing simd128 typed array without
        simd flag
4c47b89 V8 profiling patch rebased on Chromium v34
54c5a1b Revert "V8 profiling patch rebased on Chromium v34"
edd9fe8 Merge pull request #7 from dp7/master
0483117 V8 profiling patch rebased on Chromium v34
2b716f2 Revert "V8 profiling patch rebased on Chromuim v34"
9f0736d Merge pull request #6 from dp7/master
075f828 V8 profiling patch rebased on Chromuim v34
```
