### PR TITLE
[Tizen] packaging: enable ozone-wayland's VKB support.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -141,7 +141,7 @@ if [ -n "${BUILDDIR_NAME}" ]; then
 fi
 
 %if %{with wayland}
-GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1"
+GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1 -Denable_ozone_wayland_vkb=1"
 %endif
 
 # --no-parallel is added because chroot does not mount a /dev/shm, this will


### PR DESCRIPTION
It is currently disabled by the default, but we need the feature and can help
test it.
