### PR TITLE
[Extension] Fix ";" typo after if-clause

### DIFF
--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -216,7 +216,7 @@ void XWalkExtensionProcessHost::StartProcess() {
 }
 
 void XWalkExtensionProcessHost::StopProcess() {
-  if (process_);
+  if (process_)
     process_.reset();
   if (channel_)
     channel_.reset();


### PR DESCRIPTION
It will cause process_.reset() runs every time.
