### PR TITLE
New manifest API implementation (part 1)

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -64,12 +64,8 @@ class Application
   enum LaunchEntryPoint {
     AppMainKey = 1 << 0,  // app.main
     LaunchLocalPathKey = 1 << 1,  // app.launch.local_path
-    // NOTE: The following key is only used for "dummy" hosted apps,
-    // which can be using any arbitrary URL, incl. remote ones.
-    // For now this should be disabled for all other cases as this will
-    // require special care with permissions etc.
     URLKey = 1 << 2,  // url
-    Default = AppMainKey | LaunchLocalPathKey
+    Default = AppMainKey | LaunchLocalPathKey | URLKey
   };
   typedef unsigned LaunchEntryPoints;
 
@@ -77,7 +73,7 @@ class Application
     LaunchParams() :
         entry_points(Default),
         launcher_pid(0),
-        window_state(ui::SHOW_STATE_DEFAULT) {}
+        force_fullscreen(false) {}
 
     LaunchEntryPoints entry_points;
 
@@ -85,8 +81,7 @@ class Application
     // process.
     int32 launcher_pid;
 
-    // Sets the initial state for the application windows.
-    ui::WindowShowState window_state;
+    bool force_fullscreen;
   };
 
   // Closes all the application's runtimes (application pages).
@@ -160,7 +155,8 @@ class Application
 
   // Try to extract the URL from different possible keys for entry points in the
   // manifest, returns it and the entry point used.
-  GURL GetURLForLaunch(const LaunchParams& params, LaunchEntryPoint* used);
+  GURL GetStartURL(const LaunchParams& params, LaunchEntryPoint* used);
+  ui::WindowShowState GetWindowShowState(const LaunchParams& params);
 
   GURL GetURLFromAppMainKey();
   GURL GetURLFromLocalPathKey();

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -123,8 +123,7 @@ bool ApplicationSystem::LaunchWithCommandLineParam(
         kOnLaunched, scoped_ptr<base::ListValue>(new base::ListValue));
 
   Application::LaunchParams launch_params;
-  if (cmd_line.HasSwitch(switches::kFullscreen))
-    launch_params.window_state = ui::SHOW_STATE_FULLSCREEN;
+  launch_params.force_fullscreen = cmd_line.HasSwitch(switches::kFullscreen);
 
   if (application_service_->Launch(param, launch_params)) {
     return true;
@@ -164,8 +163,7 @@ bool ApplicationSystem::LaunchWithCommandLineParam<GURL>(
   }
 
   Application::LaunchParams launch_params;
-  if (cmd_line.HasSwitch(switches::kFullscreen))
-    launch_params.window_state = ui::SHOW_STATE_FULLSCREEN;
+  launch_params.force_fullscreen = cmd_line.HasSwitch(switches::kFullscreen);
   launch_params.entry_points = Application::URLKey;
 
   return !!application_service_->Launch(application_data, launch_params);

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -96,8 +96,7 @@ void RunningApplicationsManager::OnLaunch(
 
   Application::LaunchParams params;
   params.launcher_pid = launcher_pid;
-  if (fullscreen)
-    params.window_state = ui::SHOW_STATE_FULLSCREEN;
+  params.force_fullscreen = fullscreen;
 
   Application* application = application_service_->Launch(app_id, params);
   if (!application) {


### PR DESCRIPTION
The following steps from http://w3c.github.io/manifest/#processing-the-manifest
are implemented (considering the known limitations):
1) steps for processing the start_url member
2) steps for processing the display member
