### PR TITLE
M35 Gardening.

### DIFF
--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -36,7 +36,10 @@ bool XWalkMainDelegate::BasicStartupComplete(int* exit_code) {
   loggingSettings.logging_dest = logging::LOG_TO_SYSTEM_DEBUG_LOG;
   logging::InitLogging(loggingSettings);
   SetContentClient(content_client_.get());
-#if defined(OS_WIN)
+#if defined(OS_MACOSX)
+  OverrideFrameworkBundlePath();
+  OverrideChildProcessPath();
+#elif defined(OS_WIN)
   CommandLine* command_line = CommandLine::ForCurrentProcess();
   std::string process_type =
           command_line->GetSwitchValueASCII(switches::kProcessType);
@@ -48,11 +51,6 @@ bool XWalkMainDelegate::BasicStartupComplete(int* exit_code) {
 }
 
 void XWalkMainDelegate::PreSandboxStartup() {
-#if defined(OS_MACOSX)
-  OverrideFrameworkBundlePath();
-  OverrideChildProcessPath();
-#endif  // OS_MACOSX
-
   RegisterPathProvider();
   InitializeResourceBundle();
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -680,6 +680,11 @@
                 }],
               ],
             }],
+            ['icu_use_data_file_flag==1', {
+              'mac_bundle_resources': [
+                '<(PRODUCT_DIR)/icudtl.dat',
+              ],
+            }],
           ],
         },  # target xwalk_framework
         {


### PR DESCRIPTION
Mac was not running and had a fatal check at launch. This commit
fixes the problem by copying the newly icudat*.dat to the Mac bundle.
Also make sure that the override of the bundle path is done at the
right moment and this before the PreSandboxStartup for it to work.

Upstream CL : https://codereview.chromium.org/109013004
