### PR TITLE
[SMACK] change xwalk binary smack exec label

### DIFF
--- a/packaging/crosswalk.manifest
+++ b/packaging/crosswalk.manifest
@@ -2,4 +2,10 @@
  <request>
     <domain name="_"/>
  </request>
+ <assign>
+    <filesystem path="/usr/bin/xwalk" exec_label="User" />
+    <filesystem path="/usr/bin/xwalkctl" exec_label="User" />
+    <filesystem path="/usr/bin/xwalk-launcher" exec_label="User" />
+    <filesystem path="/usr/bin/xwalk-pkg-helper" exec_label="User" />
+ </assign>
 </manifest>


### PR DESCRIPTION
*In order to make all xwalk binaries running with same User domain label,
 we enforce "exec" property for these binaries
