### PR TITLE
[Android] Use Java long for JNI pointer

### DIFF
--- a/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
+++ b/extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java
@@ -18,7 +18,7 @@ import org.chromium.base.JNINamespace;
 @JNINamespace("xwalk::extensions")
 public abstract class XWalkExtensionAndroid {
     private final static String TAG = "XWalkExtensionAndroid";
-    private int mXWalkExtension;
+    private long mXWalkExtension;
 
     public XWalkExtensionAndroid(String name, String jsApi) {
         mXWalkExtension = nativeGetOrCreateExtension(name, jsApi, null);
@@ -62,8 +62,8 @@ public abstract class XWalkExtensionAndroid {
     @CalledByNative
     public abstract String handleSyncMessage(int instanceID, String message);
 
-    private native int nativeGetOrCreateExtension(String name, String jsApi, String[] entryPoints);
-    private native void nativePostMessage(int nativeXWalkExtensionAndroid, int instanceID, String message);
-    private native void nativeBroadcastMessage(int nativeXWalkExtensionAndroid, String message);
-    private native void nativeDestroyExtension(int nativeXWalkExtensionAndroid);
+    private native long nativeGetOrCreateExtension(String name, String jsApi, String[] entryPoints);
+    private native void nativePostMessage(long nativeXWalkExtensionAndroid, int instanceID, String message);
+    private native void nativeBroadcastMessage(long nativeXWalkExtensionAndroid, String message);
+    private native void nativeDestroyExtension(long nativeXWalkExtensionAndroid);
 }

--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -197,7 +197,7 @@ void XWalkExtensionAndroidInstance::HandleSyncMessage(
   SendSyncReplyToJS(scoped_ptr<base::Value>(ret_val));
 }
 
-static jint GetOrCreateExtension(JNIEnv* env, jobject obj, jstring name,
+static jlong GetOrCreateExtension(JNIEnv* env, jobject obj, jstring name,
                                  jstring js_api, jobjectArray js_entry_points) {
   xwalk::XWalkBrowserMainPartsAndroid* main_parts =
       ToAndroidMainParts(XWalkContentBrowserClient::Get()->main_parts());
@@ -215,7 +215,7 @@ static jint GetOrCreateExtension(JNIEnv* env, jobject obj, jstring name,
     static_cast<XWalkExtensionAndroid*>(extension)->BindToJavaObject(env, obj);
   }
 
-  return reinterpret_cast<jint>(extension);
+  return reinterpret_cast<intptr_t>(extension);
 }
 
 bool RegisterXWalkExtensionAndroid(JNIEnv* env) {

--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -55,8 +55,8 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
     private XWalkGeolocationPermissions mGeolocationPermissions;
     private XWalkLaunchScreenManager mLaunchScreenManager;
 
-    int mXWalkContent;
-    int mWebContents;
+    long mXWalkContent;
+    long mWebContents;
     boolean mReadyToLoad = false;
     String mPendingUrl = null;
     String mPendingData = null;
@@ -606,20 +606,20 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
         }
     }
 
-    private native int nativeInit(XWalkWebContentsDelegate webViewContentsDelegate,
+    private native long nativeInit(XWalkWebContentsDelegate webViewContentsDelegate,
             XWalkContentsClientBridge bridge);
-    private static native void nativeDestroy(int nativeXWalkContent);
-    private native int nativeGetWebContents(int nativeXWalkContent,
+    private static native void nativeDestroy(long nativeXWalkContent);
+    private native long nativeGetWebContents(long nativeXWalkContent,
             XWalkContentsIoThreadClient ioThreadClient,
             InterceptNavigationDelegate delegate);
-    private native void nativeClearCache(int nativeXWalkContent, boolean includeDiskFiles);
-    private native String nativeDevToolsAgentId(int nativeXWalkContent);
-    private native String nativeGetVersion(int nativeXWalkContent);
-    private native void nativeSetJsOnlineProperty(int nativeXWalkContent, boolean networkUp);
-    private native boolean nativeSetManifest(int nativeXWalkContent, String path, String manifest);
-    private native int nativeGetRoutingID(int nativeXWalkContent);
+    private native void nativeClearCache(long nativeXWalkContent, boolean includeDiskFiles);
+    private native String nativeDevToolsAgentId(long nativeXWalkContent);
+    private native String nativeGetVersion(long nativeXWalkContent);
+    private native void nativeSetJsOnlineProperty(long nativeXWalkContent, boolean networkUp);
+    private native boolean nativeSetManifest(long nativeXWalkContent, String path, String manifest);
+    private native int nativeGetRoutingID(long nativeXWalkContent);
     private native void nativeInvokeGeolocationCallback(
-            int nativeXWalkContent, boolean value, String requestingFrame);
-    private native byte[] nativeGetState(int nativeXWalkContent);
-    private native boolean nativeSetState(int nativeXWalkContent, byte[] state);
+            long nativeXWalkContent, boolean value, String requestingFrame);
+    private native byte[] nativeGetState(long nativeXWalkContent);
+    private native boolean nativeSetState(long nativeXWalkContent, byte[] state);
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -51,7 +51,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     private boolean mIsFullscreen = false;
 
     // The native peer of the object
-    private int mNativeContentsClientBridge;
+    private long mNativeContentsClientBridge;
 
     private class InterceptNavigationDelegateImpl implements InterceptNavigationDelegate {
         private XWalkContentsClient mContentsClient;
@@ -471,7 +471,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     // Used by the native peer to set/reset a weak ref to the native peer.
     @CalledByNative
-    private void setNativeContentsClientBridge(int nativeContentsClientBridge) {
+    private void setNativeContentsClientBridge(long nativeContentsClientBridge) {
         mNativeContentsClientBridge = nativeContentsClientBridge;
     }
 
@@ -572,7 +572,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         nativeCancelJsResult(mNativeContentsClientBridge, id);
     }
 
-    void exitFullscreen(int nativeWebContents) {
+    void exitFullscreen(long nativeWebContents) {
         if (mNativeContentsClientBridge == 0) return;
         nativeExitFullscreen(mNativeContentsClientBridge, nativeWebContents);
     }
@@ -618,23 +618,23 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     //--------------------------------------------------------------------------------------------
     //  Native methods
     //--------------------------------------------------------------------------------------------
-    private native void nativeProceedSslError(int nativeXWalkContentsClientBridge,
+    private native void nativeProceedSslError(long nativeXWalkContentsClientBridge,
             boolean proceed, int id);
 
-    private native void nativeConfirmJsResult(int nativeXWalkContentsClientBridge, int id,
+    private native void nativeConfirmJsResult(long nativeXWalkContentsClientBridge, int id,
             String prompt);
-    private native void nativeCancelJsResult(int nativeXWalkContentsClientBridge, int id);
-    private native void nativeExitFullscreen(int nativeXWalkContentsClientBridge, int nativeWebContents);
-    private native void nativeNotificationDisplayed(int nativeXWalkContentsClientBridge, int id,
+    private native void nativeCancelJsResult(long nativeXWalkContentsClientBridge, int id);
+    private native void nativeExitFullscreen(long nativeXWalkContentsClientBridge, long nativeWebContents);
+    private native void nativeNotificationDisplayed(long nativeXWalkContentsClientBridge, int id,
             int processId, int routeId);
-    private native void nativeNotificationError(int nativeXWalkContentsClientBridge, int id,
+    private native void nativeNotificationError(long nativeXWalkContentsClientBridge, int id,
             String error, int processId, int routeId);
-    private native void nativeNotificationClicked(int nativeXWalkContentsClientBridge, int id,
+    private native void nativeNotificationClicked(long nativeXWalkContentsClientBridge, int id,
             int processId, int routeId);
-    private native void nativeNotificationClosed(int nativeXWalkContentsClientBridge, int id,
+    private native void nativeNotificationClosed(long nativeXWalkContentsClientBridge, int id,
             boolean byUser, int processId, int routeId);
-    private native void nativeOnFilesSelected(int nativeXWalkContentsClientBridge,
+    private native void nativeOnFilesSelected(long nativeXWalkContentsClientBridge,
             int processId, int renderId, int mode_flags, String filepath, String displayName);
-    private native void nativeOnFilesNotSelected(int nativeXWalkContentsClientBridge,
+    private native void nativeOnFilesNotSelected(long nativeXWalkContentsClientBridge,
             int processId, int renderId, int mode_flags);
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkDevToolsServer.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDevToolsServer.java
@@ -12,7 +12,7 @@ import org.chromium.base.JNINamespace;
 @JNINamespace("xwalk")
 class XWalkDevToolsServer {
 
-    private int mNativeDevToolsServer = 0;
+    private long mNativeDevToolsServer = 0;
 
     public XWalkDevToolsServer(String socketName) {
         mNativeDevToolsServer = nativeInitRemoteDebugging(socketName);
@@ -35,9 +35,9 @@ class XWalkDevToolsServer {
         nativeAllowConnectionFromUid(mNativeDevToolsServer, uid);
     }
 
-    private native int nativeInitRemoteDebugging(String socketName);
-    private native void nativeDestroyRemoteDebugging(int devToolsServer);
-    private native boolean nativeIsRemoteDebuggingEnabled(int devToolsServer);
-    private native void nativeSetRemoteDebuggingEnabled(int devToolsServer, boolean enabled);
-    private native void nativeAllowConnectionFromUid(int devToolsServer, int uid);
+    private native long nativeInitRemoteDebugging(String socketName);
+    private native void nativeDestroyRemoteDebugging(long devToolsServer);
+    private native boolean nativeIsRemoteDebuggingEnabled(long devToolsServer);
+    private native void nativeSetRemoteDebuggingEnabled(long devToolsServer, boolean enabled);
+    private native void nativeAllowConnectionFromUid(long devToolsServer, int uid);
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkHttpAuthHandler.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkHttpAuthHandler.java
@@ -14,7 +14,7 @@ import org.chromium.base.JNINamespace;
 @JNINamespace("xwalk")
 public class XWalkHttpAuthHandler {
 
-    private int mNativeXWalkHttpAuthHandler;
+    private long mNativeXWalkHttpAuthHandler;
     private final boolean mFirstAttempt;
 
     public void proceed(String username, String password) {
@@ -36,11 +36,11 @@ public class XWalkHttpAuthHandler {
     }
 
     @CalledByNative
-    public static XWalkHttpAuthHandler create(int nativeXWalkAuthHandler, boolean firstAttempt) {
+    public static XWalkHttpAuthHandler create(long nativeXWalkAuthHandler, boolean firstAttempt) {
         return new XWalkHttpAuthHandler(nativeXWalkAuthHandler, firstAttempt);
     }
 
-    private XWalkHttpAuthHandler(int nativeXWalkHttpAuthHandler, boolean firstAttempt) {
+    private XWalkHttpAuthHandler(long nativeXWalkHttpAuthHandler, boolean firstAttempt) {
         mNativeXWalkHttpAuthHandler = nativeXWalkHttpAuthHandler;
         mFirstAttempt = firstAttempt;
     }
@@ -50,8 +50,8 @@ public class XWalkHttpAuthHandler {
         mNativeXWalkHttpAuthHandler = 0;
     }
 
-    private native void nativeProceed(int nativeXWalkHttpAuthHandler,
+    private native void nativeProceed(long nativeXWalkHttpAuthHandler,
             String username, String password);
-    private native void nativeCancel(int nativeXWalkHttpAuthHandler);
+    private native void nativeCancel(long nativeXWalkHttpAuthHandler);
 }
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkSettings.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkSettings.java
@@ -65,7 +65,7 @@ public class XWalkSettings {
     private static boolean sAppCachePathIsSet = false;
 
     // The native side of this object.
-    private int mNativeXWalkSettings = 0;
+    private long mNativeXWalkSettings = 0;
 
     // A flag to avoid sending superfluous synchronization messages.
     private boolean mIsUpdateWebkitPrefsMessagePending = false;
@@ -137,7 +137,7 @@ public class XWalkSettings {
         }
     }
 
-    public XWalkSettings(Context context, int nativeWebContents,
+    public XWalkSettings(Context context, long nativeWebContents,
             boolean isAccessFromFileURLsGrantedByDefault) {
         ThreadUtils.assertOnUiThread();
         mContext = context;
@@ -158,7 +158,7 @@ public class XWalkSettings {
         setWebContents(nativeWebContents);
     }
 
-    void setWebContents(int nativeWebContents) {
+    void setWebContents(long nativeWebContents) {
         synchronized (mXWalkSettingsLock) {
             if (mNativeXWalkSettings != 0) {
                 nativeDestroy(mNativeXWalkSettings);
@@ -173,7 +173,7 @@ public class XWalkSettings {
     }
 
     @CalledByNative
-    private void nativeXWalkSettingsGone(int nativeXWalkSettings) {
+    private void nativeXWalkSettingsGone(long nativeXWalkSettings) {
         assert mNativeXWalkSettings != 0 && mNativeXWalkSettings == nativeXWalkSettings;
         mNativeXWalkSettings = 0;
     }
@@ -656,15 +656,15 @@ public class XWalkSettings {
         }
     }
 
-    private native int nativeInit(int webContentsPtr);
+    private native long nativeInit(long webContentsPtr);
 
-    private native void nativeDestroy(int nativeXWalkSettings);
+    private native void nativeDestroy(long nativeXWalkSettings);
 
     private static native String nativeGetDefaultUserAgent();
 
-    private native void nativeUpdateEverythingLocked(int nativeXWalkSettings);
+    private native void nativeUpdateEverythingLocked(long nativeXWalkSettings);
 
-    private native void nativeUpdateUserAgent(int nativeXWalkSettings);
+    private native void nativeUpdateUserAgent(long nativeXWalkSettings);
 
-    private native void nativeUpdateWebkitPreferences(int nativeXWalkSettings);
+    private native void nativeUpdateWebkitPreferences(long nativeXWalkSettings);
 }

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -106,7 +106,7 @@ XWalkContent* XWalkContent::FromWebContents(
   return XWalkContentUserData::GetContents(web_contents);
 }
 
-jint XWalkContent::GetWebContents(
+jlong XWalkContent::GetWebContents(
     JNIEnv* env, jobject obj, jobject io_thread_client,
     jobject intercept_navigation_delegate) {
   if (!web_contents_) {
@@ -116,7 +116,7 @@ jint XWalkContent::GetWebContents(
     render_view_host_ext_.reset(
         new XWalkRenderViewHostExt(web_contents_.get()));
   }
-  return reinterpret_cast<jint>(web_contents_.get());
+  return reinterpret_cast<intptr_t>(web_contents_.get());
 }
 
 content::WebContents* XWalkContent::CreateWebContents(
@@ -341,11 +341,11 @@ jboolean XWalkContent::SetState(JNIEnv* env, jobject obj, jbyteArray state) {
   return RestoreFromPickle(&iterator, web_contents_.get());
 }
 
-static jint Init(JNIEnv* env, jobject obj, jobject web_contents_delegate,
+static jlong Init(JNIEnv* env, jobject obj, jobject web_contents_delegate,
     jobject contents_client_bridge) {
   XWalkContent* xwalk_core_content =
     new XWalkContent(env, obj, web_contents_delegate, contents_client_bridge);
-  return reinterpret_cast<jint>(xwalk_core_content);
+  return reinterpret_cast<intptr_t>(xwalk_core_content);
 }
 
 bool RegisterXWalkContent(JNIEnv* env) {
@@ -384,7 +384,7 @@ void ShowGeolocationPromptHelper(const JavaObjectWeakGlobalRef& java_ref,
 
 void XWalkContent::ShowGeolocationPrompt(
     const GURL& requesting_frame,
-    const base::Callback<void(bool)>& callback) {
+    const base::Callback<void(bool)>& callback) { // NOLINT
   GURL origin = requesting_frame.GetOrigin();
   bool show_prompt = pending_geolocation_prompts_.empty();
   pending_geolocation_prompts_.push_back(OriginCallback(origin, callback));

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -35,7 +35,7 @@ class XWalkContent {
   static XWalkContent* FromID(int render_process_id, int render_view_id);
   static XWalkContent* FromWebContents(content::WebContents* web_contents);
 
-  jint GetWebContents(JNIEnv* env, jobject obj, jobject io_thread_client,
+  jlong GetWebContents(JNIEnv* env, jobject obj, jobject io_thread_client,
                       jobject delegate);
   void ClearCache(JNIEnv* env, jobject obj, jboolean include_disk_files);
   ScopedJavaLocalRef<jstring> DevToolsAgentId(JNIEnv* env, jobject obj);
@@ -62,7 +62,7 @@ class XWalkContent {
 
   // Geolocation API support
   void ShowGeolocationPrompt(const GURL& origin,
-                             const base::Callback<void(bool)>& callback);
+                             const base::Callback<void(bool)>& callback); // NOLINT
   void HideGeolocationPrompt(const GURL& origin);
   void InvokeGeolocationCallback(JNIEnv* env,
                                  jobject obj,
@@ -82,7 +82,7 @@ class XWalkContent {
   // GURL is supplied by the content layer as requesting frame.
   // Callback is supplied by the content layer, and is invoked with the result
   // from the permission prompt.
-  typedef std::pair<const GURL, const base::Callback<void(bool)> > \
+  typedef std::pair<const GURL, const base::Callback<void(bool)> >  /* NOLINT */ \
           OriginCallback;
   // The first element in the list is always the currently pending request.
   std::list<OriginCallback> pending_geolocation_prompts_;

--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -54,7 +54,7 @@ XWalkContentsClientBridge::XWalkContentsClientBridge(JNIEnv* env, jobject obj)
     : java_ref_(env, obj) {
   DCHECK(obj);
   Java_XWalkContentsClientBridge_setNativeContentsClientBridge(
-      env, obj, reinterpret_cast<jint>(this));
+      env, obj, reinterpret_cast<intptr_t>(this));
 }
 
 XWalkContentsClientBridge::~XWalkContentsClientBridge() {
@@ -73,7 +73,7 @@ void XWalkContentsClientBridge::AllowCertificateError(
     int cert_error,
     net::X509Certificate* cert,
     const GURL& request_url,
-    const base::Callback<void(bool)>& callback,
+    const base::Callback<void(bool)>& callback, // NOLINT
     bool* cancel_request) {
 
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
@@ -335,7 +335,7 @@ void XWalkContentsClientBridge::CancelJsResult(JNIEnv*, jobject, int id) {
 }
 
 void XWalkContentsClientBridge::ExitFullscreen(
-    JNIEnv*, jobject, jint j_web_contents) {
+    JNIEnv*, jobject, jlong j_web_contents) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
   WebContents* web_contents = reinterpret_cast<WebContents*>(j_web_contents);
   if (web_contents) {

--- a/runtime/browser/android/xwalk_contents_client_bridge.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge.h
@@ -45,7 +45,7 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase {
   virtual void AllowCertificateError(int cert_error,
                                      net::X509Certificate* cert,
                                      const GURL& request_url,
-                                     const base::Callback<void(bool)>& callback,
+                                     const base::Callback<void(bool)>& callback, // NOLINT
                                      bool* cancel_request) OVERRIDE;
 
   virtual void RunJavaScriptDialog(
@@ -91,7 +91,7 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase {
   void ProceedSslError(JNIEnv* env, jobject obj, jboolean proceed, jint id);
   void ConfirmJsResult(JNIEnv*, jobject, int id, jstring prompt);
   void CancelJsResult(JNIEnv*, jobject, int id);
-  void ExitFullscreen(JNIEnv*, jobject, jint web_contents);
+  void ExitFullscreen(JNIEnv*, jobject, jlong web_contents);
   void NotificationDisplayed(
       JNIEnv*, jobject, int id, int process_id, int route_id);
   void NotificationError(
@@ -109,7 +109,7 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase {
  private:
   JavaObjectWeakGlobalRef java_ref_;
 
-  typedef const base::Callback<void(bool)> CertErrorCallback;
+  typedef const base::Callback<void(bool)> CertErrorCallback; // NOLINT
   IDMap<CertErrorCallback, IDMapOwnPointer> pending_cert_error_callbacks_;
   IDMap<content::JavaScriptDialogManager::DialogClosedCallback, IDMapOwnPointer>
       pending_js_dialog_callbacks_;

--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -197,27 +197,27 @@ bool RegisterXWalkDevToolsServer(JNIEnv* env) {
   return RegisterNativesImpl(env);
 }
 
-static jint InitRemoteDebugging(JNIEnv* env,
+static jlong InitRemoteDebugging(JNIEnv* env,
                                 jobject obj,
                                 jstring socketName) {
   XWalkDevToolsServer* server = new XWalkDevToolsServer(
       base::android::ConvertJavaStringToUTF8(env, socketName));
-  return reinterpret_cast<jint>(server);
+  return reinterpret_cast<intptr_t>(server);
 }
 
-static void DestroyRemoteDebugging(JNIEnv* env, jobject obj, jint server) {
+static void DestroyRemoteDebugging(JNIEnv* env, jobject obj, jlong server) {
   delete reinterpret_cast<XWalkDevToolsServer*>(server);
 }
 
 static jboolean IsRemoteDebuggingEnabled(JNIEnv* env,
                                          jobject obj,
-                                         jint server) {
+                                         jlong server) {
   return reinterpret_cast<XWalkDevToolsServer*>(server)->IsStarted();
 }
 
 static void SetRemoteDebuggingEnabled(JNIEnv* env,
                                       jobject obj,
-                                      jint server,
+                                      jlong server,
                                       jboolean enabled) {
   XWalkDevToolsServer* devtools_server =
       reinterpret_cast<XWalkDevToolsServer*>(server);
@@ -230,7 +230,7 @@ static void SetRemoteDebuggingEnabled(JNIEnv* env,
 
 static void AllowConnectionFromUid(JNIEnv* env,
                                     jobject obj,
-                                    jint server,
+                                    jlong server,
                                     jint uid) {
   XWalkDevToolsServer* devtools_server =
       reinterpret_cast<XWalkDevToolsServer*>(server);

--- a/runtime/browser/android/xwalk_http_auth_handler.cc
+++ b/runtime/browser/android/xwalk_http_auth_handler.cc
@@ -28,7 +28,7 @@ XWalkHttpAuthHandler::XWalkHttpAuthHandler(XWalkLoginDelegate* login_delegate,
   JNIEnv* env = base::android::AttachCurrentThread();
   http_auth_handler_.Reset(
       Java_XWalkHttpAuthHandler_create(
-          env, reinterpret_cast<jint>(this), first_auth_attempt));
+          env, reinterpret_cast<intptr_t>(this), first_auth_attempt));
 }
 
 XWalkHttpAuthHandler:: ~XWalkHttpAuthHandler() {

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -87,7 +87,7 @@ struct XWalkSettings::FieldIds {
   jfieldID default_video_poster_url;
 };
 
-XWalkSettings::XWalkSettings(JNIEnv* env, jobject obj, jint web_contents)
+XWalkSettings::XWalkSettings(JNIEnv* env, jobject obj, jlong web_contents)
     : WebContentsObserver(
           reinterpret_cast<content::WebContents*>(web_contents)),
       xwalk_settings_(env, obj) {
@@ -98,8 +98,8 @@ XWalkSettings::~XWalkSettings() {
     ScopedJavaLocalRef<jobject> scoped_obj = xwalk_settings_.get(env);
     jobject obj = scoped_obj.obj();
     if (!obj) return;
-    Java_XWalkSettings_nativeXWalkSettingsGone(env, obj,
-                                               reinterpret_cast<jint>(this));
+    Java_XWalkSettings_nativeXWalkSettingsGone(
+        env, obj, reinterpret_cast<intptr_t>(this));
 }
 
 void XWalkSettings::Destroy(JNIEnv* env, jobject obj) {
@@ -224,11 +224,11 @@ void XWalkSettings::RenderViewCreated(
   UpdateEverything();
 }
 
-static jint Init(JNIEnv* env,
+static jlong Init(JNIEnv* env,
                  jobject obj,
-                 jint web_contents) {
+                 jlong web_contents) {
   XWalkSettings* settings = new XWalkSettings(env, obj, web_contents);
-  return reinterpret_cast<jint>(settings);
+  return reinterpret_cast<intptr_t>(settings);
 }
 
 static jstring GetDefaultUserAgent(JNIEnv* env, jclass clazz) {

--- a/runtime/browser/android/xwalk_settings.h
+++ b/runtime/browser/android/xwalk_settings.h
@@ -18,7 +18,7 @@ class XWalkRenderViewHostExt;
 
 class XWalkSettings : public content::WebContentsObserver {
  public:
-  XWalkSettings(JNIEnv* env, jobject obj, jint web_contents);
+  XWalkSettings(JNIEnv* env, jobject obj, jlong web_contents);
   virtual ~XWalkSettings();
 
   // Called from Java.

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -144,7 +144,6 @@
       'type': 'none',
       'variables': {
         'jni_gen_package': 'xwalk',
-        'jni_generator_ptr_type': 'int',
       },
       'sources': [
         'runtime/android/core/src/org/xwalk/core/AndroidProtocolHandler.java',
@@ -180,7 +179,6 @@
       'type': 'none',
       'variables': {
         'jni_gen_package': 'xwalk',
-        'jni_generator_ptr_type': 'int',
       },
       'sources': [
         'extensions/android/java/src/org/xwalk/core/extensions/XWalkExtensionAndroid.java',


### PR DESCRIPTION
- replace all stashed pointers in java from
  "int mNative" to "long mNative".
- change all casts from "reinterpret_cast<jint>"
  (and other variations) to "reinterpret_cast<intptr_t>"
  that would then be expanded to jlong.

Upstream switched to long by default so we don't need
to special case our JNI generators anymore.
