### PR TITLE
[Tizen][Performance] Enable Accelerated 2D Canvas.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -34,6 +34,9 @@ void XWalkBrowserMainPartsTizen::PreMainMessageLoopStart() {
   CommandLine* command_line = CommandLine::ForCurrentProcess();
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
 
+  // Enable Accelerated 2D Canvas.
+  command_line->AppendSwitch(switches::kGpuNoContextLost);
+
   const char* gl_name;
   if (base::PathExists(base::FilePath("/usr/lib/libGL.so")))
     gl_name = gfx::kGLImplementationDesktopName;


### PR DESCRIPTION
If GPU context can be lost, Accelerated 2D Canvas is disabled, because there is
no way to recover Accelerated 2D Canvas when GPU crashes. However, interestingly,
Android and ChromeOS mark it false to take advantage of Accelerated 2D Canvas
without fallback solution. They just take a risk.

So gfx::GLSurfaceEGL::IsCreateContextRobustnessSupported() decides whether to
enable A2DC. Currently, IVB supports context robustness, but ATOM might not
support it. Tizen takes a risk like Android and ChromeOS.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1452
