### PR TITLE
[Android] Remove all java source files in xwalk_core_library

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -61,61 +61,6 @@ def CopyProjectFiles(project_source, out_dir):
     shutil.copy2(source_file, target_file)
 
 
-def CopyJavaSources(project_source, out_dir):
-  """cp <path>/java/src/<package>
-        out/Release/xwalk_core_library/src/<package>
-  """
-
-  print 'Copying Java sources...'
-  target_source_dir = os.path.join(
-      out_dir, LIBRARY_PROJECT_NAME, 'src')
-  if not os.path.exists(target_source_dir):
-    os.makedirs(target_source_dir)
-
-  # FIXME(wang16): There is an assumption here the package names listed
-  # here are all beginned with "org". If the assumption is broken in
-  # future, the logic needs to be adjusted accordingly.
-  java_srcs_to_copy = [
-      # R.javas
-      'content/public/android/java/resource_map/org/chromium/content/R.java',
-      'ui/android/java/resource_map/org/chromium/ui/R.java',
-  ]
-
-  for source in java_srcs_to_copy:
-    # find the src/org in the path
-    slash_org_pos = source.find(r'/org/')
-    if slash_org_pos < 0:
-      raise Exception('Invalid java source path: %s' % source)
-    source_path = os.path.join(project_source, source)
-    package_path = source[slash_org_pos+1:]
-    target_path = os.path.join(target_source_dir, package_path)
-    if os.path.isfile(source_path):
-      if not os.path.isdir(os.path.dirname(target_path)):
-        os.makedirs(os.path.dirname(target_path))
-      shutil.copyfile(source_path, target_path)
-    else:
-      shutil.copytree(source_path, target_path)
-
-
-def CopyGeneratedSources(out_dir):
-  """cp out/Release/xwalk_core_shell_apk/
-            native_libraries_java/NativeLibraries.java
-        out/Release/xwalk_core_library/src/org/
-            chromium/base/library_loader/NativeLibraries.java
-  """
-
-  print 'Copying generated source files...'
-
-  source_file = os.path.join(out_dir, XWALK_CORE_SHELL_APK,
-                             'native_libraries_java',
-                             'NativeLibraries.java')
-  target_file = os.path.join(out_dir, LIBRARY_PROJECT_NAME, 'src', 'org',
-                             'chromium', 'base', 'library_loader',
-                             'NativeLibraries.java')
-  if not os.path.isdir(os.path.dirname(target_file)):
-    os.makedirs(os.path.dirname(target_file))
-  shutil.copyfile(source_file, target_file)
-
 def CopyJSBindingFiles(project_source, out_dir):
   print 'Copying js binding files...'
   jsapi_dir = os.path.join(out_dir,
@@ -285,9 +230,6 @@ def main(argv):
 
   # Copy Eclipse project files of library project.
   CopyProjectFiles(options.source, out_dir)
-  # Copy Java sources of chromium and xwalk.
-  CopyJavaSources(options.source, out_dir)
-  CopyGeneratedSources(out_dir)
   # Copy binaries and resuorces.
   CopyResources(options.source, out_dir)
   CopyBinaries(out_dir)
@@ -299,6 +241,10 @@ def main(argv):
   mode = os.path.basename(os.path.normpath(out_dir))
   RemoveUnusedFilesInReleaseMode(mode,
       os.path.join(out_dir, LIBRARY_PROJECT_NAME, 'libs'))
+  # Create empty src directory
+  src_dir = os.path.join(out_project_dir, 'src')
+  if not os.path.isdir(src_dir):
+    os.mkdir(src_dir)
   print 'Your Android library project has been created at %s' % (
       out_project_dir)
 

--- a/runtime/android/core_library_empty/AndroidManifest.xml
+++ b/runtime/android/core_library_empty/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--  Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+
+  Use of this source code is governed by a BSD-style license that can be
+  found in the LICENSE file.
+-->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.xwalk.core.library.empty">
+
+    <application android:name="android.app.Application"
+        android:label="XWalkCoreLibraryEmpty" android:hardwareAccelerated="true">
+    </application>
+
+  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
+</manifest>

--- a/runtime/android/core_library_empty/src/README.md
+++ b/runtime/android/core_library_empty/src/README.md
@@ -1,0 +1,11 @@
+# Source folder for xwalk_core_library_empty_apk
+## Why it's empty
+The "xwalk_core_library_empty_apk" is an apk target which
+only depends on xwalk_core_java. The purpose of it is to
+get all the classes compiled from the code chromium generated
+for each apk.
+So there is no java src here.
+## Why put me here
+To make git keep the folder, the src directory is needed to
+build an apk.
+

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -3,6 +3,9 @@
 # found in the LICENSE file.
 
 {
+  'variables': {
+    'core_library_empty_apk_name': 'XWalkCoreLibraryEmpty',
+  },
   'targets': [
     {
       'target_name': 'pack_xwalk_core_library',
@@ -29,17 +32,67 @@
       ],
     },
     {
+      'target_name': 'xwalk_core_library_empty_apk',
+      'type': 'none',
+      'dependencies': [
+        'libxwalkcore',
+        'xwalk_core_java',
+      ],
+      'variables': {
+        'apk_name': '<(core_library_empty_apk_name)',
+        'java_in_dir': 'runtime/android/core_library_empty',
+        'native_lib_target': 'libxwalkcore',
+      },
+      'includes': [ '../build/java_apk.gypi' ],
+    },
+    {
+      # pack classes compiled from the java files chromium generated into a
+      # jar file.
+      'target_name': 'chromium_generated_java',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_core_library_empty_apk',
+      ],
+      'variables': {
+        'jar_name': '<(_target_name).jar',
+        'jar_final_path': '<(PRODUCT_DIR)/lib.java/<(jar_name)',
+        'jar_excluded_classes': [
+          '*org/xwalk/*',
+        ],
+      },
+      'actions': [
+        {
+          'action_name': 'jar_<(_target_name)',
+          'message': 'Creating <(_target_name) jar',
+          'inputs': [
+            '<(DEPTH)/build/android/gyp/util/build_utils.py',
+            '<(DEPTH)/build/android/gyp/util/md5_check.py',
+            '<(DEPTH)/build/android/gyp/jar.py',
+            '<(PRODUCT_DIR)/apks/<(core_library_empty_apk_name).apk',
+          ],
+          'outputs': [
+            '<(jar_final_path)',
+          ],
+          'action': [
+            'python', '<(DEPTH)/build/android/gyp/jar.py',
+            '--classes-dir=<(PRODUCT_DIR)/xwalk_core_library_empty_apk/classes',
+            '--jar-path=<(jar_final_path)',
+            '--excluded-classes=<(jar_excluded_classes)',
+          ],
+        },
+      ],
+    },
+    {
       'target_name': 'xwalk_core_library_java',
       'type': 'none',
       'dependencies': [
         'xwalk_core_java',
+        'chromium_generated_java',
       ],
       'variables': {
-        'java_in_dir': 'runtime/android/core',
         'classes_dir': '<(PRODUCT_DIR)/<(_target_name)/classes',
         'jar_name': '<(_target_name).jar',
         'jar_final_path': '<(PRODUCT_DIR)/lib.java/<(jar_name)',
-        'jar_excluded_classes': [ '*/R.class', '*/R##*.class' ],
       },
       'all_dependent_settings': {
         'variables': {


### PR DESCRIPTION
In previous commit a3cd81484.
Some chromium generated source files including R.java and
NativeLibraries.java are still copied into xwalk_core_library.

With this commit, an empty apk target xwalk_core_library_empty
which only depends on xwalk_core_java with no extra code will
be used to get the classes for the chromium generated java codes.
And package them into a jar file.
