### PR TITLE
[Android] Add test case for getAPIVersion().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetAPIVersionTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetAPIVersionTest.java
@@ -1,0 +1,35 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Test suite for getAPIVersion().
+ */
+public class GetAPIVersionTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"GetAPIVersion"})
+    public void testGetAPIVersion() throws Throwable {
+        String version = getAPIVersionOnUiThread();
+        Pattern pattern = Pattern.compile("^[0-9]+(.[0-9]+)$");
+        Matcher matcher = pattern.matcher(version);
+        assertTrue("The API version is invalid.", matcher.find());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -520,4 +520,13 @@ public class XWalkViewTestBase
             }
         });
     }
+
+    protected String getAPIVersionOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return mXWalkView.getAPIVersion();
+            }
+        });
+    }
 }


### PR DESCRIPTION
This patch is to add test case for getAPIVersion().
Verify the api version with regular expression.
