### PR TITLE
[Runtime] Fix using uninitialized variable "is_valid_" for WGT package extracting.

### DIFF
--- a/application/browser/installer/package.cc
+++ b/application/browser/installer/package.cc
@@ -18,7 +18,8 @@ namespace application {
 
 Package::Package(const base::FilePath& source_path)
     : source_path_(source_path),
-      is_extracted_(false) {
+      is_extracted_(false),
+      is_valid_(false) {
 }
 
 Package::~Package() {
@@ -44,11 +45,6 @@ bool Package::Extract(base::FilePath* target_path) {
   if (is_extracted_) {
     *target_path = temp_dir_.path();
     return true;
-  }
-
-  if (!IsValid()) {
-    LOG(ERROR) << "XPK/WGT file is not valid.";
-    return false;
   }
 
   if (!CreateTempDirectory()) {

--- a/application/browser/installer/package.h
+++ b/application/browser/installer/package.h
@@ -29,7 +29,7 @@ class Package {
   static scoped_ptr<Package> Create(const base::FilePath& path);
   // The function will unzip the XPK/WGT file and return the target path where
   // to decompress by the parameter |target_path|.
-  bool Extract(base::FilePath* target_path);
+  virtual bool Extract(base::FilePath* target_path);
  protected:
   explicit Package(const base::FilePath& source_path);
   scoped_ptr<ScopedStdioHandle> file_;

--- a/application/browser/installer/wgt_package.cc
+++ b/application/browser/installer/wgt_package.cc
@@ -55,6 +55,8 @@ WGTPackage::WGTPackage(const base::FilePath& path)
   if (!value.empty())
     id_ = GenerateId(value);
 
+  is_valid_ = true;
+
   scoped_ptr<ScopedStdioHandle> file(
         new ScopedStdioHandle(base::OpenFile(path, "rb")));
 
@@ -63,6 +65,3 @@ WGTPackage::WGTPackage(const base::FilePath& path)
 
 }  // namespace application
 }  // namespace xwalk
-
-
-

--- a/application/browser/installer/xpk_package.cc
+++ b/application/browser/installer/xpk_package.cc
@@ -88,5 +88,19 @@ bool XPKPackage::VerifySignature() {
   return true;
 }
 
+bool XPKPackage::Extract(base::FilePath* target_path) {
+  if (is_extracted_) {
+    *target_path = temp_dir_.path();
+    return true;
+  }
+
+  if (!IsValid()) {
+    LOG(ERROR) << "The XPK file is not valid.";
+    return false;
+  }
+
+  return Package::Extract(target_path);
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/browser/installer/xpk_package.h
+++ b/application/browser/installer/xpk_package.h
@@ -30,6 +30,7 @@ class XPKPackage : public Package {
   };
   virtual ~XPKPackage();
   explicit XPKPackage(const base::FilePath& path);
+  virtual bool Extract(base::FilePath* target_path);
 
  private:
   // verify the signature in the xpk package


### PR DESCRIPTION
The uninitialized variable "is_valid_" in package.cc(h) may lead to
error when installing a WGT package, and it should be initialized before
using it in Extract method.
