### PR TITLE
[Android] Refine the pause/resume behavior for packaged web app

### DIFF
--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -52,11 +52,13 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
 
     @Override
     public void onResume() {
+        mXWalkView.resumeTimers();
         mXWalkView.onShow();
     }
 
     @Override
     public void onPause() {
+        mXWalkView.pauseTimers();
         mXWalkView.onHide();
     }
 


### PR DESCRIPTION
[Android] Refine the pause/resume behavior for packaged web app …
- Pause all timers when the activity is paused, and resume them when the
  activity is resumed.
- Add boolean flag to indicate if the timers are paused or XWalkView is hidden
- Update the API documentations for pauseTimers/resumeTimers are also

BUG=https://crosswalk-project.org/jira/browse/XWALK-1603
