### PR TITLE
[Tizen][Runtime] Add support for Tizen Metadata.

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -76,6 +76,10 @@ const char kCSPReportOnlyKey[] =
     "widget.content-security-policy-report-only.#text";
 const char kTizenSettingKey[] = "widget.setting";
 const char kTizenHardwareKey[] = "widget.setting.@hwkey";
+const char kTizenMetaDataKey[] = "widget.metadata";
+// Child keys inside 'kTizenMetaDataKey'
+const char kTizenMetaDataNameKey[] = "@key";
+const char kTizenMetaDataValueKey[] = "@value";
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -68,6 +68,9 @@ namespace application_widget_keys {
   extern const char kCSPReportOnlyKey[];
   extern const char kTizenSettingKey[];
   extern const char kTizenHardwareKey[];
+  extern const char kTizenMetaDataKey[];
+  extern const char kTizenMetaDataNameKey[];
+  extern const char kTizenMetaDataValueKey[];
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -12,6 +12,7 @@
 #if defined(OS_TIZEN)
 #include "xwalk/application/common/manifest_handlers/navigation_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_application_handler.h"
+#include "xwalk/application/common/manifest_handlers/tizen_metadata_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
 #endif
 #include "xwalk/application/common/manifest_handlers/permissions_handler.h"
@@ -79,6 +80,7 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   handlers.push_back(new NavigationHandler);
   handlers.push_back(new TizenApplicationHandler);
   handlers.push_back(new TizenSettingHandler);
+  handlers.push_back(new TizenMetaDataHandler);
 #endif
   widget_registry_ = new ManifestHandlerRegistry(handlers);
   return widget_registry_;

--- a/application/common/manifest_handlers/tizen_metadata_handler.cc
+++ b/application/common/manifest_handlers/tizen_metadata_handler.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/tizen_metadata_handler.h"
+
+#include <map>
+#include <utility>
+
+#include "base/strings/utf_string_conversions.h"
+#include "base/values.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+typedef std::pair<std::string, std::string> MetaDataPair;
+typedef std::map<std::string, std::string> MetaDataMap;
+typedef std::map<std::string, std::string>::const_iterator MetaDataIter;
+
+namespace {
+
+MetaDataPair ParseMetaDataItem(const base::DictionaryValue* dict,
+                               base::string16* error) {
+  DCHECK(dict && dict->IsType(base::Value::TYPE_DICTIONARY));
+  MetaDataPair result;
+  std::string value;
+  if (!dict->GetString(keys::kTizenMetaDataNameKey, &result.first) ||
+      !dict->GetString(keys::kTizenMetaDataValueKey, &result.second)) {
+    *error = base::ASCIIToUTF16("Invalid key/value of tizen metaData.");
+  }
+
+  return result;
+}
+}  // namespace
+
+namespace application {
+
+TizenMetaDataInfo::TizenMetaDataInfo() {}
+
+TizenMetaDataInfo::~TizenMetaDataInfo() {}
+
+bool TizenMetaDataInfo::HasKey(const std::string& key) const {
+  return metadata_.find(key) != metadata_.end();
+}
+
+std::string TizenMetaDataInfo::GetValue(const std::string& key) const {
+  MetaDataIter it = metadata_.find(key);
+  if (it != metadata_.end())
+    return it->second;
+  return std::string("");
+}
+
+void TizenMetaDataInfo::SetValue(const std::string& key,
+                                 const std::string& value) {
+  metadata_.insert(MetaDataPair(key, value));
+}
+
+TizenMetaDataHandler::TizenMetaDataHandler() {
+}
+
+TizenMetaDataHandler::~TizenMetaDataHandler() {}
+
+bool TizenMetaDataHandler::Parse(scoped_refptr<ApplicationData> application,
+                                 base::string16* error) {
+  scoped_ptr<TizenMetaDataInfo> metadata_info(new TizenMetaDataInfo);
+  const Manifest* manifest = application->GetManifest();
+  DCHECK(manifest);
+
+  base::Value* metadata_value = NULL;
+  if (!manifest->Get(keys::kTizenMetaDataKey, &metadata_value)) {
+    *error = base::ASCIIToUTF16("Failed to get value of tizen metaData");
+  }
+
+  MetaDataPair metadata_item;
+  if (metadata_value && metadata_value->IsType(base::Value::TYPE_DICTIONARY)) {
+    base::DictionaryValue* dict;
+    metadata_value->GetAsDictionary(&dict);
+    metadata_item = ParseMetaDataItem(dict, error);
+    metadata_info->SetValue(metadata_item.first, metadata_item.second);
+  } else if (metadata_value && metadata_value->IsType(base::Value::TYPE_LIST)) {
+    base::ListValue* list;
+    metadata_value->GetAsList(&list);
+
+    for (base::ListValue::iterator it = list->begin();
+         it != list->end(); ++it) {
+      base::DictionaryValue* dict;
+      (*it)->GetAsDictionary(&dict);
+      metadata_item = ParseMetaDataItem(dict, error);
+      metadata_info->SetValue(metadata_item.first, metadata_item.second);
+    }
+  }
+
+  application->SetManifestData(keys::kTizenMetaDataKey,
+                               metadata_info.release());
+  return true;
+}
+
+std::vector<std::string> TizenMetaDataHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kTizenMetaDataKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/tizen_metadata_handler.h
+++ b/application/common/manifest_handlers/tizen_metadata_handler.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_METADATA_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_METADATA_HANDLER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "base/values.h"
+#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest_handler.h"
+
+namespace xwalk {
+namespace application {
+
+class TizenMetaDataInfo : public ApplicationData::ManifestData {
+ public:
+  TizenMetaDataInfo();
+  virtual ~TizenMetaDataInfo();
+
+  bool HasKey(const std::string& key) const;
+  std::string GetValue(const std::string& key) const;
+  void SetValue(const std::string& key, const std::string& value);
+  const std::map<std::string, std::string>& metadata() const {
+    return metadata_;
+  }
+
+ private:
+  std::map<std::string, std::string> metadata_;
+};
+
+class TizenMetaDataHandler : public ManifestHandler {
+ public:
+  TizenMetaDataHandler();
+  virtual ~TizenMetaDataHandler();
+
+  virtual bool Parse(scoped_refptr<ApplicationData> application,
+                     base::string16* error) OVERRIDE;
+  virtual std::vector<std::string> Keys() const OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(TizenMetaDataHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_METADATA_HANDLER_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -126,6 +126,8 @@
             'common/manifest_handlers/navigation_handler.h',
             'common/manifest_handlers/tizen_application_handler.cc',
             'common/manifest_handlers/tizen_application_handler.h',
+            'common/manifest_handlers/tizen_metadata_handler.cc',
+            'common/manifest_handlers/tizen_metadata_handler.h',
             'common/manifest_handlers/tizen_setting_handler.cc',
             'common/manifest_handlers/tizen_setting_handler.h',
           ],


### PR DESCRIPTION
'metadata' element supports metadata information shared with other web
applications. The defined metadata can be accessed (read-only) through
the Tizen Application API.

BUG=XWALK-1495
