### PR TITLE
[Android] Add the @interface JavascriptInterface.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/JavascriptInterface.java
+++ b/runtime/android/core/src/org/xwalk/core/JavascriptInterface.java
@@ -1,0 +1,24 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as being able to be exposed to JavaScript.  This is used for
+ * safety purposes so that only explicitly marked methods get exposed instead
+ * of every method in a class.
+ * See the explanation for {@link XWalkView#addJavascriptInterface(Object, String)}
+ * about the usage.
+ */
+@SuppressWarnings("javadoc")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface JavascriptInterface {
+}

--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -192,7 +192,8 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
     }
 
     public void addJavascriptInterface(Object object, String name) {
-        mContentViewCore.addJavascriptInterface(object, name);
+        mContentViewCore.addPossiblyUnsafeJavascriptInterface(object, name,
+                JavascriptInterface.class);
     }
 
     public void evaluateJavascript(String script, ValueCallback<String> callback) {

--- a/runtime/android/core/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkView.java
@@ -253,7 +253,7 @@ public class XWalkView extends android.widget.FrameLayout {
 
     /**
      * Reload a web app with a given mode.
-     * @param the reload mode.
+     * @param mode the reload mode.
      */
     public void reload(int mode) {
         if (mContent == null) return;
@@ -315,6 +315,8 @@ public class XWalkView extends android.widget.FrameLayout {
 
     /**
      * Injects the supplied Java object into this XWalkView.
+     * Each method defined in the class of the object should be
+     * marked with {@link JavascriptInterface} if it's called by JavaScript.
      * @param object the supplied Java object, called by JavaScript.
      * @param name the name injected in JavaScript.
      */


### PR DESCRIPTION
This annotation is used for XWalkView.addJavascriptInterface. This
is for security check so all Java methods called by JavaScript code
should be marked with this annotation.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1596
