### PR TITLE
[Android] Enable the immersive fullscreen with manifest.

### DIFF
--- a/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
+++ b/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
@@ -5,7 +5,10 @@
 package org.xwalk.app.template;
 
 import android.graphics.Color;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
+import android.view.WindowManager;
 import android.view.KeyEvent;
 import android.view.View;
 import android.widget.TextView;
@@ -42,4 +45,26 @@ public class AppTemplateActivity extends XWalkRuntimeActivityBase {
             setContentView(msgText);
         }
     }
+
+    private void enterFullscreen() {
+        if (VERSION.SDK_INT >= VERSION_CODES.KITKAT &&
+                ((getWindow().getAttributes().flags &
+                        WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0)) {
+            View decorView = getWindow().getDecorView();
+            decorView.setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+                    View.SYSTEM_UI_FLAG_FULLSCREEN |
+                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+        }
+    }
+
+    public void setIsFullscreen(boolean isFullscreen) {
+        if (isFullscreen) {
+            enterFullscreen();
+        }
+    }
+
 }

--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -172,21 +172,21 @@ def ReplaceString(file_path, src, dest):
   file_handle.close()
 
 
-def SetVariable(file_path, variable, value):
+def SetVariable(file_path, string_line, variable, value):
   function_string = ('%sset%s(%s);\n' %
                     ('        ', variable, value))
   temp_file_path = file_path + '.backup'
   file_handle = open(temp_file_path, 'w+')
   for line in open(file_path):
     file_handle.write(line)
-    if (line.find('public void onCreate(Bundle savedInstanceState)') >= 0):
+    if (line.find(string_line) >= 0):
       file_handle.write(function_string)
   file_handle.close()
   shutil.move(temp_file_path, file_path)
 
 
 def CustomizeJava(sanitized_name, package, app_url, app_local_path,
-                  enable_remote_debugging):
+                  enable_remote_debugging, display_as_fullscreen):
   root_path =  os.path.join(sanitized_name, 'src',
                             package.replace('.', os.path.sep))
   dest_activity = os.path.join(root_path, sanitized_name + 'Activity.java')
@@ -214,7 +214,13 @@ def CustomizeJava(sanitized_name, package, app_url, app_local_path,
         sys.exit(8)
 
   if enable_remote_debugging:
-    SetVariable(dest_activity, 'RemoteDebugging', 'true')
+    SetVariable(dest_activity,
+                'public void onCreate(Bundle savedInstanceState)',
+                'RemoteDebugging', 'true')
+  if display_as_fullscreen:
+    SetVariable(dest_activity,
+                'super.onCreate(savedInstanceState)',
+                'IsFullscreen', 'true')
 
 
 def CopyExtensionFile(extension_name, suffix, src_path, dest_path):
@@ -339,17 +345,17 @@ def CustomizeExtensions(sanitized_name, name, extensions):
 
 def CustomizeAll(app_versionCode, description, icon, permissions, app_url,
                  app_root, app_local_path, enable_remote_debugging,
-                 fullscreen_flag, extensions, launch_screen_img,
+                 display_as_fullscreen, extensions, launch_screen_img,
                  package='org.xwalk.app.template', name='AppTemplate',
-                 app_version='1.0.0', orientation='unspecified'):
+                 app_version='1.0.0', orientation='unspecified') :
   sanitized_name = ReplaceInvalidChars(name, 'apkname')
   try:
     Prepare(sanitized_name, package, app_root)
     CustomizeXML(sanitized_name, package, app_versionCode, app_version,
-                 description, name, orientation, icon, fullscreen_flag,
+                 description, name, orientation, icon, display_as_fullscreen,
                  launch_screen_img, permissions)
     CustomizeJava(sanitized_name, package, app_url, app_local_path,
-                  enable_remote_debugging)
+                  enable_remote_debugging, display_as_fullscreen)
     CustomizeExtensions(sanitized_name, name, extensions)
   except SystemExit as ec:
     print('Exiting with error code: %d' % ec.code)

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -134,10 +134,10 @@ class ManifestJsonParser(object):
     ret_dict['plugin'] = ''
     if 'plugin' in self.data_src:
       ret_dict['plugin'] = self.data_src['plugin']
