### PR TITLE
[Android] Support keeping-screen-on for web apps

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -177,7 +177,8 @@ def SetVariable(file_path, string_line, variable, value):
 
 
 def CustomizeJava(sanitized_name, package, app_url, app_local_path,
-                  enable_remote_debugging, display_as_fullscreen):
+                  enable_remote_debugging, display_as_fullscreen,
+                  keep_screen_on):
   root_path =  os.path.join(sanitized_name, 'src',
                             package.replace('.', os.path.sep))
   dest_activity = os.path.join(root_path, sanitized_name + 'Activity.java')
@@ -212,6 +213,12 @@ def CustomizeJava(sanitized_name, package, app_url, app_local_path,
     SetVariable(dest_activity,
                 'super.onCreate(savedInstanceState)',
                 'IsFullscreen', 'true')
+  if keep_screen_on:
+    ReplaceString(
+        dest_activity,
+        'super.onCreate(savedInstanceState);',
+        'super.onCreate(savedInstanceState);\n        '+
+        'getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);')
 
 
 def CopyExtensionFile(extension_name, suffix, src_path, dest_path):
@@ -403,10 +410,10 @@ def CustomizeIcon(sanitized_name, app_root, icon, icon_dict):
 
 def CustomizeAll(app_versionCode, description, icon_dict, permissions, app_url,
                  app_root, app_local_path, enable_remote_debugging,
-                 display_as_fullscreen, extensions, launch_screen_img,
-                 icon, package='org.xwalk.app.template', name='AppTemplate',
-                 app_version='1.0.0', orientation='unspecified',
-                 xwalk_command_line=''):
+                 display_as_fullscreen, keep_screen_on, extensions,
+                 launch_screen_img, icon, package='org.xwalk.app.template',
+                 name='AppTemplate', app_version='1.0.0',
+                 orientation='unspecified', xwalk_command_line=''):
   sanitized_name = ReplaceInvalidChars(name, 'apkname')
   try:
     Prepare(sanitized_name, package, app_root)
@@ -415,7 +422,8 @@ def CustomizeAll(app_versionCode, description, icon_dict, permissions, app_url,
                  display_as_fullscreen, icon, launch_screen_img, permissions,
                  app_root)
     CustomizeJava(sanitized_name, package, app_url, app_local_path,
-                  enable_remote_debugging, display_as_fullscreen)
+                  enable_remote_debugging, display_as_fullscreen,
+                  keep_screen_on)
     CustomizeExtensions(sanitized_name, name, extensions)
     GenerateCommandLineFile(sanitized_name, xwalk_command_line)
   except SystemExit as ec:
@@ -459,6 +467,8 @@ def main():
   parser.add_option('-f', '--fullscreen', action='store_true',
                     dest='fullscreen', default=False,
                     help='Make application fullscreen.')
+  parser.add_option('--keep-screen-on', action='store_true', default=False,
+                    help='Support keeping screen on')
   info = ('The path list for external extensions separated by os separator.'
           'On Linux and Mac, the separator is ":". On Windows, it is ";".'
           'Such as: --extensions="/path/to/extension1:/path/to/extension2"')
@@ -496,7 +506,7 @@ def main():
     CustomizeAll(options.app_versionCode, options.description, icon_dict,
                  options.permissions, options.app_url, options.app_root,
                  options.app_local_path, options.enable_remote_debugging,
-                 options.fullscreen, options.extensions,
+                 options.fullscreen, options.keep_screen_on, options.extensions,
                  options.launch_screen_img, icon, options.package, options.name,
                  options.app_version, options.orientation,
                  options.xwalk_command_line)

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -209,7 +209,7 @@ def Customize(options):
   CustomizeAll(app_versionCode, options.description, options.icon_dict,
                options.permissions, options.app_url, app_root,
                options.app_local_path, remote_debugging,
-               fullscreen_flag, options.extensions,
+               fullscreen_flag, options.keep_screen_on, options.extensions,
                options.launch_screen_img, icon, package, name, app_version,
                orientation, options.xwalk_command_line)
 
@@ -639,6 +639,8 @@ def main(argv):
   group.add_option('-f', '--fullscreen', action='store_true',
                    dest='fullscreen', default=False,
                    help='Make application fullscreen.')
+  group.add_option('--keep-screen-on', action='store_true', default=False,
+                   help='Support keeping screen on')
   info = ('The path of application icon. '
           'Such as: --icon=/path/to/your/customized/icon')
   group.add_option('--icon', help=info)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -648,6 +648,7 @@ class TestMakeApk(unittest.TestCase):
            '--enable-remote-debugging',
            '--extensions=%s' % extension_path,
            '--fullscreen',
+           '--keep-screen-on',
            '%s' % icon,
            '--name=Example',
            '--orientation=landscape',
@@ -660,6 +661,8 @@ class TestMakeApk(unittest.TestCase):
     self.assertTrue(os.path.exists(activity))
     # Test remote debugging option.
     self.assertTrue(content.find('setRemoteDebugging') != -1)
+    # Test keep screen on option
+    self.assertTrue(content.find('FLAG_KEEP_SCREEN_ON') != -1)
 
     manifest = 'Example/AndroidManifest.xml'
     with open(manifest, 'r') as content_file:


### PR DESCRIPTION
Provide '--keep-screen-on' arguments in packaging tool
and apply keep-screen-on flag to the activity,
then the activity will request keep screen on for the whole life.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1411
