### PR TITLE
[SysApps][Android] Support lastUpdated in Contacts API

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/extension/api/contacts/ContactFinder.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/api/contacts/ContactFinder.java
@@ -6,6 +6,8 @@ package org.xwalk.core.extension.api.contacts;
 
 import android.content.ContentResolver;
 import android.database.Cursor;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.provider.ContactsContract.Data;
 import android.provider.ContactsContract.CommonDataKinds.Email;
 import android.provider.ContactsContract.CommonDataKinds.Event;
@@ -261,10 +263,11 @@ public class ContactFinder {
                 long id = c.getLong(c.getColumnIndex(Data.CONTACT_ID));
                 if (!dataMap.containsKey(id)) dataMap.put(id, new ContactData());
                 ContactData d = dataMap.get(id);
+                if (d.lastUpdated == null && VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
+                    d.lastUpdated = mUtils.getLastUpdated(id);
+                }
                 String mime = c.getString(c.getColumnIndex(Data.MIMETYPE));
-                if (mime.equals(ContactConstants.CUSTOM_MIMETYPE_LASTUPDATED)) {
-                    d.lastUpdated = c.getString(c.getColumnIndex(Data.DATA1));
-                } else if (mime.equals(StructuredName.CONTENT_ITEM_TYPE)) {
+                if (mime.equals(StructuredName.CONTENT_ITEM_TYPE)) {
                     d.oName = addString(d.oName, c, "displayName", StructuredName.DISPLAY_NAME);
                     d.oName = addArrayTop(d.oName, c, "honorificPrefixes", StructuredName.PREFIX);
                     d.oName = addArrayTop(d.oName, c, "givenNames", StructuredName.GIVEN_NAME);

--- a/runtime/android/core/src/org/xwalk/core/extension/api/contacts/ContactSaver.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/api/contacts/ContactSaver.java
@@ -170,10 +170,6 @@ public class ContactSaver {
         }
     }
 
-    private void buildByDate(String name, String mimeType, String data) {
-        buildByDate(name, mimeType, data, null, 0);
-    }
-
     private void buildByDate(String name, String mimeType, String data, String type, int dateType) {
         if (!mContact.has(name)) return;
 
@@ -200,12 +196,12 @@ public class ContactSaver {
         }
     }
 
-    private void PutToContact(String id) {
-        if (id == null) return;
+    private void PutToContact(String name, String value) {
+        if (name == null) return;
         try {
-            mContact.put("id", id);
+            mContact.put(name, value);
         } catch (JSONException e) {
-            Log.e(TAG, "Failed to put id " + id + " into contact" + e.toString());
+            Log.e(TAG, "Failed to set " + name + " = " + value + " for contact" + e.toString());
         }
     }
 
@@ -281,7 +277,6 @@ public class ContactSaver {
             }
         }
 
-        buildByDate("lastUpdated", ContactConstants.CUSTOM_MIMETYPE_LASTUPDATED, Data.DATA1);
         buildByEvent("birthday", Event.TYPE_BIRTHDAY);
         buildByEvent("anniversary", Event.TYPE_ANNIVERSARY);
 
@@ -311,8 +306,11 @@ public class ContactSaver {
                         + "new raw ids are: " + newRawIds.toString());
                 return mContact;
             }
-            String id = mUtils.getId(newRawIds.iterator().next());
-            PutToContact(id);
+            mId = mUtils.getId(newRawIds.iterator().next());
+            PutToContact("id", mId);
+        }
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2 ) {
+            PutToContact("lastUpdated", String.valueOf(mUtils.getLastUpdated(Long.valueOf(mId))));
         }
         return mContact;
     }

--- a/runtime/android/core/src/org/xwalk/core/extension/api/contacts/ContactUtils.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/api/contacts/ContactUtils.java
@@ -108,6 +108,29 @@ public class ContactUtils {
         }
     }
 
+    /**
+     * Get lastUpdatedTimestamp and return as JS date format
+     * @param long e.g. 987654321012
+     * @return string e.g. "2001-04-19T04:25:21.012Z"
+     */
+    @android.annotation.TargetApi(android.os.Build.VERSION_CODES.JELLY_BEAN_MR2)
+    public String getLastUpdated(long contactId) {
+        String[] projection = new String[]{ContactsContract.Contacts.CONTACT_LAST_UPDATED_TIMESTAMP};
+
+        Uri uri = ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, contactId);
+        Cursor cursor = mResolver.query(uri, projection, null, null, null);
+        try {
+            if (cursor.moveToNext()) {
+                return timeConvertToJS(cursor.getLong(0));
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return null;
+    }
+
     public Set<String> getCurrentRawIds() {
         Cursor c = null;
         try {
@@ -276,5 +299,16 @@ public class ContactUtils {
             Log.e(TAG, "dateFormat - parse failed: " + e.toString());
         }
         return date;
+    }
+
+    /**
+     * Convert epoch seconds to JS date format
+     * @param long e.g. 61
+     * @return string e.g. "1969-12-31T00:01:01Z"
+     */
+    private String timeConvertToJS(long seconds) {
+        final SimpleDateFormat df =
+                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", java.util.Locale.getDefault());
+        return df.format(new java.util.Date(seconds));
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/extension/api/contacts/contacts_api.js
+++ b/runtime/android/core/src/org/xwalk/core/extension/api/contacts/contacts_api.js
@@ -175,7 +175,7 @@ window.ContactName = function(init) {
 
 window.Contact = function(init) {
   this.id = null;
-  this.lastUpdated = null;
+  this.lastUpdated = new Date();
   this.name = init.name;
   this.emails = init.emails;
   this.photos = init.photos;


### PR DESCRIPTION
This adds support of getting lastupdated time in Contact API, it includes following scenarios:
1. When new a contact, current time will be saved into the contact.
2. When update a contact, we let underlying database to handle the last updated timestamp. This is the only way to keep it right as we can't predict other apps of modifying system's contacts.
3. When function of find is called, the last updated timestamp field will be fetched from the database and inserted into the results.
4. Only Android version >=API 18 will be supported, as the last updated timestamp field in the database was first introduced in API 18. 
5. For lower Android versions, the lastUpdated timestamp will be seen when creating a new contact, but it will not be saved or returned in search results.

BUG=[XWALK-1028](https://crosswalk-project.org/jira/browse/XWALK-1028)
