### PR TITLE
[Runtime] Fix getting the wrong value from widget API toString method.

### DIFF
--- a/application/extension/application_widget_api.js
+++ b/application/extension/application_widget_api.js
@@ -128,6 +128,10 @@ var WidgetStorage = function() {
 var widgetStorage = new WidgetStorage();
 exports.preferences = widgetStorage;
 
+exports.toString = function() {
+  return '[object Widget]';
+}
+
 Object.defineProperty(exports, 'preferences', {
   configurable: false,
   enumerable: false,


### PR DESCRIPTION
According to W3C widget API specification, the widget.toString() method
should return "[object Widget]" value.

BUG=XWALK-1667
