### PR TITLE
[Tizen][Runtime] Enable "allow-navigation" feature for Tizen legacy WGT package.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -399,7 +399,7 @@ void Application::InitSecurityPolicy() {
 #if defined(OS_TIZEN)
       // On Tizen, CSP mode has higher priority, and WARP will be disabled
       // if the application is under CSP mode.
-      || application_data_->GetManifest()->HasPath(widget_keys::kCSPKey)
+      || application_data_->HasCSPDefined()
 #endif
       )
     return;

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -363,5 +363,13 @@ PermissionSet ApplicationData::GetManifestPermissions() const {
   return permissions;
 }
 
+#if defined(OS_TIZEN)
+bool ApplicationData::HasCSPDefined() const {
+  return (manifest_->HasPath(widget_keys::kCSPKey) ||
+          manifest_->HasPath(widget_keys::kCSPReportOnlyKey) ||
+          manifest_->HasPath(widget_keys::kAllowNavigationKey));
+}
+#endif
+
 }   // namespace application
 }   // namespace xwalk

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -134,6 +134,10 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   bool HasMainDocument() const;
   Manifest::PackageType GetPackageType() const;
 
+#if defined(OS_TIZEN)
+  bool HasCSPDefined() const;
+#endif
+
  private:
   friend class base::RefCountedThreadSafe<ApplicationData>;
   friend class ApplicationStorageImpl;

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -63,6 +63,8 @@ const char kAccessSubdomainsKey[] = "@subdomains";
 const char kIcon128Key[] = "widget.icon.@src";
 const char kTizenAppIdKey[] = "widget.application.@package";
 const char kAllowNavigationKey[] = "widget.allow-navigation.#text";
+const char kCSPReportOnlyKey[] =
+    "widget.content-security-policy-report-only.#text";
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -58,6 +58,7 @@ namespace application_widget_keys {
   extern const char kTizenAppIdKey[];
   extern const char kIcon128Key[];
   extern const char kAllowNavigationKey[];
+  extern const char kCSPReportOnlyKey[];
 #endif
 }  // namespace application_widget_keys
 

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -108,6 +108,10 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
       int render_process_id,
       int render_view_id,
       int notification_id) OVERRIDE;
+#if defined(OS_TIZEN)
+  virtual bool CanCommitURL(
+      content::RenderProcessHost* process_host, const GURL& url) OVERRIDE;
+#endif
 
 #if defined(OS_ANDROID)
   virtual void ResourceDispatcherHostCreated();


### PR DESCRIPTION
In Tizen WGT package configure document, the tizen:allow-nevigation
tag will list all allowed domains of navigation links can be displayed
in web application.

Please refer to the section "0260 Tizen Navigation Policy"
https://source.tizen.org/sites/default/files/page/tizen-2.2-wrt-core-spec.pdf
for more details.
