### PR TITLE
M35 Gardening: simd command line parameters is not being parsed

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -105,14 +105,16 @@ void XWalkBrowserMainParts::PreMainMessageLoopStart() {
   // FIXME: Add comment why this is needed on Android and Tizen.
   command_line->AppendSwitch(switches::kAllowFileAccessFromFiles);
 
-  // Enable SIMD.JS API by default.
-  std::string js_flags("--simd_object");
-  if (command_line->HasSwitch(switches::kJavaScriptFlags)) {
-    js_flags += " ";
-    js_flags +=
-        command_line->GetSwitchValueASCII(switches::kJavaScriptFlags);
-  }
-  command_line->AppendSwitchASCII(switches::kJavaScriptFlags, js_flags);
+  // FIXME(huningxin): This flag is not being recognized and Crosswalk
+  // is printing "Error: unrecognized flag --simd_object" at startup.
+  //
+  //std::string js_flags("--simd_object");
+  //if (command_line->HasSwitch(switches::kJavaScriptFlags)) {
+  //  js_flags += " ";
+  //  js_flags +=
+  //      command_line->GetSwitchValueASCII(switches::kJavaScriptFlags);
+  //}
+  //command_line->AppendSwitchASCII(switches::kJavaScriptFlags, js_flags);
 
   startup_url_ = GetURLFromCommandLine(*command_line);
 }


### PR DESCRIPTION
Crosswalk is printing the following error during startup:

Error: unrecognized flag --simd_object
Try --help for options

As side effect, other flags passed to V8 (like enable the GC interface, needed
by the extension tests) are being ignored.
