### PR TITLE
Revert "[Android] Add xwalk_core_sample_apk to xwalk_builder"

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -633,7 +633,6 @@
             'xwalk_runtime_lib_apk',
             'xwalk_app_hello_world_apk',
             'xwalk_app_template',
-            'xwalk_core_sample_apk',
           ],
         }],
       ],

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -535,13 +535,12 @@
       'target_name': 'xwalk_core_sample_apk',
       'type': 'none',
       'dependencies': [
-        'xwalk_core_library',
+        'libxwalkcore',
+        'xwalk_core_extensions_java',
+        'xwalk_core_java',
+        'xwalk_core_shell_apk_pak',
       ],
       'variables': {
-        #TODO(guangzhen): Currently it's using gyp to build this target.
-        #                 Need only depend on xwalk_core_library, and use ant build?
-        #                 It needs further investigation.
-        #                 BUG=https://crosswalk-project.org/jira/browse/XWALK-1324
         'apk_name': 'CrosswalkSample',
         'java_in_dir': 'runtime/android/sample',
         'resource_dir': 'runtime/android/sample/res',


### PR DESCRIPTION
This reverts commit 5c52d2d319a221130e142798d889452209b23a69.

This commit will break the build when clean build.
Need further investigation about gyp dependency.
