### PR TITLE
[Runtime] Fix identify the app package type while loading it.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -156,7 +156,7 @@ GURL Application::GetURLFromRelativePathKey(const std::string& key) {
   std::string entry_page;
   if (!manifest->GetString(key, &entry_page)
       || entry_page.empty()) {
-    if (data_->GetPackageType() == Manifest::TYPE_XPK)
+    if (data_->GetPackageType() == Package::XPK)
       return GURL();
 
     base::FileEnumerator iter(data_->Path(), true,
@@ -322,7 +322,7 @@ bool Application::SetPermission(PermissionType type,
 }
 
 void Application::InitSecurityPolicy() {
-  if (data_->GetPackageType() != Manifest::TYPE_WGT)
+  if (data_->GetPackageType() != Package::WGT)
     return;
 
   const WARPInfo* info = static_cast<WARPInfo*>(
@@ -375,7 +375,7 @@ bool Application::CanRequestURL(const GURL& url) const {
     return true;
 
   // Only WGT package need to check the url request permission.
-  if (data_->GetPackageType() != Manifest::TYPE_WGT)
+  if (data_->GetPackageType() != Package::WGT)
     return true;
 
   // Always can request itself resources.

--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -260,7 +260,7 @@ ApplicationProtocolHandler::MaybeCreateJob(
   const std::string& path = request->url().path();
 
   std::list<std::string> locales;
-  if (application && application->GetPackageType() == Manifest::TYPE_WGT) {
+  if (application && application->GetPackageType() == Package::WGT) {
     GetUserAgentLocales(
         xwalk::XWalkRunner::GetInstance()->GetLocale(), locales);
     GetUserAgentLocales(application->GetManifest()->default_locale(), locales);

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -107,7 +107,8 @@ bool ApplicationService::Install(const base::FilePath& path, std::string* id) {
 
   std::string error;
   scoped_refptr<ApplicationData> application_data = LoadApplication(
-      unpacked_dir, app_id, Manifest::COMMAND_LINE, &error);
+      unpacked_dir, app_id, Manifest::COMMAND_LINE,
+      package->type(), &error);
   if (!application_data) {
     LOG(ERROR) << "Error during application installation: " << error;
     return false;
@@ -208,6 +209,7 @@ bool ApplicationService::Update(const std::string& id,
       LoadApplication(unpacked_dir,
                       app_id,
                       Manifest::COMMAND_LINE,
+                      package->type(),
                       &error);
   if (!new_application) {
     LOG(ERROR) << "An error occurred during application updating: " << error;
@@ -245,6 +247,7 @@ bool ApplicationService::Update(const std::string& id,
   new_application = LoadApplication(app_dir,
                                     app_id,
                                     Manifest::COMMAND_LINE,
+                                    package->type(),
                                     &error);
   if (!new_application) {
     LOG(ERROR) << "Error during loading new package: " << error;

--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -70,7 +70,7 @@ void ApplicationTizen::InitSecurityPolicy() {
     return;
   }
 
-  if (data_->GetPackageType() != Manifest::TYPE_WGT)
+  if (data_->GetPackageType() != Package::WGT)
     return;
 
   // Always enable security mode when under CSP mode.

--- a/application/browser/installer/package.h
+++ b/application/browser/installer/package.h
@@ -22,14 +22,21 @@ namespace application {
 //  XPKPackage::Validate()
 class Package {
  public:
+  enum Type {
+    WGT,
+    XPK
+  };
+
   virtual ~Package();
   bool IsValid() const { return is_valid_; }
   const std::string& Id() const { return id_; }
+  Type type() const { return type_; }
   // Factory method for creating a package
   static scoped_ptr<Package> Create(const base::FilePath& path);
   // The function will unzip the XPK/WGT file and return the target path where
   // to decompress by the parameter |target_path|.
   virtual bool Extract(base::FilePath* target_path);
+
  protected:
   explicit Package(const base::FilePath& source_path);
   scoped_ptr<ScopedStdioHandle> file_;
@@ -42,6 +49,7 @@ class Package {
   base::ScopedTempDir temp_dir_;
   // Represent if the package has been extracted.
   bool is_extracted_;
+  Type type_;
 };
 
 }  // namespace application

--- a/application/browser/installer/wgt_package.cc
+++ b/application/browser/installer/wgt_package.cc
@@ -25,6 +25,7 @@ WGTPackage::WGTPackage(const base::FilePath& path)
   : Package(path) {
   if (!base::PathExists(path))
     return;
+  type_ = WGT;
   base::FilePath extracted_path;
   if (!Extract(&extracted_path))
     return;

--- a/application/browser/installer/xpk_package.cc
+++ b/application/browser/installer/xpk_package.cc
@@ -25,6 +25,7 @@ XPKPackage::XPKPackage(const base::FilePath& path)
   : Package(path) {
   if (!base::PathExists(path))
     return;
+  type_ = XPK;
   scoped_ptr<ScopedStdioHandle> file(
       new ScopedStdioHandle(base::OpenFile(path, "rb")));
   file_ = file.Pass();

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -131,7 +131,7 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   void ClearPermissions();
   PermissionSet GetManifestPermissions() const;
 
-  Manifest::PackageType GetPackageType() const;
+  Package::Type GetPackageType() const { return package_type_; }
 
 #if defined(OS_TIZEN)
   bool HasCSPDefined() const;
@@ -222,6 +222,9 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   // Application's persistent permissions.
   StoredPermissionMap permission_map_;
+
+  // The package type, wgt or xpk.
+  Package::Type package_type_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationData);
 };

--- a/application/common/application_file_util.h
+++ b/application/common/application_file_util.h
@@ -9,6 +9,7 @@
 #include <map>
 
 #include "base/memory/ref_counted.h"
+#include "xwalk/application/browser/installer/package.h"
 #include "xwalk/application/common/manifest.h"
 
 
@@ -37,11 +38,13 @@ scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_root,
     const std::string& application_id,
     Manifest::SourceType source_type,
+    Package::Type package_type,
     std::string* error);
 
 // Loads an application manifest from the specified directory. Returns NULL
 // on failure, with a description of the error in |error|.
 base::DictionaryValue* LoadManifest(const base::FilePath& application_root,
+                                    Package::Type package_type,
                                     std::string* error);
 
 // Get a relative file path from an app:// URL.

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -119,51 +119,51 @@ const char kPlatformAppNeedsManifestVersion2[] =
 
 namespace application {
 
-const char* GetNameKey(Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT)
+const char* GetNameKey(Package::Type package_type) {
+  if (package_type == Package::WGT)
     return application_widget_keys::kNameKey;
 
   return application_manifest_keys::kNameKey;
 }
 
-const char* GetVersionKey(Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT)
+const char* GetVersionKey(Package::Type package_type) {
+  if (package_type == Package::WGT)
     return application_widget_keys::kVersionKey;
 
   return application_manifest_keys::kVersionKey;
 }
 
-const char* GetWebURLsKey(Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT)
+const char* GetWebURLsKey(Package::Type package_type) {
+  if (package_type == Package::WGT)
     return application_widget_keys::kWebURLsKey;
 
   return application_manifest_keys::kWebURLsKey;
 }
 
-const char* GetLaunchLocalPathKey(Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT)
+const char* GetLaunchLocalPathKey(Package::Type package_type) {
+  if (package_type == Package::WGT)
     return application_widget_keys::kLaunchLocalPathKey;
 
   return application_manifest_keys::kLaunchLocalPathKey;
 }
 
-const char* GetCSPKey(Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT)
+const char* GetCSPKey(Package::Type package_type) {
+  if (package_type == Package::WGT)
     return application_widget_keys::kCSPKey;
 
   return application_manifest_keys::kCSPKey;
 }
 
 #if defined(OS_TIZEN)
-const char* GetTizenAppIdKey(Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT)
+const char* GetTizenAppIdKey(Package::Type package_type) {
+  if (package_type == Package::WGT)
     return application_widget_keys::kTizenAppIdKey;
 
   return application_manifest_keys::kTizenAppIdKey;
 }
 
-const char* GetIcon128Key(Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT)
+const char* GetIcon128Key(Package::Type package_type) {
+  if (package_type == Package::WGT)
     return application_widget_keys::kIcon128Key;
 
   return application_manifest_keys::kIcon128Key;

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -98,14 +98,14 @@ namespace application_manifest_errors {
 namespace application {
 
 typedef application::Manifest Manifest;
-const char* GetNameKey(Manifest::PackageType type);
-const char* GetVersionKey(Manifest::PackageType type);
-const char* GetWebURLsKey(Manifest::PackageType type);
-const char* GetLaunchLocalPathKey(Manifest::PackageType type);
-const char* GetCSPKey(Manifest::PackageType type);
+const char* GetNameKey(Package::Type type);
+const char* GetVersionKey(Package::Type type);
+const char* GetWebURLsKey(Package::Type type);
+const char* GetLaunchLocalPathKey(Package::Type type);
+const char* GetCSPKey(Package::Type type);
 #if defined(OS_TIZEN)
-const char* GetTizenAppIdKey(Manifest::PackageType type);
-const char* GetIcon128Key(Manifest::PackageType type);
+const char* GetTizenAppIdKey(Package::Type type);
+const char* GetIcon128Key(Package::Type type);
 #endif
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -82,11 +82,6 @@ Manifest::Manifest(SourceType source_type,
 
   if (data_->HasKey(widget_keys::kWidgetKey) &&
       data_->Get(widget_keys::kWidgetKey, NULL))
-    package_type_ = TYPE_WGT;
-  else
-    package_type_ = TYPE_XPK;
-
-  if (IsWGTPackaged())
     ParseWGTI18n();
 
   // Unittest may not have an xwalkrunner, so we should check here.

--- a/application/common/manifest.h
+++ b/application/common/manifest.h
@@ -14,6 +14,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/strings/string16.h"
 #include "base/values.h"
+#include "xwalk/application/browser/installer/package.h"
 #include "xwalk/application/common/install_warning.h"
 
 namespace xwalk {
@@ -38,12 +39,6 @@ class Manifest {
     TYPE_HOSTED_APP,
     TYPE_PACKAGED_APP
   };
-
-  enum PackageType {
-    TYPE_WGT = 0,
-    TYPE_XPK
-  };
-
 
   Manifest(SourceType source_type, scoped_ptr<base::DictionaryValue> value);
   virtual ~Manifest();
@@ -70,10 +65,6 @@ class Manifest {
 
   bool IsPackaged() const { return type_ == TYPE_PACKAGED_APP; }
   bool IsHosted() const { return type_ == TYPE_HOSTED_APP; }
-
-  PackageType GetPackageType() const { return package_type_; }
-  bool IsXPKPackaged() const { return package_type_ == TYPE_XPK; }
-  bool IsWGTPackaged() const { return package_type_ == TYPE_WGT; }
 
   // These access the wrapped manifest value, returning false when the property
   // does not exist or if the manifest type can't access it.
@@ -145,8 +136,6 @@ class Manifest {
   scoped_ptr<std::list<std::string> > user_agent_locales_;
 
   Type type_;
-
-  PackageType package_type_;
 
   DISALLOW_COPY_AND_ASSIGN(Manifest);
 };

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -59,8 +59,8 @@ ManifestHandlerRegistry::~ManifestHandlerRegistry() {
 }
 
 ManifestHandlerRegistry*
-ManifestHandlerRegistry::GetInstance(Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT)
+ManifestHandlerRegistry::GetInstance(Package::Type package_type) {
+  if (package_type == Package::WGT)
     return GetInstanceForWGT();
   return GetInstanceForXPK();
 }
@@ -75,7 +75,7 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   handlers.push_back(new WidgetHandler);
   handlers.push_back(new WARPHandler);
 #if defined(OS_TIZEN)
-  handlers.push_back(new CSPHandler(Manifest::TYPE_WGT));
+  handlers.push_back(new CSPHandler(Package::WGT));
   handlers.push_back(new NavigationHandler);
   handlers.push_back(new TizenApplicationHandler);
   handlers.push_back(new TizenSettingHandler);
@@ -93,7 +93,7 @@ ManifestHandlerRegistry::GetInstanceForXPK() {
   std::vector<ManifestHandler*> handlers;
   // FIXME: Add manifest handlers here like this:
   // handlers.push_back(new xxxHandler);
-  handlers.push_back(new CSPHandler(Manifest::TYPE_XPK));
+  handlers.push_back(new CSPHandler(Package::XPK));
   handlers.push_back(new PermissionsHandler);
   xpk_registry_ = new ManifestHandlerRegistry(handlers);
   return xpk_registry_;
@@ -143,8 +143,8 @@ bool ManifestHandlerRegistry::ValidateAppManifest(
 
 // static
 void ManifestHandlerRegistry::SetInstanceForTesting(
-    ManifestHandlerRegistry* registry, Manifest::PackageType package_type) {
-  if (package_type == Manifest::TYPE_WGT) {
+    ManifestHandlerRegistry* registry, Package::Type package_type) {
+  if (package_type == Package::WGT) {
     widget_registry_ = registry;
     return;
   }

--- a/application/common/manifest_handler.h
+++ b/application/common/manifest_handler.h
@@ -56,7 +56,7 @@ class ManifestHandlerRegistry {
   ~ManifestHandlerRegistry();
 
   static ManifestHandlerRegistry* GetInstance(
-      Manifest::PackageType package_type);
+      Package::Type package_type);
 
   bool ParseAppManifest(
        scoped_refptr<ApplicationData> application, base::string16* error);
@@ -77,7 +77,7 @@ class ManifestHandlerRegistry {
 
   // Sets a new global registry, for testing purposes.
   static void SetInstanceForTesting(ManifestHandlerRegistry* registry,
-                                    Manifest::PackageType package_type);
+                                    Package::Type package_type);
 
   static ManifestHandlerRegistry* GetInstanceForWGT();
   static ManifestHandlerRegistry* GetInstanceForXPK();

--- a/application/common/manifest_handler_unittest.cc
+++ b/application/common/manifest_handler_unittest.cc
@@ -32,14 +32,14 @@ class ScopedTestingManifestHandlerRegistry {
       : registry_(
           new ManifestHandlerRegistry(handlers)),
         prev_registry_(
-          ManifestHandlerRegistry::GetInstance(Manifest::TYPE_XPK)) {
+          ManifestHandlerRegistry::GetInstance(Package::XPK)) {
     ManifestHandlerRegistry::SetInstanceForTesting(
-        registry_.get(), Manifest::TYPE_XPK);
+        registry_.get(), Package::XPK);
   }
 
   ~ScopedTestingManifestHandlerRegistry() {
     ManifestHandlerRegistry::SetInstanceForTesting(
-        prev_registry_, Manifest::TYPE_XPK);
+        prev_registry_, Package::XPK);
   }
 
   scoped_ptr<ManifestHandlerRegistry> registry_;

--- a/application/common/manifest_handlers/csp_handler.cc
+++ b/application/common/manifest_handlers/csp_handler.cc
@@ -21,7 +21,7 @@ CSPInfo::CSPInfo() {
 CSPInfo::~CSPInfo() {
 }
 
-CSPHandler::CSPHandler(Manifest::PackageType type)
+CSPHandler::CSPHandler(Package::Type type)
     : package_type_(type) {
 }
 
@@ -62,7 +62,7 @@ bool CSPHandler::Parse(scoped_refptr<ApplicationData> application,
 }
 
 bool CSPHandler::AlwaysParseForType(Manifest::Type type) const {
-  return package_type_ == Manifest::TYPE_XPK;
+  return package_type_ == Package::XPK;
 }
 
 std::vector<std::string> CSPHandler::Keys() const {

--- a/application/common/manifest_handlers/csp_handler.h
+++ b/application/common/manifest_handlers/csp_handler.h
@@ -32,7 +32,7 @@ class CSPInfo : public ApplicationData::ManifestData {
 
 class CSPHandler : public ManifestHandler {
  public:
-  explicit CSPHandler(Manifest::PackageType type);
+  explicit CSPHandler(Package::Type type);
   virtual ~CSPHandler();
 
   virtual bool Parse(scoped_refptr<ApplicationData> application,
@@ -41,7 +41,7 @@ class CSPHandler : public ManifestHandler {
   virtual std::vector<std::string> Keys() const OVERRIDE;
 
  private:
-  Manifest::PackageType package_type_;
+  Package::Type package_type_;
 
   DISALLOW_COPY_AND_ASSIGN(CSPHandler);
 };

--- a/application/common/manifest_handlers/warp_handler_unittest.cc
+++ b/application/common/manifest_handlers/warp_handler_unittest.cc
@@ -52,7 +52,7 @@ TEST_F(WARPHandlerTest, OneWARP) {
   manifest.Set(keys::kAccessKey, warp);
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  EXPECT_EQ(application->GetPackageType(), Package::WGT);
   const WARPInfo* info = GetWARPInfo(application);
   EXPECT_TRUE(info);
   scoped_ptr<base::ListValue> list(info->GetWARP()->DeepCopy());
@@ -76,7 +76,7 @@ TEST_F(WARPHandlerTest, WARPs) {
 
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  EXPECT_EQ(application->GetPackageType(), Package::WGT);
 
   const WARPInfo* info = GetWARPInfo(application);
   EXPECT_TRUE(info);

--- a/application/common/manifest_handlers/widget_handler_unittest.cc
+++ b/application/common/manifest_handlers/widget_handler_unittest.cc
@@ -161,7 +161,7 @@ TEST_F(WidgetHandlerTest,
   scoped_refptr<ApplicationData> application;
   application = CreateApplication(*(manifest.get()));
   EXPECT_TRUE(application);
-  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  EXPECT_EQ(application->GetPackageType(), Package::WGT);
   // Get widget info from this application.
   WidgetInfo* info = GetWidgetInfo(application);
   EXPECT_TRUE(info);
@@ -193,7 +193,7 @@ TEST_F(WidgetHandlerTest,
   scoped_refptr<ApplicationData> application;
   application = CreateApplication(*(manifest.get()));
   EXPECT_TRUE(application);
-  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  EXPECT_EQ(application->GetPackageType(), Package::WGT);
   // Get widget info from this application.
   WidgetInfo* info = GetWidgetInfo(application);
   EXPECT_TRUE(info);


### PR DESCRIPTION
Current implementation identify package type by configure document
name, 'manifest.json' will be recognized as XPK package, and
'config.xml' will be WGT package, but it's not always right if both
'manifest.json' and 'config.xml' exist in one package.

This patch add a package type parameter when loading it, to make sure
that unpacking and parsing package use the same package type.
