### PR TITLE
[Runtime] Add i18n support for widget

### DIFF
--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -373,8 +373,7 @@ bool ApplicationData::HasCSPDefined() const {
 
 bool ApplicationData::SetApplicationLocale(const std::string& locale,
                                            base::string16* error) {
-  // TODO(hongzhang): we need to update app data.
-  // like manifest_i18n_data.SetLocale(locale);
+  manifest_->SetSystemLocale(locale);
   if (!LoadName(error))
     return false;
   if (!LoadDescription(error))

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -45,6 +45,8 @@ const char kIcon128Key[] = "icons.128";
 // manifest keys for widget applications.
 namespace application_widget_keys {
 const char kNamespaceKey[] = "@namespace";
+const char kXmlLangKey[] = "@lang";
+const char kDefaultLocaleKey[] = "widget.@defaultlocale";
 const char kNameKey[] = "widget.name.#text";
 const char kVersionKey[] = "widget.@version";
 const char kWidgetKey[] = "widget";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -42,6 +42,8 @@ namespace application_manifest_keys {
 
 namespace application_widget_keys {
   extern const char kNamespaceKey[];
+  extern const char kXmlLangKey[];
+  extern const char kDefaultLocaleKey[];
   extern const char kNameKey[];
   extern const char kLaunchLocalPathKey[];
   extern const char kWebURLsKey[];

--- a/application/common/manifest.h
+++ b/application/common/manifest.h
@@ -5,6 +5,7 @@
 #ifndef XWALK_APPLICATION_COMMON_MANIFEST_H_
 #define XWALK_APPLICATION_COMMON_MANIFEST_H_
 
+#include <list>
 #include <map>
 #include <string>
 #include <set>
@@ -72,6 +73,7 @@ class Manifest {
 
   PackageType GetPackageType() const { return package_type_; }
   bool IsXPKPackaged() const { return package_type_ == TYPE_XPK; }
+  bool IsWGTPackaged() const { return package_type_ == TYPE_WGT; }
 
   // These access the wrapped manifest value, returning false when the property
   // does not exist or if the manifest type can't access it.
@@ -81,8 +83,17 @@ class Manifest {
   bool Get(const std::string& path, base::Value** out_value) const;
   bool GetBoolean(const std::string& path, bool* out_value) const;
   bool GetInteger(const std::string& path, int* out_value) const;
+
+  // If the path is supported by i18n, we can get a locale string from
+  // this two GetString function. The following is locale priority:
+  // Application locale (locale get from system).                 | high
+  // Default locale (defaultlocale attribute of widget element)
+  // Unlocalized (the element without xml:lang attribute)
+  // Auto ("en-us"(tizen is "en-gb") will be considered as a default)
+  // First (the worst case we get the first element)              | low
   bool GetString(const std::string& path, std::string* out_value) const;
   bool GetString(const std::string& path, base::string16* out_value) const;
+
   bool GetDictionary(const std::string& path,
                      const base::DictionaryValue** out_value) const;
   bool GetList(const std::string& path,
@@ -99,7 +110,20 @@ class Manifest {
   // Note: only use this when you KNOW you don't need the validation.
   const base::DictionaryValue* value() const { return data_.get(); }
 
+  const std::string& default_locale() const {
+    return default_locale_;
+  }
+
+  // Update user agent locale when system locale is changed.
+  void SetSystemLocale(const std::string& locale);
+
  private:
+  void ParseWGTI18n();
+  void ParseWGTI18nEachPath(const std::string& path);
+  bool ParseWGTI18nEachElement(base::Value* value,
+                               const std::string& path,
+                               const std::string& locale = "");
+
   // Returns true if the application can specify the given |path|.
   bool CanAccessPath(const std::string& path) const;
   bool CanAccessKey(const std::string& key) const;
@@ -115,6 +139,10 @@ class Manifest {
 
   // The underlying dictionary representation of the manifest.
   scoped_ptr<base::DictionaryValue> data_;
+  scoped_ptr<base::DictionaryValue> i18n_data_;
+
+  std::string default_locale_;
+  scoped_ptr<std::list<std::string> > user_agent_locales_;
 
   Type type_;
 


### PR DESCRIPTION
ManifestI18NData will have an entity stored in
the ApplicationData entity, and we can get
local values from this entity.

ManifestI18NData will prase i18n items from a
path list. And we can get a locale value or string
from ManifestI18NData entity.

And the application will get the correct value of name
or description if name or description is a list.
