### PR TITLE
[Android] Use library Context to get Inflater for shared mode

### DIFF
--- a/runtime/android/runtime/src/org/xwalk/runtime/MixedContext.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/MixedContext.java
@@ -42,6 +42,9 @@ class MixedContext extends ContextWrapper {
 
     @Override
     public Object getSystemService(String name) {
+        if (name.equals(Context.LAYOUT_INFLATER_SERVICE)) {
+            return super.getSystemService(name);
+        }
         return mActivityCtx.getSystemService(name);
     }
 }


### PR DESCRIPTION
For color picker on Android, it uses ColorPickerAdvanced and
ColorPickerSimple which is customized view. So the inflater
should contain the ClassLoader which has loaded the relevant
classes. As for shared mode, it's library Context.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1534
