### PR TITLE
[Tizen] packaging: Remove dead %patch calls.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -107,14 +107,6 @@ cp -a src/xwalk/LICENSE LICENSE.xwalk
 
 %patch1
 
-%if "%{tizen}" < "3.0"
-%patch2
-%patch3
-%patch4
-%patch5 -p1
-%patch6
-%endif
-
 %if %{with wayland}
 %patch8
 %endif


### PR DESCRIPTION
We don't care about Tizen 2 anymore, and the referenced files do not even 
exist anymore.
