### PR TITLE
packaging: enable xdg-shell for minimization

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -141,7 +141,7 @@ if [ -n "${BUILDDIR_NAME}" ]; then
 fi
 
 %if %{with wayland}
-GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1 -Denable_ozone_wayland_vkb=1"
+GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1 -Denable_ozone_wayland_vkb=1 -Denable_xdg_shell=1"
 %endif
 
 # --no-parallel is added because chroot does not mount a /dev/shm, this will


### PR DESCRIPTION
Activate xdg-shell, so the "minimize" button works under Tizen

We enable the build-time option "xdg-shell" for Tizen. Tested OK
with the latest Tizen Common image, it should work reliably with
upcoming snapshots & releases as we are taking care of
protocol versions compatibility.

Change-Id: I1474cf48a42bd693dc68e0296a8e4e3d815042ed
Signed-off-by: Manuel Bachmann manuel.bachmann@open.eurogiciel.org
