### PR TITLE
[Application] Add application hide support

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -29,6 +29,10 @@
 #include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_common_messages.h"
 
+#if defined(OS_TIZEN)
+#include "xwalk/runtime/browser/ui/native_app_window.h"
+#endif
+
 #if defined(USE_OZONE) && defined(OS_TIZEN)
 #include "base/message_loop/message_pump_ozone.h"
 #include "content/public/browser/render_view_host.h"
@@ -234,6 +238,17 @@ void Application::Terminate(TerminationMode mode) {
   std::for_each(to_be_closed.begin(), to_be_closed.end(),
                 std::mem_fun(&Runtime::Close));
 }
+
+#if defined(OS_TIZEN)
+void Application::Hide() {
+  DCHECK(runtimes_.size());
+  std::set<Runtime*>::iterator it = runtimes_.begin();
+  for (; it != runtimes_.end(); ++it) {
+    if ((*it)->window())
+      (*it)->window()->Hide();
+  }
+}
+#endif
 
 Runtime* Application::GetMainDocumentRuntime() const {
   return HasMainDocument() ? main_runtime_ : NULL;

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -99,6 +99,10 @@ class Application
   };
   void Terminate(TerminationMode = Normal);
 
+#if defined(OS_TIZEN)
+  void Hide();
+#endif
+
   // Returns Runtime (application page) containing the application's
   // 'main document'. The main document is the main entry point of
   // the application to the system. This method will return 'NULL'

--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -47,6 +47,11 @@ class RunningApplicationObject : public dbus::ManagedObject {
       dbus::MethodCall* method_call,
       dbus::ExportedObject::ResponseSender response_sender);
 
+#if defined(OS_TIZEN)
+  void OnHide(dbus::MethodCall* method_call,
+              dbus::ExportedObject::ResponseSender response_sender);
+#endif
+
   void ListenForOwnerChange();
   void UnlistenForOwnerChange();
   void OnNameOwnerChanged(const std::string& service_owner);


### PR DESCRIPTION
Tizen Application.hide() API need this support to hide current application.

When Hide method is called on the runnning application object, all windows
owned by this application will be hide.

NOTE: Wayland doesn't implement window minimize at the moment. 
