### PR TITLE
[Android] Add icudtl.dat into xwalk_core_library

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -199,6 +199,7 @@ def CopyBinaries(out_dir):
     os.mkdir(res_value_dir)
 
   paks_to_copy = [
+      'icudtl.dat',
       'xwalk.pak',
   ]
 


### PR DESCRIPTION
It's needed after rebase to chromium 35.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1389
