### PR TITLE
[Android] Add test cases for stopLoading().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/StopLoadingTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/StopLoadingTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for stopLoading().
+ */
+public class StopLoadingTest extends XWalkViewTestBase {
+    final String url = "file:///android_asset/www/index1.html";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @SmallTest
+    @Feature({"stopLoading"})
+    public void testStopLoadingWithStop() throws Throwable {
+        stopLoadingSync(url);
+        assertEquals("", getTitleOnUiThread());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -544,4 +544,23 @@ public class XWalkViewTestBase
             }
         });
     }
+
+    protected void stopLoadingOnUiThread() throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.stopLoading();
+            }
+        });
+    }
+
+    protected void stopLoadingSync(final String url) throws Exception {
+        CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
+        int currentCallCount = pageFinishedHelper.getCallCount();
+
+        loadUrlAsync(url);
+        stopLoadingOnUiThread();
+        pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
+    }
 }


### PR DESCRIPTION
This patch is to add test cases for stopLoading().
Open an inexistent url, then execute stopLoading(), the load will be
stopped, title is empty.