### PR TITLE
[Android] Use int instead of enum for reload mode

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -165,13 +165,13 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
         }
     }
 
-    public void reload(XWalkView.ReloadMode mode) {
+    public void reload(int mode) {
         if (mReadyToLoad) {
             switch (mode) {
-                case IGNORE_CACHE:
+                case XWalkView.RELOAD_IGNORE_CACHE:
                     mContentView.getContentViewCore().reloadIgnoringCache(true);
                     break;
-                case NORMAL:
+                case XWalkView.RELOAD_NORMAL:
                 default:
                     mContentView.getContentViewCore().reload(true);
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkView.java
@@ -54,6 +54,11 @@ public class XWalkView extends android.widget.FrameLayout {
     private Context mContext;
     private XWalkExtensionManager mExtensionManager;
 
+    /** Normal reload mode as default. */
+    public static final int RELOAD_NORMAL = 0;
+    /** Reload mode with bypassing the cache. */
+    public static final int RELOAD_IGNORE_CACHE = 1;
+
     /**
      * Constructor for inflating via XML.
      * @param context  a Context object used to access application assets.
@@ -247,20 +252,10 @@ public class XWalkView extends android.widget.FrameLayout {
     }
 
     /**
-     * The reload mode.
-     */
-    public enum ReloadMode {
-        /** Normal reload as default. */
-        NORMAL,
-        /** Reload bypassing the cache. */
-        IGNORE_CACHE
-    }
-
-    /**
      * Reload a web app with a given mode.
      * @param the reload mode.
      */
-    public void reload(ReloadMode mode) {
+    public void reload(int mode) {
         if (mContent == null) return;
         checkThreadSafety();
         mContent.reload(mode);

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -298,7 +298,7 @@ public class XWalkViewShellActivity extends FragmentActivity
         mReloadButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (mActiveView != null) mActiveView.reload(XWalkView.ReloadMode.NORMAL);
+                if (mActiveView != null) mActiveView.reload(XWalkView.RELOAD_NORMAL);
             }
         });
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ReloadTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ReloadTest.java
@@ -51,7 +51,7 @@ public class ReloadTest extends XWalkViewTestBase {
         String url = mWebServer.setResponse("/reload.html", html1, null);
         loadUrlSync(url);
         mWebServer.setResponse("/reload.html", html2, null);
-        reloadSync(XWalkView.ReloadMode.IGNORE_CACHE);
+        reloadSync(XWalkView.RELOAD_IGNORE_CACHE);
         //TODO(guangzhen) When reload finished, immediately call getTitle will get wrong title.
         Thread.sleep(1000);
         assertEquals(title2, getTitleOnUiThread());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -395,7 +395,7 @@ public class XWalkViewTestBase
                 TimeUnit.SECONDS);
     }
 
-    protected void reloadSync(final XWalkView.ReloadMode mode) throws Exception {
+    protected void reloadSync(final int mode) throws Exception {
         runTestWaitPageFinished(new Runnable(){
             @Override
             public void run() {


### PR DESCRIPTION
Use int as the parameter is more straightforward for the reload(),
to make embedder easy to use the api.
