### PR TITLE
Revert "[Runtime Model] Packaging the XPK package generator in Linux &

### DIFF
--- a/tools/build/linux/FILES.cfg
+++ b/tools/build/linux/FILES.cfg
@@ -52,9 +52,4 @@ FILES = [
     'filename': 'Makefile.templ',
     'buildtype': ['dev', 'official'],
   },
-# XPK package generator
-  {
-    'filename': 'tools/make_xpk.py',
-    'buildtype': ['dev', 'official'],
-  },
 ]

--- a/tools/build/win/FILES.cfg
+++ b/tools/build/win/FILES.cfg
@@ -91,9 +91,4 @@ FILES = [
     'buildtype': ['dev', 'official'],
     'archive': 'xwalk-win32-syms.zip',
   },
-# XPK package generator
-  {
-    'filename': 'tools/make_xpk.py',
-    'buildtype': ['dev', 'official'],
-  },
 ]

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -616,7 +616,6 @@
           'dependencies': [
             'xwalk',
             'xwalk_all_tests',
-            'xwalk_xpk_generator',
           ],
         },
         {
@@ -637,18 +636,6 @@
             'xwalk_app_template',
           ],
         }],
-      ],
-    },
-    {
-      'target_name': 'xwalk_xpk_generator',
-      'type': 'none',
-      'copies': [
-        {
-          'destination': '<(PRODUCT_DIR)/tools',
-          'files': [
-            'tools/make_xpk.py',
-          ],
-        },
       ],
     },
   ], # targets


### PR DESCRIPTION
Windows"

We've never officially shipped any Windows or Linux archives, so this target
is not really serving any purpose.

This reverts commit 0b649e3b21882fe3b61afa8a4f46e6f54f51f144.
