### PR TITLE
[Runtime] Fix the crash due to the sanity check

### DIFF
--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -320,7 +320,7 @@ ApplicationProtocolHandler::MaybeCreateJob(
   }
 
   std::list<std::string> locales;
-  if (application->GetPackageType() == Manifest::TYPE_WGT) {
+  if (application && application->GetPackageType() == Manifest::TYPE_WGT) {
     GetUserAgentLocales(
         xwalk::XWalkRunner::GetInstance()->GetLocale(), locales);
     GetUserAgentLocales(application->GetManifest()->default_locale(), locales);


### PR DESCRIPTION
Miss the sanity check of the ApplicaionData used in
ApplicationProtocolHandler::MaybeCreateJob().

BUG=XWALK-1677
