### PR TITLE
[Tools] fetch_deps: Stop passing --force and --with_branch_heads to gclient.

### DIFF
--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -45,7 +45,6 @@ class DepsFetcher(object):
 
   def DoGclientSyncForChromium(self):
     gclient_cmd = ['gclient', 'sync', '--verbose', '--reset',
-                   '--force', '--with_branch_heads',
                    '--delete_unversioned_trees']
     gclient_cmd.append('--gclientfile=%s' %
                        os.path.basename(self._new_gclient_file))


### PR DESCRIPTION
--with_branch_heads has no use for us as users of fetch_deps are not 
interested in those extra blink/chromium/v8/etc branches.

--force makes us query all repositories every time we sync even if they did 
not change, which makes runhooks needlessly slow.
