### PR TITLE
[Android] Allow XWalkUIClient to overwrite openFileChooser

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClient.java
@@ -178,6 +178,9 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
     public abstract boolean hasEnteredFullscreen();
 
+    public abstract boolean shouldOverrideRunFileChooser(
+            int processId, int renderId, int mode, String acceptTypes, boolean capture);
+
     // TODO (michaelbai): Remove this method once the same method remove from
     // XWalkContentsClientAdapter.
     public void onShowCustomView(View view,

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -5,12 +5,16 @@
 
 package org.xwalk.core;
 
+import android.content.ContentResolver;
 import android.content.Intent;
+import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Picture;
+import android.net.Uri;
 import android.net.http.SslCertificate;
 import android.net.http.SslError;
 import android.os.Message;
+import android.provider.MediaStore;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
@@ -384,6 +388,79 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
+    public boolean shouldOverrideRunFileChooser(
+            final int processId, final int renderId, final int modeFlags,
+            String acceptTypes, boolean capture) {
+        if (!isOwnerActivityRunning()) return false;
+        abstract class UriCallback implements ValueCallback<Uri> {
+            boolean syncNullReceived = false;
+            boolean syncCallFinished = false;
+            protected String resolveFileName(Uri uri, ContentResolver contentResolver) {
+                if (contentResolver == null || uri == null) return "";
+                Cursor cursor = null;
+                try {
+                    cursor = contentResolver.query(uri, null, null, null, null);
+
+                    if (cursor != null && cursor.getCount() >= 1) {
+                        cursor.moveToFirst();
+                        int index = cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME);
+                        if (index > -1) return cursor.getString(index);
+                    }
+                } catch (NullPointerException e) {
+                    // Some android models don't handle the provider call correctly.
+                    // see crbug.com/345393
+                    return "";
+                } finally {
+                    if (cursor != null) cursor.close();
+                }
+                return "";
+            }
+        }
+        UriCallback uploadFile = new UriCallback() {
+            boolean completed = false;
+            @Override
+            public void onReceiveValue(Uri value) {
+                if (completed) {
+                    throw new IllegalStateException("Duplicate openFileChooser result");
+                }
+                completed = true;
+                if (value == null && !syncCallFinished) {
+                    syncNullReceived = true;
+                    return;
+                }
+                if (value == null) {
+                    nativeOnFilesNotSelected(mNativeContentsClientBridge,
+                            processId, renderId, modeFlags);
+                } else {
+                    String result = "";
+                    String displayName = null;
+                    if (ContentResolver.SCHEME_FILE.equals(value.getScheme())) {
+                        result = value.getSchemeSpecificPart();
+                        displayName = value.getLastPathSegment();
+                    } else if (ContentResolver.SCHEME_CONTENT.equals(value.getScheme())) {
+                        result = value.toString();
+                        displayName = resolveFileName(
+                                value, mXWalkView.getActivity().getContentResolver());
+                    } else {
+                        result = value.getPath();
+                        displayName = value.getLastPathSegment();
+                    }
+                    if (displayName == null || displayName.isEmpty()) displayName = result;
+                    nativeOnFilesSelected(mNativeContentsClientBridge,
+                            processId, renderId, modeFlags, result, displayName);
+                }
+            }
+        };
+        mXWalkUIClient.openFileChooser(
+                mXWalkView, uploadFile, acceptTypes, Boolean.toString(capture));
+        uploadFile.syncCallFinished = true;
+        // File chooser requires user interaction, valid derives should handle it in async process.
+        // If the ValueCallback receive a sync result with null value, it is considered the
+        // file chooser is not overridden.
+        return !uploadFile.syncNullReceived;
+    }
+
+    @Override
     public ContentVideoViewClient getContentVideoViewClient() {
         return new XWalkContentVideoViewClient(this, mXWalkView.getActivity(), mXWalkView);
     }
@@ -460,16 +537,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
                     XWalkUIClient.JavascriptMessageType.JAVASCRIPT_BEFOREUNLOAD, url, message, "",
                             result);
         }
-    }
-
-    // @CalledByNative
-    // TODO(yongsheng): Native side should call file chooser.
-    public void runFileChooser(final int processId, final int renderId, final int mode_flags,
-            String acceptTypes, String title, String defaultFilename, boolean capture) {
-        if (!isOwnerActivityRunning()) return;
-        // TODO(yongsheng): Implement it.
-        // mXWalkUIClient.openFileChooser(mXWalkView, ...);
-        // See https://crosswalk-project.org/jira/browse/XWALK-1241.
     }
 
     @CalledByNative
@@ -562,4 +629,8 @@ class XWalkContentsClientBridge extends XWalkContentsClient
             int processId, int routeId);
     private native void nativeNotificationClosed(int nativeXWalkContentsClientBridge, int id,
             boolean byUser, int processId, int routeId);
