### PR TITLE
[Android] Fix xwalk_app_template crash issue after rebasing to 35

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -291,6 +291,11 @@ def Execution(options, sanitized_name):
     pak_des_path = os.path.join(sanitized_name, 'assets', 'xwalk.pak')
     shutil.copy(pak_src_path, pak_des_path)
 
+    # Prepare the icudtl.dat for embedded mode.
+    icudtl_src_path = os.path.join('native_libs_res', 'icudtl.dat')
+    icudtl_des_path = os.path.join(sanitized_name, 'assets', 'icudtl.dat')
+    shutil.copy(icudtl_src_path, icudtl_des_path)
+
     js_src_dir = os.path.join('native_libs_res', 'jsapi')
     js_des_dir = os.path.join(sanitized_name, 'assets', 'jsapi')
     if os.path.exists(js_des_dir):

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -138,7 +138,8 @@ class TestMakeApk(unittest.TestCase):
     for res_file in common_files:
       self.assertTrue(out.find(res_file) != -1)
     if self._mode.find('embedded') != -1:
-      embedded_related_files = ['xwalk.pak',
+      embedded_related_files = ['icudtl.dat',
+                                'xwalk.pak',
                                 'device_capabilities_api.js',
                                 'launch_screen_api.js',
                                 'presentation_api.js',


### PR DESCRIPTION
The apps which were packaged with xwalk_app_template will crash.
It's because the icudtl.dat was not packaged into the apk.

BUG=XWALK-1383
