### PR TITLE
[Android] Support the default_orientation in packaging tool.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -16,6 +16,7 @@ from handle_xml import AddElementAttributeAndText
 from handle_xml import EditElementAttribute
 from handle_xml import EditElementValueByNodeName
 from handle_permissions import HandlePermissions
+from manifest_json_parser import default_orientation_mapping_table
 from xml.dom import minidom
 
 def ReplaceInvalidChars(value, mode='default'):
@@ -371,8 +372,9 @@ def CustomizeAll(app_versionCode, description, icon, permissions, app_url,
                  app_root, app_local_path, enable_remote_debugging,
                  display_as_fullscreen, extensions, launch_screen_img,
                  package='org.xwalk.app.template', name='AppTemplate',
-                 app_version='1.0.0', orientation='unspecified') :
+                 app_version='1.0.0', default_orientation='any') :
   sanitized_name = ReplaceInvalidChars(name, 'apkname')
+  orientation = default_orientation_mapping_table.get(default_orientation)
   try:
     Prepare(sanitized_name, package, app_root)
     CustomizeXML(sanitized_name, package, app_versionCode, app_version,
@@ -427,11 +429,11 @@ def main():
           'Such as: --extensions="/path/to/extension1:/path/to/extension2"')
   parser.add_option('--extensions', help=info)
   info = ('The orientation of the web app\'s display on the device. '
-          'Such as: --orientation=landscape. The default value is "unspecified"'
-          'The value options are the same as those on the Android: '
-          'http://developer.android.com/guide/topics/manifest/'
-          'activity-element.html#screen')
-  parser.add_option('--orientation', help=info)
+          'Such as: --default_orientation=landscape.'
+          'The default value is "any". The permitted values are from: '
+          'http://w3c.github.io/manifest/#default_orientation-member')
+  parser.add_option('--default_orientation', dest='default_orientation',
+                    help=info)
   parser.add_option('--launch-screen-img',
                     help='The fallback image for launch_screen')
   options, _ = parser.parse_args()
@@ -446,8 +448,8 @@ def main():
       options.app_root = os.path.join('test_data', 'manifest')
     if options.package == None:
       options.package = 'org.xwalk.app.template'
-    if options.orientation == None:
-      options.orientation = 'unspecified'
+    if options.default_orientation == None:
+      options.default_orientation = 'any'
     if options.app_version == None:
       options.app_version = '1.0.0'
     CustomizeAll(options.app_versionCode, options.description, icon_dict,
@@ -455,7 +457,7 @@ def main():
                  options.app_local_path, options.enable_remote_debugging,
                  options.fullscreen, options.extensions,
                  options.launch_screen_img, options.package, options.name,
-                 options.app_version, options.orientation)
+                 options.app_version, options.default_orientation)
   except SystemExit as ec:
     print('Exiting with error code: %d' % ec.code)
     return ec.code

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -18,6 +18,7 @@ sys.path.append('scripts/gyp')
 from customize import ReplaceInvalidChars, CustomizeAll
 from dex import AddExeExtensions
 from handle_permissions import permission_mapping_table
+from manifest_json_parser import CheckDefaultOrientation
 from manifest_json_parser import HandlePermissionList
 from manifest_json_parser import ManifestJsonParser
 
@@ -200,15 +201,15 @@ def Customize(options):
   fullscreen_flag = ''
   if options.fullscreen:
     fullscreen_flag = '-f'
-  orientation = 'unspecified'
-  if options.orientation:
-    orientation = options.orientation
+  default_orientation = 'any'
+  if options.default_orientation:
+    default_orientation = options.default_orientation
   CustomizeAll(app_versionCode, options.description, options.icon_dict,
                options.permissions, options.app_url, app_root,
                options.app_local_path, remote_debugging,
                fullscreen_flag, options.extensions,
                options.launch_screen_img, package, name, app_version,
-               orientation)
+               default_orientation)
 
 
 def Execution(options, sanitized_name):
@@ -618,12 +619,12 @@ def main(argv):
   info = ('The path of application icon. '
           'Such as: --icon=/path/to/your/customized/icon')
   group.add_option('--icon', help=info)
-  info = ('The orientation of the web app\'s display on the device. '
-          'For example, --orientation=landscape. The default value is '
-          '\'unspecified\'. The permitted values are from Android: '
-          'http://developer.android.com/guide/topics/manifest/'
-          'activity-element.html#screen')
-  group.add_option('--orientation', help=info)
+  info = ('The default orientation of the web app\'s display on the device. '
+          'For example, --default-orientation=landscape. The default value is '
+          '\'any\'. The permitted values are from: '
+          'http://w3c.github.io/manifest/#default_orientation-member')
+  group.add_option('--default_orientation', dest='default_orientation',
+                   help=info)
   info = ('The list of permissions to be used by web application. For example, '
           '--permissions=geolocation:webgl')
   group.add_option('--permissions', help=info)
@@ -688,6 +689,8 @@ def main(argv):
                    'please use "--app-url" option; If the entry is local, '
                    'please use "--app-root" and '
                    '"--app-local-path" options together!')
