### PR TITLE
[Android] Show launch screen dialog when no 'image' provided

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
@@ -128,8 +128,9 @@ public class XWalkLaunchScreenManager
                 mLaunchScreenDialog.getWindow().setBackgroundDrawable(bgDrawable);
                 // Set foreground image
                 RelativeLayout root = getLaunchScreenLayout(imageBorderList);
-                if (root == null) return;
-                mLaunchScreenDialog.setContentView(root);
+                // The root layout can be null when there is no 'image' provided in the manifest.
+                // We can just display the background instead of no launch screen dialog displayed.
+                if (root != null) mLaunchScreenDialog.setContentView(root);
                 mLaunchScreenDialog.show();
 
                 // Change the layout depends on the orientation change.


### PR DESCRIPTION
Previously, when there is no 'image' provided, the launch screen dialog will not be displayed.
It should be displayed, because the backgrounds need to be displayed until the ready_when state.

BUG=XWALK-1635
(Cherry picked from commit d3a5c983c49297fcb629b259861bc4c0a30204e3)
