### PR TITLE
M35 Gardening: Do not initialize XWalkRunner twice

### DIFF
--- a/test/base/xwalk_test_suite.cc
+++ b/test/base/xwalk_test_suite.cc
@@ -4,110 +4,21 @@
 
 #include "xwalk/test/base/xwalk_test_suite.h"
 
-#include "base/command_line.h"
-#include "base/file_util.h"
-#include "base/memory/ref_counted.h"
-#include "base/metrics/stats_table.h"
-#include "base/path_service.h"
-#include "base/process/process_handle.h"
-#include "base/strings/stringprintf.h"
-#include "base/strings/utf_string_conversions.h"
-#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_content_client.h"
-#include "xwalk/runtime/common/xwalk_paths.h"
-#include "content/public/test/test_launcher.h"
-#include "net/base/net_errors.h"
-#include "net/base/net_util.h"
-#include "net/dns/mock_host_resolver.h"
-#include "testing/gtest/include/gtest/gtest.h"
-#include "ui/base/resource/resource_bundle.h"
-#include "ui/base/resource/resource_handle.h"
-
-#if defined(OS_POSIX)
-#include "base/memory/shared_memory.h"
-#endif
-
-namespace {
-
-void RemoveSharedMemoryFile(const std::string& filename) {
-  // Stats uses SharedMemory under the hood. On posix, this results in a file
-  // on disk.
-#if defined(OS_POSIX)
-  base::SharedMemory memory;
-  memory.Delete(filename);
-#endif
-}
-
-}  // namespace
-
-class XWalkTestSuiteInitializer : public testing::EmptyTestEventListener {
- public:
-  XWalkTestSuiteInitializer() {
-  }
-
-  virtual void OnTestStart(const testing::TestInfo& test_info) OVERRIDE {
-    content_client_.reset(new xwalk::XWalkContentClient);
-    content::SetContentClient(content_client_.get());
-
-    xwalk_runner_.reset(new xwalk::XWalkRunner());
-    SetBrowserClientForTesting(xwalk_runner_->GetContentBrowserClient());
-  }
-
-  virtual void OnTestEnd(const testing::TestInfo& test_info) OVERRIDE {
-    xwalk_runner_.reset();
-    content_client_.reset();
-    content::SetContentClient(NULL);
-  }
-
- private:
-  scoped_ptr<xwalk::XWalkContentClient> content_client_;
-  scoped_ptr<xwalk::XWalkRunner> xwalk_runner_;
-
-  DISALLOW_COPY_AND_ASSIGN(XWalkTestSuiteInitializer);
-};
 
 XWalkTestSuite::XWalkTestSuite(int argc, char** argv)
     : content::ContentTestSuiteBase(argc, argv) {
 }
 
-XWalkTestSuite::~XWalkTestSuite() {
-}
+XWalkTestSuite::~XWalkTestSuite() {}
 
 void XWalkTestSuite::Initialize() {
-  xwalk::RegisterPathProvider();
-
   // Initialize after overriding paths as some content paths depend on correct
   // values for DIR_EXE and DIR_MODULE.
   content::ContentTestSuiteBase::Initialize();
 
-  base::FilePath pak_dir;
-  PathService::Get(base::DIR_MODULE, &pak_dir);
-  DCHECK(!pak_dir.empty());
-  base::FilePath resources_pack_path;
-  resources_pack_path = pak_dir.Append(FILE_PATH_LITERAL("xwalk.pak"));
-  ui::ResourceBundle::InitSharedInstanceWithPakPath(resources_pack_path);
   {
     xwalk::XWalkContentClient client;
     content::ContentTestSuiteBase::RegisterContentSchemes(&client);
   }
-
-  stats_filename_ = base::StringPrintf("unit_tests-%d",
-                                       base::GetCurrentProcId());
-  RemoveSharedMemoryFile(stats_filename_);
-  stats_table_.reset(new base::StatsTable(stats_filename_, 20, 200));
-  base::StatsTable::set_current(stats_table_.get());
-
-  testing::TestEventListeners& listeners =
-      testing::UnitTest::GetInstance()->listeners();
-  listeners.Append(new XWalkTestSuiteInitializer);
-}
-
-void XWalkTestSuite::Shutdown() {
-  ResourceBundle::CleanupSharedInstance();
-
-  base::StatsTable::set_current(NULL);
-  stats_table_.reset();
-  RemoveSharedMemoryFile(stats_filename_);
-
-  base::TestSuite::Shutdown();
 }

--- a/test/base/xwalk_test_suite.h
+++ b/test/base/xwalk_test_suite.h
@@ -5,15 +5,7 @@
 #ifndef XWALK_TEST_BASE_XWALK_TEST_SUITE_H_
 #define XWALK_TEST_BASE_XWALK_TEST_SUITE_H_
 
-#include <string>
-
-#include "base/files/file_path.h"
-#include "base/memory/scoped_ptr.h"
 #include "content/public/test/content_test_suite_base.h"
-
-namespace base {
-class StatsTable;
-}
 
 class XWalkTestSuite : public content::ContentTestSuiteBase {
  public:
@@ -22,10 +14,6 @@ class XWalkTestSuite : public content::ContentTestSuiteBase {
 
  protected:
   virtual void Initialize() OVERRIDE;
-  virtual void Shutdown() OVERRIDE;
-
-  std::string stats_filename_;
-  scoped_ptr<base::StatsTable> stats_table_;
 };
 
 #endif  // XWALK_TEST_BASE_XWALK_TEST_SUITE_H_


### PR DESCRIPTION
This is all being created already when we create a XWalkMainDelegate
at XWalkTestLauncherDelegate.
