### PR TITLE
Stop checking for `tizen_mobile' in gyp wherever possible.

### DIFF
--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -63,7 +63,7 @@
             'gio',
           ],
         }],
-        ['tizen==1 or tizen_mobile==1', {
+        ['tizen==1', {
           'dependencies': [
             'gio',
             '../../../build/system.gyp:tizen_appcore_common'

--- a/application/tools/tizen/xwalk_tizen_helper.gyp
+++ b/application/tools/tizen/xwalk_tizen_helper.gyp
@@ -5,7 +5,7 @@
       'type': 'executable',
       'product_name': 'xwalk-pkg-helper',
       'conditions': [
-        ['tizen==1 or tizen_mobile==1', {
+        ['tizen==1', {
           'dependencies': [
             '../../../build/system.gyp:tizen',
             '../../../../base/base.gyp:base',

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -113,7 +113,7 @@
             'browser/linux/running_applications_manager.h',
           ],
         }],
-        [ 'tizen == 1 or tizen_mobile == 1', {
+        ['tizen==1', {
           'dependencies': [
             'build/system.gyp:tizen',
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -4,7 +4,7 @@
 
 {
   'conditions': [
-    [ 'tizen == 1 or tizen_mobile == 1', {
+    ['tizen==1', {
       'targets': [
         {
           'target_name': 'tizen_geolocation',

--- a/build/xwalk_filename_rules.gypi
+++ b/build/xwalk_filename_rules.gypi
@@ -11,7 +11,7 @@
 # every .gyp file, including Chromium's).
 {
   'target_conditions': [
-    ['tizen_mobile!=1 and tizen!=1', {
+    ['tizen!=1', {
       'sources/': [
         ['exclude', '_tizen(_unittest)?\\.(h|cc)$'],
         ['exclude', '(^|/)tizen/'],

--- a/dbus/xwalk_dbus.gyp
+++ b/dbus/xwalk_dbus.gyp
@@ -18,7 +18,7 @@
         'xwalk_service_name.h',
       ],
       'conditions': [
-        [ 'tizen == 1 or tizen_mobile == 1', {
+        ['tizen==1', {
           'sources': [
             'dbus_manager_tizen.cc',
           ],

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -267,7 +267,7 @@
         },
       },
       'conditions': [
-        [ 'tizen == 1 or tizen_mobile == 1', {
+        ['tizen==1', {
           'dependencies': [
             'build/system.gyp:tizen_geolocation',
             'sysapps/sysapps_resources.gyp:xwalk_sysapps_resources',

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -58,7 +58,7 @@
             '../skia/skia.gyp:skia',
           ],
         }],
-        ['tizen == 1 or tizen_mobile == 1', {
+        ['tizen==1', {
           'sources': [
             'application/common/manifest_handlers/navigation_handler_unittest.cc',
           ],


### PR DESCRIPTION
tizen_mobile has not been defined ever since we dropped support for Tizen 2.x
in 58841e7393074ea40e9a86bb55e8025256cf5af5, so the check has been dead for a
while.

Helps fix XWALK-1625.
