### PR TITLE
[Android] Packaging tool enable set long string in package option

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -715,6 +715,10 @@ def main(argv):
     if not options.package:
       parser.error('The package name is required! '
                    'Please use "--package" option.')
+    elif len(options.package) >= 128 :
+      parser.error('To be safe, the length of package name '
+                   'should be less than 128.')
+
     if not options.name:
       parser.error('The APK name is required! Please use "--name" option.')
     if not ((options.app_url and not options.app_root


### PR DESCRIPTION
Add a limit of 127 characters to package name.

Set the limit to 127 considering below factors: 
(1) In my investigation, I cannot find a official document specifying maximum file name of Android. 
(2) With Eclipse running on Linux, when we try to create an android App with name of more than 256 chars, it will be failed silently.
(3) http://stackoverflow.com/questions/13204807/max-file-name-length-in-android suggests no more than 127.   

BUG=https://crosswalk-project.org/jira/browse/XWALK-1460
