### PR TITLE
[Android] Fix that empty directory is not added to the generated tarball...

### DIFF
--- a/tools/tar.py
+++ b/tools/tar.py
@@ -25,7 +25,9 @@ def main(args):
   try:
     os.chdir(work_dir)
     tar = tarfile.open(tar_filename, "w:gz")
-    for root, _, files in os.walk(dir_name):
+    for root, dirs, files in os.walk(dir_name):
+      if dirs == [] and files == []:
+        tar.add(root)
       for f in files:
         tar.add(os.path.join(root, f))
     tar.close()


### PR DESCRIPTION
....

Crosswalk archive tool that's not adding the empty "src/" in "xwalk_core_library"
to the generated tarball will cause cordova builder do basic test fialed.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1654
