### PR TITLE
Roll v8-crosswalk(d54ab7f->329b763)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -9,7 +9,7 @@
 chromium_version = '34.0.1847.45'
 chromium_crosswalk_point = 'cb7bc58aa1239e2fa92d692e81ccd06fa6c82722'
 blink_crosswalk_point = 'e8b6b995b38b422c2b4d58fa5201599f1e510537'
-v8_crosswalk_point = 'd54ab7faeadc81a6ce7a28949b56adebd17a0011'
+v8_crosswalk_point = '329b763229084058a9e5db4f35bf30ecd0844006'
 
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
329b763 Merge pull request #14 from huningxin/crosswalk-5/34.0.1847.45
f4d82d2 [SIMD] Fix d8 crashes when constructing simd128 typed array without simd
