### PR TITLE
[Tizen][Runtime] Enable to open navigation link in system web browser when it's blocked by CSP mode.

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "base/callback.h"
 #include "base/compiler_specific.h"
@@ -17,6 +18,7 @@
 #include "ui/base/ui_base_types.h"
 #include "xwalk/application/browser/event_observer.h"
 #include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/security_policy.h"
 #include "xwalk/runtime/browser/runtime.h"
 
 #if defined(USE_OZONE) && defined(OS_TIZEN)
@@ -31,6 +33,7 @@ namespace application {
 
 class ApplicationHost;
 class Manifest;
+class SecurityPolicy;
 
 // The Application class is representing an active (running) application.
 // Application instances are owned by ApplicationService.
@@ -136,6 +139,7 @@ class Application
   bool SetPermission(PermissionType type,
                      const std::string& permission_name,
                      StoredPermission perm);
+  bool CanRequestURL(const GURL& url) const;
 
  private:
   bool HasMainDocument() const;
@@ -165,6 +169,7 @@ class Application
   bool IsTerminating() const { return finish_observer_; }
 
   void InitSecurityPolicy();
+  void AddSecurityPolicy(const GURL& url, bool subdomains);
 
 #if defined(USE_OZONE) && defined(OS_TIZEN)
   virtual base::EventStatus WillProcessEvent(
@@ -185,6 +190,9 @@ class Application
   std::map<std::string, std::string> name_perm_map_;
   // Application's session permissions.
   StoredPermissionMap permission_map_;
+  // Security policy set.
+  ScopedVector<SecurityPolicy> security_policy_;
+  bool is_security_mode_;
 
   DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/application/common/security_policy.cc
+++ b/application/common/security_policy.cc
@@ -1,0 +1,16 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/security_policy.h"
+
+namespace xwalk {
+namespace application {
+
+SecurityPolicy::SecurityPolicy(const GURL& url, bool subdomains)
+    : url_(url),
+      subdomains_(subdomains) {
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/security_policy.h
+++ b/application/common/security_policy.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_SECURITY_POLICY_H_
+#define XWALK_APPLICATION_COMMON_SECURITY_POLICY_H_
+#include "url/gurl.h"
+
+namespace xwalk {
+namespace application {
+
+class SecurityPolicy {
+ public:
+  enum SecurityMode {
+    NoSecurity,
+    CSP,
+    WARP
+  };
+  SecurityPolicy(const GURL& url, bool subdomains);
+  const GURL& url() const { return url_; }
+  bool subdomains() const { return subdomains_; }
+
+ private:
+  GURL url_;
+  bool subdomains_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_SECURITY_POLICY_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -76,6 +76,8 @@
         'common/permission_policy_manager.cc',
         'common/permission_policy_manager.h',
         'common/permission_types.h',
+        'common/security_policy.cc',
+        'common/security_policy.h',
 
         'extension/application_event_extension.cc',
         'extension/application_event_extension.h',

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -110,9 +110,22 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
       int render_process_id,
       int render_view_id,
       int notification_id) OVERRIDE;
-#if defined(OS_TIZEN)
-  virtual bool CanCommitURL(
-      content::RenderProcessHost* process_host, const GURL& url) OVERRIDE;
+#if !defined(OS_ANDROID)
+  virtual bool CanCreateWindow(const GURL& opener_url,
+                               const GURL& opener_top_level_frame_url,
+                               const GURL& source_origin,
+                               WindowContainerType container_type,
+                               const GURL& target_url,
+                               const content::Referrer& referrer,
+                               WindowOpenDisposition disposition,
+                               const blink::WebWindowFeatures& features,
+                               bool user_gesture,
+                               bool opener_suppressed,
+                               content::ResourceContext* context,
+                               int render_process_id,
+                               bool is_guest,
+                               int opener_id,
+                               bool* no_javascript_access) OVERRIDE;
 #endif
 
 #if defined(OS_ANDROID)

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -8,6 +8,7 @@
 #include "ipc/ipc_message_macros.h"
 #include "ipc/ipc_platform_file.h"
 #include "url/gurl.h"
+#include "xwalk/application/common/security_policy.h"
 
 // Singly-included section for enums and custom IPC traits.
 #ifndef XWALK_RUNTIME_COMMON_XWALK_COMMON_MESSAGES_H_
@@ -23,6 +24,7 @@ namespace IPC {
 
 #define IPC_MESSAGE_START ViewMsgStart
 
+IPC_ENUM_TRAITS(xwalk::application::SecurityPolicy::SecurityMode)
 //-----------------------------------------------------------------------------
 // RenderView messages
 // These are messages sent from the browser to the renderer process.
@@ -32,8 +34,10 @@ IPC_MESSAGE_CONTROL3(ViewMsg_SetAccessWhiteList,  // NOLINT
                      GURL /* dest */,
                      bool /* allow_subdomains */)
 
-IPC_MESSAGE_CONTROL1(ViewMsg_EnableWarpMode,    // NOLINT
-                     GURL /* application url */)
+IPC_MESSAGE_CONTROL2(ViewMsg_EnableSecurityMode,    // NOLINT
+                     GURL /* application url */,
+                     xwalk::application::SecurityPolicy::SecurityMode
+                     /* security mode */)
 
 IPC_MESSAGE_ROUTED1(ViewMsg_HWKeyPressed, int /*keycode*/)  // NOLINT
 

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -164,22 +164,42 @@ bool XWalkContentRendererClient::WillSendRequest(blink::WebFrame* frame,
 #if defined(OS_ANDROID)
   return false;
 #else
-  if (!xwalk_render_process_observer_->IsWarpMode())
+  if (!xwalk_render_process_observer_->IsWarpMode()
+#if defined(OS_TIZEN)
+      && !xwalk_render_process_observer_->IsCSPMode()
+#endif
+      )
     return false;
 
   GURL origin_url(frame->document().url());
   GURL app_url(xwalk_render_process_observer_->app_url());
-  if ((url.scheme() == app_url.scheme() &&
-       url.host() == app_url.host()) ||
+#if defined(OS_TIZEN)
+  // if under CSP mode.
+  if (xwalk_render_process_observer_->IsCSPMode()) {
+    if (url.GetOrigin() != app_url.GetOrigin() &&
+        origin_url != first_party_for_cookies &&
+        first_party_for_cookies.GetOrigin() != app_url.GetOrigin() &&
+        !frame->document().securityOrigin().canRequest(url)) {
+      LOG(INFO) << "[BLOCK] allow-navigation: " << url.spec();
+      content::RenderThread::Get()->Send(new ViewMsg_OpenLinkExternal(url));
+      *new_url = GURL();
+      return true;
+    }
+    return false;
+  }
+#endif
+  // if under WARP mode.
+  if (url.GetOrigin() == app_url.GetOrigin() ||
       frame->document().securityOrigin().canRequest(url)) {
     LOG(INFO) << "[PASS] " << origin_url.spec() << " request " << url.spec();
     return false;
   }
 
   LOG(INFO) << "[BLOCK] " << origin_url.spec() << " request " << url.spec();
-
 #if defined(OS_TIZEN)
-  if (origin_url.spec().empty())
+  if (url.GetOrigin() != app_url.GetOrigin() &&
+      origin_url != first_party_for_cookies &&
+      first_party_for_cookies.GetOrigin() != app_url.GetOrigin())
     content::RenderThread::Get()->Send(new ViewMsg_OpenLinkExternal(url));
 #endif
 

--- a/runtime/renderer/xwalk_render_process_observer_generic.cc
+++ b/runtime/renderer/xwalk_render_process_observer_generic.cc
@@ -44,7 +44,7 @@ void AddAccessWhiteListEntry(
 
 XWalkRenderProcessObserver::XWalkRenderProcessObserver()
     : is_webkit_initialized_(false),
-      is_warp_mode_(false) {
+      security_mode_(application::SecurityPolicy::NoSecurity) {
 }
 
 XWalkRenderProcessObserver::~XWalkRenderProcessObserver() {
@@ -55,7 +55,7 @@ bool XWalkRenderProcessObserver::OnControlMessageReceived(
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(XWalkRenderProcessObserver, message)
     IPC_MESSAGE_HANDLER(ViewMsg_SetAccessWhiteList, OnSetAccessWhiteList)
-    IPC_MESSAGE_HANDLER(ViewMsg_EnableWarpMode, OnEnableWarpMode)
+    IPC_MESSAGE_HANDLER(ViewMsg_EnableSecurityMode, OnEnableSecurityMode)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
   return handled;
@@ -89,9 +89,10 @@ void XWalkRenderProcessObserver::OnSetAccessWhiteList(const GURL& source,
         AccessWhitelistItem(source, dest, allow_subdomains));
 }
 
-void XWalkRenderProcessObserver::OnEnableWarpMode(const GURL& url) {
+void XWalkRenderProcessObserver::OnEnableSecurityMode(
+    const GURL& url, application::SecurityPolicy::SecurityMode mode) {
   app_url_ = url;
-  is_warp_mode_ = true;
+  security_mode_ = mode;
 }
 
 }  // namespace xwalk

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -11,6 +11,7 @@
 #include "content/public/renderer/render_process_observer.h"
 #include "url/gurl.h"
 #include "v8/include/v8.h"
+#include "xwalk/application/common/security_policy.h"
 
 namespace blink {
 class WebFrame;
@@ -36,16 +37,23 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   virtual void WebKitInitialized() OVERRIDE;
   virtual void OnRenderProcessShutdown() OVERRIDE;
 
-  bool IsWarpMode() const { return is_warp_mode_; }
+  bool IsWarpMode() const {
+    return security_mode_ == application::SecurityPolicy::WARP;
+  }
+  bool IsCSPMode() const {
+    return security_mode_ == application::SecurityPolicy::CSP;
+  }
+
   const GURL& app_url() const { return app_url_; }
 
  private:
   void OnSetAccessWhiteList(
       const GURL& source, const GURL& dest, bool allow_subdomains);
-  void OnEnableWarpMode(const GURL& url);
+  void OnEnableSecurityMode(
+      const GURL& url, application::SecurityPolicy::SecurityMode mode);
 
   bool is_webkit_initialized_;
-  bool is_warp_mode_;
+  application::SecurityPolicy::SecurityMode security_mode_;
   GURL app_url_;
 };
 }  // namespace xwalk


### PR DESCRIPTION
On Tizen platform, the allow-navigation policy will control the behavior
for opening a navigation link in web app, if the navigation link domain
is not list in it, the action will be blocked and the link should be
opened in system web browser.
