### PR TITLE
[TIZEN]: Define OS_POSIX

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -10,10 +10,10 @@
     },
     'conditions': [
       ['tizen==1', {
-        'defines': ['OS_TIZEN=1'],
+        'defines': ['OS_TIZEN=1', 'OS_POSIX=1'],
       }],
       ['tizen_mobile==1', {
-        'defines': ['OS_TIZEN_MOBILE=1', 'OS_TIZEN=1'],
+        'defines': ['OS_TIZEN_MOBILE=1', 'OS_TIZEN=1', 'OS_POSIX=1'],
       }],
     ],
     'includes': [


### PR DESCRIPTION
TIZEN is not handled as posix OS.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1294

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
