### PR TITLE
[Android] Try to match cpu arch before loading xwalk core

### DIFF
--- a/app/android/app_hello_world/res/values/strings.xml
+++ b/app/android/app_hello_world/res/values/strings.xml
@@ -15,7 +15,4 @@ found in the LICENSE file.
     <string name="dialog_message_update_runtime_lib_warning">An update is recommended for &quot;Crosswalk Runtime Library&quot;.</string>
     <string name="dialog_title_install_runtime_lib">Crosswalk Runtime Library not found</string>
     <string name="dialog_message_install_runtime_lib">Please install &quot;Crosswalk Runtime Library&quot; first.</string>
-    <string name="dialog_title_install_right_abi">Mismatch on process architecture between Crosswalk and your device</string>
-    <string name="dialog_message_install_right_abi_embedded">Please install %1$s packaged with Crosswalk for %2$s.</string>
-    <string name="dialog_message_install_right_abi_shared">Please install &quot;Crosswalk Runtime Library&quot; for %1$s.</string>
 </resources>

--- a/app/android/app_template/res/values/strings.xml
+++ b/app/android/app_template/res/values/strings.xml
@@ -15,7 +15,4 @@ found in the LICENSE file.
     <string name="dialog_message_update_runtime_lib_warning">An update is recommended for &quot;Crosswalk Runtime Library&quot;.</string>
     <string name="dialog_title_install_runtime_lib">Crosswalk Runtime Library not found</string>
     <string name="dialog_message_install_runtime_lib">Please install &quot;Crosswalk Runtime Library&quot; first.</string>
-    <string name="dialog_title_install_right_abi">Mismatch on process architecture between Crosswalk and your device</string>
-    <string name="dialog_message_install_right_abi_embedded">Please install %1$s packaged with Crosswalk for %2$s.</string>
-    <string name="dialog_message_install_right_abi_shared">Please install &quot;Crosswalk Runtime Library&quot; for %1$s.</string>
 </resources>

--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -164,19 +164,6 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
                 title = getString("dialog_title_install_runtime_lib");
                 message = getString("dialog_message_install_runtime_lib");
                 break;
-            case XWalkRuntimeLibraryException.XWALK_CORE_LIBRARY_SO_NOT_EXIST:
-                title = getString("dialog_title_install_right_abi");
-                if (XWalkRuntimeClient.libraryIsEmbedded()) {
-                    String appName = getPackageManager().getApplicationLabel(
-                            getApplicationContext().getApplicationInfo()).toString();
-                    if (appName == null) appName = getApplicationContext().getPackageName();
-                    message = String.format(getString("dialog_message_install_right_abi_embedded"),
-                            appName, System.getProperty("os.arch"));
-                } else {
-                    message = String.format(getString("dialog_message_install_right_abi_shared"),
-                            System.getProperty("os.arch"));
-                }
-                break;
             case XWalkRuntimeLibraryException.XWALK_RUNTIME_LIBRARY_INVOKE_FAILED:
             default:
                 Exception originException = runtimeException.getOriginException();

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeLibraryException.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeLibraryException.java
@@ -19,8 +19,7 @@ public class XWalkRuntimeLibraryException extends Exception {
     public final static int XWALK_RUNTIME_LIBRARY_NOT_INSTALLED = 1;
     public final static int XWALK_RUNTIME_LIBRARY_NOT_UP_TO_DATE_CRITICAL = 2;
     public final static int XWALK_RUNTIME_LIBRARY_NOT_UP_TO_DATE_WARNING = 3;
-    public final static int XWALK_CORE_LIBRARY_SO_NOT_EXIST = 4;
-    public final static int XWALK_RUNTIME_LIBRARY_INVOKE_FAILED = 5;
+    public final static int XWALK_RUNTIME_LIBRARY_INVOKE_FAILED = 4;
     
     private int mType;
     private Exception mOriginException;

--- a/runtime/android/core/strings/android_xwalk_strings.grd
+++ b/runtime/android/core/strings/android_xwalk_strings.grd
@@ -41,6 +41,18 @@
       <message desc="Prompt for the http authentication login [CHAR-LIMIT=32]" name="IDS_HTTP_AUTH_LOG_IN">
         Log In
       </message>
+      <message desc="Title for the CPU architecture mismatch dialog [CHAR-LIMIT=50]" name="IDS_CPU_ARCH_MISMATCH_TITLE">
+        Mismatch of CPU architecture for Crosswalk
+      </message>
+      <message desc="Message for the CPU architecture mismatch dialog [CHAR-LIMIT=150]" name="IDS_CPU_ARCH_MISMATCH_MESSAGE">
+        Unfortunately this application was not created for %1$s based devices, please take a moment to notify the developer about it. Thanks.
+      </message>
+      <message desc="Label of the button for going to Google Play Store [CHAR-LIMIT=32]" name="IDS_GOTO_STORE_BUTTON_LABEL">
+        Go to Google Play Store
+      </message>
+      <message desc="Label of the button for reporting to developer [CHAR-LIMIT=32]" name="IDS_REPORT_FEEDBACK_BUTTON_LABEL">
+        Report to developer
+      </message>
     </messages>
   </release>
 

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -101,6 +101,8 @@ public class XWalkViewShellActivity extends FragmentActivity
             getTracingController().unregisterReceiver(this);
         } catch (SecurityException e) {
             Log.w(TAG, "failed to unregister tracing receiver: " + e.getMessage());
+        } catch (IllegalArgumentException e) {
+            Log.w(TAG, "failed to unregister tracing receiver: " + e.getMessage());
         }
     }
 

