### PR TITLE
[Android] Add test case for getOriginalUrl().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetOriginalUrlTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetOriginalUrlTest.java
@@ -1,0 +1,35 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for getOriginalUrl().
+ */
+public class GetOriginalUrlTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"GetOriginalUrl"})
+    public void testGetOriginalUrl() throws Throwable {
+        String url = "file:///android_asset/www/index.html";
+        String originalUrl = "file:///android_asset/www/get_original_url.html";
+
+        loadUrlSync(originalUrl);
+        Thread.sleep(2000);
+        assertEquals(originalUrl, getOriginalUrlOnUiThread());
+        assertEquals(url, getUrlOnUiThread());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -502,4 +502,22 @@ public class XWalkViewTestBase
 
         return viewPair;
     }
+
+    protected String getUrlOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return mXWalkView.getUrl();
+            }
+        });
+    }
+
+    protected String getOriginalUrlOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return mXWalkView.getOriginalUrl();
+            }
+        });
+    }
 }

--- a/test/android/data/get_original_url.html
+++ b/test/android/data/get_original_url.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<script type="text/javascript">
+    window.location.href = "index.html"
+</script>
+<title>
+Test for get original url
+</title>
+</head>
+<body>
+    Test for get original url.
+</body>
+</html>

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -42,6 +42,7 @@
         'resource_dir': 'runtime/android/core_shell/res',
         'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/www/get_original_url.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/www/index.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/xwalk.pak',
         ],
@@ -58,6 +59,7 @@
         {
           'destination': '<(PRODUCT_DIR)/xwalk_xwview/assets/www',
           'files': [
+            'test/android/data/get_original_url.html',
             'test/android/data/index.html',
           ],
         }


### PR DESCRIPTION
This patch is to add test case for getOriginalUrl().
Open a url, redirect to another url, get the url or original url
and compare it with the expected result.