### PR TITLE
[Runtime] Fix i18n data loss BUG when storage to db

### DIFF
--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -270,9 +270,6 @@ void Manifest::ParseWGTI18nEachPath(const std::string& path) {
         get_first_one = ParseWGTI18nEachElement(*it, path, kLocaleFirstOne);
     }
   }
-  // After Parse we remove this path from data_ for saving memory.
-  scoped_ptr<base::Value> remove_value;
-  data_->Remove(path, &remove_value);
 }
 
 bool Manifest::ParseWGTI18nEachElement(base::Value* value,


### PR DESCRIPTION
We get manifest from file first time after application
installed, and we storage this manifest data to db, after
that we will get manifest data from db.

We parse i18n items into i18n_data_ and remove they from
data_, But we only storage data_ in db, so we can not get
i18n items after we reload the manifest data from db.
