### PR TITLE
[Tizen][Runtime] Add support for 'hwkey' in Tizen widget configuration.

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -19,6 +19,10 @@
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/runtime/browser/runtime.h"
 
+#if defined(USE_OZONE) && defined(OS_TIZEN)
+#include "base/message_loop/message_pump_observer.h"
+#endif
+
 namespace xwalk {
 
 class RuntimeContext;
@@ -34,7 +38,12 @@ class Manifest;
 // terminated.
 // There's one-to-one correspondence between Application and Render Process
 // Host, obtained from its "runtimes" (pages).
-class Application : public Runtime::Observer {
+class Application
+  :
+#if defined(USE_OZONE) && defined(OS_TIZEN)
+  public base::MessagePumpObserver,
+#endif
+  public Runtime::Observer {
  public:
   virtual ~Application();
 
@@ -156,6 +165,12 @@ class Application : public Runtime::Observer {
   bool IsTerminating() const { return finish_observer_; }
 
   void InitSecurityPolicy();
+
+#if defined(USE_OZONE) && defined(OS_TIZEN)
+  virtual base::EventStatus WillProcessEvent(
+      const base::NativeEvent& event) OVERRIDE;
+  virtual void DidProcessEvent(const base::NativeEvent& event) OVERRIDE;
+#endif
 
   RuntimeContext* runtime_context_;
   const scoped_refptr<ApplicationData> application_data_;

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -35,6 +35,8 @@ IPC_MESSAGE_CONTROL3(ViewMsg_SetAccessWhiteList,  // NOLINT
 IPC_MESSAGE_CONTROL1(ViewMsg_EnableWarpMode,    // NOLINT
                      GURL /* application url */)
 
+IPC_MESSAGE_ROUTED1(ViewMsg_HWKeyPressed, int /*keycode*/)  // NOLINT
+
 // These are messages sent from the renderer to the browser process.
 #if defined(OS_TIZEN)
 IPC_MESSAGE_CONTROL1(ViewMsg_OpenLinkExternal,  // NOLINT

--- a/runtime/renderer/tizen/xwalk_render_view_ext_tizen.cc
+++ b/runtime/renderer/tizen/xwalk_render_view_ext_tizen.cc
@@ -1,0 +1,90 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/renderer/tizen/xwalk_render_view_ext_tizen.h"
+
+#include <string>
+
+#include "base/bind.h"
+#include "base/strings/utf_string_conversions.h"
+#include "content/public/renderer/render_frame.h"
+#include "content/public/renderer/render_view.h"
+#include "third_party/WebKit/public/web/WebDocument.h"
+#include "third_party/WebKit/public/web/WebFrame.h"
+#include "third_party/WebKit/public/web/WebScriptSource.h"
+#include "third_party/WebKit/public/web/WebView.h"
+#include "ui/events/keycodes/keyboard_codes_posix.h"
+#include "xwalk/runtime/common/xwalk_common_messages.h"
+
+namespace {
+std::string GenerateEventJs(const std::string& name) {
+  std::string result;
+  std::string defineJs =
+    "var event = new Event('tizenhwkey');"
+    "function defineProps(val) {"
+    "  Object.defineProperty(event, 'keyName', {"
+    "    enumerable: false,"
+    "    configurable: false,"
+    "    writable: false,"
+    "    value: val"
+    "  });"
+    "}";
+  std::string nameJs = "defineProps('" + name + "');";
+  std::string dispatchJs = "document.dispatchEvent(event);";
+  result += defineJs;
+  result += nameJs;
+  result += dispatchJs;
+
+  return result;
+}
+}  // namespace
+
+namespace xwalk {
+
+XWalkRenderViewExtTizen::XWalkRenderViewExtTizen(
+    content::RenderView* render_view)
+    : content::RenderViewObserver(render_view) {
+  render_view_ = render_view;
+  DCHECK(render_view_);
+}
+
+XWalkRenderViewExtTizen::~XWalkRenderViewExtTizen() {
+}
+
+// static
+void XWalkRenderViewExtTizen::RenderViewCreated(
+    content::RenderView* render_view) {
+  new XWalkRenderViewExtTizen(render_view);  // |render_view| takes ownership.
+}
+
+bool XWalkRenderViewExtTizen::OnMessageReceived(const IPC::Message& message) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP(XWalkRenderViewExtTizen, message)
+    IPC_MESSAGE_HANDLER(ViewMsg_HWKeyPressed,
+                        OnHWKeyPressed)
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+  return handled;
+}
+
+void XWalkRenderViewExtTizen::OnHWKeyPressed(int keycode) {
+  std::string event_name;
+  if (keycode == ui::VKEY_BACK) {
+    event_name = "back";
+  } else if (keycode == ui::VKEY_HOME) {
+    event_name = "menu";
+  } else {
+    LOG(INFO) << "Unknown input key code, only support 'back' & 'menu'"
+                  "at present.";
+    return;
+  }
+
+  content::RenderFrame* render_frame = render_view_->GetMainRenderFrame();
+  blink::WebFrame* web_frame = render_frame->GetWebFrame();
+  blink::WebScriptSource source =
+      blink::WebScriptSource(base::ASCIIToUTF16(GenerateEventJs(event_name)));
+  web_frame->executeScript(source);
+}
+
+}  // namespace xwalk

--- a/runtime/renderer/tizen/xwalk_render_view_ext_tizen.h
+++ b/runtime/renderer/tizen/xwalk_render_view_ext_tizen.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_RENDERER_TIZEN_XWALK_RENDER_VIEW_EXT_TIZEN_H_
+#define XWALK_RUNTIME_RENDERER_TIZEN_XWALK_RENDER_VIEW_EXT_TIZEN_H_
+
+#include "base/basictypes.h"
+#include "base/compiler_specific.h"
+#include "content/public/renderer/render_view_observer.h"
+
+namespace xwalk {
+
+class XWalkRenderViewExtTizen : public content::RenderViewObserver {
+ public:
+  static void RenderViewCreated(content::RenderView* render_view);
+
+ private:
+  explicit XWalkRenderViewExtTizen(content::RenderView* render_view);
+  virtual ~XWalkRenderViewExtTizen();
+
+  // RenderView::Observer:
+  virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
+
+  void OnHWKeyPressed(int keycode);
+
+  content::RenderView* render_view_;
+  DISALLOW_COPY_AND_ASSIGN(XWalkRenderViewExtTizen);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_RENDERER_TIZEN_XWALK_RENDER_VIEW_EXT_TIZEN_H_

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -35,6 +35,10 @@
 #include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
 #endif
 
+#if defined(OS_TIZEN)
+#include "xwalk/runtime/renderer/tizen/xwalk_render_view_ext_tizen.h"
+#endif
+
 namespace xwalk {
 
 namespace {
@@ -111,6 +115,8 @@ void XWalkContentRendererClient::RenderViewCreated(
     content::RenderView* render_view) {
 #if defined(OS_ANDROID)
   XWalkRenderViewExt::RenderViewCreated(render_view);
+#elif defined(OS_TIZEN)
+  XWalkRenderViewExtTizen::RenderViewCreated(render_view);
 #endif
 }
 

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -243,6 +243,8 @@
         'runtime/renderer/android/xwalk_render_view_ext.h',
         'runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc',
         'runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h',
+        'runtime/renderer/tizen/xwalk_render_view_ext_tizen.cc',
+        'runtime/renderer/tizen/xwalk_render_view_ext_tizen.h',
         'runtime/renderer/xwalk_content_renderer_client.cc',
         'runtime/renderer/xwalk_content_renderer_client.h',
         'runtime/renderer/xwalk_render_process_observer_generic.cc',


### PR DESCRIPTION
Tizen WRT Core Spec shows that when hardware key(‘back’, ‘menu’) is
pressed, WRT MUST send the “tizenhwkey” custom event to the Web
Application if the <tizen::setting hwkey=”disable”/> element is not
specified. Therefore, app developer can add customized behavior for
this.

Spec:
https://source.tizen.org/sites/default/files/page/tizen-2.2-wrt-core-spec.pdf
(item 0470)

This implementation will fetch event from OzoneMessagePump, if it is a
key event, and at the same time the 'hwkey' flag is not disabled in
widget configuration, browser process will send the event to render process,
so that RP can handle the hardware key event.

BUG=XWALK-1166
