### PR TITLE
[DO NOT MERGE] Add i18n support for widget handler

### DIFF
--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -201,6 +201,7 @@ ApplicationData::ApplicationData(const base::FilePath& path,
     : manifest_version_(0),
       is_dirty_(false),
       manifest_(manifest.release()),
+      manifest_i18n_data_(new ManifestI18NData),
       finished_parsing_manifest_(false) {
   DCHECK(path.empty() || path.IsAbsolute());
   path_ = path;

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -24,6 +24,7 @@
 #include "url/gurl.h"
 #include "xwalk/application/common/install_warning.h"
 #include "xwalk/application/common/manifest.h"
+#include "xwalk/application/common/manifest_i18n_data.h"
 #include "xwalk/application/common/permission_types.h"
 
 namespace base {
@@ -109,6 +110,10 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   const Manifest* GetManifest() const {
     return manifest_.get();
+  }
+
+  ManifestI18NData* GetManifestI18NData() {
+    return manifest_i18n_data_.get();
   }
 
   // System events
@@ -205,6 +210,9 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   // The manifest from which this application was created.
   scoped_ptr<Manifest> manifest_;
+
+  // The i18n independent manifest.
+  scoped_ptr<ManifestI18NData> manifest_i18n_data_;
 
   // Stored parsed manifest data.
   ManifestDataMap manifest_data_;

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -35,14 +35,16 @@ const char kIcon128Key[] = "icons.128";
 // manifest keys for widget applications.
 namespace application_widget_keys {
 const char kNamespaceKey[] = "@namespace";
-const char kNameKey[] = "widget.name.#text";
+const char kTextKey[] = "#text";
+const char kXmlLangKey[] = "@xml:lang";
+const char kDefaultLocaleKey[] = "widget.@defaultlocale";
+const char kNameKey[] = "widget.name";
 const char kVersionKey[] = "widget.@version";
 const char kWidgetKey[] = "widget";
 const char kLaunchLocalPathKey[] = "widget.content.@src";
 const char kWebURLsKey[] = "widget.@id";
 const char kAuthorKey[] = "widget.author.#text";
-const char kDescriptionKey[] = "widget.description.#text";
-const char kShortNameKey[] = "widget.name.@short";
+const char kDescriptionKey[] = "widget.description";
 const char kIDKey[] = "widget.@id";
 const char kAuthorEmailKey[] = "widget.author.@email";
 const char kAuthorHrefKey[] = "widget.author.@href";
@@ -51,6 +53,9 @@ const char kWidthKey[] = "widget.@width";
 const char kPreferencesKey[] = "widget.preference";
 const char kCSPKey[] = "widget.content-security-policy.#text";
 const char kAccessKey[] = "widget.access";
+
+// Child keys inside 'kNameKey'.
+const char kNameShortNameKey[] = "@short";
 
 // Child keys inside 'kPreferencesKey'.
 const char kPreferencesNameKey[] = "@name";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -35,6 +35,9 @@ namespace application_manifest_keys {
 
 namespace application_widget_keys {
   extern const char kNamespaceKey[];
+  extern const char kTextKey[];
+  extern const char kXmlLangKey[];
+  extern const char kDefaultLocaleKey[];
   extern const char kNameKey[];
   extern const char kLaunchLocalPathKey[];
   extern const char kWebURLsKey[];
@@ -46,12 +49,13 @@ namespace application_widget_keys {
   extern const char kCSPKey[];
   extern const char kAuthorKey[];
   extern const char kDescriptionKey[];
-  extern const char kShortNameKey[];
   extern const char kIDKey[];
   extern const char kAuthorEmailKey[];
   extern const char kAuthorHrefKey[];
   extern const char kHeightKey[];
   extern const char kWidthKey[];
+  extern const char kNameShortNameKey[];
+
   extern const char kPreferencesKey[];
   extern const char kPreferencesNameKey[];
   extern const char kPreferencesValueKey[];

--- a/application/common/manifest_handlers/widget_handler.h
+++ b/application/common/manifest_handlers/widget_handler.h
@@ -11,6 +11,7 @@
 #include "base/values.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/manifest_handler.h"
+#include "xwalk/application/common/manifest_i18n_data.h"
 
 namespace xwalk {
 namespace application {
@@ -22,11 +23,14 @@ class WidgetInfo : public ApplicationData::ManifestData {
   void SetString(const std::string& key, const std::string& value);
   void Set(const std::string& key, base::Value* value);
 
-  base::DictionaryValue* GetWidgetInfo() {
-    return value_.get();
+  base::DictionaryValue* GetWidgetInfo();
+
+  void SetManifestI18NData(ManifestI18NData* manifest_i18n_data) {
+    manifest_i18n_data_ = manifest_i18n_data;
   }
 
  private:
+  ManifestI18NData* manifest_i18n_data_;
   scoped_ptr<base::DictionaryValue> value_;
 };
 

--- a/application/common/manifest_handlers/widget_handler_unittest.cc
+++ b/application/common/manifest_handlers/widget_handler_unittest.cc
@@ -91,15 +91,21 @@ class WidgetHandlerTest: public testing::Test {
   void SetAllInfoToManifest(base::DictionaryValue* manifest) {
     // Insert some key-value pairs into manifest use full key
     manifest->SetString(keys::kAuthorKey,      author);
-    manifest->SetString(keys::kDescriptionKey, decription);
-    manifest->SetString(keys::kNameKey,        name);
-    manifest->SetString(keys::kShortNameKey,   shortName);
     manifest->SetString(keys::kVersionKey,     version);
     manifest->SetString(keys::kIDKey,          ID);
     manifest->SetString(keys::kAuthorEmailKey, authorEmail);
     manifest->SetString(keys::kAuthorHrefKey,  authorHref);
     manifest->SetString(keys::kHeightKey,      height);
     manifest->SetString(keys::kWidthKey,       width);
+
+    base::DictionaryValue* name_value = new base::DictionaryValue;
+    name_value->SetString(keys::kTextKey, name);
+    name_value->SetString(keys::kNameShortNameKey, shortName);
+    manifest->Set(keys::kNameKey,        name_value);
+
+    base::DictionaryValue* desc_value = new base::DictionaryValue;
+    desc_value->SetString(keys::kTextKey, decription);
+    manifest->Set(keys::kDescriptionKey, desc_value);
   }
 
   // No Preferences and full other information
@@ -120,7 +126,9 @@ class WidgetHandlerTest: public testing::Test {
 
 TEST_F(WidgetHandlerTest, ParseManifestWithOnlyNameAndVersion) {
   base::DictionaryValue manifest;
-  manifest.SetString(keys::kNameKey, "no name");
+  base::DictionaryValue* name_value = new base::DictionaryValue;
+  name_value->SetString(keys::kTextKey, "no name");
+  manifest.Set(keys::kNameKey,        name_value);
   manifest.SetString(keys::kVersionKey, "0");
 
   scoped_refptr<ApplicationData> application = CreateApplication(manifest);

--- a/application/common/manifest_i18n_data.cc
+++ b/application/common/manifest_i18n_data.cc
@@ -1,0 +1,94 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_i18n_data.h"
+
+#include <map>
+#include <utility>
+
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+namespace {
+const char kAutoLocale[] = "en-gb";
+const char kDefalut[] = "default";
+
+const std::string GetLocalKey(const std::string local,
+                              const std::string key) {
+  std::string local_key(local);
+  if (local_key.empty())
+    local_key.append(kDefalut);
+  local_key.append(".");
+  local_key.append(key);
+  return local_key;
+}
+}  // namespace
+
+namespace application {
+
+ManifestI18NData::ManifestI18NData()
+    : value_(new base::DictionaryValue) {}
+
+void ManifestI18NData::ParseFromPath(const Manifest* manifest,
+                                     const std::string& path) {
+  base::Value* value = NULL;
+  manifest->Get(path, &value);
+  if (value) {
+    if (value->IsType(base::Value::TYPE_DICTIONARY)) {
+      base::DictionaryValue* dict;
+      value->GetAsDictionary(&dict);
+      ParseEachElement(dict, path);
+    } else if (value->IsType(base::Value::TYPE_LIST)) {
+      base::ListValue* list;
+      value->GetAsList(&list);
+      for (base::ListValue::iterator it = list->begin();
+         it != list->end(); ++it) {
+        base::DictionaryValue* dict;
+        (*it)->GetAsDictionary(&dict);
+        ParseEachElement(dict, path);
+      }
+    }
+  }
+}
+
+bool ManifestI18NData::GetString(const std::string& locale,
+                                 const std::string& key,
+                                 std::string* out_value) const {
+  return value_->GetString(GetLocalKey(locale, key), out_value);
+}
+
+bool ManifestI18NData::GetString(const std::string& key,
+                                  std::string* out_value) const {
+  bool get = value_->GetString(GetLocalKey(kAutoLocale, key), out_value);
+  get = get || value_->GetString(GetLocalKey(kDefalut, key), out_value);
+  get = get || value_->GetString(GetLocalKey(default_locale_, key), out_value);
+  // TODO(Hongzhang): Get system locale like system_locale = GetSystemLocale();
+  std::string system_locale;
+  return get || value_->GetString(GetLocalKey(system_locale, key), out_value);
+}
+
+void ManifestI18NData::ParseEachElement(const base::DictionaryValue* dict,
+                                        const std::string& path) {
+  std::string xml_lang;
+  dict->GetString(keys::kXmlLangKey, &xml_lang);
+
+  base::DictionaryValue::Iterator iter(*dict);
+  while (!iter.IsAtEnd()) {
+    if (iter.value().IsType(base::Value::TYPE_STRING)) {
+      std::string string_value;
+      iter.value().GetAsString(&string_value);
+      std::string keyWithPath(path);
+      keyWithPath.append(".");
+      keyWithPath.append(iter.key());
+      value_->SetString(GetLocalKey(xml_lang, keyWithPath), string_value);
+    }
+    iter.Advance();
+  }
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_i18n_data.h
+++ b/application/common/manifest_i18n_data.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_I18N_DATA_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_I18N_DATA_H_
+
+#include <string>
+#include <vector>
+
+#include "base/values.h"
+#include "xwalk/application/common/manifest.h"
+
+namespace xwalk {
+namespace application {
+
+class ManifestI18NData {
+ public:
+  ManifestI18NData();
+  // Parse i18n element(s) from a path(the value of this path should
+  // be DictionaryValue or ListValue).
+  void ParseFromPath(const Manifest* manifest,
+                     const std::string& path);
+
+  // Get a local string according to the locale.
+  bool GetString(const std::string& locale,
+                 const std::string& key,
+                 std::string* out_value) const;
+
+  // Get a local string according to the following locale priority:
+  // System locale (locale get from system).                      | high
+  // Default locale (defaultlocale attribute of widget element)
+  // Default (the element without xml:lang attribute)
+  // Auto ("en-gb" will be considered as a default)               | low
+  bool GetString(const std::string& key, std::string* out_value) const;
+
+  void SetDefaultLocale(const std::string& default_locale) {
+    default_locale_ = default_locale;
+  }
+
+ private:
+  void ParseEachElement(const base::DictionaryValue* value,
+                        const std::string& path);
+
+  scoped_ptr<base::DictionaryValue> value_;
+  std::string default_locale_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_I18N_DATA_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -60,6 +60,8 @@
         'common/install_warning.h',
         'common/manifest.cc',
         'common/manifest.h',
+        'common/manifest_i18n_data.cc',
+        'common/manifest_i18n_data.h',
         'common/manifest_handler.cc',
         'common/manifest_handler.h',
         'common/manifest_handlers/csp_handler.cc',


### PR DESCRIPTION
Widget handler will prase i18n items from
manifest and WidgetInfo can get dynamic local
values after prase.

ManifestI18NData will have an entity stored in
the ApplicationData entity, and we can get
local values from this entity.

And since keys::kNamekey and keys::kDescriptionKey
was changed, the unittest also need have some
change.
