### PR TITLE
[Android] Use XWalkBaseActivity for each demo in Crosswalk Sample

### DIFF
--- a/runtime/android/sample/assets/index.html
+++ b/runtime/android/sample/assets/index.html
@@ -1,6 +1,5 @@
 <html>
     <body>
         Hello World.
-        <script>alert('Hello World!')</script>
     </body>
 </html>

--- a/runtime/android/sample/src/org/xwalk/core/sample/LoadAppFromManifestActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/LoadAppFromManifestActivity.java
@@ -6,19 +6,18 @@ package org.xwalk.core.sample;
 
 import org.xwalk.core.XWalkView;
 
-import android.app.Activity;
 import android.os.Bundle;
 
-public class LoadAppFromManifestActivity extends Activity {
+public class LoadAppFromManifestActivity extends XWalkBaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.xwview_layout);
-        XWalkView xwalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
 
         // The manifest definition, please refer to the link:
         // https://crosswalk-project.org/#wiki/Crosswalk-manifest 
-        xwalkView.loadAppFromManifest("file:///android_asset/manifest.json", null);
+        mXWalkView.loadAppFromManifest("file:///android_asset/manifest.json", null);
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/MultiXWalkViewActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/MultiXWalkViewActivity.java
@@ -6,11 +6,12 @@ package org.xwalk.core.sample;
 
 import org.xwalk.core.XWalkView;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.widget.LinearLayout;
 
