### PR TITLE
[Runtime] Enable cookie for app and devtool schemes

### DIFF
--- a/application/common/constants.cc
+++ b/application/common/constants.cc
@@ -17,6 +17,7 @@ const base::FilePath::CharType kMessagesFilename[] =
     FILE_PATH_LITERAL("messages.json");
 const char kGeneratedMainDocumentFilename[] =
     "_generated_main_document.html";
+const char kCookieDatabaseFilename[] = "ApplicationCookies";
 
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/constants.h
+++ b/application/common/constants.h
@@ -25,6 +25,9 @@ extern const base::FilePath::CharType kMessagesFilename[];
 // The filename to use for main document generated from app.main.scripts.
 extern const char kGeneratedMainDocumentFilename[];
 
+// The name of cookies database file.
+extern const char kCookieDatabaseFilename[];
+
 }  // namespace application
 }  // namespace xwalk
 


### PR DESCRIPTION
Enable the content SQLite based cookie storage.
All installed applications will share the same database file, but the
access will be restricted by their application ID.

BUG=XWALK-1587
