### PR TITLE
[Android] Fix that crosswalk crashes if the application name has a space...

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -27,7 +27,7 @@ def ReplaceInvalidChars(value, mode='default'):
   if mode == 'default':
     invalid_chars = '\/:*?"<>|- '
   elif mode == 'apkname':
-    invalid_chars = '\/:.*?"<>|-'
+    invalid_chars = '\/:.*?"<>|- '
   for c in invalid_chars:
     if mode == 'apkname' and c in value:
       print("Illegal character: '%s' is replaced with '_'" % c)


### PR DESCRIPTION
... in it

Replace the space in the application name with '_'.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1476
