### PR TITLE
[Extension] Implemented bulk data transmission enhancement feature.

### DIFF
--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include "base/memory/shared_memory.h"
 #include "base/values.h"
 #include "ipc/ipc_channel_handle.h"
 #include "ipc/ipc_message_macros.h"
@@ -74,6 +75,10 @@ IPC_MESSAGE_CONTROL2(XWalkExtensionServerMsg_PostMessageToNative,  // NOLINT(*)
 IPC_MESSAGE_CONTROL2(XWalkExtensionClientMsg_PostMessageToJS,  // NOLINT(*)
                      int64_t /* instance id */,
                      base::ListValue /* contents */)
+
+IPC_MESSAGE_CONTROL2(XWalkExtensionClientMsg_PostOutOfLineMessageToJS,  // NOLINT(*)
+                     base::SharedMemoryHandle /* message buffer */,
+                     size_t /* buffer size */)
 
 IPC_SYNC_MESSAGE_CONTROL2_1(XWalkExtensionServerMsg_SendSyncMessageToNative,  // NOLINT(*)
                             int64_t /* instance id */,

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/shared_memory.h"
 #include "base/memory/weak_ptr.h"
 #include "base/synchronization/lock.h"
 #include "base/values.h"
@@ -51,6 +52,7 @@ class XWalkExtensionServer : public IPC::Listener,
 
   // IPC::Listener Implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
+  virtual void OnChannelConnected(int32 peer_pid) OVERRIDE;
 
   // Different types of ExtensionServers are initialized with different
   // permission delegates: For out-of-process extensions the extension
@@ -113,6 +115,8 @@ class XWalkExtensionServer : public IPC::Listener,
   // The exported symbols for extensions already registered.
   typedef std::set<std::string> ExtensionSymbolsSet;
   ExtensionSymbolsSet extension_symbols_;
+
+  base::ProcessHandle renderer_process_handle_;
 
   XWalkExtension::PermissionsDelegate* permissions_delegate_;
 };

--- a/extensions/renderer/xwalk_extension_client.cc
+++ b/extensions/renderer/xwalk_extension_client.cc
@@ -44,6 +44,8 @@ bool XWalkExtensionClient::OnMessageReceived(const IPC::Message& message) {
   IPC_BEGIN_MESSAGE_MAP(XWalkExtensionClient, message)
     IPC_MESSAGE_HANDLER(XWalkExtensionClientMsg_PostMessageToJS,
         OnPostMessageToJS)
+    IPC_MESSAGE_HANDLER(XWalkExtensionClientMsg_PostOutOfLineMessageToJS,
+        OnPostOutOfLineMessageToJS)
     IPC_MESSAGE_HANDLER(XWalkExtensionClientMsg_InstanceDestroyed,
         OnInstanceDestroyed)
     IPC_MESSAGE_UNHANDLED(handled = false)
@@ -74,6 +76,17 @@ void XWalkExtensionClient::OnPostMessageToJS(int64_t instance_id,
   const base::Value* value;
   msg.Get(0, &value);
   it->second->HandleMessageFromNative(*value);
+}
+
+void XWalkExtensionClient::OnPostOutOfLineMessageToJS(
+    base::SharedMemoryHandle handle, size_t size) {
+  CHECK(base::SharedMemory::IsHandleValid(handle));
+
+  base::SharedMemory shared_memory(handle, true);
+  shared_memory.Map(size);
+
+  IPC::Message message(static_cast<char*>(shared_memory.memory()), size);
+  OnMessageReceived(message);
 }
 
 void XWalkExtensionClient::DestroyInstance(int64_t instance_id) {

--- a/extensions/renderer/xwalk_extension_client.h
+++ b/extensions/renderer/xwalk_extension_client.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/memory/scoped_ptr.h"
+#include "base/memory/shared_memory.h"
 #include "base/values.h"
 #include "ipc/ipc_listener.h"
 
@@ -73,6 +74,8 @@ class XWalkExtensionClient : public IPC::Listener {
   // Message Handlers.
   void OnInstanceDestroyed(int64_t instance_id);
   void OnPostMessageToJS(int64_t instance_id, const base::ListValue& msg);
+  void OnPostOutOfLineMessageToJS(base::SharedMemoryHandle handle,
+                                  size_t size);
 
   IPC::Sender* sender_;
   ExtensionAPIMap extension_apis_;


### PR DESCRIPTION
Enhanced the feature of postMessage and postSyncMessage by
introduced shared memory when transmitting big bulk of data, also
used a threshold kLargeThreashouldBytes to control if we need to
use shared memory or IPC message.

The feature was implemented based on some new IPC message for
requesting shared memory, appending shared memory between renderer
process and extension process, with some message handler functions
both in XWalkExtensionServer and XWalkExtensionClient. Also added
a buffer map both in XWalkExtensionInstance and
XWalkExtensionModule to hold the transmitting data temporarily,
and provided interface functions to handle the buffer for each
transmission.

Also implemented a test case in extensions/test.

BUG: https://crosswalk-project.org/jira/browse/XWALK-1377
