### PR TITLE
[Android] Enable hardware acceleration video decoding for WebRTC

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -88,11 +88,10 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
 #endif
 
-  // Disable HW encoding/decoding acceleration for WebRTC on Android.
-  // FIXME: Remove these switches for Android when Android OS is removed from
+  // Disable HW encoding acceleration for WebRTC on Android.
+  // FIXME: Remove this switch for Android when Android OS is removed from
   // GPU accelerated_video_decode blacklist or we stop ignoring the GPU
   // blacklist.
-  command_line->AppendSwitch(switches::kDisableWebRtcHWDecoding);
   command_line->AppendSwitch(switches::kDisableWebRtcHWEncoding);
 
   // WebAudio is disabled on android x86 platform, and only enabled on android


### PR DESCRIPTION
Chrome for Android has already enabled hardware webrtc decoding by default.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1304