-public class MultiXWalkViewActivity extends Activity {
+public class MultiXWalkViewActivity extends XWalkBaseActivity {
+
+    private XWalkView mXWalkView2;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -24,13 +25,39 @@ public class MultiXWalkViewActivity extends Activity {
                 LinearLayout.LayoutParams.MATCH_PARENT);
         params.weight = 1;
 
-        XWalkView view1 = new XWalkView(this, this);
-        parent.addView(view1, params);
+        mXWalkView = new XWalkView(this, this);
+        parent.addView(mXWalkView, params);
 
-        XWalkView view2 = new XWalkView(this, this);
-        parent.addView(view2, params);
+        mXWalkView2 = new XWalkView(this, this);
+        parent.addView(mXWalkView2, params);
 
-        view1.load("http://www.intel.com", null);
-        view2.load("http://www.baidu.com", null);
+        mXWalkView.load("http://www.intel.com", null);
+        mXWalkView2.load("http://www.baidu.com", null);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (mXWalkView2 != null) {
+            mXWalkView2.onHide();
+            mXWalkView2.pauseTimers();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mXWalkView2 != null) {
+            mXWalkView2.onShow();
+            mXWalkView2.resumeTimers();
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (mXWalkView2 != null) {
+            mXWalkView2.onDestroy();
+        }
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/OnHideOnShowActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/OnHideOnShowActivity.java
@@ -6,12 +6,9 @@ package org.xwalk.core.sample;
 
 import org.xwalk.core.XWalkView;
 
-import android.app.Activity;
 import android.os.Bundle;
 
-public class OnHideOnShowActivity extends Activity {
-
-    private XWalkView mXWalkView;
+public class OnHideOnShowActivity extends XWalkBaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -19,20 +16,8 @@ public class OnHideOnShowActivity extends Activity {
         setContentView(R.layout.xwview_layout);
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
 
+        // The web page below will display a video.
+        // When home button is pressed, the activity will be in background, and the video will be paused.
         mXWalkView.load("http://www.w3.org/2010/05/video/mediaevents.html", null);
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        // It will pause the video, when the app in background.
-        mXWalkView.onHide();
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        // Need to call onShow() when onHide() was called.
-        mXWalkView.onShow();
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/PauseTimersActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/PauseTimersActivity.java
@@ -6,17 +6,15 @@ package org.xwalk.core.sample;
 
 import org.xwalk.core.XWalkView;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.ImageButton;
 
-public class PauseTimersActivity extends Activity {
+public class PauseTimersActivity extends XWalkBaseActivity {
 
     private ImageButton mButton;
     private boolean isPaused;
-    XWalkView mXWalkView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/runtime/android/sample/src/org/xwalk/core/sample/ResourceAndUIClientsActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/ResourceAndUIClientsActivity.java
@@ -9,20 +9,19 @@ import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
 
-import android.app.Activity;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 
-public class ResourceAndUIClientsActivity extends Activity {
+public class ResourceAndUIClientsActivity extends XWalkBaseActivity {
 
     private static final String TAG = ResourceAndUIClientsActivity.class.getName();
 
-    class ResourceCLient extends XWalkResourceClient {
+    class ResourceClient extends XWalkResourceClient {
 
-        public ResourceCLient(XWalkView xwalkView) {
+        public ResourceClient(XWalkView xwalkView) {
             super(xwalkView);
         }
 
@@ -96,9 +95,9 @@ public class ResourceAndUIClientsActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.xwview_layout);
-        XWalkView xwalkView = (XWalkView) findViewById(R.id.xwalkview);
-        xwalkView.setResourceClient(new ResourceCLient(xwalkView));
-        xwalkView.setUIClient(new UIClient(xwalkView));
-        xwalkView.load("http://www.baidu.com", null);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
+        mXWalkView.setUIClient(new UIClient(mXWalkView));
+        mXWalkView.load("http://www.baidu.com", null);
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkBaseActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkBaseActivity.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.sample;
+
+import org.xwalk.core.XWalkView;
+
+import android.app.Activity;
+
+public class XWalkBaseActivity extends Activity {
+    protected XWalkView mXWalkView;
+
+    /*
+     * When the activity is paused, XWalkView.onHide() and XWalkView.pauseTimers() need to be called.
+     */
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (mXWalkView != null) {
+            mXWalkView.onHide();
+            mXWalkView.pauseTimers();
+        }
+    }
+
+    /*
+     * When the activity is resumed, XWalkView.onShow() and XWalkView.resumeTimers() need to be called.
+     */
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mXWalkView != null) {
+            mXWalkView.onShow();
+            mXWalkView.resumeTimers();
+        }
+    }
+
+    /*
+     * Call onDestroy on XWalkView to release native resources when the activity is destroyed.
+     */
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (mXWalkView != null) {
+            mXWalkView.onDestroy();
+        }
+    }
+}

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkNavigationActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkNavigationActivity.java
@@ -7,17 +7,15 @@ package org.xwalk.core.sample;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkNavigationHistory;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.ImageButton;
 
-public class XWalkNavigationActivity extends Activity {
+public class XWalkNavigationActivity extends XWalkBaseActivity {
 
     private ImageButton mNextButton;
     private ImageButton mPrevButton;
-    private XWalkView mXWalkView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkPreferencesActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkPreferencesActivity.java
@@ -7,21 +7,20 @@ package org.xwalk.core.sample;
 import org.xwalk.core.XWalkPreferences;
 import org.xwalk.core.XWalkView;
 
-import android.app.Activity;
 import android.os.Bundle;
 
-public class XWalkPreferencesActivity extends Activity {
+public class XWalkPreferencesActivity extends XWalkBaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.xwview_layout);
-        XWalkView xwalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
 
         // Enable remote debugging.
         // You can debug the web content via PC chrome.
         XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
 
-        xwalkView.load("http://www.baidu.com/", null);
+        mXWalkView.load("http://www.baidu.com/", null);
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkViewWithLayoutActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkViewWithLayoutActivity.java
@@ -6,16 +6,15 @@ package org.xwalk.core.sample;
 
 import org.xwalk.core.XWalkView;
 
-import android.app.Activity;
 import android.os.Bundle;
 
-public class XWalkViewWithLayoutActivity extends Activity {
+public class XWalkViewWithLayoutActivity extends XWalkBaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.xwview_layout);
-        XWalkView xwalkView = (XWalkView) findViewById(R.id.xwalkview);
-        xwalkView.load("http://www.baidu.com/", null);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView.load("http://www.baidu.com/", null);
     }
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -670,6 +670,7 @@
             'xwalk_runtime_lib_apk',
             'xwalk_app_hello_world_apk',
             'xwalk_app_template',
+            'xwalk_core_sample_apk'
           ],
         }],
       ],


### PR DESCRIPTION
1. XWalkBaseActivity will control the XWalkView lifecycle, such as onHide, onShow and onDestroy.
   All other demos need to override from this base activity.
2. Add CrosswalkSample to xwalk_builder. (it's not the final solution, will track it with XWALK-1593)

TODO: Removed alert in manifest demo, it will cause crash when onDestroy() is called.
      XWALK-1639

BUG=XWALK-1631
