### PR TITLE
DEPS.xwalk: Roll ozone-wayland (39d93a6 -> a4e3e96).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@ deps_xwalk = {
   'src/v8': 'https://github.com/crosswalk-project/v8-crosswalk.git@%s' % v8_crosswalk_point,
 
   # Ozone-Wayland is required for Wayland support in Chromium.
-  'src/ozone': 'https://github.com/01org/ozone-wayland.git@39d93a66777395d5c9ca11da95c436b9192d9725',
+  'src/ozone': 'https://github.com/01org/ozone-wayland.git@a4e3e96b1e1c51cecf5f7bc162b0d98064c95bc2',
 }
 vars_xwalk = {
 }


### PR DESCRIPTION
a4e3e96 Build Fix.
282d501 Backport parts of 08cd65ef and 7f2153f3.
5c7b2cd OzoneDisplay: Remove logic in DefaultDisplaySpec

This includes changes required to allow oz-wl to build with compilers that
support the `override' keyword, as well as a build fix for Tizen IVI/Generic
due to sign warnings turned errors.
