### PR TITLE
[Tizen][Runtime] Fix can not open a blocked navigation link in web browser.

### DIFF
--- a/runtime/browser/runtime_platform_util_tizen.cc
+++ b/runtime/browser/runtime_platform_util_tizen.cc
@@ -4,18 +4,28 @@
 
 #include "xwalk/runtime/browser/runtime_platform_util.h"
 
+#include "base/file_util.h"
 #include "base/logging.h"
 #include "base/process/kill.h"
 #include "base/process/launch.h"
 #include "url/gurl.h"
 
 namespace platform_util {
+namespace {
+// The system default web browser path.
+// In some Tizen releases, there exists a system browser called 'MiniBrowser',
+// which we can use to open an external link from a web app.
+const char kWebBrowserPath[] = "/usr/bin/MiniBrowser";
+}  // namespace
 
 void OpenExternal(const GURL& url) {
   if (url.SchemeIsHTTPOrHTTPS()) {
-    LOG(INFO) << "Open in MiniBrowser.";
+    LOG(INFO) << "Open in WebBrowser.";
     std::vector<std::string> argv;
-    argv.push_back("MiniBrowser");
+    if (base::PathExists(base::FilePath(kWebBrowserPath)))
+      argv.push_back(kWebBrowserPath);
+    else
+      argv.push_back("xwalk");
     argv.push_back(url.spec());
     base::ProcessHandle handle;
 


### PR DESCRIPTION
On Tizen common image, the MiniBrowser is invalid, so open a blocked
navigation link in a separate xwalk instead.

BUG=XWALK-1605
