### PR TITLE
[Tizen] Fail to launch the "Webapi/Runtime" component

### DIFF
--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -62,10 +62,8 @@ class RunningApplicationObject : public dbus::ManagedObject {
 
   void OnLauncherDisappeared();
 
-  scoped_ptr<dbus::FileDescriptor> CreateClientFileDescriptor();
   void SendChannel(dbus::MethodCall* method_call,
-                   dbus::ExportedObject::ResponseSender response_sender,
-                   scoped_ptr<dbus::FileDescriptor> client_fd);
+                   dbus::ExportedObject::ResponseSender response_sender);
 
   scoped_refptr<dbus::Bus> bus_;
   std::string launcher_name_;


### PR DESCRIPTION
The issue occurred because EP file descriptor was attempted
to pass before it was initialized (before EP actually started).

BUG=XWALK-1432
