### PR TITLE
[Android] Enable Chromium command line support

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -342,12 +342,21 @@ def CustomizeExtensions(sanitized_name, name, extensions):
     extension_json_file.write(extensions_string)
     extension_json_file.close()
 
+def GenerateCommandLineFile(sanitized_name, xwalk_command_line):
+  if xwalk_command_line == '':
+    return
+  assets_path = os.path.join(sanitized_name, 'assets')
+  file_path = os.path.join(assets_path, 'xwalk-command-line')
+  command_line_file = open(file_path, 'w')
+  command_line_file.write('xwalk ' + xwalk_command_line)
+
 
 def CustomizeAll(app_versionCode, description, icon, permissions, app_url,
                  app_root, app_local_path, enable_remote_debugging,
                  display_as_fullscreen, extensions, launch_screen_img,
                  package='org.xwalk.app.template', name='AppTemplate',
-                 app_version='1.0.0', orientation='unspecified') :
+                 app_version='1.0.0', orientation='unspecified',
+                 xwalk_command_line=''):
   sanitized_name = ReplaceInvalidChars(name, 'apkname')
   try:
     Prepare(sanitized_name, package, app_root)
@@ -357,6 +366,7 @@ def CustomizeAll(app_versionCode, description, icon, permissions, app_url,
     CustomizeJava(sanitized_name, package, app_url, app_local_path,
                   enable_remote_debugging, display_as_fullscreen)
     CustomizeExtensions(sanitized_name, name, extensions)
+    GenerateCommandLineFile(sanitized_name, xwalk_command_line)
   except SystemExit as ec:
     print('Exiting with error code: %d' % ec.code)
     sys.exit(ec.code)
@@ -412,6 +422,11 @@ def main():
   parser.add_option('--orientation', help=info)
   parser.add_option('--launch-screen-img',
                     help='The fallback image for launch_screen')
+  info = ('Use command lines.'
+          'Crosswalk is powered by Chromium and supports Chromium command line.'
+          'For example, '
+          '--xwalk-command-line=\'--chromium-command-1 --xwalk-command-2\'')
+  parser.add_option('--xwalk-command-line', default='', help=info)
   options, _ = parser.parse_args()
   try:
     CustomizeAll(options.app_versionCode, options.description, options.icon,
@@ -419,7 +434,8 @@ def main():
                  options.app_local_path, options.enable_remote_debugging,
                  options.fullscreen, options.extensions,
                  options.launch_screen_img, options.package, options.name,
-                 options.app_version, options.orientation)
+                 options.app_version, options.orientation,
+                 options.xwalk_command_line)
   except SystemExit as ec:
     print('Exiting with error code: %d' % ec.code)
     return ec.code

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -219,7 +219,7 @@ def Customize(options):
                options.app_local_path, remote_debugging,
                fullscreen_flag, options.extensions,
                options.launch_screen_img, package, name, app_version,
-               orientation)
+               orientation, options.xwalk_command_line)
 
 
 def Execution(options, sanitized_name):
@@ -612,6 +612,11 @@ def main(argv):
           'be made by adding a prefix based on architecture to the version '
           'code base. For example, --app-versionCodeBase=24')
   group.add_option('--app-versionCodeBase', type='int', help=info)
+  info = ('Use command lines.'
+          'Crosswalk is powered by Chromium and supports Chromium command line.'
+          'For example, '
+          '--xwalk-command-line=\'--chromium-command-1 --xwalk-command-2\'')
+  group.add_option('--xwalk-command-line', default='', help=info)
   info = ('The description of the application. For example, '
           '--description=YourApplicationDescription')
   group.add_option('--description', help=info)

--- a/runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkViewDelegate.java
@@ -5,10 +5,14 @@
 package org.xwalk.core;
 
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.lang.StringBuilder;
 import java.util.HashSet;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.content.res.Resources.NotFoundException;
 import android.os.Build;
 import android.util.Log;
@@ -35,6 +39,37 @@ class XWalkViewDelegate {
     private static final String TAG = "XWalkViewDelegate";
     private static final String XWALK_RESOURCES_LIST_RES_NAME = "xwalk_resources_list";
 
+    private static final String COMMAND_LINE_FILE = "xwalk-command-line";
+
+    private static String[] readCommandLine(Context context) {
+        InputStreamReader reader = null;
+
+        try {
+            InputStream input =
+                    context.getAssets().open(COMMAND_LINE_FILE, AssetManager.ACCESS_BUFFER);
+            int length;
+            int size = 1024;
+            char[] buffer = new char[size];
+            StringBuilder builder = new StringBuilder();
+
+            reader = new InputStreamReader(input, "UTF-8");
+            while ((length = reader.read(buffer, 0, size)) != -1) {
+                builder.append(buffer, 0, length);
+            }
+
+            return CommandLine.tokenizeQuotedAruments(
+                    builder.toString().toCharArray());
+        } catch (IOException e) {
+            return null;
+        } finally {
+            try {
+                if (reader != null) reader.close();
+            } catch (IOException e) {
+                Log.e(TAG, "Unable to close file reader.", e);
+            }
+        }
+    }
+
     public static void init(XWalkView xwalkView) {
         if (sInitialized) {
             return;
@@ -51,7 +86,7 @@ class XWalkViewDelegate {
         // the object to guarantee the CommandLine object is not null and the
         // consequent prodedure does not crash.
         if (!CommandLine.isInitialized())
-            CommandLine.init(null);
+            CommandLine.init(readCommandLine(context.getApplicationContext()));
 
         // If context's applicationContext is not the same package with itself,
         // It's a cross package invoking, load core library from library apk.


### PR DESCRIPTION
Add the mechanism to support the Chromium command line in xwalk.
1 Read commands from the command line file which locates in assets
in xwalk core.
2 Expose the option to set the Chromium command line in make_apk.py.

BUG=XWALK-1269
