### PR TITLE
Roll v8-crosswalk(702dcf9->d54ab7f)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -9,7 +9,7 @@
 chromium_version = '34.0.1847.45'
 chromium_crosswalk_point = 'cb7bc58aa1239e2fa92d692e81ccd06fa6c82722'
 blink_crosswalk_point = 'e8b6b995b38b422c2b4d58fa5201599f1e510537'
-v8_crosswalk_point = '702dcf9c6e58d90e85594fbe54579ade631fe3b5'
+v8_crosswalk_point = 'd54ab7faeadc81a6ce7a28949b56adebd17a0011'
 
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
d54ab7f Merge pull request #16 from dp7/crosswalk-5/34.0.1847.45
50e7d31 Fixed a limit for static initializers (cherry picked from commit c4235bbfec17fa203ecac0aec1c95901a2f7bf84)
35425e2 V8 profiling patch rebased on Chromium v34 (cherry picked from commit 4c47b893f2299aebbe796f22d15bb8c0182e81db)
9b0508c Revert "V8 profiling patch rebased on Chromium v34"
c286bee V8 profiling patch rebased on Chromium v34
d94a02c Revert "V8 profiling patch rebased on Chromuim v34"
2e9ea33 V8 profiling patch rebased on Chromuim v34
