### PR TITLE
[Tizen][Runtime] Enable to display navigation link in system web browser when it's blocked by WARP.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -428,7 +428,10 @@ void Application::InitSecurityPolicy() {
             app_url, dest_url, (subdomains == "true")));
   }
   if (enable_warp_mode)
-    GetHost(main_runtime_)->Send(new ViewMsg_EnableWarpMode());
+    GetHost(main_runtime_)->Send(
+        new ViewMsg_EnableWarpMode(
+            ApplicationData::GetBaseURLFromApplicationId(
+                application_data_->ID())));
 }
 
 }  // namespace application

--- a/runtime/browser/runtime_platform_util_tizen.cc
+++ b/runtime/browser/runtime_platform_util_tizen.cc
@@ -1,0 +1,27 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/runtime_platform_util.h"
+
+#include "base/logging.h"
+#include "base/process/kill.h"
+#include "base/process/launch.h"
+#include "url/gurl.h"
+
+namespace platform_util {
+
+void OpenExternal(const GURL& url) {
+  if (url.SchemeIsHTTPOrHTTPS()) {
+    LOG(INFO) << "Open in MiniBrowser.";
+    std::vector<std::string> argv;
+    argv.push_back("MiniBrowser");
+    argv.push_back(url.spec());
+    base::ProcessHandle handle;
+
+    if (base::LaunchProcess(argv, base::LaunchOptions(), &handle))
+      base::EnsureProcessGetsReaped(handle);
+  }
+}
+
+}  // namespace platform_util

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -25,6 +25,7 @@
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime_quota_permission_context.h"
 #include "xwalk/runtime/browser/speech/speech_recognition_manager_delegate.h"
+#include "xwalk/runtime/browser/xwalk_render_message_filter.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 
 #if defined(OS_ANDROID)
