### PR TITLE
To remove one redundant conditional statement

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -749,8 +749,7 @@ def main(argv):
   except SystemExit as ec:
     CleanDir(options.name)
     CleanDir('out')
-    if os.path.exists(xpk_temp_dir):
-      CleanDir(xpk_temp_dir)
+    CleanDir(xpk_temp_dir)
     return ec.code
   return 0
 


### PR DESCRIPTION
@rakuco @junmin-zhu.

One word fix, found when I read code. Please help to check, thank you:

A redundant conditional statement, since function "CleanDir" will check if directory exists.
