### PR TITLE
[Tizen][Runtime] Redirect javascript console to launcher

### DIFF
--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -8,10 +8,14 @@
 #include <string>
 #include <vector>
 
+#include "base/strings/stringprintf.h"
+#include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/render_process_host.h"
+#include "content/public/common/url_utils.h"
 
 #include "xwalk/runtime/browser/ui/native_app_window.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_common_messages.h"
 
 #if defined(USE_OZONE)
@@ -23,6 +27,10 @@
 #include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
 #endif
 
+#include "xwalk/application/browser/application_system_linux.h"
+#include "xwalk/application/browser/application_service_provider_linux.h"
+#include "xwalk/application/browser/linux/running_applications_manager.h"
+#include "xwalk/application/browser/linux/running_application_object.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/manifest_handlers/navigation_handler.h"
 
@@ -90,6 +98,37 @@ void ApplicationTizen::InitSecurityPolicy() {
       new ViewMsg_EnableSecurityMode(
           ApplicationData::GetBaseURLFromApplicationId(id()),
           SecurityPolicy::CSP));
+}
+
+void ApplicationTizen::OnAddMessageToConsole(content::WebContents* source,
+                                             int32 level,
+                                             const base::string16& message,
+                                             int32 line_no,
+                                             const base::string16& source_id) {
+  ApplicationSystemLinux* app_system_linux =
+      static_cast<ApplicationSystemLinux*>(
+          XWalkRunner::GetInstance()->app_system());
+
+  RunningApplicationObject* running_application_object =
+      app_system_linux->service_provider()->GetRunningApplicationObject(this);
+
+  if (!running_application_object)
+    return;
+
+  // Pass through log level only on WebUI pages to limit console spew.
+  int32 resolved_level =
+      content::HasWebUIScheme(source->GetLastCommittedURL()) ? level : 0;
+
+  std::string log_message;
+  if (resolved_level >= ::logging::GetMinLogLevel()) {
+    log_message = base::StringPrintf("[CONSOLE(%d)] \"%s\""
+                                     ", source: %s (%d)",
+                                     resolved_level,
+                                     base::UTF16ToUTF8(message).c_str(),
+                                     base::UTF16ToUTF8(source_id).c_str(),
+                                     line_no);
+  }
+  running_application_object->SendLogToLauncher(log_message);
 }
 
 #if defined(USE_OZONE)

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -31,6 +31,12 @@ class ApplicationTizen : //  NOLINT
 
   virtual void InitSecurityPolicy() OVERRIDE;
 
+  virtual void OnAddMessageToConsole(content::WebContents* source,
+                                     int32 level,
+                                     const base::string16& message,
+                                     int32 line_no,
+                                     const base::string16& source_id) OVERRIDE;
+
 #if defined(USE_OZONE)
   virtual base::EventStatus WillProcessEvent(
       const base::NativeEvent& event) OVERRIDE;

--- a/application/browser/linux/running_application_object.cc
+++ b/application/browser/linux/running_application_object.cc
@@ -222,5 +222,12 @@ void RunningApplicationObject::ExtensionProcessCreated(
   dbus_object()->SendSignal(&signal);
 }
 
+void RunningApplicationObject::SendLogToLauncher(const std::string& log) {
+  dbus::Signal signal(kRunningApplicationDBusInterface, "PrintLog");
+  dbus::MessageWriter writer(&signal);
+  writer.AppendVariantOfString(log);
+  dbus_object()->SendSignal(&signal);
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -36,6 +36,8 @@ class RunningApplicationObject : public dbus::ManagedObject {
 
   void ExtensionProcessCreated(const IPC::ChannelHandle& handle);
 
+  void SendLogToLauncher(const std::string& log);
+
  private:
   void TerminateApplication(Application::TerminationMode mode);
 

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -122,6 +122,17 @@ static void on_app_signal(GDBusProxy* proxy,
                           gpointer user_data) {
   if (!strcmp(signal_name, "EPChannelCreated")) {
     init_extension_process_channel(proxy);
+  } else if (!strcmp(signal_name, "PrintLog")) {
+    if (parameters) {
+      GVariant* log_variant;
+      g_variant_get(parameters, "(v)", &log_variant);
+
+      if (log_variant) {
+        const gchar* log;
+        g_variant_get(log_variant, "s", &log);
+        fprintf(stderr, "%s\n", log);
+      }
+    }
   } else {
     fprintf(stderr, "Unkown signal received: %s\n", signal_name);
   }

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -346,6 +346,22 @@ void Runtime::RequestMediaAccessPermission(
       web_contents, request, callback);
 }
 
+#if defined(OS_TIZEN)
+bool Runtime::AddMessageToConsole(content::WebContents* source,
+                                  int32 level,
+                                  const base::string16& message,
+                                  int32 line_no,
+                                  const base::string16& source_id) {
+  if (!XWalkRunner::GetInstance()->is_running_as_service())
+    return false;
+
+  if (observer_)
+    observer_->OnAddMessageToConsole(source, level, message,
+                                     line_no, source_id);
+  return true;
+}
+#endif
+
 void Runtime::RenderProcessGone(base::TerminationStatus status) {
   content::RenderProcessHost* rph = web_contents_->GetRenderProcessHost();
   VLOG(1) << "RenderProcess id: " << rph->GetID() << " is gone!";

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -50,6 +50,14 @@ class Runtime : public content::WebContentsDelegate,
       // Called when a Runtime instance is removed.
       virtual void OnRuntimeRemoved(Runtime* runtime) = 0;
 
+#if defined(OS_TIZEN)
+      virtual void OnAddMessageToConsole(content::WebContents* source,
+                                         int32 level,
+                                         const base::string16& message,
+                                         int32 line_no,
+                                         const base::string16& source_id) = 0;
+#endif
+
     protected:
       virtual ~Observer() {}
   };
@@ -132,6 +140,14 @@ class Runtime : public content::WebContentsDelegate,
       content::WebContents* web_contents,
       const content::MediaStreamRequest& request,
       const content::MediaResponseCallback& callback) OVERRIDE;
+
+#if defined(OS_TIZEN)
+  virtual bool AddMessageToConsole(content::WebContents* source,
+                                   int32 level,
+                                   const base::string16& message,
+                                   int32 line_no,
+                                   const base::string16& source_id) OVERRIDE;
+#endif
 
   // Overridden from content::WebContentsObserver.
   virtual void DidUpdateFaviconURL(int32 page_id,


### PR DESCRIPTION
On server mode, all log will print to systemd, but it is
meaningless to print javascript console log to systemd. So
redirect javascript console to launcher.

BUG=XWALK-1656
