### PR TITLE
[Android] Apk will crash when set ‘undefined’ arch option

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -576,7 +576,7 @@ def main(argv):
   info = ('The target architecture of the embedded runtime. Supported values '
           'are \'x86\' and \'arm\'. Note, if undefined, APKs for all possible '
           'architestures will be generated.')
-  parser.add_option('--arch', help=info)
+  parser.add_option('--arch', choices=("x86", "arm"), help=info)
   group = optparse.OptionGroup(parser, 'Application Source Options',
       'This packaging tool supports 3 kinds of web application source: '
       '1) XPK package; 2) manifest.json; 3) various command line options, '

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -661,6 +661,28 @@ class TestMakeApk(unittest.TestCase):
       else:
         self.assertFalse(os.path.isfile('Example_1.0.0._arm.apk'))
       self.assertFalse(os.path.isfile('Example_1.0.0_x86.apk'))
+      Clean('Example', '1.0.0')
+      cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+             '--package=org.xwalk.example', '--app-url=http://www.intel.com',
+             self._mode]
+      RunCommand(cmd)
+      if 'arm' in self.archs():
+        self.assertTrue(os.path.isfile('Example_1.0.0_arm.apk'))
+        self.checkApk('Example_1.0.0_arm.apk', 'arm')
+      else:
+        self.assertFalse(os.path.isfile('Example_1.0.0._arm.apk'))
+      if 'x86' in self.archs():
+        self.assertTrue(os.path.isfile('Example_1.0.0_x86.apk'))
+        self.checkApk('Example_1.0.0_x86.apk', 'x86')
+      else:
+        self.assertFalse(os.path.isfile('Example_1.0.0._x86.apk'))
+      Clean('Example', '1.0.0')
+      cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+             '--package=org.xwalk.example', '--app-url=http://www.intel.com',
+             '--arch=undefined', self._mode]
+      out = RunCommand(cmd)
+      error_msg = 'invalid choice: \'undefined\''
+      self.assertTrue(out.find(error_msg) != -1)
 
   def testVerbose(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',


### PR DESCRIPTION
To clean the logic to three paths:
(1) Specified "option.arch" with known values ('x86' and 'arm').
(2) Specified "option.arch" with unknown values.
(3) Unspecified "option.arch".

BUG=XWALK-1618
