### PR TITLE
[Android] Correct the usage of all_dependent_settings for core library

### DIFF
--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -65,6 +65,11 @@
           '*org/xwalk/*',
         ],
       },
+      'all_dependent_settings': {
+        'variables': {
+          'input_jars_paths': ['<(jar_final_path)'],
+        },
+      },
       'actions': [
         {
           'action_name': 'jar_<(_target_name)',
@@ -98,15 +103,6 @@
         'classes_dir': '<(PRODUCT_DIR)/<(_target_name)/classes',
         'jar_name': '<(_target_name).jar',
         'jar_final_path': '<(PRODUCT_DIR)/lib.java/<(jar_name)',
-        #TODO(wang16): figure out why the 'jar_final_path' defined in chromium_generated_java
-        #              not added into following all_dependent_settings setting chain.
-        #              BUG=https://crosswalk-project.org/jira/browse/XWALK-1575
-        'input_jars_paths': ['<(PRODUCT_DIR)/lib.java/chromium_generated_java.jar'],
-      },
-      'all_dependent_settings': {
-        'variables': {
-          'input_jars_paths': ['<(jar_final_path)'],
-        },
       },
       'actions': [
         {


### PR DESCRIPTION
Previously, the all_dependent_settings is incorrectly used
in xwalk_core_library.gypi.
It's not used to include all the settings for some target's
dependencies. It's actually do settings for all the targets
depends on the one declares all_dependent_settings.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1575
