### PR TITLE
[Android] Construct the package name with specified app name in command ...

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -90,19 +90,28 @@ def GetVersion(path):
   return version_str
 
 
+def VerifyAndConstructPackageName(options, app_name=None, parser=None):
+  package_prefix = 'org.xwalk.'
+  if options.name:
+    VerifyAppName(options.name)
+  elif options.manifest:
+    VerifyAppName(app_name)
+    options.name = app_name
+  else:
+    parser.error('The APK name is required! Please use "--name" option.')
+  if options.package:
+    VerifyAppName(options.package, 'packagename')
+  elif options.manifest and app_name:
+    VerifyAppName(app_name)
+    options.package = package_prefix + app_name.lower()
+  else:
+    options.package = package_prefix + options.name.lower()
+
+
 def ParseManifest(options):
   parser = ManifestJsonParser(os.path.expanduser(options.manifest))
   app_name = parser.GetAppName()
-  if options.package:
-    VerifyAppName(options.package, 'packagename')
-  else:
-    VerifyAppName(app_name)
-    options.package = 'org.xwalk.' + app_name.lower()
-  if options.name:
-    VerifyAppName(options.name)
-  else:
-    VerifyAppName(app_name)
-    options.name = app_name
+  VerifyAndConstructPackageName(options, app_name)
   if not options.app_version:
     options.app_version = parser.GetVersion()
   if not options.app_versionCode and not options.app_versionCodeBase:
@@ -703,15 +712,7 @@ def main(argv):
       options.manifest = manifest_path
 
   if not options.manifest:
-    if options.package:
-      VerifyAppName(options.package, 'packagename')
-    else:
-      parser.error('The package name is required! '
-                   'Please use "--package" option.')
-    if options.name:
-      VerifyAppName(options.name)
-    else:
-      parser.error('The APK name is required! Please use "--name" option.')
+    VerifyAndConstructPackageName(options, parser=parser)
     if not ((options.app_url and
              not options.app_root and
              not options.app_local_path) or

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -333,7 +333,7 @@ class TestMakeApk(unittest.TestCase):
            self._mode]
     out = RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
-    self.assertTrue(out.find('The package name is required!') != -1)
+    self.assertTrue(out.find('The package name is required!') == -1)
     Clean('Example', '1.0.0')
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', self._mode]
@@ -887,6 +887,12 @@ class TestMakeApk(unittest.TestCase):
     result = GetResultWithOption(self._mode, manifest_path)
     self.assertTrue(result.find(app_name_error) != -1)
 
+    name = 'example'
+    manifest_path = os.path.join(directory, '..', 'manifest_no_name.json')
+    result = GetResultWithOption(self._mode, manifest_path, name)
+    self.assertTrue(result.find(package_name_error) == -1)
+    Clean(name, version)
+
     package = 'org.xwalk.example'
     name = '_hello'
     result = GetResultWithOption(self._mode, name=name, package=package)
@@ -912,6 +918,10 @@ class TestMakeApk(unittest.TestCase):
 
     package = 'org.xwalk.example_'
     result = GetResultWithOption(self._mode, name=name, package=package)
+    self.assertTrue(result.find(package_name_error) == -1)
+    Clean(name, version)
+
+    result = GetResultWithOption(self._mode, name=name)
     self.assertTrue(result.find(package_name_error) == -1)
     Clean(name, version)
 


### PR DESCRIPTION
...line.

This patch is to construct the package name with specified app name in
command line.
If the app name in manifest.json is empty, construct the package name with
the app name which is specified in command line.

BUG=XWALK-1730
