### PR TITLE
[Android] Add the test case for addJavascriptInterface.

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/AddJavascriptInterfaceTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/AddJavascriptInterfaceTest.java
@@ -1,0 +1,85 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+import org.xwalk.core.JavascriptInterface;
+
+/**
+ * Test suite for addJavascriptInterface().
+ */
+public class AddJavascriptInterfaceTest extends XWalkViewTestBase {
+    final String mExpectedStr = "xwalk";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    class TestJavascriptInterface {
+        public String getTextWithoutAnnotation() {
+            return mExpectedStr;
+        }
+
+        @JavascriptInterface
+        public String getText() {
+            return mExpectedStr;
+        }
+    }
+
+    private void addJavascriptInterface() {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().addJavascriptInterface(new TestJavascriptInterface(),
+                        "testInterface");
+            }
+        });
+    }
+
+    private void raisesExceptionAndSetTitle(String script) throws Throwable {
+        executeJavaScriptAndWaitForResult("try { var title = " +
+                                          script + ";" +
+                                          "  document.title = title;" +
+                                          "} catch (exception) {" +
+                                          "  document.title = \"xwalk\";" +
+                                          "}");
+    }
+
+    @SmallTest
+    @Feature({"AddJavascriptInterface"})
+    public void testAddJavascriptInterface() throws Throwable {
+        final String name = "add_js_interface.html";
+
+        addJavascriptInterface();
+        loadAssetFile(name);
+        assertEquals(mExpectedStr, getTitleOnUiThread());
+    }
+
+    @SmallTest
+    @Feature({"AddJavascriptInterface"})
+    public void testAddJavascriptInterfaceWithAnnotation() throws Throwable {
+        final String name = "index.html";
+        final String xwalkStr = "\"xwalk\"";
+        String result;
+
+        addJavascriptInterface();
+        loadAssetFile(name);
+
+        result = executeJavaScriptAndWaitForResult("testInterface.getText()");
+        assertEquals(xwalkStr, result);
+
+        raisesExceptionAndSetTitle("testInterface.getTextWithoutAnnotation()");
+
+        String title = getTitleOnUiThread();
+        assertEquals(mExpectedStr, title);
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -24,6 +24,7 @@ import org.chromium.content.browser.LoadUrlParams;
 import org.chromium.content.browser.test.util.CallbackHelper;
 import org.chromium.content.browser.test.util.Criteria;
 import org.chromium.content.browser.test.util.CriteriaHelper;
+
 import org.xwalk.core.XWalkClient;
 import org.xwalk.core.XWalkNavigationHistory;
 import org.xwalk.core.XWalkResourceClient;

--- a/test/android/data/add_js_interface.html
+++ b/test/android/data/add_js_interface.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<script type="text/javascript">
+    function setTitle()
+    {
+        document.title = testInterface.getText();
+    }
+</script>
+<title></title>
+</head>
+
+<body onload="setTitle()">
+</body>
+</html>

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -110,6 +110,7 @@
         'java_in_dir': 'test/android/core/javatests',
         'is_test_apk': 1,
         'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/add_js_interface.html',
           '<(PRODUCT_DIR)/xwalk_xwview_test/assets/broadcast.html',
           '<(PRODUCT_DIR)/xwalk_xwview_test/assets/echo.html',
           '<(PRODUCT_DIR)/xwalk_xwview_test/assets/echoSync.html',
@@ -126,6 +127,7 @@
         {
           'destination': '<(PRODUCT_DIR)/xwalk_xwview_test/assets',
           'files': [
+            'test/android/data/add_js_interface.html',
             'test/android/data/broadcast.html',
             'test/android/data/echo.html',
             'test/android/data/echoSync.html',


### PR DESCRIPTION
In this test case, we should use "@JavascriptInterface", it's from
"org.chromium.content.browser.JavascriptInterface", not
"android.webkit.JavascriptInterface".
In addition, if the target sdk version will be equal to or greater
than 17, "@JvascriptInterface" is required.

BUG=XWALK-1595
