### PR TITLE
[Android] Fix Python 3 compatibility issue in packaging tools.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -161,7 +161,7 @@ def CustomizeThemeXML(name, fullscreen, app_manifest):
     EditElementValueByNodeName(theme_xmldoc, 'item',
                                'android:windowBackground',
                                '@drawable/launchscreen_bg')
-  theme_file = open(theme_path, 'wb')
+  theme_file = open(theme_path, 'w')
   theme_xmldoc.writexml(theme_file, encoding='utf-8')
   theme_file.close()
 

--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -64,11 +64,11 @@ def CopyDrawables(image_dict, orientation, sanitized_name, name, app_root):
   # If no supported images found, find the closest one as 1x.
   if not has_image:
     closest = ''
-    delta = sys.maxint
+    delta = sys.maxsize
     for(k, v) in image_dict.items():
       items = k.split('x')
       if len(items) == 2:
-        float_value = sys.maxint
+        float_value = sys.maxsize
         try:
           float_value = float(items[0])
         except ValueError:


### PR DESCRIPTION
- Fix the open file mode which will cause str type error in Python 3
- Use sys.maxsize instead of sys.maxint since sys.maxint is remove in Python 3

BUG=https://crosswalk-project.org/jira/browse/XWALK-1721
