### PR TITLE
[Tizen][Runtime] Update application information in DBus service when updating.

### DIFF
--- a/application/browser/linux/installed_applications_manager.cc
+++ b/application/browser/linux/installed_applications_manager.cc
@@ -72,6 +72,13 @@ void InstalledApplicationsManager::OnApplicationUninstalled(
   adaptor_.RemoveManagedObject(GetInstalledPathForAppID(app_id));
 }
 
+void InstalledApplicationsManager::OnApplicationUpdated(
+    const std::string& app_id) {
+  if (scoped_refptr<ApplicationData> app =
+      app_storage_->GetApplicationData(app_id))
+    OnApplicationNameChanged(app_id, app->Name());
+}
+
 void InstalledApplicationsManager::OnApplicationNameChanged(
     const std::string& app_id, const std::string& app_name) {
   InstalledApplicationObject* object =

--- a/application/browser/linux/installed_applications_manager.h
+++ b/application/browser/linux/installed_applications_manager.h
@@ -34,6 +34,7 @@ class InstalledApplicationsManager : public ApplicationService::Observer {
   // ApplicationService::Observer implementation.
   void virtual OnApplicationInstalled(const std::string& app_id) OVERRIDE;
   void virtual OnApplicationUninstalled(const std::string& app_id) OVERRIDE;
+  void virtual OnApplicationUpdated(const std::string& app_id) OVERRIDE;
   void virtual OnApplicationNameChanged(const std::string& app_id,
                                         const std::string& app_name) OVERRIDE;
 


### PR DESCRIPTION
When updating application, the information cached in DBus service should
be synced as well.

BUG=XWALK-1231
