### PR TITLE
[Runtime] Support to load application resources by the locale setting.

### DIFF
--- a/application/common/application_resource.cc
+++ b/application/common/application_resource.cc
@@ -12,6 +12,10 @@
 
 namespace xwalk {
 namespace application {
+namespace {
+const base::FilePath::StringType WGT_LOCALE_DIRECTORY =
+    FILE_PATH_LITERAL("locales");
+}  // namespace
 
 ApplicationResource::ApplicationResource() : follow_symlinks_anywhere_(false) {
 }
@@ -41,6 +45,17 @@ const base::FilePath& ApplicationResource::GetFilePath() const {
   if (!full_resource_path_.empty())
     return full_resource_path_;
 
+  for (std::list<std::string>::const_iterator it = locales_.begin();
+       it != locales_.end(); ++it) {
+    full_resource_path_ = GetFilePath(
+        application_root_,
+        base::FilePath(WGT_LOCALE_DIRECTORY)
+        .AppendASCII(*it).Append(relative_path_),
+        follow_symlinks_anywhere_ ?
+        FOLLOW_SYMLINKS_ANYWHERE : SYMLINKS_MUST_RESOLVE_WITHIN_ROOT);
+    if (!full_resource_path_.empty())
+      return full_resource_path_;
+  }
   full_resource_path_ = GetFilePath(
       application_root_, relative_path_,
       follow_symlinks_anywhere_ ?

--- a/application/common/application_resource.h
+++ b/application/common/application_resource.h
@@ -5,6 +5,7 @@
 #ifndef XWALK_APPLICATION_COMMON_APPLICATION_RESOURCE_H_
 #define XWALK_APPLICATION_COMMON_APPLICATION_RESOURCE_H_
 
+#include <list>
 #include <string>
 
 #include "base/files/file_path.h"
@@ -60,6 +61,12 @@ class ApplicationResource {
   const base::FilePath& application_root() const { return application_root_; }
   const base::FilePath& relative_path() const { return relative_path_; }
 
+  // Setters
+  void SetLocales(const std::list<std::string>& locales) {
+    locales_ = locales;
+    full_resource_path_.clear();
+  }
+
   bool empty() const { return application_root().empty(); }
 
   // Unit test helpers.
@@ -83,6 +90,9 @@ class ApplicationResource {
 
   // Full path to application resource. Starts empty.
   mutable base::FilePath full_resource_path_;
+
+  // The User Agent localization information.
+  std::list<std::string> locales_;
 };
 
 }  // namespace application


### PR DESCRIPTION
For WGT package, the W3C widget specification defines the concept of
folder-based localization, which is the process whereby an author places
files inside folders that are named in a manner that conforms to a
language-range ABNF rule. That is, by naming folders in lower-case using
values derived from the IANA Language Subtag Registry such as "en-us",
"en-gb", and so on. These locale folders are then placed inside the
container for localized content which is a reserved folder at the root
of the widget package whose folder-name case-sensitively matches the
string 'locales'.

For more details, please refer to
http://www.w3.org/TR/widgets/#folder-based-localization.

The related feature is XWALK-1030 and XWALK-1503
