### PR TITLE
[Tizen][Runtime] Fix xwalkctl can not print right encode for string

### DIFF
--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -8,6 +8,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <locale.h>
 
 #include "xwalk/application/tools/linux/dbus_connection.h"
 #include "xwalk/application/tools/linux/xwalk_tizen_user.h"
@@ -172,6 +173,7 @@ static void list_applications(GDBusObjectManager* installed) {
 }
 
 int main(int argc, char* argv[]) {
+  setlocale(LC_ALL, "");
   GError* error = NULL;
   GOptionContext* context;
   bool success;


### PR DESCRIPTION
g_print will convert the encoding of string according to
locale, but unfortunately the default locale is "C", and
g_print will convert string to ASCII for print when the
terminal might use utf8 encode.

To slove this problem, we can set empty locale on xwalkctl
start, and the program will get locale from environment
variables.

And we can export environment variable
like : export LC_ALL="zh_CN.utf8"
according to the actual situation of your terminal.
