### PR TITLE
[Application] Fix launcher idle callback return value and EP message loop type

### DIFF
--- a/application/tools/linux/xwalk_extension_process_launcher.cc
+++ b/application/tools/linux/xwalk_extension_process_launcher.cc
@@ -10,7 +10,7 @@ XWalkExtensionProcessLauncher::XWalkExtensionProcessLauncher()
     : base::Thread("LauncherExtensionService"),
       is_started_(false) {
   base::Thread::Options thread_options;
-  thread_options.message_loop_type = base::MessageLoop::TYPE_UI;
+  thread_options.message_loop_type = base::MessageLoop::TYPE_DEFAULT;
   StartWithOptions(thread_options);
 }
 

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -95,7 +95,7 @@ static void on_app_properties_changed(GDBusProxy* proxy,
 static gboolean init_extension_process_channel(gpointer data) {
   GDBusProxy* app_proxy = static_cast<GDBusProxy*>(data);
   if (ep_launcher->is_started())
-    return TRUE;
+    return FALSE;
   // Get the client socket file descriptor from fd_list. The reply will
   // contains an index to the list.
   GUnixFDList* fd_list;
@@ -112,7 +112,7 @@ static gboolean init_extension_process_channel(gpointer data) {
   int client_fd = g_unix_fd_list_get(fd_list, client_fd_idx, NULL);
 
   ep_launcher->Launch(channel_id, client_fd);
-  return TRUE;
+  return FALSE;
 }
 
 static void on_app_signal(GDBusProxy* proxy,


### PR DESCRIPTION
1. init_extension_process_channel should return FALSE, otherwise it will be
   called endlessly.
2. Thread running EP logic should have a TYPE_DEFAULT message loop type. As
   on Linux system, the launcher's main thread already has a Glib message pump(TYPE_UI).
