### PR TITLE
[TIZEN MOBILE] Drop XI21 hack.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -1,15 +1,5 @@
 {
   'variables': {
-    # Enable multitouch support with XInput2.1. When it is enabled, unlike
-    # XInput2.2, there are no XI_TouchBegin, XI_TouchUpdate and XI_TouchEnd
-    # raw touch events emitted from touch device. Instead, the touch event is
-    # simulated by a normal mouse event, since X server maintains multiple
-    # virtual touch screen devices as floating device, each of them can
-    # simulate a touch event tracked by the device id of event source, as a
-    # result, multi-touch support works with these simulated touch events
-    # dispatched from floating device.
-    'enable_xi21_mt%': 0,
-
     'tizen%': 0,
     'tizen_mobile%': 0,
   },
@@ -19,9 +9,6 @@
       'tizen_mobile%': '<(tizen_mobile)',
     },
     'conditions': [
-      ['enable_xi21_mt==1', {
-        'defines': ['ENABLE_XI21_MT=1'],
-      }],
       ['tizen==1', {
         'defines': ['OS_TIZEN=1'],
       }],

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -186,8 +186,6 @@ ${GYP_EXTRA_FLAGS} \
 -Duse_system_libexif=1 \
 -Duse_system_libxml=1 \
 -Duse_system_nspr=1 \
--Denable_xi21_mt=1 \
--Duse_xi2_mt=0 \
 -Denable_hidpi=1
 
 make %{?_smp_mflags} -C "${BUILDDIR_NAME}" BUILDTYPE=Release xwalk xwalkctl xwalk_launcher xwalk-pkg-helper


### PR DESCRIPTION
Tizen IVI does not ues XInput, and Tizen 3.0 supports XInput2.2, so
enable_xi21_mt=1 and use_xi2_mt=0 aren't needed anymore.
