### PR TITLE
[Extensions] Add command line switch xwalk-extension-cmd-prefix

### DIFF
--- a/extensions/common/xwalk_extension_switches.cc
+++ b/extensions/common/xwalk_extension_switches.cc
@@ -19,4 +19,8 @@ const char kXWalkExtensionProcess[] = "xwalk-extension-process";
 // Specifies where XWalk will look for external extensions.
 const char kXWalkExternalExtensionsPath[] = "external-extensions-path";
 
+// The contents of this flag are prepended to the extension command line.
+// Useful values might be "valgrind" or "xterm -e gdb --args".
+const char kXWalkExtensionCmdPrefix[] = "xwalk-extension-cmd-prefix";
+
 }  // namespace switches

--- a/extensions/common/xwalk_extension_switches.h
+++ b/extensions/common/xwalk_extension_switches.h
@@ -11,6 +11,7 @@ namespace switches {
 extern const char kXWalkDisableExtensionProcess[];
 extern const char kXWalkExtensionProcess[];
 extern const char kXWalkExternalExtensionsPath[];
+extern const char kXWalkExtensionCmdPrefix[];
 
 }  // namespace switches
 


### PR DESCRIPTION
This will prepend the contents of this flag to the command line
when starting extension process, it works as same as the switch
"--renderer-cmd-prefix", could be useful if we need to debug
the extension process at its very beginning.
Useful values might be "valgrind" or "xterm -e gdb --args".