@@ -156,6 +157,7 @@ XWalkContentBrowserClient::GetWebContentsViewDelegate(
 void XWalkContentBrowserClient::RenderProcessWillLaunch(
     content::RenderProcessHost* host) {
   xwalk_runner_->OnRenderProcessWillLaunch(host);
+  host->AddFilter(new XWalkRenderMessageFilter);
 }
 
 content::MediaObserver* XWalkContentBrowserClient::GetMediaObserver() {

--- a/runtime/browser/xwalk_render_message_filter.cc
+++ b/runtime/browser/xwalk_render_message_filter.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/xwalk_render_message_filter.h"
+
+#include "xwalk/runtime/common/xwalk_common_messages.h"
+#include "xwalk/runtime/browser/runtime_platform_util.h"
+
+namespace xwalk {
+
+XWalkRenderMessageFilter::XWalkRenderMessageFilter()
+    : BrowserMessageFilter(ViewMsgStart) {
+}
+
+bool XWalkRenderMessageFilter::OnMessageReceived(
+    const IPC::Message& message,
+    bool* message_was_ok) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP_EX(XWalkRenderMessageFilter, message, *message_was_ok)
+#if defined(OS_TIZEN)
+    IPC_MESSAGE_HANDLER(ViewMsg_OpenLinkExternal, OnOpenLinkExternal)
+#endif
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+
+  return handled;
+}
+
+#if defined(OS_TIZEN)
+void XWalkRenderMessageFilter::OnOpenLinkExternal(const GURL& url) {
+  LOG(INFO) << "OpenLinkExternal: " << url.spec();
+  platform_util::OpenExternal(url);
+}
+#endif
+
+}  // namespace xwalk

--- a/runtime/browser/xwalk_render_message_filter.h
+++ b/runtime/browser/xwalk_render_message_filter.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef XWALK_RUNTIME_BROWSER_XWALK_RENDER_MESSAGE_FILTER_H_
+#define XWALK_RUNTIME_BROWSER_XWALK_RENDER_MESSAGE_FILTER_H_
+
+#include "content/public/browser/browser_message_filter.h"
+#include "url/gurl.h"
+
+namespace xwalk {
+// XWalkBrowserMessageFilter response to recieve and send message between
+// browser process and renderer process.
+class XWalkRenderMessageFilter : public content::BrowserMessageFilter {
+ public:
+  XWalkRenderMessageFilter();
+  virtual bool OnMessageReceived(const IPC::Message& message,
+                                 bool* message_was_ok) OVERRIDE;
+
+ private:
+#if defined(OS_TIZEN)
+  void OnOpenLinkExternal(const GURL& url);
+#endif
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkRenderMessageFilter);
+};
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_XWALK_RENDER_MESSAGE_FILTER_H_

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -32,4 +32,11 @@ IPC_MESSAGE_CONTROL3(ViewMsg_SetAccessWhiteList,  // NOLINT
                      GURL /* dest */,
                      bool /* allow_subdomains */)
 
-IPC_MESSAGE_CONTROL0(ViewMsg_EnableWarpMode)  // NOLINT
+IPC_MESSAGE_CONTROL1(ViewMsg_EnableWarpMode,    // NOLINT
+                     GURL /* application url */)
+
+// These are messages sent from the renderer to the browser process.
+#if defined(OS_TIZEN)
+IPC_MESSAGE_CONTROL1(ViewMsg_OpenLinkExternal,  // NOLINT
+                     GURL /* target link */)
+#endif  // OS_TIZEN  // NOLINT

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
@@ -9,6 +9,9 @@
 #include "base/files/file_path.h"
 #include "net/base/net_util.h"
 #include "url/gurl.h"
+#include "xwalk/application/common/constants.h"
+#include "third_party/WebKit/public/web/WebFrame.h"
+#include "third_party/WebKit/public/web/WebDocument.h"
 
 namespace xwalk {
 
@@ -43,9 +46,13 @@ bool URLHasAppOrFileScheme(const GURL& url) {
 };  // namespace
 
 bool XWalkContentRendererClientTizen::WillSendRequest(
-    blink::WebFrame*, content::PageTransition, const GURL& url,
-    const GURL& first_party_for_cookies, GURL* new_url) {
+    blink::WebFrame* frame, content::PageTransition transition_type,
+    const GURL& url, const GURL& first_party_for_cookies, GURL* new_url) {
   DCHECK(new_url);
+
+  if (XWalkContentRendererClient::WillSendRequest(
+          frame, transition_type, url, first_party_for_cookies, new_url))
+    return true;
 
   if (!URLHasAppOrFileScheme(first_party_for_cookies))
     return false;

--- a/runtime/renderer/xwalk_render_process_observer_generic.cc
+++ b/runtime/renderer/xwalk_render_process_observer_generic.cc
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "content/public/renderer/render_thread.h"
 #include "ipc/ipc_message_macros.h"
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
 #include "third_party/WebKit/public/platform/WebString.h"
@@ -88,7 +89,8 @@ void XWalkRenderProcessObserver::OnSetAccessWhiteList(const GURL& source,
         AccessWhitelistItem(source, dest, allow_subdomains));
 }
 
-void XWalkRenderProcessObserver::OnEnableWarpMode() {
+void XWalkRenderProcessObserver::OnEnableWarpMode(const GURL& url) {
+  app_url_ = url;
   is_warp_mode_ = true;
 }
 

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -37,14 +37,16 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   virtual void OnRenderProcessShutdown() OVERRIDE;
 
   bool IsWarpMode() const { return is_warp_mode_; }
+  const GURL& app_url() const { return app_url_; }
 
  private:
   void OnSetAccessWhiteList(
       const GURL& source, const GURL& dest, bool allow_subdomains);
-  void OnEnableWarpMode();
+  void OnEnableWarpMode(const GURL& url);
 
   bool is_webkit_initialized_;
   bool is_warp_mode_;
+  GURL app_url_;
 };
 }  // namespace xwalk
 

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -154,6 +154,7 @@
         'runtime/browser/runtime_platform_util_aura.cc',
         'runtime/browser/runtime_platform_util_linux.cc',
         'runtime/browser/runtime_platform_util_mac.mm',
+        'runtime/browser/runtime_platform_util_tizen.cc',
         'runtime/browser/runtime_platform_util_win.cc',
         'runtime/browser/runtime_quota_permission_context.cc',
         'runtime/browser/runtime_quota_permission_context.h',
@@ -204,6 +205,8 @@
         'runtime/browser/xwalk_component.h',
         'runtime/browser/xwalk_content_browser_client.cc',
         'runtime/browser/xwalk_content_browser_client.h',
+        'runtime/browser/xwalk_render_message_filter.cc',
+        'runtime/browser/xwalk_render_message_filter.h',
         'runtime/browser/xwalk_runner.cc',
         'runtime/browser/xwalk_runner.h',
         'runtime/browser/xwalk_runner_android.cc',
@@ -265,6 +268,9 @@
             'runtime/browser/ui/screen_orientation.h',
             'runtime/extension/screen_orientation_extension.cc',
             'runtime/extension/screen_orientation_extension.h',
+          ],
+          'sources!':[
+            'runtime/browser/runtime_platform_util_linux.cc',
           ],
         }],
         ['OS=="android"',{


### PR DESCRIPTION
On Tizen platform, when a navigation link is blocked by WARP policy,
it'd be opened in external web browser instead.

This patch will enable complete WARP mode in Tizen, the related JIRA bug is https://crosswalk-project.org/jira/browse/XWALK-1169.
