### PR TITLE
[Android] Post onRsourceLoadStarted on UI thread

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -473,7 +473,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
 
             // Notify a resource load is started. This is not the best place to start the callback
             // but it's a workable way.
-            mContentsClientBridge.onResourceLoadStarted(url);
+            mContentsClientBridge.getCallbackHelper().postOnResourceLoadStarted(url);
 
             WebResourceResponse webResourceResponse = mContentsClientBridge.shouldInterceptRequest(url);
             InterceptedRequestData interceptedRequestData = null;

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClient.java
@@ -120,6 +120,10 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
     public abstract WebResourceResponse shouldInterceptRequest(String url);
 
+    public abstract void onResourceLoadStarted(String url);
+
+    public abstract void onResourceLoadFinished(String url);
+
     public abstract void onLoadResource(String url);
 
     public abstract boolean shouldOverrideUrlLoading(String url);

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -179,12 +179,14 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         return null;
     }
 
+    @Override
     public void onResourceLoadStarted(String url) {
         if (isOwnerActivityRunning()) {
             mXWalkResourceClient.onLoadStarted(mXWalkView, url);
         }
     }
 
+    @Override
     public void onResourceLoadFinished(String url) {
         if (isOwnerActivityRunning()) {
             mXWalkResourceClient.onLoadFinished(mXWalkView, url);

--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClientCallbackHelper.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClientCallbackHelper.java
@@ -71,6 +71,7 @@ class XWalkContentsClientCallbackHelper {
     private final static int MSG_ON_DOWNLOAD_START = 3;
     private final static int MSG_ON_RECEIVED_LOGIN_REQUEST = 4;
     private final static int MSG_ON_RECEIVED_ERROR = 5;
+    private final static int MSG_ON_RESOURCE_LOAD_STARTED = 6;
 
     private final XWalkContentsClient mContentsClient;
 
@@ -103,6 +104,11 @@ class XWalkContentsClientCallbackHelper {
                     OnReceivedErrorInfo info = (OnReceivedErrorInfo) msg.obj;
                     mContentsClient.onReceivedError(info.mErrorCode, info.mDescription,
                             info.mFailingUrl);
+                    break;
+                }
+                case MSG_ON_RESOURCE_LOAD_STARTED: {
+                    final String url = (String) msg.obj;
+                    mContentsClient.onResourceLoadStarted(url);
                     break;
                 }
                 default:
@@ -139,5 +145,9 @@ class XWalkContentsClientCallbackHelper {
     public void postOnReceivedError(int errorCode, String description, String failingUrl) {
         OnReceivedErrorInfo info = new OnReceivedErrorInfo(errorCode, description, failingUrl);
         mHandler.sendMessage(mHandler.obtainMessage(MSG_ON_RECEIVED_ERROR, info));
+    }
+
+    public void postOnResourceLoadStarted(String url) {
+        mHandler.sendMessage(mHandler.obtainMessage(MSG_ON_RESOURCE_LOAD_STARTED, url));
     }
 }


### PR DESCRIPTION
The shouldInterceptRequest method which invokes onRsourceLoadStarted
is called from IO thread, and onResourceLoadStarted must be called
from UI thread, since XWalkResourceClient.onLoadStarted is called
by it in chain.

BUG=XWALK-1695
