### PR TITLE
[Runtime] Add application locale to application system

### DIFF
--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -35,6 +35,10 @@ class ApplicationService : public Application::Observer {
     virtual void OnApplicationInstalled(const std::string& app_id) {}
     virtual void OnApplicationUninstalled(const std::string& app_id) {}
     virtual void OnApplicationUpdated(const std::string& app_id) {}
+    // When we change the application locale, we might get a new name in
+    // the new locale.
+    virtual void OnApplicationNameChanged(const std::string& app_id,
+                                          const std::string& app_name) {}
 
     virtual void DidLaunchApplication(Application* app) {}
     virtual void WillDestroyApplication(Application* app) {}
@@ -50,6 +54,7 @@ class ApplicationService : public Application::Observer {
   bool Install(const base::FilePath& path, std::string* id);
   bool Uninstall(const std::string& id);
   bool Update(const std::string& id, const base::FilePath& path);
+  bool ChangeLocale(const std::string& locale);
 
   Application* Launch(scoped_refptr<ApplicationData> application_data,
                       const Application::LaunchParams& launch_params);

--- a/application/browser/linux/installed_application_object.cc
+++ b/application/browser/linux/installed_application_object.cc
@@ -42,6 +42,12 @@ InstalledApplicationObject::InstalledApplicationObject(
   properties()->Set(kInstalledApplicationDBusInterface, "Name", name.Pass());
 }
 
+void InstalledApplicationObject::OnApplicationNameChanged(
+    const std::string& app_name) {
+  scoped_ptr<base::Value> name(base::Value::CreateStringValue(app_name));
+  properties()->Set(kInstalledApplicationDBusInterface, "Name", name.Pass());
+}
+
 void InstalledApplicationObject::ExportUninstallMethod(
     dbus::ExportedObject::MethodCallCallback method_call_callback,
     dbus::ExportedObject::OnExportedCallback on_exported_callback) {

--- a/application/browser/linux/installed_application_object.h
+++ b/application/browser/linux/installed_application_object.h
@@ -26,6 +26,7 @@ class InstalledApplicationObject : public dbus::ManagedObject {
       scoped_refptr<dbus::Bus> bus, const dbus::ObjectPath& path,
       const ApplicationData* app);
 
+  void OnApplicationNameChanged(const std::string& app_name);
   // Set the callback used when the Uninstall() method is called in an
   // ApplicationObject.
   void ExportUninstallMethod(

--- a/application/browser/linux/installed_applications_manager.cc
+++ b/application/browser/linux/installed_applications_manager.cc
@@ -72,6 +72,14 @@ void InstalledApplicationsManager::OnApplicationUninstalled(
   adaptor_.RemoveManagedObject(GetInstalledPathForAppID(app_id));
 }
 
+void InstalledApplicationsManager::OnApplicationNameChanged(
+    const std::string& app_id, const std::string& app_name) {
+  InstalledApplicationObject* object =
+      static_cast<InstalledApplicationObject*>(
+          adaptor_.GetManagedObject(GetInstalledPathForAppID(app_id)));
+  object->OnApplicationNameChanged(app_name);
+}
+
 void InstalledApplicationsManager::AddInitialObjects() {
   const ApplicationData::ApplicationDataMap& apps =
       app_storage_->GetInstalledApplications();

--- a/application/browser/linux/installed_applications_manager.h
+++ b/application/browser/linux/installed_applications_manager.h
@@ -34,6 +34,8 @@ class InstalledApplicationsManager : public ApplicationService::Observer {
   // ApplicationService::Observer implementation.
   void virtual OnApplicationInstalled(const std::string& app_id) OVERRIDE;
   void virtual OnApplicationUninstalled(const std::string& app_id) OVERRIDE;
+  void virtual OnApplicationNameChanged(const std::string& app_id,
+                                        const std::string& app_name) OVERRIDE;
 
   void AddInitialObjects();
   void AddObject(scoped_refptr<const ApplicationData> app);

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -371,5 +371,16 @@ bool ApplicationData::HasCSPDefined() const {
 }
 #endif
 
+bool ApplicationData::SetApplicationLocale(const std::string& locale,
+                                           base::string16* error) {
+  // TODO(hongzhang): we need to update app data.
+  // like manifest_i18n_data.SetLocale(locale);
+  if (!LoadName(error))
+    return false;
+  if (!LoadDescription(error))
+    return false;
+  return true;
+}
+
 }   // namespace application
 }   // namespace xwalk

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -138,6 +138,8 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   bool HasCSPDefined() const;
 #endif
 
+  bool SetApplicationLocale(const std::string& locale, base::string16* error);
+
  private:
   friend class base::RefCountedThreadSafe<ApplicationData>;
   friend class ApplicationStorageImpl;

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -12,6 +12,7 @@
           'variables': {
             'packages': [
               'capi-location-manager',
+              'vconf',
             ],
           },
           'direct_dependent_settings': {

--- a/runtime/browser/tizen/tizen_locale_listener.cc
+++ b/runtime/browser/tizen/tizen_locale_listener.cc
@@ -1,0 +1,108 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/tizen/tizen_locale_listener.h"
+
+#include <vconf.h>
+#include <algorithm>
+
+#include "base/logging.h"
+#include "content/public/browser/browser_thread.h"
+#include "xwalk/runtime/browser/xwalk_runner_tizen.h"
+#include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/browser/application_service.h"
+
+namespace xwalk {
+namespace {
+const char kTizenDefaultLocale[] = "en-GB";
+const char kTizenLocaleListenerThreadName[] = "TizenLocaleListener";
+
+bool TizenLocaleToBCP47Locale(const std::string& tizen_locale,
+                              std::string* out_BCP47_locale) {
+  if (tizen_locale.empty())
+    return false;
+
+  // Tizen locale format [language[_territory][.codeset][@modifier]] .
+  // Conver to BCP47 format language[-territory] .
+  *out_BCP47_locale = tizen_locale.substr(0, tizen_locale.find_first_of("."));
+  std::replace(out_BCP47_locale->begin(), out_BCP47_locale->end(), '_', '-');
+  return true;
+}
+
+void OnVconfLangSetChanged(keynode_t *key, void *user_data) {
+  if (vconf_keynode_get_type(key) != VCONF_TYPE_STRING)
+    return;
+  TizenLocaleListener* tizen_locale_listener =
+      static_cast<TizenLocaleListener*>(user_data);
+
+  std::string locale;
+  if (TizenLocaleToBCP47Locale(vconf_keynode_get_str(key), &locale)) {
+    content::BrowserThread::PostTask(content::BrowserThread::UI, FROM_HERE,
+        base::Bind(&TizenLocaleListener::SetLocale,
+                   base::Unretained(tizen_locale_listener),
+                   locale));
+  }
+}
+
+std::string GetSystemLocale() {
+  std::string tizen_locale;
+  char* langset = vconf_get_str(VCONFKEY_LANGSET);
+  if (langset) {
+    tizen_locale = langset;
+  } else {
+    LOG(ERROR) << "Can not get VCONFKEY_LANGSET from vconf or "
+               << "VCONFKEY_LANGSET vlaue is not a string value";
+  }
+  free(langset);
+
+  // Tizen take en-GB as default.
+  std::string BCP47_locale(kTizenDefaultLocale);
+  TizenLocaleToBCP47Locale(tizen_locale, &BCP47_locale);
+  return BCP47_locale;
+}
+
+}  // namespace
+
+TizenLocaleListener::TizenLocaleListener()
+    : SimpleThread(kTizenLocaleListenerThreadName),
+      locale_(GetSystemLocale()) {
+  vconf_notify_key_changed(VCONFKEY_LANGSET, OnVconfLangSetChanged, this);
+  main_loop_ = g_main_loop_new(NULL, FALSE);
+  Start();
+}
+
+TizenLocaleListener::~TizenLocaleListener() {
+  g_main_loop_quit(main_loop_);
+  g_main_loop_unref(main_loop_);
+  SimpleThread::Join();
+  vconf_ignore_key_changed(VCONFKEY_LANGSET, OnVconfLangSetChanged);
+}
+
+void TizenLocaleListener::Run() {
+  g_main_loop_run(main_loop_);
+}
+
+std::string TizenLocaleListener::GetLocale() const {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  // Note: we can only get locale from main thread for thread safe.
+  return locale_;
+}
+
+void TizenLocaleListener::SetLocale(const std::string& locale) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  // Note: we can only set locale from main thread for thread safe.
+  // If you need set locale from other thread, please PostTask to main thread.
+  if (locale_ == locale)
+    return;
+
+  LOG(INFO) << "Locale change from " << locale_ << " to " << locale;
+  locale_ = locale;
+
+  application::ApplicationSystem* application_system_ =
+      XWalkRunnerTizen::GetInstance()->app_system();
+  if (application_system_)
+    application_system_->application_service()->ChangeLocale(locale);
+}
+
+}  // namespace xwalk

--- a/runtime/browser/tizen/tizen_locale_listener.h
+++ b/runtime/browser/tizen/tizen_locale_listener.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_LOCALE_LISTENER_H_
+#define XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_LOCALE_LISTENER_H_
+
+#include <glib.h>
+#include <string>
+
+#include "base/threading/simple_thread.h"
+
+namespace xwalk {
+
+class TizenLocaleListener : public base::SimpleThread {
+  public:
+    TizenLocaleListener();
+    virtual ~TizenLocaleListener();
+
+    virtual void Run() OVERRIDE;
+
+    // Get the latest application locale from system.
+    // locale is a langtag defined in [BCP47]
+    std::string GetLocale() const;
+    // Set the locale and apply this locale to all applications.
+    // Locale is a langtag defined in [BCP47].
+    // This function will called by TizenLocaleListener when locale is changed.
+    void SetLocale(const std::string& locale);
+
+  private:
+    GMainLoop*  main_loop_;
+    // The locale is a langtag defined in [BCP47]
+    std::string locale_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_TIZEN_TIZEN_LOCALE_LISTENER_H_

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -32,6 +32,7 @@ namespace xwalk {
 
 namespace {
 
+const char kDefaultLocale[] = "en-US";
 XWalkRunner* g_xwalk_runner = NULL;
 
 }  // namespace
@@ -84,6 +85,10 @@ void XWalkRunner::PostMainMessageLoopRun() {
   DestroyComponents();
   extension_service_.reset();
   runtime_context_.reset();
+}
+
+std::string XWalkRunner::GetLocale() const {
+  return kDefaultLocale;
 }
 
 void XWalkRunner::CreateComponents() {

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_RUNTIME_BROWSER_XWALK_RUNNER_H_
 #define XWALK_RUNTIME_BROWSER_XWALK_RUNNER_H_
 
+#include <string>
+
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/scoped_vector.h"
 #include "base/values.h"
@@ -75,6 +77,10 @@ class XWalkRunner {
   // Stages of main parts. See content/browser_main_parts.h for description.
   void PreMainMessageLoopRun();
   void PostMainMessageLoopRun();
+
+  // Get the latest application locale from system.
+  // locale is a langtag defined in [BCP47]
+  virtual std::string GetLocale() const;
 
  protected:
   XWalkRunner();

--- a/runtime/browser/xwalk_runner_tizen.cc
+++ b/runtime/browser/xwalk_runner_tizen.cc
@@ -19,4 +19,8 @@ XWalkRunnerTizen* XWalkRunnerTizen::GetInstance() {
   return static_cast<XWalkRunnerTizen*>(XWalkRunner::GetInstance());
 }
 
+std::string XWalkRunnerTizen::GetLocale() const {
+  return tizen_locale_listener_.GetLocale();
+}
+
 }  // namespace xwalk

--- a/runtime/browser/xwalk_runner_tizen.h
+++ b/runtime/browser/xwalk_runner_tizen.h
@@ -5,7 +5,10 @@
 #ifndef XWALK_RUNTIME_BROWSER_XWALK_RUNNER_TIZEN_H_
 #define XWALK_RUNTIME_BROWSER_XWALK_RUNNER_TIZEN_H_
 
+#include <string>
+
 #include "xwalk/runtime/browser/xwalk_runner.h"
+#include "xwalk/runtime/browser/tizen/tizen_locale_listener.h"
 
 namespace xwalk {
 
@@ -20,9 +23,15 @@ class XWalkRunnerTizen : public XWalkRunner {
 
   virtual ~XWalkRunnerTizen();
 
+  // Get the latest application locale from system.
+  // locale is a langtag defined in [BCP47]
+  virtual std::string GetLocale() const OVERRIDE;
+
  private:
   friend class XWalkRunner;
   XWalkRunnerTizen();
+
+  TizenLocaleListener tizen_locale_listener_;
 };
 
 }  // namespace xwalk

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -276,6 +276,8 @@
             'runtime/browser/ui/screen_orientation.h',
             'runtime/extension/screen_orientation_extension.cc',
             'runtime/extension/screen_orientation_extension.h',
+            'runtime/browser/tizen/tizen_locale_listener.cc',
+            'runtime/browser/tizen/tizen_locale_listener.h',
           ],
           'sources!':[
             'runtime/browser/runtime_platform_util_linux.cc',


### PR DESCRIPTION
Add a class ApplicationLocale to get and handle locale
from system.

Implement the GetApplicationLocale() interface for
content browser client.

Note: I only realized get system locale from tizen,
other platform will get "en-US" as default.
