### PR TITLE
packaging: Remove ash flags from compilation

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -147,7 +147,7 @@ if [ -n "${BUILDDIR_NAME}" ]; then
 fi
 
 %if %{with wayland}
-GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ash=1 -Duse_ozone=1"
+GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1"
 %endif
 
 # --no-parallel is added because chroot does not mount a /dev/shm, this will


### PR DESCRIPTION
There shouldn't be any difference in the binary though, case xwalk is not
pulling any Ash dependencies.
