### PR TITLE
[Android] Add space support in name field of manifest.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -25,8 +25,8 @@ from xml.dom import minidom
 
 def VerifyAppName(value, mode='default'):
   descrpt = 'The app'
-  sample = 'helloworld, hello_world, hello_world1'
-  regex = r'^([a-zA-Z](\w)*)+$'
+  sample = 'helloworld, hello world, hello_world, hello_world1'
+  regex = r'[a-zA-Z][\w ]*$'
 
   if len(value) >= 128:
     print('To be safe, the length of package name or app name '
@@ -39,10 +39,14 @@ def VerifyAppName(value, mode='default'):
 
   if not re.match(regex, value):
     print('Error: %s name should be started with letters and should not '
-          'conatin invalid characters.\n'
-          'It may conatin letters, numbers and underscores\n'
+          'contain invalid characters.\n'
+          'It may contain letters, numbers, blank spaces and underscores\n'
           'Sample: %s' % (descrpt, sample))
     sys.exit(6)
+
+
+def ReplaceSpaceWithUnderscore(value):
+  return value.replace(' ', '_')
 
 
 def ReplaceInvalidChars(value, mode='default'):

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -16,7 +16,7 @@ import sys
 sys.path.append('scripts/gyp')
 
 from customize import VerifyAppName, CustomizeAll, \
-                      ParseParameterForCompressor
+                      ParseParameterForCompressor, ReplaceSpaceWithUnderscore
 from dex import AddExeExtensions
 from handle_permissions import permission_mapping_table
 from manifest_json_parser import HandlePermissionList
@@ -97,12 +97,14 @@ def ParseManifest(options):
     VerifyAppName(options.package, 'packagename')
   else:
     VerifyAppName(app_name)
+    app_name = ReplaceSpaceWithUnderscore(app_name)
     options.package = 'org.xwalk.' + app_name.lower()
   if options.name:
     VerifyAppName(options.name)
+    options.name = ReplaceSpaceWithUnderscore(options.name)
   else:
     VerifyAppName(app_name)
-    options.name = app_name
+    options.name = ReplaceSpaceWithUnderscore(app_name)
   if not options.app_version:
     options.app_version = parser.GetVersion()
   if not options.app_versionCode and not options.app_versionCodeBase:
@@ -710,6 +712,7 @@ def main(argv):
                    'Please use "--package" option.')
     if options.name:
       VerifyAppName(options.name)
+      options.name = ReplaceSpaceWithUnderscore(options.name)
     else:
       parser.error('The APK name is required! Please use "--name" option.')
     if not ((options.app_url and

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -887,6 +887,10 @@ class TestMakeApk(unittest.TestCase):
     result = GetResultWithOption(self._mode, manifest_path)
     self.assertTrue(result.find(app_name_error) != -1)
 
+    manifest_path = os.path.join(directory, 'manifest_contain_space_name.json')
+    result = GetResultWithOption(self._mode, manifest_path)
+    self.assertTrue(result.find(app_name_error) == -1)
+
     package = 'org.xwalk.example'
     name = '_hello'
     result = GetResultWithOption(self._mode, name=name, package=package)

--- a/app/tools/android/test_data/manifest/invalidchars/manifest_contain_space_name.json
+++ b/app/tools/android/test_data/manifest/invalidchars/manifest_contain_space_name.json
@@ -1,0 +1,14 @@
+{
+  "name": "app name ",
+  "version": "1.0.0",
+  "launch_path": "http://www.intel.com",
+  "app": {
+      "launch": {
+          "local_path": "index.html"
+      }
+  },
+  "description": "a sample description",
+  "origin": "app://app.id",
+  "default_locale": "en",
+  "fullscreen":"true"
+}


### PR DESCRIPTION
This patch is add space support in name field of manifest.
If the app name contains blank space, replace it with underscore.

BUG=XWALK-1718