-    if 'fullscreen' in self.data_src:
-      ret_dict['fullscreen'] = self.data_src['fullscreen']
+    if 'display' in self.data_src and 'fullscreen' in self.data_src['display']:
+      ret_dict['fullscreen'] = 'true'
     else:
-      ret_dict['fullscreen'] = 'False'
+      ret_dict['fullscreen'] = ''
     ret_dict['launch_screen_img'] = ''
     if 'launch_screen' in self.data_src:
       if 'default' not in self.data_src['launch_screen']:

--- a/app/tools/android/test_data/manifest/manifest.json
+++ b/app/tools/android/test_data/manifest/manifest.json
@@ -18,5 +18,5 @@
     "Messaging"],
   "required_version": "1.28.1.0",
   "plugin": [],
-  "fullscreen":"true"
+  "display": ["fullscreen"]
 }

--- a/app/tools/android/test_data/manifest/manifest_app_launch_local_path.json
+++ b/app/tools/android/test_data/manifest/manifest_app_launch_local_path.json
@@ -14,5 +14,5 @@
   "permissions": ["geolocation"],
   "required_version": "1.28.1.0",
   "plugin": [],
-  "fullscreen":"true"
+  "display": ["fullscreen"]
 }

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -13,6 +13,7 @@ const char kAppMainScriptsKey[] = "app.main.scripts";
 const char kAppMainSourceKey[] = "app.main.source";
 const char kCSPKey[] = "content_security_policy";
 const char kDescriptionKey[] = "description";
+const char kDisplay[] = "display";
 const char kLaunchLocalPathKey[] = "app.launch.local_path";
 const char kLaunchScreen[] = "launch_screen";
 const char kLaunchScreenReadyWhen[] = "launch_screen.ready_when";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -15,6 +15,7 @@ namespace application_manifest_keys {
   extern const char kAppMainSourceKey[];
   extern const char kCSPKey[];
   extern const char kDescriptionKey[];
+  extern const char kDisplay[];
   extern const char kLaunchLocalPathKey[];
   extern const char kLaunchScreen[];
   extern const char kLaunchScreenReadyWhen[];

--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -356,6 +356,11 @@ public class XWalkContent extends FrameLayout {
         loadUrl(url);
     }
 
+    @CalledByNative
+    public void onGetFullscreenFlagFromManifest(boolean enterFullscreen) {
+        if (enterFullscreen) getXWalkWebChromeClient().onToggleFullscreen(true);
+    }
+
     public void destroy() {
         if (mXWalkContent == 0) return;
 

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -44,6 +44,7 @@ using base::android::ScopedJavaLocalRef;
 using content::BrowserThread;
 using content::WebContents;
 using navigation_interception::InterceptNavigationDelegate;
+using xwalk::application_manifest_keys::kDisplay;
 
 namespace xwalk {
 
@@ -234,6 +235,17 @@ jboolean XWalkContent::SetManifest(JNIEnv* env,
 
   ScopedJavaLocalRef<jstring> url_buffer =
       base::android::ConvertUTF8ToJavaString(env, url);
+
+  if (manifest.HasPath(kDisplay)) {
+    std::string display_string;
+    manifest.GetString(kDisplay, &display_string);
+    // TODO(David): update the handling process of the display strings
+    // including fullscreen etc.
+    bool display_as_fullscreen = (
+        display_string.find("fullscreen") != std::string::npos);
+    Java_XWalkContent_onGetFullscreenFlagFromManifest(
+        env, obj, display_as_fullscreen ? JNI_TRUE : JNI_FALSE);
+  }
 
   // Check whether need to display launch screen. (Read from manifest.json)
   if (manifest.HasPath(


### PR DESCRIPTION
The fullscreen setting in manifest doesn't work with Android 4.4,
this is because there is no way to declare immersive mode in the
manifest or window flags. This fix resolves this issue by checking
the manifest fullscreen setting via manifest parser and calling the
corresponding functions of setting the immersive fullscreen mode.
In addition, the command-line parameter of immersive fullscreen
mode is also supported for packaging tool.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1200
(cherry picked from commit 35a3c9ae41b9e86c749caf8457a4cde3545fe916)
