### PR TITLE
[Android] Fix crash issue when exit core shell

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java
@@ -45,6 +45,10 @@ class XWalkViewDelegate {
         // features such as location provider to listen to activity status.
         ApplicationStatusManager.init(xwalkView.getActivity().getApplication());
 
+        // We will miss activity onCreate() status in ApplicationStatusManager,
+        // informActivityStarted() will simulate these callbacks.
+        ApplicationStatusManager.informActivityStarted(xwalkView.getActivity());
+
         final Context context = xwalkView.getViewContext();
 
         // Last place to initialize CommandLine object. If you haven't initialize


### PR DESCRIPTION
The initialization of ApplicationStatusManager is too late.
Need to inform our activity has been started.

This patch depends on https://github.com/crosswalk-project/chromium-crosswalk/pull/142

BUG=XWALK-1366