--- a/runtime/app/android/xwalk_jni_registrar.cc
+++ b/runtime/app/android/xwalk_jni_registrar.cc
@@ -19,6 +19,7 @@
 #include "xwalk/runtime/browser/android/xwalk_dev_tools_server.h"
 #include "xwalk/runtime/browser/android/xwalk_http_auth_handler.h"
 #include "xwalk/runtime/browser/android/xwalk_settings.h"
+#include "xwalk/runtime/browser/android/xwalk_view_delegate.h"
 #include "xwalk/runtime/browser/android/xwalk_web_contents_delegate.h"
 
 namespace xwalk {
@@ -41,6 +42,7 @@ static base::android::RegistrationMethod kXWalkRegisteredMethods[] = {
   { "XWalkExtensionAndroid", extensions::RegisterXWalkExtensionAndroid },
   { "XWalkHttpAuthHandler", RegisterXWalkHttpAuthHandler },
   { "XWalkSettings", RegisterXWalkSettings },
+  { "XWalkViewDelegate", RegisterXWalkViewDelegate },
   { "XWalkWebContentsDelegate", RegisterXWalkWebContentsDelegate },
 };
 

--- a/runtime/browser/android/xwalk_view_delegate.cc
+++ b/runtime/browser/android/xwalk_view_delegate.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2014 Intel Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/android/xwalk_view_delegate.h"
+
+#include "base/android/jni_android.h"
+#include "jni/XWalkViewDelegate_jni.h"
+
+namespace xwalk {
+
+jboolean IsLibraryBuiltForIA(JNIEnv* env, jclass jcaller) {
+#if defined(ARCH_CPU_X86)
+  return JNI_TRUE;
+#else
+  return JNI_FALSE;
+#endif
+}
+
+bool RegisterXWalkViewDelegate(JNIEnv* env) {
+  return RegisterNativesImpl(env) >= 0;
+}
+
+}  // namespace xwalk

--- a/runtime/browser/android/xwalk_view_delegate.h
+++ b/runtime/browser/android/xwalk_view_delegate.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2014 Intel Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_ANDROID_XWALK_VIEW_DELEGATE_H_
+#define XWALK_RUNTIME_BROWSER_ANDROID_XWALK_VIEW_DELEGATE_H_
+
+#include <jni.h>
+
+namespace xwalk {
+
+bool RegisterXWalkViewDelegate(JNIEnv* env);
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_ANDROID_XWALK_VIEW_DELEGATE_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -121,6 +121,8 @@
         'runtime/browser/android/xwalk_request_interceptor.cc',
         'runtime/browser/android/xwalk_request_interceptor.h',
         'runtime/browser/android/xwalk_settings.cc',
+        'runtime/browser/android/xwalk_view_delegate.cc',
+        'runtime/browser/android/xwalk_view_delegate.h',
         'runtime/browser/android/xwalk_web_contents_delegate.cc',
         'runtime/browser/android/xwalk_web_contents_delegate.h',
         'runtime/browser/android/xwalk_web_contents_view_delegate.cc',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -156,6 +156,7 @@
         'runtime/android/core/src/org/xwalk/core/XWalkCookieManager.java',
         'runtime/android/core/src/org/xwalk/core/XWalkDevToolsServer.java',
         'runtime/android/core/src/org/xwalk/core/XWalkSettings.java',
+        'runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java',
         'runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegate.java',
       ],
       'includes': ['../build/jni_generator.gypi'],


### PR DESCRIPTION
It's extremely slow to load ARM binaries on ia devices.
And it hurts user experience. Add a method in libxwalkcore.so
to tell XWalkViewDelegate whether the binary is built for IA.

Currently, the notification is only a Toast and then an exception
will be thrown. The upper layer should catch the exception and
prompt more appropriate UI to user.

TODO: Define the UI for the cpu mismatch error and remove
the toast notification.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1283
