### PR TITLE
Activate xdg-shell, so the "minimize" button works under Tizen

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -141,7 +141,7 @@ if [ -n "${BUILDDIR_NAME}" ]; then
 fi
 
 %if %{with wayland}
-GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1 -Denable_ozone_wayland_vkb=1"
+GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1 -Denable_ozone_wayland_vkb=1 -Denable_xdg_shell=1"
 %endif
 
 # --no-parallel is added because chroot does not mount a /dev/shm, this will


### PR DESCRIPTION
We enable the build-time option "xdg-shell" for Tizen. Tested OK
with the latest Tizen Common & IVI images, it should work reliably
with upcoming snapshots & releases as we are taking care of
protocol versions compatibility.

BUG=XWALK-1382

Signed-off-by: Manuel Bachmann manuel.bachmann@open.eurogiciel.org
