### PR TITLE
[Android] Refine the argument processing for compressor.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -80,17 +80,6 @@ def GetFilesByExt(path, ext, sub_dir=True):
     return []
 
 
-def ParseParameterForCompressor(option, value, values, parser):
-  if ((not values or values.startswith('-'))
-      and value.find('--compressor') != -1):
-    values = 'all'
-  val = values
-  if parser.rargs and not parser.rargs[0].startswith('-'):
-    val = parser.rargs[0]
-    parser.rargs.pop(0)
-  setattr(parser.values, option.dest, val)
-
-
 def CompressSourceFiles(app_root, compressor):
   js_list = []
   css_list = []
@@ -556,13 +545,9 @@ def main():
           'For example, '
           '--xwalk-command-line=\'--chromium-command-1 --xwalk-command-2\'')
   parser.add_option('--xwalk-command-line', default='', help=info)
-  info = ('Minify and obfuscate javascript and css.'
-          '--compressor: compress javascript and css.'
-          '--compressor=js: compress javascript.'
-          '--compressor=css: compress css.')
-  parser.add_option('--compressor', dest='compressor', action='callback',
-                    callback=ParseParameterForCompressor,
-                    type='string', nargs=0, help=info)
+  info = ('Minify and obfuscate javascript and css. Supported values '
+          'are \'all\', \'css\' and \'js\'. Such as: --compressor=all')
+  parser.add_option('--compressor', choices=('all', 'css', 'js'), help=info)
   options, _ = parser.parse_args()
   try:
     icon_dict = {144: 'icons/icon_144.png',

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -14,8 +14,7 @@ import subprocess
 import sys
 
 from app_info import AppInfo
-from customize import VerifyPackageName, CustomizeAll, \
-                      ParseParameterForCompressor
+from customize import VerifyPackageName, CustomizeAll
 from extension_manager import GetExtensionList, GetExtensionStatus
 from handle_permissions import permission_mapping_table
 from util import AllArchitectures, CleanDir, GetVersion, RunCommand
@@ -543,13 +542,9 @@ def main(argv):
   info = ('Passcode for alias\'s private key in the keystore, '
           'For example, --keystore-alias-passcode=alias-code')
   group.add_option('--keystore-alias-passcode', help=info)
-  info = ('Minify and obfuscate javascript and css.'
-          '--compressor: compress javascript and css.'
-          '--compressor=js: compress javascript.'
-          '--compressor=css: compress css.')
-  group.add_option('--compressor', dest='compressor', action='callback',
-                   callback=ParseParameterForCompressor, type='string',
-                   nargs=0, help=info)
+  info = ('Minify and obfuscate javascript and css. Supported values '
+          'are \'all\', \'css\' and \'js\'. Such as: --compressor=all')
+  parser.add_option('--compressor', choices=('all', 'css', 'js'), help=info)
   parser.add_option_group(group)
   options, _ = parser.parse_args()
   if len(argv) == 1:

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -967,24 +967,24 @@ class TestMakeApk(unittest.TestCase):
     js_file = os.path.join(js_folder, 'test.js')
     fun = self.assertTrue
     name = 'Example'
+    invalid_choice = 'invalid choice'
+    requires_arg = 'requires an argument'
 
     cmd = ['python', 'customize.py',
            '--name=%s' % name,
            '--package=org.xwalk.example',
            '--compressor',
            '--app-root=%s' % app_root]
-    RunCommand(cmd)
-    CompareSizeForCompressor('all', css_file, 'css', name, fun)
-    CompareSizeForCompressor('all', js_file, 'js', name, fun)
+    result = RunCommand(cmd)
+    self.assertIn(invalid_choice, result)
 
     cmd = ['python', 'customize.py',
            '--name=%s' % name,
            '--package=org.xwalk.example',
            '--app-root=%s' % app_root,
            '--compressor']
-    RunCommand(cmd)
-    CompareSizeForCompressor('all', css_file, 'css', name, fun)
-    CompareSizeForCompressor('all', js_file, 'js', name, fun)
+    result = RunCommand(cmd)
+    self.assertIn(requires_arg, result)
 
     cmd = ['python', 'customize.py',
            '--name=%s' % name,
@@ -1015,9 +1015,8 @@ class TestMakeApk(unittest.TestCase):
            '--package=org.xwalk.example',
            '--app-root=%s' % app_root,
            '--compressor=other']
-    RunCommand(cmd)
-    CompareSizeForCompressor(None, css_file, 'css', name, fun)
-    CompareSizeForCompressor(None, js_file, 'js', name, fun)
+    result = RunCommand(cmd)
+    self.assertIn(invalid_choice, result)
 
     Clean(name, '1.0.0')
 


### PR DESCRIPTION
This patch is to refine the argument processing for compressor.
In prior version, the packaging process will not be terminated when the
option value for compressor is wrong.
Now use the "choices" parameter, if the argument is not in the acceptable
value list, provide the advice to user to refine the option.

BUG=XWALK-1672