### PR TITLE
[Android] Enable app cache on Android by default

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkSettings.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkSettings.java
@@ -504,14 +504,8 @@ public class XWalkSettings {
      */
     @CalledByNative
     private boolean getAppCacheEnabled() {
-        // This should only be called from UpdateWebkitPreferences, which is called
-        // either from the constructor, or with mXWalkSettingsLock being held.
-        if (!mAppCacheEnabled) {
-            return false;
-        }
-        synchronized (sGlobalContentSettingsLock) {
-            return sAppCachePathIsSet;
-        }
+        // When no app cache path is set, use chromium default cache path.
+        return mAppCacheEnabled;
     }
 
     /**

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetAppCacheEnabledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetAppCacheEnabledTest.java
@@ -117,8 +117,7 @@ public class SetAppCacheEnabledTest extends XWalkViewTestBase {
         final XWalkContent xWalkContent = getXWalkContentOnMainSync(xWalkView);
         final XWalkSettings settings = getXWalkSettings(xWalkView);
         settings.setJavaScriptEnabled(true);
-        // Note that the cache isn't actually enabled until the call to setAppCachePath.
-        settings.setAppCacheEnabled(true);
+        settings.setAppCacheEnabled(false);
 
         TestWebServer webServer = null;
         try {
@@ -134,7 +133,8 @@ public class SetAppCacheEnabledTest extends XWalkViewTestBase {
             // disabled, other than checking that it didn't try to fetch the manifest.
             Thread.sleep(1000);
             assertEquals(0, webServer.getRequestCount(helper.getManifestPath()));
-            settings.setAppCachePath("111");  // Enables AppCache.
+            // Enables AppCache. Use the default path if app cache path isn't set.
+            settings.setAppCacheEnabled(true);
             loadUrlSyncByContent(
                     xWalkContent,
                     mContentClient,


### PR DESCRIPTION
Currently, app cache flag is enabled by default, but it can't work if
app cache path is not set explicitly. Actually, Chromium doesn't explore
the interface to setting app cache directory.

Crosswalk should not have this limitation, when no app cache is specified,
we should use chromium default cache path instead.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1355
