### PR TITLE
[Runtime] Support identifying namespace of content element in WGT config.xml

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -49,6 +49,8 @@ const char kNameKey[] = "widget.name.#text";
 const char kVersionKey[] = "widget.@version";
 const char kWidgetKey[] = "widget";
 const char kLaunchLocalPathKey[] = "widget.content.@src";
+const char kContentKey[] = "widget.content";
+const char kContentSrcKey[] = "@src";
 const char kWebURLsKey[] = "widget.@id";
 const char kAuthorKey[] = "widget.author.#text";
 const char kDescriptionKey[] = "widget.description.#text";
@@ -92,6 +94,7 @@ const char kTizenMetaDataValueKey[] = "@value";
 #endif
 }  // namespace application_widget_keys
 
+const char kWidgetNamespecePrefix[] = "http://www.w3.org/ns/widgets";
 #if defined(OS_TIZEN)
 const char kTizenNamespacePrefix[] = "http://tizen.org/ns/widgets";
 #endif

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -44,6 +44,9 @@ namespace application_widget_keys {
   extern const char kNamespaceKey[];
   extern const char kNameKey[];
   extern const char kLaunchLocalPathKey[];
+  extern const char kContentKey[];
+  // Child keys inside 'kContentKey'
+  extern const char kContentSrcKey[];
   extern const char kWebURLsKey[];
   extern const char kWidgetKey[];
   extern const char kVersionKey[];
@@ -80,6 +83,7 @@ namespace application_widget_keys {
 #endif
 }  // namespace application_widget_keys
 
+extern const char kWidgetNamespecePrefix[];
 #if defined(OS_TIZEN)
 extern const char kTizenNamespacePrefix[];
 #endif


### PR DESCRIPTION
In Tizen platform, there are two kinds of element to set the application
start page in configure document (config.xml), the <content> and
tizen:content, the content element with tizen namespace represents the
host app starting page, the other one is for common packaged app.

This patch can choose the right one for packaged app, the tizen specific
one will be ignored when launching from local page.

This patch will support to get the first one if multiple content elements
are defined in config.xml as well.
