### PR TITLE
[Runtime] Add i18n support for widget info

### DIFF
--- a/application/common/manifest_handlers/widget_handler.cc
+++ b/application/common/manifest_handlers/widget_handler.cc
@@ -93,6 +93,18 @@ void WidgetInfo::Set(const std::string& key, base::Value* value) {
   value_->Set(key, value);
 }
 
+void WidgetInfo::SetName(const std::string& name) {
+  value_->SetString(kName, name);
+}
+
+void WidgetInfo::SetShortName(const std::string& short_name) {
+  value_->SetString(kShortName, short_name);
+}
+
+void WidgetInfo::SetDescription(const std::string& description) {
+  value_->SetString(kDecription, description);
+}
+
 WidgetHandler::WidgetHandler() {}
 
 WidgetHandler::~WidgetHandler() {}

--- a/application/common/manifest_handlers/widget_handler.h
+++ b/application/common/manifest_handlers/widget_handler.h
@@ -22,6 +22,12 @@ class WidgetInfo : public ApplicationData::ManifestData {
   void SetString(const std::string& key, const std::string& value);
   void Set(const std::string& key, base::Value* value);
 
+  // Name, shrot name and description are i18n items, they will be set
+  // if their value were changed after loacle was changed.
+  void SetName(const std::string& name);
+  void SetShortName(const std::string& short_name);
+  void SetDescription(const std::string& description);
+
   base::DictionaryValue* GetWidgetInfo() {
     return value_.get();
   }


### PR DESCRIPTION
After locale was changed, we need to update widget info.
So that application widget api will get a localiation value.
