### PR TITLE
[Tizen][Runtime] Fix MessagePumpOzone issue for M36 rebase.

### DIFF
--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -15,7 +15,6 @@
 #include "xwalk/runtime/common/xwalk_common_messages.h"
 
 #if defined(USE_OZONE)
-#include "base/message_loop/message_pump_ozone.h"
 #include "content/public/browser/render_view_host.h"
 #include "ui/events/event.h"
 #include "ui/events/event_constants.h"
@@ -42,15 +41,9 @@ ApplicationTizen::ApplicationTizen(
     RuntimeContext* runtime_context,
     Application::Observer* observer)
     : Application(data, runtime_context, observer) {
-#if defined(USE_OZONE)
-  base::MessagePumpOzone::Current()->AddObserver(this);
-#endif
 }
 
 ApplicationTizen::~ApplicationTizen() {
-#if defined(USE_OZONE)
-  base::MessagePumpOzone::Current()->RemoveObserver(this);
-#endif
 }
 
 void ApplicationTizen::Hide() {
@@ -105,11 +98,6 @@ void ApplicationTizen::InitSecurityPolicy() {
 }
 
 #if defined(USE_OZONE)
-base::EventStatus ApplicationTizen::WillProcessEvent(
-    const base::NativeEvent& event) {
-  return base::EVENT_CONTINUE;
-}
-
 void ApplicationTizen::DidProcessEvent(
     const base::NativeEvent& event) {
   ui::Event* ui_event = static_cast<ui::Event*>(event);

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -4,20 +4,13 @@
 #ifndef XWALK_APPLICATION_BROWSER_APPLICATION_TIZEN_H_
 #define XWALK_APPLICATION_BROWSER_APPLICATION_TIZEN_H_
 
+#include "base/event_types.h"
 #include "xwalk/application/browser/application.h"
-
-#if defined(USE_OZONE)
-#include "base/message_loop/message_pump_observer.h"
-#endif
 
 namespace xwalk {
 namespace application {
 
-class ApplicationTizen : //  NOLINT
-#if defined(USE_OZONE)
-  public base::MessagePumpObserver,
-#endif
-  public Application {
+class ApplicationTizen : public Application {
  public:
   virtual ~ApplicationTizen();
   void Hide();
@@ -32,9 +25,7 @@ class ApplicationTizen : //  NOLINT
   virtual void InitSecurityPolicy() OVERRIDE;
 
 #if defined(USE_OZONE)
-  virtual base::EventStatus WillProcessEvent(
-      const base::NativeEvent& event) OVERRIDE;
-  virtual void DidProcessEvent(const base::NativeEvent& event) OVERRIDE;
+  virtual void DidProcessEvent(const base::NativeEvent& event);
 #endif
 };
 


### PR DESCRIPTION
MessagePumpOzone and MessagePumpObserver are deprecated in M36.
This patch removes related codes in Crosswalk in order to make it
compilable for M36 rebase.

Effect of this change is temporarily 'hwkey' feature doesn't work.

The following fix patch will be provided once we have successfully
switched to M36.

BUG=XWALK-1420
