### PR TITLE
Roll v8-crosswalk (9b0508c -> 50e7d31)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -9,7 +9,7 @@
 chromium_version = '34.0.1847.45'
 chromium_crosswalk_point = 'cb7bc58aa1239e2fa92d692e81ccd06fa6c82722'
 blink_crosswalk_point = 'e8b6b995b38b422c2b4d58fa5201599f1e510537'
-v8_crosswalk_point = 'd54ab7faeadc81a6ce7a28949b56adebd17a0011'
+v8_crosswalk_point = '50e7d31c8eabf60789bd5fcdcc7d30ceb4874507'
 
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
50e7d31 Fixed a limit for static initializers (cherry picked from commit c4235bbfec17fa203ecac0aec1c95901a2f7bf84)
35425e2 V8 profiling patch rebased on Chromium v34 (cherry picked from commit 4c47b893f2299aebbe796f22d15bb8c0182e8)
