### PR TITLE
[Android] Fix the potential memory issue in XWalkPreferences

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -438,6 +438,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
     public void destroy() {
         if (mXWalkContent == 0) return;
 
+        XWalkPreferences.unload(this);
         // Reset existing notification service in order to destruct it.
         setNotificationService(null);
         // Remove its children used for page rendering from view hierarchy.


### PR DESCRIPTION
- Use WeakReference instead to make sure the key listener can be GC-ed
- Add unload internal method to remove the listener from the global list

BUG=https://crosswalk-project.org/jira/browse/XWALK-1613
