### PR TITLE
[Android] Place README.md in empty src of xwalk_core_library

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -245,6 +245,14 @@ def main(argv):
   src_dir = os.path.join(out_project_dir, 'src')
   if not os.path.isdir(src_dir):
     os.mkdir(src_dir)
+  readme = os.path.join(src_dir, 'README.md')
+  open(readme, 'w').write(
+      "# Source folder for xwalk_core_library\n"
+      "## Why it's empty\n"
+      "xwalk_core_library doesn't contain java sources.\n"
+      "## Why put me here\n"
+      "To make archives keep the folder, "
+      "the src directory is needed to build an apk by ant.")
   print 'Your Android library project has been created at %s' % (
       out_project_dir)
 


### PR DESCRIPTION
Otherwise, the archiving will ignore the empty src folder.
The build.xml in android sdk using ant to create apk requires
a src folder even it's empty.

BUG=XWALK-1650, XWALK-1654

(cherry-pick from commit e5d674d)
