### PR TITLE
[Android] Call resumeTimers before presentation context is closed

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/extension/api/presentation/XWalkPresentationContent.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/api/presentation/XWalkPresentationContent.java
@@ -67,6 +67,10 @@ public class XWalkPresentationContent {
     }
 
     public void close() {
+        // Since pauseTimers is a global request, we should make sure the JS timers
+        // of its openercontext is resumed before the presentation content is being
+        // destroyed.
+        mContentView.resumeTimers();
         mContentView.onDestroy();
         mPresentationId = INVALID_PRESENTATION_ID;
         mContentView = null;


### PR DESCRIPTION
The presentation context might be closed if its hosting display is
disappeared. All JS timers will be suspended in the opener context once
pauseTimer is called in the presentation context since the pauseTimers
is a global request.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1589
