### PR TITLE
[Android] Add test case for getXWalkVersion().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetXWalkVersionTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetXWalkVersionTest.java
@@ -1,0 +1,35 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Test suite for getXWalkVersion().
+ */
+public class GetXWalkVersionTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"GetXWalkVersion"})
+    public void testGetXWalkVersion() throws Throwable {
+        String version = getXWalkVersionOnUiThread();
+        Pattern pattern = Pattern.compile("\\d+\\.\\d+\\.\\d+\\.\\d+");
+        Matcher matcher = pattern.matcher(version);
+        assertTrue("The Crosswalk version is invalid.", matcher.find());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -529,4 +529,13 @@ public class XWalkViewTestBase
             }
         });
     }
+
+    protected String getXWalkVersionOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return mXWalkView.getXWalkVersion();
+            }
+        });
+    }
 }


### PR DESCRIPTION
This patch is to add test case for getXWalkVersion().
Verify the xwalk version with regular expression.
