### PR TITLE
[Android] Force using ContentVideoViewLegacy to make the android fullscr...

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -102,6 +102,12 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
     command_line->AppendSwitch(switches::kEnableWebAudio);
 #endif
 
+  // For fullscreen video playback, the ContentVideoView is still buggy, so
+  // we switch back to ContentVideoViewLegacy for temp.
+  // TODO(shouqun): Remove this flag when ContentVideoView is ready.
+  command_line->AppendSwitch(
+      switches::kDisableOverlayFullscreenVideoSubtitle);
+
   XWalkBrowserMainParts::PreMainMessageLoopStart();
 
   startup_url_ = GURL();


### PR DESCRIPTION
...een video works.

Currently the default ContentVideoView in upstream is not ready for production usage. Bugs
are many about focus related. We turn to use ContentVideoViewLegacy now and when bug in
chromium is fixed, will revert the change.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1608
