### PR TITLE
make_apkg.py: Catch library and version errors

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -508,14 +508,24 @@ def MakeApk(options, sanitized_name):
       valid_archs = ['x86', 'armeabi-v7a']
       packaged_archs = []
       for arch in valid_archs:
-        if os.path.isfile(os.path.join('native_libs', arch, 'libs',
-                                       arch, 'libxwalkcore.so')):
+        lib_path = os.path.join('native_libs', arch, 'libs',
+                                arch, 'libxwalkcore.so')
+        if os.path.isfile(lib_path):
           if arch.find('x86') != -1:
             options.arch = 'x86'
           elif arch.find('arm') != -1:
             options.arch = 'arm'
           Execution(options, sanitized_name)
           packaged_archs.append(options.arch)
+        else:
+          print('Warning: failed to create package for arch "%s" '
+                'due to missing library %s' %
+                (arch, lib_path))
+
+      if len(packaged_archs) == 0:
+        print('No packages created, aborting')
+        sys.exit(13)
+
       for arch in packaged_archs:
         PrintPackageInfo(options.target_dir, sanitized_name,
                          app_version, arch)


### PR DESCRIPTION
When creating (x86/ARM) packages, emit a warning if the
corresponding architecture libxwalkcore.so is not found.
If no packages have been created due to missing
libxwalkcore.so, abort with an error message.

Also, check if values <=0 are passed to --app-versionCode or
--app-versionCodeBase, and abort with an error message in case.