+    if options.default_orientation:
+      CheckDefaultOrientation(options.default_orientation)
     if options.permissions:
       permission_list = options.permissions.split(':')
     else:

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -567,7 +567,7 @@ class TestMakeApk(unittest.TestCase):
   def testOrientation(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '--orientation=landscape', self._mode]
+           '--default_orientation=landscape', self._mode]
     RunCommand(cmd)
     manifest = 'Example/AndroidManifest.xml'
     with open(manifest, 'r') as content_file:
@@ -636,7 +636,7 @@ class TestMakeApk(unittest.TestCase):
            '--fullscreen',
            '%s' % icon,
            '--name=Example',
-           '--orientation=landscape',
+           '--default_orientation=landscape',
            '--package=org.xwalk.example',
            '--permissions=geolocation']
     RunCommand(cmd)

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -19,6 +19,36 @@ import os
 import re
 import sys
 
+
+
+# The mapping table is refer to :
+# 1. W3C manifest default_orientation member.
+#    http://w3c.github.io/manifest/#default_orientation-member
+# 2. Android manifest screenorientation definition.
+#     http://developer.android.com/guide/topics/manifest/
+#     activity-element.html#screen
+# TODO: update the mapping table and add related APIs in
+#       xwalk runtime for Android.
+default_orientation_mapping_table = {
+    'any': 'unspecified',
+    'landscape': 'landscape',
+    'portrait': 'portrait'
+}
+
+
+def CheckDefaultOrientation(default_orientation):
+  """This function is used to check whether default orientation value is valid.
+
+  Args:
+    default_orientation: the default orientation string e.g.["portrait"].
+
+  """
+  if (default_orientation.lower() not in
+      list(default_orientation_mapping_table.keys())):
+    print('Error: illegal default_orientation value: %s.' % default_orientation)
+    sys.exit(1)
+
+
 def HandlePermissionList(permission_list):
   """This function is used to handle the permission list and return the string
   of permissions.
@@ -71,20 +101,21 @@ class ManifestJsonParser(object):
       A dictionary to the corresponding items. the dictionary keys are
       described as follows, the value is set to "" if the value of the
       key is not set.
-    app_name:         The application name.
-    version:          The version number.
-    icons:            An array of icons.
-    app_url:          The url of application, e.g. hosted app.
-    description:      The description of application.
-    app_root:         The root path of the web, this flag allows to package
-                      local web application as apk.
-    app_local_path:   The relative path of entry file based on app_root,
-                      this flag should work with "--app-root" together.
-    permissions:      The permission list.
-    required_version: The required crosswalk runtime version.
-    plugin:           The plug-in information.
-    fullscreen:       The fullscreen flag of the application.
-    launch_screen:    The launch screen configuration.
+    app_name:            The application name.
+    version:             The version number.
+    icons:               An array of icons.
+    app_url:             The url of application, e.g. hosted app.
+    description:         The description of application.
+    app_root:            The root path of the web, this flag allows to package
+                         local web application as apk.
+    app_local_path:      The relative path of entry file based on app_root,
+                         this flag should work with "--app-root" together.
+    permissions:         The permission list.
+    required_version:    The required crosswalk runtime version.
+    plugin:              The plug-in information.
+    fullscreen:          The fullscreen flag of the application.
+    launch_screen:       The launch screen configuration.
+    default_orientation: The default orientation of the application.
     """
     ret_dict = {}
     if 'name' not in self.data_src:
@@ -148,6 +179,11 @@ class ManifestJsonParser(object):
         print('Error: no \'image\' field for \'launch_screen.default\'.')
         sys.exit(1)
       ret_dict['launch_screen_img'] = default['image']
+    if 'default_orientation' in self.data_src:
+      CheckDefaultOrientation(self.data_src['default_orientation'])
+      ret_dict['default_orientation'] = self.data_src['default_orientation']
+    else:
+      ret_dict['default_orientation'] = ''
     return ret_dict
 
   def ShowItems(self):
@@ -165,7 +201,7 @@ class ManifestJsonParser(object):
     print("plugins: %s" % self.GetPlugins())
     print("fullscreen: %s" % self.GetFullScreenFlag())
     print('launch_screen.default.image: %s' % self.GetLaunchScreenImg())
-
+    print("default_orientation: %s" % self.GetDefaultOrientation())
 
   def GetAppName(self):
     """Return the application name."""
@@ -214,6 +250,10 @@ class ManifestJsonParser(object):
   def GetLaunchScreenImg(self):
     """Return the default img for launch_screen."""
     return self.ret_dict['launch_screen_img']
+
+  def GetDefaultOrientation(self):
+    """Return the default orientation of the application."""
+    return self.ret_dict['default_orientation']
 
 
 def main(argv):

--- a/app/tools/android/test_data/manifest/manifest.json
+++ b/app/tools/android/test_data/manifest/manifest.json
@@ -18,5 +18,6 @@
     "Messaging"],
   "required_version": "1.28.1.0",
   "plugin": [],
-  "display": ["fullscreen"]
+  "display": ["fullscreen"],
+  "default_orientation": "any"
 }


### PR DESCRIPTION
Since the filed of 'default_orientation' is added in current W3C
manifest, this pull request adds the corresponding support in packaging
tool including manifest parser and command line option handler.

BUG=XWALK-1267