+    private native void nativeOnFilesSelected(int nativeXWalkContentsClientBridge,
+            int processId, int renderId, int mode_flags, String filepath, String displayName);
+    private native void nativeOnFilesNotSelected(int nativeXWalkContentsClientBridge,
+            int processId, int renderId, int mode_flags);
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
@@ -166,7 +166,13 @@ public class XWalkUIClient {
     /**
      * Tell the client to open a file chooser.
      * @param view the owner XWalkView instance.
-     * @param uploadFile the callback class to handle the result from caller.
+     * @param uploadFile the callback class to handle the result from caller. It MUST
+     *        be invoked in all cases. Leave it not invoked will block all following
+     *        requests to open file chooser.
+     * @param acceptType value of the 'accept' attribute of the input tag associated
+     *        with this file picker.
+     * @param capture value of the 'capture' attribute of the input tag associated
+     *        with this file picker
      */
     public void openFileChooser(XWalkView view, ValueCallback<Uri> uploadFile,
             String acceptType, String capture) {

--- a/runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegate.java
@@ -26,6 +26,11 @@ abstract class XWalkWebContentsDelegate extends WebContentsDelegateAndroid {
     public abstract void rendererResponsive();
 
     @CalledByNative
+    public abstract boolean shouldOverrideRunFileChooser(
+            int processId, int renderId, int mode,
+            String acceptTypes, boolean capture);
+
+    @CalledByNative
     public void updatePreferredSize(int widthCss, int heightCss) {
     }
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegateAdapter.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkWebContentsDelegateAdapter.java
@@ -56,4 +56,14 @@ class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
 
         return false;
     }
+
+    @Override
+    public boolean shouldOverrideRunFileChooser(int processId, int renderId, int mode,
+            String acceptTypes, boolean capture) {
+        if (mXWalkContentsClient != null) {
+            return mXWalkContentsClient.shouldOverrideRunFileChooser(processId, renderId, mode,
+                    acceptTypes, capture);
+        }
+        return false;
+    }
 }

--- a/runtime/browser/android/xwalk_contents_client_bridge.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge.h
@@ -100,6 +100,11 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase {
       JNIEnv*, jobject, int id, int process_id, int route_id);
   void NotificationClosed(
       JNIEnv*, jobject, int id, bool by_user, int process_id, int route_id);
+  void OnFilesSelected(
+      JNIEnv*, jobject, int process_id, int render_id,
+      int mode, jstring filepath, jstring display_name);
+  void OnFilesNotSelected(
+      JNIEnv*, jobject, int process_id, int render_id, int mode);
 
  private:
   JavaObjectWeakGlobalRef java_ref_;

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -4,17 +4,26 @@
 
 #include "xwalk/runtime/browser/android/xwalk_web_contents_delegate.h"
 
+#include <vector>
+
+#include "base/android/jni_string.h"
 #include "base/android/scoped_java_ref.h"
 #include "base/lazy_instance.h"
 #include "base/message_loop/message_loop.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/common/file_chooser_params.h"
 #include "jni/XWalkWebContentsDelegate_jni.h"
 #include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
 #include "xwalk/runtime/browser/runtime_file_select_helper.h"
 #include "xwalk/runtime/browser/runtime_javascript_dialog_manager.h"
+#include "ui/shell_dialogs/selected_file_info.h"
 
 using base::android::AttachCurrentThread;
+using base::android::ConvertUTF16ToJavaString;
 using base::android::ScopedJavaLocalRef;
+using content::FileChooserParams;
 using content::WebContents;
 
 namespace xwalk {
@@ -78,7 +87,31 @@ void XWalkWebContentsDelegate::UpdatePreferredSize(
 void XWalkWebContentsDelegate::RunFileChooser(
     content::WebContents* web_contents,
     const content::FileChooserParams& params) {
-  RuntimeFileSelectHelper::RunFileChooser(web_contents, params);
+  JNIEnv* env = AttachCurrentThread();
+
+  ScopedJavaLocalRef<jobject> java_delegate = GetJavaDelegate(env);
+  if (!java_delegate.obj())
+    return;
+
+  if (params.mode == FileChooserParams::Save) {
+    // Save not supported, so cancel it.
+    web_contents->GetRenderViewHost()->FilesSelectedInChooser(
+         std::vector<ui::SelectedFileInfo>(),
+         params.mode);
+    return;
+  }
+  int mode = static_cast<int>(params.mode);
+  jboolean overridden =
+      Java_XWalkWebContentsDelegate_shouldOverrideRunFileChooser(env,
+          java_delegate.obj(),
+          web_contents->GetRenderProcessHost()->GetID(),
+          web_contents->GetRenderViewHost()->GetRoutingID(),
+          mode,
+          ConvertUTF16ToJavaString(env,
+              JoinString(params.accept_types, ',')).obj(),
+          params.capture);
+  if (overridden == JNI_FALSE)
+    RuntimeFileSelectHelper::RunFileChooser(web_contents, params);
 }
 
 content::JavaScriptDialogManager*


### PR DESCRIPTION
Previous, select file is handled within xwalk_web_contents_delegate
and the openFileChooser API in XWalkUIClient is not working.
"openFileChooser" is used in android.webkit.WebChromeClient, which
is adopted by many current webview users (e.g. Cordova).

In this commit, it dispatch the request to XWalkUIClient which is
empty implementation. If the derives override the implementation,
it can invoke the callback somewhere to provide the chosen file.
Otherwise, it will fallback to internal solution using
RuntimeFileSelectHelper::RunFileChooser.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1561
