### PR TITLE
[Android] Export xwalk core library as a jar

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -76,25 +76,9 @@ def CopyJavaSources(project_source, out_dir):
   # here are all beginned with "org". If the assumption is broken in
   # future, the logic needs to be adjusted accordingly.
   java_srcs_to_copy = [
-      # Chromium java sources.
-      'base/android/java/src/org/chromium/base',
-      'content/public/android/java/src/org/chromium/content',
-      'content/public/android/java/src/org/chromium/content_public',
-      'media/base/android/java/src/org/chromium/media',
-      'net/android/java/src/org/chromium/net',
-      'ui/android/java/src/org/chromium/ui',
-      'components/navigation_interception/android/java/'
-          'src/org/chromium/components/navigation_interception',
-      'components/web_contents_delegate_android/android/java/'
-          'src/org/chromium/components/web_contents_delegate_android',
-
       # R.javas
       'content/public/android/java/resource_map/org/chromium/content/R.java',
       'ui/android/java/resource_map/org/chromium/ui/R.java',
-
-      # XWalk java sources.
-      'xwalk/runtime/android/core/src/org/xwalk/core',
-      'xwalk/extensions/android/java/src/org/xwalk/core/extensions',
   ]
 
   for source in java_srcs_to_copy:
@@ -114,40 +98,13 @@ def CopyJavaSources(project_source, out_dir):
 
 
 def CopyGeneratedSources(out_dir):
