### PR TITLE
Enable the use of the viewport meta tag

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -61,7 +61,6 @@ GURL GetURLFromCommandLine(const CommandLine& command_line) {
 
 namespace xswitches {
 // Redefine settings not exposed by content module.
-const char kEnableViewport[] = "enable-viewport";
 const char kEnableOverlayScrollbars[] = "enable-overlay-scrollbars";
 }
 
@@ -91,7 +90,8 @@ XWalkBrowserMainParts::~XWalkBrowserMainParts() {
 
 void XWalkBrowserMainParts::PreMainMessageLoopStart() {
   CommandLine* command_line = CommandLine::ForCurrentProcess();
-  command_line->AppendSwitch(xswitches::kEnableViewport);
+  command_line->AppendSwitch(switches::kEnableViewport);
+  command_line->AppendSwitch(switches::kEnableViewportMeta);
 
   command_line->AppendSwitch(xswitches::kEnableOverlayScrollbars);
 


### PR DESCRIPTION
SSIA. Add '--enable-viewport-meta' command line argument
by default.
