### PR TITLE
[Tizen] packaging: explicitly disable GNOME Keyring support.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -164,6 +164,7 @@ ${GYP_EXTRA_FLAGS} \
 -Duse_aura=1 \
 -Duse_cups=0 \
 -Duse_gconf=0 \
+-Duse_gnome_keyring=0 \
 -Duse_kerberos=0 \
 -Duse_system_bzip2=1 \
 -Duse_system_libexif=1 \


### PR DESCRIPTION
gnome-keyring isn't packaged for Tizen, and we are not interested in using it
at the moment anyway.

While support for it is disabled by default when Aura is used in M34, this is
not the case anymore since Chromium r251992 (part of M35). Prepare for it by
explicitly disabling the support in master so that the actual commit that 
moves to M35 in crosswalk is smaller.
