### PR TITLE
[Android] envsetup: Stop unsetting CHROMIUM_GYP_FILE.

### DIFF
--- a/build/android/envsetup.sh
+++ b/build/android/envsetup.sh
@@ -7,8 +7,6 @@ SCRIPT_DIR="$(dirname "${BASH_SOURCE:-$0}")"
 
 . ${SCRIPT_DIR}/../../../build/android/envsetup.sh "$@"
 
-unset CHROMIUM_GYP_FILE
-
 export PATH=$PATH:${CHROME_SRC}/xwalk/build/android
 
 xwalk_android_gyp() {


### PR DESCRIPTION
This is one step towards simplifying our envsetup.sh. Chromium stopped 
touching CHROMIUM_GYP_FILE in r248748, and it is safe for us to do the same.
