### PR TITLE
[Linux] Add NaCl support

### DIFF
--- a/runtime/app/xwalk_main_delegate.h
+++ b/runtime/app/xwalk_main_delegate.h
@@ -26,6 +26,9 @@ class XWalkMainDelegate : public content::ContentMainDelegate {
   virtual void PreSandboxStartup() OVERRIDE;
   virtual int RunProcess(const std::string& process_type,
       const content::MainFunctionParams& main_function_params) OVERRIDE;
+#if defined(OS_POSIX) && !defined(OS_ANDROID)
+  virtual content::ZygoteForkDelegate* ZygoteStarting() OVERRIDE;
+#endif
   virtual content::ContentBrowserClient* CreateContentBrowserClient() OVERRIDE;
   virtual content::ContentRendererClient*
       CreateContentRendererClient() OVERRIDE;

--- a/runtime/browser/nacl_host/nacl_browser_delegate_impl.cc
+++ b/runtime/browser/nacl_host/nacl_browser_delegate_impl.cc
@@ -1,0 +1,81 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/nacl_host/nacl_browser_delegate_impl.h"
+
+#include "base/path_service.h"
+#include "content/public/browser/browser_thread.h"
+#include "ppapi/c/private/ppb_nacl_private.h"
+#include "xwalk/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h"
+#include "xwalk/runtime/common/xwalk_paths.h"
+
+namespace {
+
+// Calls OnKeepaliveOnUIThread on UI thread.
+void OnKeepalive(
+    const content::BrowserPpapiHost::OnKeepaliveInstanceData& instance_data,
+    const base::FilePath& profile_data_directory) {
+  DCHECK(!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+}
+
+}  // namespace
+
+NaClBrowserDelegateImpl::NaClBrowserDelegateImpl() {
+}
+
+NaClBrowserDelegateImpl::~NaClBrowserDelegateImpl() {
+}
+
+void NaClBrowserDelegateImpl::ShowMissingArchInfobar(int render_process_id,
+                                                     int render_view_id) {
+}
+
+bool NaClBrowserDelegateImpl::DialogsAreSuppressed() {
+  return true;
+}
+
+bool NaClBrowserDelegateImpl::GetCacheDirectory(base::FilePath* cache_dir) {
+  return PathService::Get(xwalk::DIR_DATA_PATH, cache_dir);
+}
+
+bool NaClBrowserDelegateImpl::GetPluginDirectory(base::FilePath* plugin_dir) {
+  return PathService::Get(xwalk::DIR_INTERNAL_PLUGINS, plugin_dir);
+}
+
+bool NaClBrowserDelegateImpl::GetPnaclDirectory(base::FilePath* pnacl_dir) {
+  return PathService::Get(xwalk::DIR_PNACL_COMPONENT, pnacl_dir);
+}
+
+bool NaClBrowserDelegateImpl::GetUserDirectory(base::FilePath* user_dir) {
+  return PathService::Get(xwalk::DIR_DATA_PATH, user_dir);
+}
+
+std::string NaClBrowserDelegateImpl::GetVersionString() const {
+  return "Chrome/" CHROME_VERSION " Crosswalk/" XWALK_VERSION;
+}
+
+ppapi::host::HostFactory* NaClBrowserDelegateImpl::CreatePpapiHostFactory(
+    content::BrowserPpapiHost* ppapi_host) {
+  return new xwalk::XWalkBrowserPepperHostFactory(ppapi_host);
+}
+
+void NaClBrowserDelegateImpl::SetDebugPatterns(std::string debug_patterns) {
+}
+
+bool NaClBrowserDelegateImpl::URLMatchesDebugPatterns(
+    const GURL& manifest_url) {
+  return false;
+}
+
+// This function is security sensitive.  Be sure to check with a security
+// person before you modify it.
+bool NaClBrowserDelegateImpl::MapUrlToLocalFilePath(
+    const GURL& file_url, bool use_blocking_api, base::FilePath* file_path) {
+  return false;
+}
+
+content::BrowserPpapiHost::OnKeepaliveCallback
+NaClBrowserDelegateImpl::GetOnKeepaliveCallback() {
+  return base::Bind(&OnKeepalive);
+}

--- a/runtime/browser/nacl_host/nacl_browser_delegate_impl.h
+++ b/runtime/browser/nacl_host/nacl_browser_delegate_impl.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_NACL_HOST_NACL_BROWSER_DELEGATE_IMPL_H_
+#define XWALK_RUNTIME_BROWSER_NACL_HOST_NACL_BROWSER_DELEGATE_IMPL_H_
+
+#include <string>
+
+#include "components/nacl/browser/nacl_browser_delegate.h"
+
+class NaClBrowserDelegateImpl : public NaClBrowserDelegate {
+ public:
+  NaClBrowserDelegateImpl();
+  virtual ~NaClBrowserDelegateImpl();
+
+  virtual void ShowMissingArchInfobar(int render_process_id,
+                                      int render_view_id) OVERRIDE;
+  virtual bool DialogsAreSuppressed() OVERRIDE;
+  virtual bool GetCacheDirectory(base::FilePath* cache_dir) OVERRIDE;
+  virtual bool GetPluginDirectory(base::FilePath* plugin_dir) OVERRIDE;
+  virtual bool GetPnaclDirectory(base::FilePath* pnacl_dir) OVERRIDE;
+  virtual bool GetUserDirectory(base::FilePath* user_dir) OVERRIDE;
+  virtual std::string GetVersionString() const OVERRIDE;
+  virtual ppapi::host::HostFactory* CreatePpapiHostFactory(
+      content::BrowserPpapiHost* ppapi_host) OVERRIDE;
+  virtual bool MapUrlToLocalFilePath(const GURL& url,
+                                     bool is_blocking,
+                                     base::FilePath* file_path) OVERRIDE;
+  virtual void SetDebugPatterns(std::string debug_patterns) OVERRIDE;
+  virtual bool URLMatchesDebugPatterns(const GURL& manifest_url) OVERRIDE;
+  virtual content::BrowserPpapiHost::OnKeepaliveCallback
+      GetOnKeepaliveCallback() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(NaClBrowserDelegateImpl);
+};
+
+#endif  // XWALK_RUNTIME_BROWSER_NACL_HOST_NACL_BROWSER_DELEGATE_IMPL_H_

--- a/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.cc
+++ b/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.cc
@@ -1,0 +1,33 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h"
+
+#include "content/public/browser/browser_ppapi_host.h"
+#include "ppapi/host/ppapi_host.h"
+#include "ppapi/host/resource_host.h"
+
+using ppapi::host::ResourceHost;
+
+namespace xwalk {
+
+XWalkBrowserPepperHostFactory::XWalkBrowserPepperHostFactory(
+    content::BrowserPpapiHost* host)
+    : host_(host) {
+}
+
+XWalkBrowserPepperHostFactory::~XWalkBrowserPepperHostFactory() {
+}
+
+scoped_ptr<ResourceHost> XWalkBrowserPepperHostFactory::CreateResourceHost(
+    ppapi::host::PpapiHost* host,
+    const ppapi::proxy::ResourceMessageCallParams& params,
+    PP_Instance instance,
+    const IPC::Message& message) {
+  DCHECK(host == host_->GetPpapiHost());
+
+  return scoped_ptr<ResourceHost>();
+}
+
+}  // namespace xwalk

--- a/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h
+++ b/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_RENDERER_HOST_PEPPER_XWALK_BROWSER_PEPPER_HOST_FACTORY_H_
+#define XWALK_RUNTIME_BROWSER_RENDERER_HOST_PEPPER_XWALK_BROWSER_PEPPER_HOST_FACTORY_H_
+
+#include "ppapi/host/host_factory.h"
+
+namespace content {
+class BrowserPpapiHost;
+}  // namespace content
+
+namespace xwalk {
+
+class XWalkBrowserPepperHostFactory : public ppapi::host::HostFactory {
+ public:
+  // Non-owning pointer to the filter must outlive this class.
+  explicit XWalkBrowserPepperHostFactory(content::BrowserPpapiHost* host);
+  virtual ~XWalkBrowserPepperHostFactory();
+
+  virtual scoped_ptr<ppapi::host::ResourceHost> CreateResourceHost(
+      ppapi::host::PpapiHost* host,
+      const ppapi::proxy::ResourceMessageCallParams& params,
+      PP_Instance instance,
+      const IPC::Message& message) OVERRIDE;
+
+ private:
+  // Non-owning pointer.
+  content::BrowserPpapiHost* host_;
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkBrowserPepperHostFactory);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_RENDERER_HOST_PEPPER_XWALK_BROWSER_PEPPER_HOST_FACTORY_H_

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -10,23 +10,34 @@
 #include "base/command_line.h"
 #include "base/path_service.h"
 #include "base/platform_file.h"
+#include "content/public/browser/browser_child_process_host.h"
 #include "content/public/browser/browser_main_parts.h"
+#include "content/public/browser/browser_ppapi_host.h"
+#include "content/public/browser/child_process_data.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/resource_context.h"
+#include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/main_function_params.h"
 #include "content/public/common/show_desktop_notification_params.h"
+#include "components/nacl/browser/nacl_browser.h"
+#include "components/nacl/browser/nacl_host_message_filter.h"
+#include "components/nacl/browser/nacl_process_host.h"
+#include "components/nacl/common/nacl_process_type.h"
 #include "net/ssl/ssl_info.h"
 #include "net/url_request/url_request_context_getter.h"
+#include "ppapi/host/ppapi_host.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
 #include "xwalk/runtime/browser/geolocation/xwalk_access_token_store.h"
 #include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
+#include "xwalk/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_quota_permission_context.h"
 #include "xwalk/runtime/browser/speech/speech_recognition_manager_delegate.h"
 #include "xwalk/runtime/browser/xwalk_render_message_filter.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
+#include "xwalk/runtime/common/xwalk_paths.h"
 
 #if defined(OS_ANDROID)
 #include "base/android/path_utils.h"
@@ -53,6 +64,8 @@
 #include "xwalk/runtime/browser/runtime_platform_util.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 #endif
+
+using content::BrowserChildProcessHostIterator;
 
 namespace xwalk {
 
@@ -156,6 +169,18 @@ XWalkContentBrowserClient::GetWebContentsViewDelegate(
 
 void XWalkContentBrowserClient::RenderProcessWillLaunch(
     content::RenderProcessHost* host) {
+#if !defined(DISABLE_NACL)
+  int id = host->GetID();
+  net::URLRequestContextGetter* context =
+      host->GetStoragePartition()->GetURLRequestContext();
+
+  host->AddFilter(new nacl::NaClHostMessageFilter(
+      id,
+      // TODO(Halton): IsOffTheRecord?
+      false,
+      host->GetBrowserContext()->GetPath(),
+      context));
+#endif
   xwalk_runner_->OnRenderProcessWillLaunch(host);
   host->AddFilter(new XWalkRenderMessageFilter);
 }
@@ -278,6 +303,32 @@ void XWalkContentBrowserClient::CancelDesktopNotification(
   bridge->CancelNotification(
       notification_id, render_process_id, render_view_id);
 #endif
+}
+
+void XWalkContentBrowserClient::DidCreatePpapiPlugin(
+    content::BrowserPpapiHost* browser_host) {
+#if defined(ENABLE_PLUGINS)
+  browser_host->GetPpapiHost()->AddHostFactoryFilter(
+      scoped_ptr<ppapi::host::HostFactory>(
+          new XWalkBrowserPepperHostFactory(browser_host)));
+#endif
+}
+
+content::BrowserPpapiHost*
+    XWalkContentBrowserClient::GetExternalBrowserPpapiHost(
+        int plugin_process_id) {
+  BrowserChildProcessHostIterator iter(PROCESS_TYPE_NACL_LOADER);
+  while (!iter.Done()) {
+    nacl::NaClProcessHost* host = static_cast<nacl::NaClProcessHost*>(
+        iter.GetDelegate());
+    if (host->process() &&
+        host->process()->GetData().id == plugin_process_id) {
+      // Found the plugin.
+      return host->browser_ppapi_host();
+    }
+    ++iter;
+  }
+  return NULL;
 }
 
 #if defined(OS_ANDROID)

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -115,6 +115,11 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
       content::RenderProcessHost* process_host, const GURL& url) OVERRIDE;
 #endif
 
+  virtual void DidCreatePpapiPlugin(
+      content::BrowserPpapiHost* browser_host) OVERRIDE;
+  virtual content::BrowserPpapiHost* GetExternalBrowserPpapiHost(
+      int plugin_process_id) OVERRIDE;
+
 #if defined(OS_ANDROID)
   virtual void ResourceDispatcherHostCreated();
 #endif

--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -5,13 +5,37 @@
 #include "xwalk/runtime/common/xwalk_content_client.h"
 
 #include "base/command_line.h"
+#include "base/file_util.h"
+#include "base/files/file_path.h"
+#include "base/path_service.h"
 #include "base/strings/string_piece.h"
 #include "base/strings/utf_string_conversions.h"
+#include "components/nacl/common/nacl_process_type.h"
 #include "content/public/common/content_switches.h"
 #include "content/public/common/user_agent.h"
+#include "content/public/common/pepper_plugin_info.h"
+#include "ppapi/shared_impl/ppapi_permissions.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "xwalk/application/common/constants.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
+#include "xwalk/runtime/common/xwalk_paths.h"
+
+const char* const xwalk::XWalkContentClient::kNaClPluginName = "Native Client";
+
+namespace {
+
+const char kNaClPluginMimeType[] = "application/x-nacl";
+const char kNaClPluginExtension[] = "";
+const char kNaClPluginDescription[] = "Native Client Executable";
+const uint32 kNaClPluginPermissions = ppapi::PERMISSION_PRIVATE |
+                                      ppapi::PERMISSION_DEV;
+
+const char kPnaclPluginMimeType[] = "application/x-pnacl";
+const char kPnaclPluginExtension[] = "";
+const char kPnaclPluginDescription[] = "Portable Native Client Executable";
+
+}  // namespace
 
 namespace xwalk {
 
@@ -33,6 +57,40 @@ XWalkContentClient::XWalkContentClient() {
 
 XWalkContentClient::~XWalkContentClient() {
   xwalk::GetUserAgent();
+}
+
+void XWalkContentClient::AddPepperPlugins(
+    std::vector<content::PepperPluginInfo>* plugins) {
+  // Handle Native Client just like the PDF plugin. This means that it is
+  // enabled by default for the non-portable case.  This allows apps installed
+  // from the Chrome Web Store to use NaCl even if the command line switch
+  // isn't set.  For other uses of NaCl we check for the command line switch.
+  // Specifically, Portable Native Client is only enabled by the command line
+  // switch.
+  static bool skip_nacl_file_check = false;
+  base::FilePath path;
+  if (PathService::Get(xwalk::FILE_NACL_PLUGIN, &path)) {
+    if (skip_nacl_file_check || base::PathExists(path)) {
+      content::PepperPluginInfo nacl;
+      nacl.path = path;
+      nacl.name = XWalkContentClient::kNaClPluginName;
+      content::WebPluginMimeType nacl_mime_type(kNaClPluginMimeType,
+                                                kNaClPluginExtension,
+                                                kNaClPluginDescription);
+      nacl.mime_types.push_back(nacl_mime_type);
+      if (!CommandLine::ForCurrentProcess()->HasSwitch(
+              switches::kDisablePnacl)) {
+        content::WebPluginMimeType pnacl_mime_type(kPnaclPluginMimeType,
+                                                   kPnaclPluginExtension,
+                                                   kPnaclPluginDescription);
+        nacl.mime_types.push_back(pnacl_mime_type);
+      }
+      nacl.permissions = kNaClPluginPermissions;
+      plugins->push_back(nacl);
+
+      skip_nacl_file_check = true;
+    }
+  }
 }
 
 std::string XWalkContentClient::GetProduct() const {
@@ -68,6 +126,18 @@ void XWalkContentClient::AddAdditionalSchemes(
     std::vector<std::string>* savable_schemes) {
   standard_schemes->push_back(application::kApplicationScheme);
   savable_schemes->push_back(application::kApplicationScheme);
+}
+
+std::string XWalkContentClient::GetProcessTypeNameInEnglish(int type) {
+  switch (type) {
+    case PROCESS_TYPE_NACL_LOADER:
+      return "Native Client module";
+    case PROCESS_TYPE_NACL_BROKER:
+      return "Native Client broker";
+  }
+
+  DCHECK(false) << "Unknown child process type!";
+  return "Unknown";
 }
 
 }  // namespace xwalk

--- a/runtime/common/xwalk_content_client.h
+++ b/runtime/common/xwalk_content_client.h
@@ -20,6 +20,10 @@ class XWalkContentClient : public content::ContentClient {
   XWalkContentClient();
   virtual ~XWalkContentClient();
 
+  static const char* const kNaClPluginName;
+
+  virtual void AddPepperPlugins(
+      std::vector<content::PepperPluginInfo>* plugins) OVERRIDE;
   virtual std::string GetProduct() const OVERRIDE;
   virtual std::string GetUserAgent() const OVERRIDE;
   virtual base::string16 GetLocalizedString(int message_id) const OVERRIDE;
@@ -32,6 +36,7 @@ class XWalkContentClient : public content::ContentClient {
   virtual void AddAdditionalSchemes(
       std::vector<std::string>* standard_schemes,
       std::vector<std::string>* saveable_shemes) OVERRIDE;
+  virtual std::string GetProcessTypeNameInEnglish(int type) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkContentClient);

--- a/runtime/common/xwalk_paths.h
+++ b/runtime/common/xwalk_paths.h
@@ -14,6 +14,11 @@ enum {
   PATH_START = 1000,
   DIR_DATA_PATH = PATH_START,  // Directory where the cache and local storage
                                // data resides.
+  DIR_INTERNAL_PLUGINS,        // Directory where internal plugins reside.
+
+  FILE_NACL_PLUGIN,            // Full path to the internal NaCl plugin file.
+  DIR_PNACL_COMPONENT,         // Full path to the latest PNaCl version
+                               // (subdir of DIR_PNACL_BASE).
   DIR_TEST_DATA,               // Directory where unit test data resides.
   DIR_WGT_STORAGE_PATH,        // Directory where widget storage data resides.
   PATH_END

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -6,21 +6,26 @@
 
 namespace switches {
 
-// Specifies the data path directory, which XWalk runtime will look for its
-// state, e.g. cache, localStorage etc.
-const char kXWalkDataPath[] = "data-path";
-
 // Specifies the icon file for the app window.
 const char kAppIcon[] = "app-icon";
+
+// Disables the usage of Portable Native Client.
+const char kDisablePnacl[] = "disable-pnacl";
+
+// Enable all the experimental features in XWalk.
+const char kExperimentalFeatures[] = "enable-xwalk-experimental-features";
 
 // Specifies the window whether launched with fullscreen mode.
 const char kFullscreen[] = "fullscreen";
 
+// Specifies install an application.
+const char kInstall[] = "install";
+
 // Specifies list all installed applications.
 const char kListApplications[] = "list-apps";
 
-// Specifies install an application.
-const char kInstall[] = "install";
+// List the command lines feature flags.
+const char kListFeaturesFlags[] = "list-features-flags";
 
 // Specifies uninstall an application from runtime.
 const char kUninstall[] = "uninstall";
@@ -33,10 +38,8 @@ const char kXWalkAllowExternalExtensionsForRemoteSources[] =
 // issue these requests is platform-specific.
 const char kXWalkRunAsService[] = "run-as-service";
 
-// List the command lines feature flags.
-const char kListFeaturesFlags[] = "list-features-flags";
-
-// Enable all the experimental features in XWalk.
-const char kExperimentalFeatures[] = "enable-xwalk-experimental-features";
+// Specifies the data path directory, which XWalk runtime will look for its
+// state, e.g. cache, localStorage etc.
+const char kXWalkDataPath[] = "data-path";
 
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -8,25 +8,17 @@
 // Defines all command line switches for XWalk.
 namespace switches {
 
-extern const char kXWalkDataPath[];
-
 extern const char kAppIcon[];
-
-extern const char kFullscreen[];
-
-extern const char kInstall[];
-
-extern const char kListApplications[];
-
-extern const char kUninstall[];
-
-extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
-
-extern const char kXWalkRunAsService[];
-
-extern const char kListFeaturesFlags[];
-
+extern const char kDisablePnacl[];
 extern const char kExperimentalFeatures[];
+extern const char kFullscreen[];
+extern const char kInstall[];
+extern const char kListApplications[];
+extern const char kListFeaturesFlags[];
+extern const char kUninstall[];
+extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
+extern const char kXWalkDataPath[];
+extern const char kXWalkRunAsService[];
 
 }  // namespace switches
 

--- a/runtime/renderer/pepper/pepper_helper.cc
+++ b/runtime/renderer/pepper/pepper_helper.cc
@@ -1,0 +1,22 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/renderer/pepper/pepper_helper.h"
+
+#include "content/public/renderer/renderer_ppapi_host.h"
+#include "ppapi/host/ppapi_host.h"
+#include "xwalk/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.h"
+
+PepperHelper::PepperHelper(content::RenderFrame* render_frame)
+    : RenderFrameObserver(render_frame) {
+}
+
+PepperHelper::~PepperHelper() {
+}
+
+void PepperHelper::DidCreatePepperPlugin(content::RendererPpapiHost* host) {
+  host->GetPpapiHost()->AddHostFactoryFilter(
+      scoped_ptr<ppapi::host::HostFactory>(
+          new XWalkRendererPepperHostFactory(host)));
+}

--- a/runtime/renderer/pepper/pepper_helper.h
+++ b/runtime/renderer/pepper/pepper_helper.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_RENDERER_PEPPER_PEPPER_HELPER_H_
+#define XWALK_RUNTIME_RENDERER_PEPPER_PEPPER_HELPER_H_
+
+#include "base/compiler_specific.h"
+#include "content/public/renderer/render_frame_observer.h"
+
+// This class listens for Pepper creation events from the RenderFrame and
+// attaches the parts required for Chrome-specific plugin support.
+class PepperHelper : public content::RenderFrameObserver {
+ public:
+  explicit PepperHelper(content::RenderFrame* render_frame);
+  virtual ~PepperHelper();
+
+  // RenderFrameObserver.
+  virtual void DidCreatePepperPlugin(content::RendererPpapiHost* host) OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(PepperHelper);
+};
+
+#endif  // XWALK_RUNTIME_RENDERER_PEPPER_PEPPER_HELPER_H_

--- a/runtime/renderer/pepper/pepper_uma_host.cc
+++ b/runtime/renderer/pepper/pepper_uma_host.cc
@@ -1,0 +1,115 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/renderer/pepper/pepper_uma_host.h"
+
+#include "base/metrics/histogram.h"
+#include "content/public/renderer/renderer_ppapi_host.h"
+#include "ppapi/c/pp_errors.h"
+#include "ppapi/host/dispatch_host_message.h"
+#include "ppapi/host/ppapi_host.h"
+#include "ppapi/proxy/ppapi_messages.h"
+
+PepperUMAHost::PepperUMAHost(
+    content::RendererPpapiHost* host,
+    PP_Instance instance,
+    PP_Resource resource)
+    : ResourceHost(host->GetPpapiHost(), instance, resource),
+      document_url_(host->GetDocumentURL(instance)),
+      is_plugin_in_process_(host->IsRunningInProcess()) {
+}
+
+PepperUMAHost::~PepperUMAHost() {
+}
+
+int32_t PepperUMAHost::OnResourceMessageReceived(
+    const IPC::Message& msg,
+    ppapi::host::HostMessageContext* context) {
+  IPC_BEGIN_MESSAGE_MAP(PepperUMAHost, msg)
+    PPAPI_DISPATCH_HOST_RESOURCE_CALL(PpapiHostMsg_UMA_HistogramCustomTimes,
+        OnHistogramCustomTimes);
+    PPAPI_DISPATCH_HOST_RESOURCE_CALL(PpapiHostMsg_UMA_HistogramCustomCounts,
+        OnHistogramCustomCounts);
+    PPAPI_DISPATCH_HOST_RESOURCE_CALL(PpapiHostMsg_UMA_HistogramEnumeration,
+        OnHistogramEnumeration);
+  IPC_END_MESSAGE_MAP()
+  return PP_ERROR_FAILED;
+}
+
+bool PepperUMAHost::IsHistogramAllowed(const std::string& histogram) {
+  return (is_plugin_in_process_ && histogram.find("NaCl.") == 0);
+}
+
+#define RETURN_IF_BAD_ARGS(_min, _max, _buckets) \
+  do { \
+    if (_min >= _max || _buckets <= 1) \
+      return PP_ERROR_BADARGUMENT; \
+  } while (0)
+
+int32_t PepperUMAHost::OnHistogramCustomTimes(
+    ppapi::host::HostMessageContext* context,
+    const std::string& name,
+    int64_t sample,
+    int64_t min,
+    int64_t max,
+    uint32_t bucket_count) {
+  if (!IsHistogramAllowed(name)) {
+    return PP_ERROR_NOACCESS;
+  }
+  RETURN_IF_BAD_ARGS(min, max, bucket_count);
+
+  base::HistogramBase* counter =
+      base::Histogram::FactoryTimeGet(
+          name,
+          base::TimeDelta::FromMilliseconds(min),
+          base::TimeDelta::FromMilliseconds(max),
+          bucket_count,
+          base::HistogramBase::kUmaTargetedHistogramFlag);
+  counter->AddTime(base::TimeDelta::FromMilliseconds(sample));
+  return PP_OK;
+}
+
+int32_t PepperUMAHost::OnHistogramCustomCounts(
+    ppapi::host::HostMessageContext* context,
+    const std::string& name,
+    int32_t sample,
+    int32_t min,
+    int32_t max,
+    uint32_t bucket_count) {
+  if (!IsHistogramAllowed(name)) {
+    return PP_ERROR_NOACCESS;
+  }
+  RETURN_IF_BAD_ARGS(min, max, bucket_count);
+
+  base::HistogramBase* counter =
+      base::Histogram::FactoryGet(
+          name,
+          min,
+          max,
+          bucket_count,
+          base::HistogramBase::kUmaTargetedHistogramFlag);
+  counter->Add(sample);
+  return PP_OK;
+}
+
+int32_t PepperUMAHost::OnHistogramEnumeration(
+    ppapi::host::HostMessageContext* context,
+    const std::string& name,
+    int32_t sample,
+    int32_t boundary_value) {
+  if (!IsHistogramAllowed(name)) {
+    return PP_ERROR_NOACCESS;
+  }
+  RETURN_IF_BAD_ARGS(0, boundary_value, boundary_value + 1);
+
+  base::HistogramBase* counter =
+      base::LinearHistogram::FactoryGet(
+          name,
+          1,
+          boundary_value,
+          boundary_value + 1,
+          base::HistogramBase::kUmaTargetedHistogramFlag);
+  counter->Add(sample);
+  return PP_OK;
+}

--- a/runtime/renderer/pepper/pepper_uma_host.h
+++ b/runtime/renderer/pepper/pepper_uma_host.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_RENDERER_PEPPER_PEPPER_UMA_HOST_H_
+#define XWALK_RUNTIME_RENDERER_PEPPER_PEPPER_UMA_HOST_H_
+
+#include <set>
+#include <string>
+
+#include "ppapi/c/pp_instance.h"
+#include "ppapi/c/pp_resource.h"
+#include "ppapi/host/resource_host.h"
+#include "url/gurl.h"
+
+namespace content {
+class RendererPpapiHost;
+}
+
+namespace ppapi {
+namespace host {
+struct HostMessageContext;
+}  // namespace host
+}  // namespace ppapi
+
+class PepperUMAHost : public ppapi::host::ResourceHost {
+ public:
+  PepperUMAHost(content::RendererPpapiHost* host,
+                PP_Instance instance,
+                PP_Resource resource);
+
+  virtual ~PepperUMAHost();
+
+  // ppapi::host::ResourceMessageHandler implementation.
+  virtual int32_t OnResourceMessageReceived(
+      const IPC::Message& msg,
+      ppapi::host::HostMessageContext* context) OVERRIDE;
+
+ private:
+  bool IsHistogramAllowed(const std::string& histogram);
+
+  int32_t OnHistogramCustomTimes(
+      ppapi::host::HostMessageContext* context,
+      const std::string& name,
+      int64_t sample,
+      int64_t min,
+      int64_t max,
+      uint32_t bucket_count);
+
+  int32_t OnHistogramCustomCounts(
+      ppapi::host::HostMessageContext* context,
+      const std::string& name,
+      int32_t sample,
+      int32_t min,
+      int32_t max,
+      uint32_t bucket_count);
+
+  int32_t OnHistogramEnumeration(
+      ppapi::host::HostMessageContext* context,
+      const std::string& name,
+      int32_t sample,
+      int32_t boundary_value);
+
+  const GURL document_url_;
+  bool is_plugin_in_process_;
+
+  // Set of origins that can use UMA private APIs from NaCl.
+  std::set<std::string> allowed_origins_;
+  // Set of histograms that can be used from this interface.
+  std::set<std::string> allowed_histograms_;
+
+  DISALLOW_COPY_AND_ASSIGN(PepperUMAHost);
+};
+
+#endif  // XWALK_RUNTIME_RENDERER_PEPPER_PEPPER_UMA_HOST_H_

--- a/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.cc
+++ b/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.cc
@@ -1,0 +1,43 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.h"
+
+#include "content/public/renderer/renderer_ppapi_host.h"
+#include "ppapi/proxy/ppapi_messages.h"
+#include "xwalk/runtime/renderer/pepper/pepper_uma_host.h"
+
+using ppapi::host::ResourceHost;
+
+XWalkRendererPepperHostFactory::XWalkRendererPepperHostFactory(
+    content::RendererPpapiHost* host)
+    : host_(host) {
+}
+
+XWalkRendererPepperHostFactory::~XWalkRendererPepperHostFactory() {
+}
+
+scoped_ptr<ResourceHost>
+XWalkRendererPepperHostFactory::CreateResourceHost(
+    ppapi::host::PpapiHost* host,
+    const ppapi::proxy::ResourceMessageCallParams& params,
+    PP_Instance instance,
+    const IPC::Message& message) {
+  DCHECK(host == host_->GetPpapiHost());
+
+  // Make sure the plugin is giving us a valid instance for this resource.
+  if (!host_->IsValidInstance(instance))
+    return scoped_ptr<ResourceHost>();
+
+  // Permissions for the following interfaces will be checked at the
+  // time of the corresponding instance's method calls.  Currently these
+  // interfaces are available only for whitelisted apps which may not have
+  // access to the other private interfaces.
+  if (message.type() == PpapiHostMsg_UMA_Create::ID) {
+    return scoped_ptr<ResourceHost>(new PepperUMAHost(
+        host_, instance, params.pp_resource()));
+  }
+
+  return scoped_ptr<ResourceHost>();
+}

--- a/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.h
+++ b/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_RENDERER_PEPPER_XWALK_RENDERER_PEPPER_HOST_FACTORY_H_
+#define XWALK_RUNTIME_RENDERER_PEPPER_XWALK_RENDERER_PEPPER_HOST_FACTORY_H_
+
+#include "ppapi/host/host_factory.h"
+
+namespace content {
+class RendererPpapiHost;
+}
+
+class XWalkRendererPepperHostFactory : public ppapi::host::HostFactory {
+ public:
+  explicit XWalkRendererPepperHostFactory(content::RendererPpapiHost* host);
+  virtual ~XWalkRendererPepperHostFactory();
+
+  // HostFactory.
+  virtual scoped_ptr<ppapi::host::ResourceHost> CreateResourceHost(
+      ppapi::host::PpapiHost* host,
+      const ppapi::proxy::ResourceMessageCallParams& params,
+      PP_Instance instance,
+      const IPC::Message& message) OVERRIDE;
+
+ private:
+  // Not owned by this object.
+  content::RendererPpapiHost* host_;
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkRendererPepperHostFactory);
+};
+
+#endif  // XWALK_RUNTIME_RENDERER_PEPPER_XWALK_RENDERER_PEPPER_HOST_FACTORY_H_

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -46,6 +46,9 @@ class XWalkContentRendererClient
   virtual void DidCreateScriptContext(
       blink::WebFrame* frame, v8::Handle<v8::Context> context,
       int extension_group, int world_id) OVERRIDE;
+  virtual bool IsExternalPepperPlugin(const std::string& module_name) OVERRIDE;
+  virtual const void* CreatePPAPIInterface(
+      const std::string& interface_name) OVERRIDE;
 #if defined(OS_ANDROID)
   virtual unsigned long long VisitedLinkHash(const char* canonical_url, // NOLINT
                                              size_t length) OVERRIDE;

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -139,6 +139,8 @@
         'runtime/browser/image_util.h',
         'runtime/browser/media/media_capture_devices_dispatcher.cc',
         'runtime/browser/media/media_capture_devices_dispatcher.h',
+        'runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.cc',
+        'runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h',
         'runtime/browser/runtime.cc',
         'runtime/browser/runtime.h',
         'runtime/browser/runtime_context.cc',
@@ -247,6 +249,12 @@
         'runtime/renderer/android/xwalk_permission_client.h',
         'runtime/renderer/android/xwalk_render_view_ext.cc',
         'runtime/renderer/android/xwalk_render_view_ext.h',
+        'runtime/renderer/pepper/pepper_helper.cc',
+        'runtime/renderer/pepper/pepper_helper.h',
+        'runtime/renderer/pepper/pepper_uma_host.cc',
+        'runtime/renderer/pepper/pepper_uma_host.h',
+        'runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.cc',
+        'runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.h',
         'runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc',
         'runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h',
         'runtime/renderer/tizen/xwalk_render_view_ext_tizen.cc',
@@ -345,6 +353,33 @@
         }, {  # use_aura==0
           'sources/': [
             ['exclude', '_aura\\.cc$'],
+          ],
+        }],
+        ['disable_nacl==0', {
+          'sources': [
+            'runtime/browser/nacl_host/nacl_browser_delegate_impl.cc',
+            'runtime/browser/nacl_host/nacl_browser_delegate_impl.h',
+          ],
+          'dependencies': [
+            '../components/nacl.gyp:nacl',
+            '../components/nacl.gyp:nacl_browser',
+            '../components/nacl.gyp:nacl_common',
+            '../components/nacl.gyp:nacl_renderer',
+            '../components/nacl.gyp:nacl_helper',
+            '../native_client/src/trusted/service_runtime/linux/nacl_bootstrap.gyp:nacl_helper_bootstrap',
+          ],
+        }],
+        ['enable_plugins==1', {
+          'dependencies': [
+            '../ppapi/ppapi_internal.gyp:ppapi_host',
+            '../ppapi/ppapi_internal.gyp:ppapi_proxy',
+            '../ppapi/ppapi_internal.gyp:ppapi_ipc',
+            '../ppapi/ppapi_internal.gyp:ppapi_shared',
+          ],
+        }, {  # enable_plugins==0
+          'sources/': [
+            ['exclude', '^runtime/browser/renderer_host/pepper/'],
+            ['exclude', '^runtime/renderer/pepper/'],
           ],
         }],
       ],


### PR DESCRIPTION
[Linux] Add NaCl support …

Based on NaCl component work (http://crbug.com/244791) from upstream,
this commit is to add Native Client(aka NaCl) support.
It now can run examples from nacl sdk.
  $ cd <nacl_sdk_dir>/pepper_canary/example
  $ TOOLCHAIN=newlib make serve
  $ xwalk http://localhost:5103

Next steps:
- Enable PNaCl
- Enable on Tizen

BUG=XWALK-1338
