### PR TITLE
[Application][Tizen] Move extension process logic to a standalone thread

### DIFF
--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -51,6 +51,8 @@
       'sources': [
         'dbus_connection.h',
         'dbus_connection.cc',
+        'xwalk_extension_process_launcher.h',
+        'xwalk_extension_process_launcher.cc',
         'xwalk_tizen_user.h',
         'xwalk_tizen_user.cc',
         'xwalk_launcher_main.cc',

--- a/application/tools/linux/xwalk_extension_process_launcher.cc
+++ b/application/tools/linux/xwalk_extension_process_launcher.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/message_loop/message_loop.h"
+#include "xwalk/application/tools/linux/xwalk_extension_process_launcher.h"
+#include "xwalk/extensions/extension_process/xwalk_extension_process.h"
+
+XWalkExtensionProcessLauncher::XWalkExtensionProcessLauncher()
+    : base::Thread("LauncherExtensionService"),
+      is_started_(false) {
+  base::Thread::Options thread_options;
+  thread_options.message_loop_type = base::MessageLoop::TYPE_UI;
+  StartWithOptions(thread_options);
+}
+
+XWalkExtensionProcessLauncher::~XWalkExtensionProcessLauncher() {
+  Stop();
+}
+
+void XWalkExtensionProcessLauncher::Launch(
+    const std::string& channel_id, int channel_fd) {
+  is_started_ = true;
+  message_loop()->PostTask(
+      FROM_HERE,
+      base::Bind(&XWalkExtensionProcessLauncher::StartExtensionProcess,
+                 base::Unretained(this), channel_id, channel_fd));
+}
+
+void XWalkExtensionProcessLauncher::StartExtensionProcess(
+    const std::string& channel_id, int channel_fd) {
+  extension_process_.reset(new xwalk::extensions::XWalkExtensionProcess(
+      IPC::ChannelHandle(channel_id, base::FileDescriptor(channel_fd, true))));
+}

--- a/application/tools/linux/xwalk_extension_process_launcher.h
+++ b/application/tools/linux/xwalk_extension_process_launcher.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_TOOLS_LINUX_XWALK_EXTENSION_PROCESS_LAUNCHER_H_
+#define XWALK_APPLICATION_TOOLS_LINUX_XWALK_EXTENSION_PROCESS_LAUNCHER_H_
+
+#include <string>
+
+#include "base/threading/thread.h"
+
+namespace xwalk {
+namespace extensions {
+class XWalkExtensionProcess;
+}
+}
+
+class XWalkExtensionProcessLauncher: public base::Thread {
+ public:
+  XWalkExtensionProcessLauncher();
+  ~XWalkExtensionProcessLauncher();
+
+  // Will be called in launcher's main thread.
+  void Launch(const std::string& channel_id, int channel_fd);
+
+  bool is_started() const { return is_started_; }
+
+ private:
+  void StartExtensionProcess(const std::string& channel_id, int channel_fd);
+
+  bool is_started_;
+  scoped_ptr<xwalk::extensions::XWalkExtensionProcess> extension_process_;
+};
+
+#endif  // XWALK_APPLICATION_TOOLS_LINUX_XWALK_EXTENSION_PROCESS_LAUNCHER_H_


### PR DESCRIPTION
The previous EP(ExtensionProcess) & launcher merge patch changed the launcher's
main thread glib message loop to Chromium message loop which is MessagePumpOzone
in Tizen. This leads to some asynchronous DBus function and signals cannot be
successfully called.

To divide the old launcher logic(mainly communicate with DBus) and new EP
logic this patch added a new XWalkLauncherExtensionService running in a separate
thread.
