### PR TITLE
Fix processing of the Manifest 'start_url' member

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -53,10 +53,11 @@ class Application : public Runtime::Observer {
 
   // Manifest keys that can be used as application entry points.
   enum LaunchEntryPoint {
-    AppMainKey = 1 << 0,  // app.main
-    LaunchLocalPathKey = 1 << 1,  // app.launch.local_path
-    URLKey = 1 << 2,  // url
-    Default = AppMainKey | LaunchLocalPathKey | URLKey
+    StartURLKey = 1 << 0,  // start_url
+    AppMainKey = 1 << 1,  // app.main
+    LaunchLocalPathKey = 1 << 2,  // app.launch.local_path
+    URLKey = 1 << 3,  // url
+    Default = StartURLKey | AppMainKey | LaunchLocalPathKey
   };
   typedef unsigned LaunchEntryPoints;
 
@@ -156,8 +157,9 @@ class Application : public Runtime::Observer {
   ui::WindowShowState GetWindowShowState(const LaunchParams& params);
 
   GURL GetURLFromAppMainKey();
-  GURL GetURLFromLocalPathKey();
   GURL GetURLFromURLKey();
+
+  GURL GetURLFromRelativePathKey(const std::string& key);
 
   friend class FinishEventObserver;
   void CloseMainDocument();

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -30,6 +30,7 @@ const char kLaunchWebURLKey[] = "app.launch.web_url";
 const char kManifestVersionKey[] = "manifest_version";
 const char kNameKey[] = "name";
 const char kPermissionsKey[] = "permissions";
+const char kStartURLKey[] = "start_url";
 const char kURLKey[] = "url";
 const char kVersionKey[] = "version";
 const char kWebURLsKey[] = "app.urls";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -29,6 +29,7 @@ namespace application_manifest_keys {
   extern const char kManifestVersionKey[];
   extern const char kNameKey[];
   extern const char kPermissionsKey[];
+  extern const char kStartURLKey[];
   extern const char kURLKey[];
   extern const char kVersionKey[];
   extern const char kWebURLsKey[];

--- a/application/test/application_multi_app_test.cc
+++ b/application/test/application_multi_app_test.cc
@@ -29,8 +29,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
   test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
   // The App1 has 2 pages: main doc page and "main.html" page.
-  EXPECT_EQ(app1->runtimes().size(), 2);
-  ASSERT_TRUE(app1->GetMainDocumentRuntime());
+  EXPECT_EQ(app1->runtimes().size(), 1);
 
   EXPECT_EQ(service->active_applications().size(), currently_running_count + 1);
   EXPECT_EQ(service->GetApplicationByID(app1->id()), app1);
@@ -51,8 +50,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
 
   // The App2 also has 2 pages: main doc page and "main.html" page.
-  EXPECT_EQ(app2->runtimes().size(), 2);
-  ASSERT_TRUE(app2->GetMainDocumentRuntime());
+  EXPECT_EQ(app2->runtimes().size(), 1);
 
   // Check that the apps have different IDs and RPH IDs.
   EXPECT_NE(app1->id(), app2->id());

--- a/application/test/data/dummy_app1/main.js
+++ b/application/test/data/dummy_app1/main.js
@@ -1,4 +1,0 @@
-setTimeout(
-  function(){
-    window.open("main.html");
-  }, 100);

--- a/application/test/data/dummy_app1/manifest.json
+++ b/application/test/data/dummy_app1/manifest.json
@@ -2,9 +2,5 @@
   "name": "dummy_app_1",
   "manifest_version": 1,
   "version": "1.0",
-  "app": {
-    "main": {
-      "scripts": ["main.js"]
-    }
-  }
+  "start_url": "main.html"
 }

--- a/application/test/data/dummy_app2/main.js
+++ b/application/test/data/dummy_app2/main.js
@@ -1,4 +1,0 @@
-setTimeout(
-  function(){
-    window.open("main.html");
-  }, 100);

--- a/application/test/data/dummy_app2/manifest.json
+++ b/application/test/data/dummy_app2/manifest.json
@@ -2,9 +2,5 @@
   "name": "dummy_app_2",
   "manifest_version": 1,
   "version": "1.0",
-  "app": {
-    "main": {
-      "scripts": ["main.js"]
-    }
-  }
+  "start_url": "main.html"
 }


### PR DESCRIPTION
Fix processing of the Manifest 'start_url' member
after resolving an ambiguousness in the spec
https://github.com/w3c/manifest/pull/200/files

From now 'start_url' manifest key is an application
entry point.

So far 'start_url' cannot contain only a relative URL
(the resulting URL is constructed using the path to
the manifest file as a base URL:
http://w3c.github.io/manifest/#dfn-steps-for-processing-the-start_url-member)

External URLs handling should be clarified in the spec
further.
