### PR TITLE
[Android] Hide classes and description refinement for Javadoc.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkClient.java
@@ -34,6 +34,8 @@ import android.widget.TextView;
 /**
  * It's the Internal class to handle legacy resource related callbacks not
  * handled by XWalkResourceClient.
+ *
+ * @hide
  */
 public class XWalkClient {
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkCookieManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkCookieManager.java
@@ -10,9 +10,10 @@ import org.chromium.base.JNINamespace;
  * XWalkCookieManager manages cookies according to RFC2109 spec.
  *
  * Methods in this class are thread safe.
+ *
+ * @hide
  */
 @JNINamespace("xwalk")
-// TODO(yongsheng): remove public modifier.
 public final class XWalkCookieManager {
     /**
      * Control whether cookie is enabled or disabled

--- a/runtime/android/core/src/org/xwalk/core/XWalkGeolocationPermissions.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkGeolocationPermissions.java
@@ -17,7 +17,7 @@ import org.chromium.net.GURLUtils;
  * This class is used to manage permissions for the WebView's Geolocation JavaScript API.
  *
  * Callbacks are posted on the UI thread.
- * TODO(yongsheng): remove public modifier.
+ * @hide
  */
 public final class XWalkGeolocationPermissions {
     /**

--- a/runtime/android/core/src/org/xwalk/core/XWalkHttpAuthHandler.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkHttpAuthHandler.java
@@ -7,8 +7,11 @@ package org.xwalk.core;
 import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
 
+/**
+ * It's for http auth handling.
+ * @hide
+ */
 @JNINamespace("xwalk")
-// TODO(yongsheng): remove public modifier.
 public class XWalkHttpAuthHandler {
 
     private int mNativeXWalkHttpAuthHandler;

--- a/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
@@ -31,8 +31,10 @@ import android.widget.LinearLayout;
 
 import org.chromium.content.browser.ContentViewRenderView.FirstRenderedFrameListener;
 
-// Provisionally set it as public due to the use of launch screen extension.
-// TODO(yongsheng): remove public modifier.
+/**
+ * Provisionally set it as public due to the use of launch screen extension.
+ * @hide
+ */
 public class XWalkLaunchScreenManager
         implements FirstRenderedFrameListener, DialogInterface.OnShowListener, PageLoadListener {
     // This string will be initialized before extension initialized,

--- a/runtime/android/core/src/org/xwalk/core/XWalkNavigationHandlerImpl.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNavigationHandlerImpl.java
@@ -15,7 +15,9 @@ import org.chromium.components.navigation_interception.NavigationParams;
 
 import org.xwalk.core.XWalkNavigationHandler;
 
-// TODO(yongsheng): remove public modifier.
+/**
+ * @hide
+ */
 public class XWalkNavigationHandlerImpl implements XWalkNavigationHandler {
     private static final String TAG = "XWalkNavigationHandlerImpl";
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkNavigationHistory.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNavigationHistory.java
@@ -77,10 +77,12 @@ public final class XWalkNavigationHistory implements Cloneable, Serializable {
     }
 
     /**
-     * The direction for navigation.
+     * The direction for web page navigation.
      */
     public enum Direction {
+        /** the backward direction for web page navigation. */
         BACKWARD,
+        /** the forward direction for web page navigation. */
         FORWARD
     }
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkNavigationItem.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNavigationItem.java
@@ -7,7 +7,7 @@ package org.xwalk.core;
 import org.chromium.content.browser.NavigationEntry;
 
 /**
- * Represent a navigation item and managed in XWalkNavigationHistory.
+ * This class represents a navigation item and is managed in XWalkNavigationHistory.
  */
 public final class XWalkNavigationItem implements Cloneable {
     private NavigationEntry mEntry;

--- a/runtime/android/core/src/org/xwalk/core/XWalkNotificationServiceImpl.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNotificationServiceImpl.java
@@ -23,7 +23,9 @@ import org.xwalk.core.XWalkContentsClientBridge;
 import org.xwalk.core.XWalkNotificationService;
 import org.xwalk.core.XWalkView;
 
-// TODO(yongsheng): remove public modifier.
+/**
+ * @hide
+ */
 public class XWalkNotificationServiceImpl implements XWalkNotificationService {
     private static final String TAG = "XWalkNotificationServiceImpl";
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkPreferences.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkPreferences.java
@@ -9,7 +9,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * This class is not thread-safe and must be called on the UI thread.
+ * This class represents the preferences and could be set by callers.
+ * It is not thread-safe and must be called on the UI thread.
  * Afterwards, the preference could be read from all threads and can impact
  * all XWalkView instances.
  */

--- a/runtime/android/core/src/org/xwalk/core/XWalkResourceClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkResourceClient.java
@@ -11,7 +11,7 @@ import android.view.View;
 import android.webkit.WebResourceResponse;
 
 /**
- * This interface notifies the embedder resource events/callbacks.
+ * This class notifies the embedder resource events/callbacks.
  */
 public class XWalkResourceClient {
 
@@ -44,7 +44,7 @@ public class XWalkResourceClient {
     /**
      * Notify the client the progress info of loading a specific url.
      * @param view the owner XWalkView instance.
-     * @param url the loading process in percent.
+     * @param progressInPercent the loading process in percent.
      */
     public void onProgressChanged(XWalkView view, int progressInPercent) {
     }

--- a/runtime/android/core/src/org/xwalk/core/XWalkSettings.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkSettings.java
@@ -16,6 +16,9 @@ import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
 import org.chromium.base.ThreadUtils;
 
+/**
+ * @hide
+ */
 @JNINamespace("xwalk")
 public class XWalkSettings {
 
@@ -585,7 +588,7 @@ public class XWalkSettings {
     }
 
     /**
-     * @returns the default User-Agent used by each ContentViewCore instance, i.e. unless
+     * @return returns the default User-Agent used by each ContentViewCore instance, i.e. unless
      * overridden by {@link #setUserAgentString()}
      */
     public static String getDefaultUserAgent() {

--- a/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
@@ -37,6 +37,10 @@ public class XWalkUIClient {
     private XWalkView mXWalkView;
     private boolean mOriginalFullscreen;
 
+    /**
+     * Constructor.
+     * @param view the owner XWalkView instance.
+     */
     public XWalkUIClient(XWalkView view) {
         mContext = view.getContext();
         mDecorView = view.getActivity().getWindow().getDecorView();
@@ -79,9 +83,13 @@ public class XWalkUIClient {
      * The type of JavaScript modal dialog.
      */
     public enum JavascriptMessageType {
+        /** JavaScript alert dialog. */
         JAVASCRIPT_ALERT,
+        /** JavaScript confirm dialog. */
         JAVASCRIPT_CONFIRM,
+        /** JavaScript prompt dialog. */
         JAVASCRIPT_PROMPT,
+        /** JavaScript dialog for a window-before-unload notification. */
         JAVASCRIPT_BEFOREUNLOAD
     }
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkView.java
@@ -47,7 +47,7 @@ public class XWalkView extends android.widget.FrameLayout {
     private XWalkExtensionManager mExtensionManager;
 
     /**
-     * Constructors for inflating via XML.
+     * Constructor for inflating via XML.
      * @param context  a Context object used to access application assets.
      * @param attrs    an AttributeSet passed to our parent.
      */
@@ -60,7 +60,7 @@ public class XWalkView extends android.widget.FrameLayout {
     }
 
     /**
-     * Constructors for Crosswalk runtime. In shared mode, context isi
+     * Constructor for Crosswalk runtime. In shared mode, context isi
      * different from activity. In embedded mode, they're same.
      * @param context  a Context object used to access application assets
      * @param activity the activity for this XWalkView.
@@ -78,6 +78,8 @@ public class XWalkView extends android.widget.FrameLayout {
     /**
      * Get the current activity passed from callers. It's never null.
      * @return the activity instance passed from callers.
+     *
+     * @hide
      */
     public Activity getActivity() {
         if (mActivity != null) {
@@ -92,6 +94,9 @@ public class XWalkView extends android.widget.FrameLayout {
     }
 
     // TODO(yongsheng): we should remove this since we have getContext()?
+    /**
+     * @hide
+     */
     public Context getViewContext() {
         return mContext;
     }
@@ -388,13 +393,13 @@ public class XWalkView extends android.widget.FrameLayout {
         mContent.setResourceClient(client);
     }
 
-    @Override
     /**
      * Inherit from android.view.View. This class needs to handle some keys like
      * 'BACK'.
      * @param keyCode passed from android.view.View.onKeyUp().
      * @param event passed from android.view.View.onKeyUp().
      */
+    @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_BACK) {
             // If there's navigation happens when app is fullscreen,
@@ -412,28 +417,42 @@ public class XWalkView extends android.widget.FrameLayout {
     }
 
     // TODO(yongsheng): this is not public.
+    /**
+     * @hide
+     */
     public XWalkSettings getSettings() {
         checkThreadSafety();
         return mContent.getSettings();
     }
 
-    // TODO(yongsheng): remove this and related test cases?
+    /**
+     * This method is used by Cordova for hacking.
+     * TODO(yongsheng): remove this and related test cases?
+     *
+     * @hide
+     */
     public void setNetworkAvailable(boolean networkUp) {
         checkThreadSafety();
         mContent.setNetworkAvailable(networkUp);
     }
 
-    // Enables remote debugging and returns the URL at which the dev tools server is listening
-    // for commands. The allowedUid argument can be used to specify the uid of the process that is
-    // permitted to connect.
-    // TODO(yongsheng): how to enable this in XWalkPreferences?
+    /**
+     * Enables remote debugging and returns the URL at which the dev tools server is listening
+     * for commands. The allowedUid argument can be used to specify the uid of the process that is
+     * permitted to connect.
+     * TODO(yongsheng): how to enable this in XWalkPreferences?
+     *
+     * @hide
+     */
     public String enableRemoteDebugging(int allowedUid) {
         checkThreadSafety();
         return mContent.enableRemoteDebugging(allowedUid);
     }
 
-    // It's used by presentation API.
-    // TODO(yongsheng): how to fix it?
+    /**
+     * It's used for Presentation API.
+     * @hide
+     */
     public int getContentID() {
         return mContent.getRoutingID();
     }
@@ -500,31 +519,46 @@ public class XWalkView extends android.widget.FrameLayout {
         mContent.navigateTo(offset);
     }
 
-    public void setOverlayVideoMode(boolean enabled) {
+    void setOverlayVideoMode(boolean enabled) {
         mContent.setOverlayVideoMode(enabled);
     }
 
     // Below methods are for test shell and instrumentation tests.
+    /**
+     * @hide
+     */
     public void setXWalkClient(XWalkClient client) {
         checkThreadSafety();
         mContent.setXWalkClient(client);
     }
 
+    /**
+     * @hide
+     */
     public void setXWalkWebChromeClient(XWalkWebChromeClient client) {
         checkThreadSafety();
         mContent.setXWalkWebChromeClient(client);
     }
 
+    /**
+     * @hide
+     */
     public void setDownloadListener(DownloadListener listener) {
         checkThreadSafety();
         mContent.setDownloadListener(listener);
     }
 
+    /**
+     * @hide
+     */
     public void setNavigationHandler(XWalkNavigationHandler handler) {
         checkThreadSafety();
         mContent.setNavigationHandler(handler);
     }
 
+    /**
+     * @hide
+     */
     public void setNotificationService(XWalkNotificationService service) {
         checkThreadSafety();
         mContent.setNotificationService(service);

--- a/runtime/android/core/src/org/xwalk/core/XWalkWebChromeClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkWebChromeClient.java
@@ -34,6 +34,8 @@ import android.widget.FrameLayout;
  * It's an internal legacy class which is to handle kinds of ui related
  * callback functions. It only handles those which are not exposed to
  * external users compared to XWalkUIClient.
+ *
+ * @hide
  */
 public class XWalkWebChromeClient {
     private Context mContext;

--- a/runtime/android/core/src/org/xwalk/core/package.html
+++ b/runtime/android/core/src/org/xwalk/core/package.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <p>Provides an embedding API for browsing web and running web applications.
+    <p>For more information about building apps with Crosswalk embedding API, see the
+    <a href="https://crosswalk-project.org/">Crosswalk project</a>.
+  </body>
+</html>


### PR DESCRIPTION
This fix aims to use Doclava(https://code.google.com/p/doclava/) to
generate java doc for embedding API. Since some classes and methods
are public but not generated as API, "@hide" is used from Doclava.
Besides, it refines some description and comments. Next is to enable
doclava in Crosswalk.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1544
