### PR TITLE
[Runtime] Add Tizen Setting handler for widget application.

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -73,6 +73,8 @@ const char kTizenAppIdKey[] = "widget.application.@package";
 const char kAllowNavigationKey[] = "widget.allow-navigation.#text";
 const char kCSPReportOnlyKey[] =
     "widget.content-security-policy-report-only.#text";
+const char kTizenSettingKey[] = "widget.setting";
+const char kTizenHardwareKey[] = "widget.setting.@hwkey";
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -65,6 +65,8 @@ namespace application_widget_keys {
   extern const char kIcon128Key[];
   extern const char kAllowNavigationKey[];
   extern const char kCSPReportOnlyKey[];
+  extern const char kTizenSettingKey[];
+  extern const char kTizenHardwareKey[];
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -12,6 +12,7 @@
 #if defined(OS_TIZEN)
 #include "xwalk/application/common/manifest_handlers/navigation_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_application_handler.h"
+#include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
 #endif
 #include "xwalk/application/common/manifest_handlers/permissions_handler.h"
 #include "xwalk/application/common/manifest_handlers/warp_handler.h"
@@ -77,6 +78,7 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   handlers.push_back(new CSPHandler(Manifest::TYPE_WGT));
   handlers.push_back(new NavigationHandler);
   handlers.push_back(new TizenApplicationHandler);
+  handlers.push_back(new TizenSettingHandler);
 #endif
   widget_registry_ = new ManifestHandlerRegistry(handlers);
   return widget_registry_;

--- a/application/common/manifest_handlers/tizen_setting_handler.cc
+++ b/application/common/manifest_handlers/tizen_setting_handler.cc
@@ -1,0 +1,64 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
+
+#include <map>
+#include <utility>
+
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+namespace application {
+
+TizenSettingInfo::TizenSettingInfo()
+    : hwkey_enabled_(true) {}
+
+TizenSettingInfo::~TizenSettingInfo() {}
+
+TizenSettingHandler::TizenSettingHandler() {}
+
+TizenSettingHandler::~TizenSettingHandler() {}
+
+bool TizenSettingHandler::Parse(scoped_refptr<ApplicationData> application,
+                                base::string16* error) {
+  scoped_ptr<TizenSettingInfo> app_info(new TizenSettingInfo);
+  const Manifest* manifest = application->GetManifest();
+  DCHECK(manifest);
+
+  std::string hwkey;
+  manifest->GetString(keys::kTizenHardwareKey, &hwkey);
+  app_info->set_hwkey_enabled(hwkey != "disable");
+
+  application->SetManifestData(keys::kTizenSettingKey,
+                               app_info.release());
+  return true;
+}
+
+bool TizenSettingHandler::Validate(
+    scoped_refptr<const ApplicationData> application,
+    std::string* error,
+    std::vector<InstallWarning>* warnings) const {
+  const Manifest* manifest = application->GetManifest();
+  DCHECK(manifest);
+  std::string hwkey;
+  manifest->GetString(keys::kTizenHardwareKey, &hwkey);
+  if (!hwkey.empty() && hwkey != "enable" && hwkey != "disable") {
+    *error = std::string("The hwkey value must be 'enable'/'disable',"
+                         " or not specified in configuration file.");
+    return false;
+  }
+  return true;
+}
+
+std::vector<std::string> TizenSettingHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kTizenSettingKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/tizen_setting_handler.h
+++ b/application/common/manifest_handlers/tizen_setting_handler.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_SETTING_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_SETTING_HANDLER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "base/values.h"
+#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest_handler.h"
+
+namespace xwalk {
+namespace application {
+
+class TizenSettingInfo : public ApplicationData::ManifestData {
+ public:
+  TizenSettingInfo();
+  virtual ~TizenSettingInfo();
+
+  void set_hwkey_enabled(bool enabled) { hwkey_enabled_ = enabled; }
+  bool hwkey_enabled() const { return hwkey_enabled_; }
+
+ private:
+  bool hwkey_enabled_;
+};
+
+class TizenSettingHandler : public ManifestHandler {
+ public:
+  TizenSettingHandler();
+  virtual ~TizenSettingHandler();
+
+  virtual bool Parse(scoped_refptr<ApplicationData> application,
+                     base::string16* error) OVERRIDE;
+  virtual bool Validate(scoped_refptr<const ApplicationData> application,
+                        std::string* error,
+                        std::vector<InstallWarning>* warnings) const OVERRIDE;
+  virtual std::vector<std::string> Keys() const OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(TizenSettingHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_SETTING_HANDLER_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -126,6 +126,8 @@
             'common/manifest_handlers/navigation_handler.h',
             'common/manifest_handlers/tizen_application_handler.cc',
             'common/manifest_handlers/tizen_application_handler.h',
+            'common/manifest_handlers/tizen_setting_handler.cc',
+            'common/manifest_handlers/tizen_setting_handler.h',
           ],
         }],
       ],


### PR DESCRIPTION
Add handler for Tizen setting element in Widget configuration, so
that we can parse and validate Tizen setting information.

This PR only supports 'hwkey' attribute at present, other attributes
e.g, 'background-support' will be added later when needed.
