### PR TITLE
[Tizen][Runtime] Fix using the wrong attribute name for hardware key setting.

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -86,7 +86,7 @@ const char kAllowNavigationKey[] = "widget.allow-navigation.#text";
 const char kCSPReportOnlyKey[] =
     "widget.content-security-policy-report-only.#text";
 const char kTizenSettingKey[] = "widget.setting";
-const char kTizenHardwareKey[] = "widget.setting.@hwkey";
+const char kTizenHardwareKey[] = "widget.setting.@hwkey-event";
 const char kTizenMetaDataKey[] = "widget.metadata";
 // Child keys inside 'kTizenMetaDataKey'
 const char kTizenMetaDataNameKey[] = "@key";


### PR DESCRIPTION
In Tizen, the <tizen:setting hwkey-event="disable" /> setting could
disable the hardware key event. But the implementation use the wrong
attribute name "hwkey", need to change it to "hwkey-event" according to
Tizen core spec feature XWALK-1491.

BUG=XWALK-1611
