### PR TITLE
[Android] Fix core shell crash issue after rebasing to Chromium35

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java
@@ -29,7 +29,10 @@ class XWalkViewDelegate {
     private static boolean sInitialized = false;
     private static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
     private static final String[] MANDATORY_PAKS = {
-            "xwalk.pak", "en-US.pak" };
+            "xwalk.pak",
+            "en-US.pak",
+            "icudtl.dat"
+    };
     private static final String[] MANDATORY_LIBRARIES = {
             "libxwalkcore.so"
     };

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -93,10 +93,6 @@
             '--classes-dir=<(PRODUCT_DIR)/xwalk_runtime_lib_apk/classes',
             '--jar-path=<(output_dir)/xwalk_native_libraries.jar',
             '--excluded-classes=<(jar_excluded_classes)',
-
-            # TODO(newt): remove this once http://crbug.com/177552 is
-            # fixed in ninja.
-            '--ignore=>!(echo \'>(_inputs)\' | md5sum)',
           ],
         },
       ],
@@ -214,6 +210,13 @@
           '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/jsapi/screen_orientation_api.js',
           '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/xwalk.pak',
         ],
+        'conditions': [
+          ['icu_use_data_file_flag==1', {
+            'additional_input_paths': [
+              '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/icudtl.dat',
+            ],
+          }],
+        ],
         'asset_location': '<(PRODUCT_DIR)/xwalk_runtime_lib/assets',
         'app_manifest_version_name': '<(xwalk_version)',
         'app_manifest_version_code': '<(xwalk_version_code)',
@@ -231,6 +234,13 @@
           'destination': '<(PRODUCT_DIR)/xwalk_runtime_lib/assets',
           'files': [
             '<(PRODUCT_DIR)/xwalk.pak',
+          ],
+          'conditions': [
+            ['icu_use_data_file_flag==1', {
+              'files': [
+                '<(PRODUCT_DIR)/icudtl.dat',
+              ],
+            }],
           ],
         },
       ],

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -44,6 +44,13 @@
           '<(PRODUCT_DIR)/xwalk_xwview/assets/www/index.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/xwalk.pak',
         ],
+        'conditions': [
+          ['icu_use_data_file_flag==1', {
+            'additional_input_paths': [
+              '<(PRODUCT_DIR)/xwalk_xwview/assets/icudtl.dat',
+            ],
+          }],
+        ],
         'asset_location': '<(PRODUCT_DIR)/xwalk_xwview/assets',
       },
       'copies': [
@@ -67,6 +74,13 @@
           'destination': '<(PRODUCT_DIR)/xwalk_xwview/assets',
           'files': [
             '<(PRODUCT_DIR)/xwalk.pak',
+          ],
+          'conditions': [
+            ['icu_use_data_file_flag==1', {
+              'files': [
+                '<(PRODUCT_DIR)/icudtl.dat',
+              ],
+            }],
           ],
         },
       ],
@@ -194,6 +208,13 @@
         'additional_input_paths': [
           '<(PRODUCT_DIR)/xwalk_runtime/assets/xwalk.pak',
         ],
+        'conditions': [
+          ['icu_use_data_file_flag==1', {
+            'additional_input_paths': [
+              '<(PRODUCT_DIR)/xwalk_runtime/assets/icudtl.dat',
+            ],
+          }],
+        ],
         'asset_location': '<(PRODUCT_DIR)/xwalk_runtime/assets',
       },
       'includes': [ '../build/java_apk.gypi' ],
@@ -209,6 +230,13 @@
           'destination': '<(PRODUCT_DIR)/xwalk_runtime/assets',
           'files': [
             '<(PRODUCT_DIR)/xwalk.pak',
+          ],
+          'conditions': [
+            ['icu_use_data_file_flag==1', {
+              'files': [
+                '<(PRODUCT_DIR)/icudtl.dat',
+              ],
+            }],
           ],
         },
       ],
@@ -309,6 +337,13 @@
           '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/www/manifest_inline_script.json',
           '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/www/csp.html',
         ],
+        'conditions': [
+          ['icu_use_data_file_flag==1', {
+            'additional_input_paths': [
+              '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/icudtl.dat',
+            ],
+          }],
+        ],
         'asset_location': '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets',
       },
       'copies': [
@@ -356,6 +391,13 @@
           'destination': '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets',
           'files': [
             '<(PRODUCT_DIR)/xwalk.pak',
+          ],
+          'conditions': [
+            ['icu_use_data_file_flag==1', {
+              'files': [
+                '<(PRODUCT_DIR)/icudtl.dat',
+              ],
+            }],
           ],
         },
       ],


### PR DESCRIPTION
icu_use_data_file_flag has been enabled on Android after Chromium35.
Need to package icudtl.dat resource.

TODO:
1. It will also be crashed on Shared mode, caused by application context issue.
2. CoreShell will be crashed when exit. Will track with XWALK-1366.

BUG=XWALK-1358
