### PR TITLE
[Android] Add test case for getUrl().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetUrlTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetUrlTest.java
@@ -1,0 +1,32 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for getUrl().
+ */
+public class GetUrlTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"GetUrl"})
+    public void testGetUrl() throws Throwable {
+        final String url = "file:///android_asset/www/index.html";
+
+        loadUrlSync(url);
+        assertEquals(url, getUrlOnUiThread());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -502,4 +502,13 @@ public class XWalkViewTestBase
 
         return viewPair;
     }
+
+    protected String getUrlOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return mXWalkView.getUrl();
+            }
+        });
+    }
 }


### PR DESCRIPTION
This patch is to add test case for getUrl().
Open a url, get the url on ui thread, compare it with the expected.