-  """cp out/Release/gen/templates/<path>
-        out/Release/xwalk_core_library/src/<path>
-     cp out/Release/xwalk_core_shell_apk/
+  """cp out/Release/xwalk_core_shell_apk/
             native_libraries_java/NativeLibraries.java
         out/Release/xwalk_core_library/src/org/
             chromium/base/library_loader/NativeLibraries.java
   """
 
   print 'Copying generated source files...'
-  generated_srcs_to_copy = [
-      'org/chromium/base/ApplicationState.java',
-      'org/chromium/base/MemoryPressureLevelList.java',
-      'org/chromium/base/library_loader/NativeLibraries.java',
-      'org/chromium/content/browser/GestureEventType.java',
-      'org/chromium/content/browser/input/PopupItemType.java',
-      'org/chromium/content/browser/PageTransitionTypes.java',
-      'org/chromium/content/browser/SpeechRecognitionError.java',
-      'org/chromium/content/common/ResultCodes.java',
-      'org/chromium/content/common/ScreenOrientationValues.java',
-      'org/chromium/content/common/TopControlsState.java',
-      'org/chromium/media/ImageFormat.java',
-      'org/chromium/net/CertificateMimeType.java',
-      'org/chromium/net/CertVerifyStatusAndroid.java',
-      'org/chromium/net/NetError.java',
-      'org/chromium/net/PrivateKeyType.java',
-      'org/chromium/ui/gfx/BitmapFormat.java',
-      'org/chromium/ui/WindowOpenDisposition.java'
-  ]
-
-  for source in generated_srcs_to_copy:
-    source_file = os.path.join(out_dir, 'gen', 'templates', source)
-    target_file = os.path.join(
-        out_dir, LIBRARY_PROJECT_NAME, 'src', source)
-    shutil.copyfile(source_file, target_file)
 
   source_file = os.path.join(out_dir, XWALK_CORE_SHELL_APK,
                              'native_libraries_java',
@@ -155,6 +112,8 @@ def CopyGeneratedSources(out_dir):
   target_file = os.path.join(out_dir, LIBRARY_PROJECT_NAME, 'src', 'org',
                              'chromium', 'base', 'library_loader',
                              'NativeLibraries.java')
+  if not os.path.isdir(os.path.dirname(target_file)):
+    os.makedirs(os.path.dirname(target_file))
   shutil.copyfile(source_file, target_file)
 
 def CopyJSBindingFiles(project_source, out_dir):
@@ -227,9 +186,7 @@ def CopyBinaries(out_dir):
     os.mkdir(libs_dir)
 
   libs_to_copy = [
-      'eyesfree_java.jar',
-      'guava_javalib.jar',
-      'jsr_305_javalib.jar',
+      'xwalk_core_library_java.jar',
   ]
 
   for lib in libs_to_copy:

--- a/build/android/merge_jars.py
+++ b/build/android/merge_jars.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# Copyright 2013 The Chromium Authors. All rights reserved.
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import fnmatch
+import optparse
+import os
+import sys
+import shutil
+import subprocess
+
+
+def GetCommandOutput(command, cwd=None):
+  proc = subprocess.Popen(command, stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT, bufsize=1,
+                          cwd=cwd)
+  output = proc.communicate()[0]
+  result = proc.returncode
+  if result:
+    raise Exception('%s: %s' % (subprocess.list2cmdline(command), output))
+  return output
+
+
+def UnpackJar(jar, classes_dir):
+  jar_cmd = ['jar', 'xvf', os.path.abspath(jar)]
+  GetCommandOutput(jar_cmd, classes_dir)
+
+
+def FindInDirectory(directory, filename_filter):
+  files = []
+  for root, _dirnames, filenames in os.walk(directory):
+    matched_files = fnmatch.filter(filenames, filename_filter)
+    files.extend((os.path.join(root, f) for f in matched_files))
+  return files
+
+
+def DoJar(classes_dir, jar_path):
+  class_files = FindInDirectory(classes_dir, '*.class')
+
+  jar_path = os.path.abspath(jar_path)
+
+  class_files_rel = [os.path.relpath(f, classes_dir) for f in class_files]
+  jar_cmd = ['jar', 'cf0', jar_path] + class_files_rel
+
+  GetCommandOutput(jar_cmd, classes_dir)
+
+
+def main():
+  parser = optparse.OptionParser()
+  info = ('The folder to place unzipped classes')
+  parser.add_option('--classes-dir', help=info)
+  info = ('The jars to merge')
+  parser.add_option('--jars', help=info)
+  info = ('The output merged jar file')
+  parser.add_option('--jar-path', help=info)
+  options, _ = parser.parse_args()
+
+  if os.path.isdir(options.classes_dir):
+    shutil.rmtree(options.classes_dir)
+  os.makedirs(options.classes_dir)
+
+  for jar in options.jars.split(' '):
+    UnpackJar(eval(jar), options.classes_dir)
+
+  DoJar(options.classes_dir, options.jar_path)
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -29,10 +29,48 @@
       ],
     },
     {
+      'target_name': 'xwalk_core_library_java',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_core_java',
+      ],
+      'variables': {
+        'java_in_dir': 'runtime/android/core',
+        'classes_dir': '<(PRODUCT_DIR)/<(_target_name)/classes',
+        'jar_name': '<(_target_name).jar',
+        'jar_final_path': '<(PRODUCT_DIR)/lib.java/<(jar_name)',
+        'jar_excluded_classes': [ '*/R.class', '*/R##*.class' ],
+      },
+      'all_dependent_settings': {
+        'variables': {
+          'input_jars_paths': ['<(jar_final_path)'],
+        },
+      },
+      'actions': [
+        {
+          'action_name': 'jars_<(_target_name)',
+          'message': 'Creating <(_target_name) jar',
+          'inputs': [
+            'build/android/merge_jars.py',
+          ],
+          'outputs': [
+            '<(PRODUCT_DIR)/pack_xwalk_core_library_java_intermediate/always_run',
+          ],
+          'action': [
+            'python', 'build/android/merge_jars.py',
+            '--classes-dir=<(classes_dir)',
+            '--jars=>(input_jars_paths)',
+            '--jar-path=<(jar_final_path)',
+          ],
+        },
+      ],
+    },
+    {
       'target_name': 'xwalk_core_library',
       'type': 'none',
       'dependencies': [
-        'xwalk_core_shell_apk'
+        'xwalk_core_shell_apk',
+        'xwalk_core_library_java',
       ],
       'actions': [
         {


### PR DESCRIPTION
Previously, xwalk core library is containing bunches
of java source code, even including many generated
code. It's hard to maintain after chromium rebase.

With this commit, merge_jars.py will help merge all the
jars from chromium and xwalk component needed by xwalk
core library into one xwalk_core_library_java.jar.

Only two things missing:
1. The R.java for resource mapping still needs to be copied
separately, because they are not included in any jar.
2. As well as the NativeLibraries.java.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1234
