### PR TITLE
[Tizen] Fix Tizen app executable path length and launcher symbol link name issues

### DIFF
--- a/application/browser/installer/tizen/service_package_installer.cc
+++ b/application/browser/installer/tizen/service_package_installer.cc
@@ -33,6 +33,7 @@ const base::FilePath kDefaultIcon(
     "/usr/share/icons/default/small/crosswalk.png");
 
 const std::string kServicePrefix("xwalk-service.");
+const std::string kAppIdPrefix("xwalk.");
 
 class FileDeleter {
  public:
@@ -65,12 +66,10 @@ bool GeneratePkgInfoXml(xwalk::application::ApplicationData* application,
     return false;
 
   std::string package_id = application->ID();
+  std::string tizen_app_id = kAppIdPrefix + package_id;
   base::FilePath execute_path =
-      app_dir.AppendASCII("bin/").AppendASCII(package_id);
+      app_dir.AppendASCII("bin/").AppendASCII(tizen_app_id);
   std::string stripped_name = application->Name();
-  stripped_name.erase(
-      std::remove_if(stripped_name.begin(), stripped_name.end(), ::isspace),
-      stripped_name.end());
 
   FILE* file = base::OpenFile(xml_path, "w");
 
@@ -84,8 +83,7 @@ bool GeneratePkgInfoXml(xwalk::application::ApplicationData* application,
   xml_writer.WriteElement("description", application->Description());
 
   xml_writer.StartElement("ui-application");
-  xml_writer.AddAttribute(
-      "appid", kServicePrefix + package_id + info::kSeparator + stripped_name);
+  xml_writer.AddAttribute("appid", tizen_app_id);
   xml_writer.AddAttribute("exec", execute_path.MaybeAsASCII());
   xml_writer.AddAttribute("type", "c++app");
   xml_writer.AddAttribute("taskmanage", "true");
@@ -119,6 +117,7 @@ namespace application {
 bool InstallApplicationForTizen(
     ApplicationData* application, const base::FilePath& data_dir) {
   std::string package_id = application->ID();
+  std::string tizen_app_id = kAppIdPrefix + package_id;
   base::FilePath app_dir =
       data_dir.AppendASCII(info::kAppDir).AppendASCII(package_id);
   base::FilePath xml_path = data_dir.AppendASCII(info::kAppDir).AppendASCII(
@@ -138,7 +137,7 @@ bool InstallApplicationForTizen(
   }
 
   base::FilePath execute_path =
-      app_dir.AppendASCII("bin/").AppendASCII(package_id);
+      app_dir.AppendASCII("bin/").AppendASCII(tizen_app_id);
 
   if (!base::CreateDirectory(execute_path.DirName())) {
     LOG(ERROR) << "Could not create directory '"

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -256,9 +256,22 @@ int main(int argc, char** argv) {
       fprintf(stderr, "No AppID informed, nothing to do.\n");
       return 0;
     }
-    appid = cmd_appid[0];
+    appid = strdup(cmd_appid[0]);
   } else {
     appid = strdup(basename(argv[0]));
+#if defined(OS_TIZEN)
+    // The Tizen application ID will have a format like
+    // "xwalk.crosswalk_32bytes_app_id".
+    gchar** tokens;
+    tokens = g_strsplit(appid, ".", 2);
+    if (g_strv_length(tokens) != 2) {
+      fprintf(stderr, "Invalid Tizen AppID, fallback to Crosswalk AppID.\n");
+    } else {
+      free(appid);
+      appid = strdup(tokens[1]);
+    }
+    g_strfreev(tokens);
+#endif
   }
 
   g_connection = get_session_bus_connection(&error);
@@ -285,5 +298,6 @@ int main(int argc, char** argv) {
     launch_application(running_apps_manager, appid, fullscreen);
   }
 
+  free(appid);
   return 0;
 }


### PR DESCRIPTION
Issues:
1. Tizen AUL will parse /proc/_/cmdline to retrieve the application ID, however
current launcher symbol link set its name to Crosswalk app ID instead of Tizen
app ID.
2. Tizen AUL can only handles proc/_/cmdline with a max 128 bytes length buffer,
however current generated app ID and the whole path can easily surpass this
limitation.

Solution:
new-tizen-app-id = "xwalk." + $crosswalk-app-id
new-app-exe-path = /home/app/.config/xwalk-service/applications/$crosswalk-app-id/bin/$new-tizen-app-id

BUG=XWALK-1434,XWALK-1435
https://crosswalk-project.org/jira/browse/XWALK-1434
https://crosswalk-project.org/jira/browse/XWALK-1435
