### PR TITLE
[Application] Fix debug mode issues for extension process running in launcher

### DIFF
--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -12,6 +12,10 @@
 #include "xwalk/application/browser/application.h"
 #include "xwalk/dbus/object_manager_adaptor.h"
 
+namespace dbus {
+class FileDescriptor;
+}
+
 namespace xwalk {
 namespace application {
 
@@ -57,6 +61,11 @@ class RunningApplicationObject : public dbus::ManagedObject {
   void OnNameOwnerChanged(const std::string& service_owner);
 
   void OnLauncherDisappeared();
+
+  scoped_ptr<dbus::FileDescriptor> CreateClientFileDescriptor();
+  void SendChannel(dbus::MethodCall* method_call,
+                   dbus::ExportedObject::ResponseSender response_sender,
+                   scoped_ptr<dbus::FileDescriptor> client_fd);
 
   scoped_refptr<dbus::Bus> bus_;
   std::string launcher_name_;

--- a/application/tools/linux/xwalk_extension_process_launcher.cc
+++ b/application/tools/linux/xwalk_extension_process_launcher.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "base/at_exit.h"
 #include "base/message_loop/message_loop.h"
 #include "xwalk/application/tools/linux/xwalk_extension_process_launcher.h"
 #include "xwalk/extensions/extension_process/xwalk_extension_process.h"
@@ -9,6 +10,7 @@
 XWalkExtensionProcessLauncher::XWalkExtensionProcessLauncher()
     : base::Thread("LauncherExtensionService"),
       is_started_(false) {
+  exit_manager_.reset(new base::AtExitManager);
   base::Thread::Options thread_options;
   thread_options.message_loop_type = base::MessageLoop::TYPE_DEFAULT;
   StartWithOptions(thread_options);
@@ -16,6 +18,10 @@ XWalkExtensionProcessLauncher::XWalkExtensionProcessLauncher()
 
 XWalkExtensionProcessLauncher::~XWalkExtensionProcessLauncher() {
   Stop();
+}
+
+void XWalkExtensionProcessLauncher::CleanUp() {
+  extension_process_.reset();
 }
 
 void XWalkExtensionProcessLauncher::Launch(

--- a/application/tools/linux/xwalk_extension_process_launcher.h
+++ b/application/tools/linux/xwalk_extension_process_launcher.h
@@ -9,6 +9,10 @@
 
 #include "base/threading/thread.h"
 
+namespace base {
+class AtExitManager;
+}
+
 namespace xwalk {
 namespace extensions {
 class XWalkExtensionProcess;
@@ -20,6 +24,9 @@ class XWalkExtensionProcessLauncher: public base::Thread {
   XWalkExtensionProcessLauncher();
   ~XWalkExtensionProcessLauncher();
 
+  // Implement base::Thread.
+  virtual void CleanUp() OVERRIDE;
+
   // Will be called in launcher's main thread.
   void Launch(const std::string& channel_id, int channel_fd);
 
@@ -29,6 +36,7 @@ class XWalkExtensionProcessLauncher: public base::Thread {
   void StartExtensionProcess(const std::string& channel_id, int channel_fd);
 
   bool is_started_;
+  scoped_ptr<base::AtExitManager> exit_manager_;
   scoped_ptr<xwalk::extensions::XWalkExtensionProcess> extension_process_;
 };
 


### PR DESCRIPTION
There are several DCHECK issues:
1. DBus FileDescriptor validity check should runs on IO allowed thread;
2. AtExitManager should be created for registering dtor callbacks;
3. XWalkExtensionProcess should be destroyed on its own thread.
