### PR TITLE
[Android] Fix Python 3 compatibility issue in packaging tools.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -92,7 +92,7 @@ def CustomizeThemeXML(sanitized_name, fullscreen, app_manifest):
     EditElementValueByNodeName(theme_xmldoc, 'item',
                                'android:windowBackground',
                                '@drawable/launchscreen_bg')
-  theme_file = open(theme_path, 'wb')
+  theme_file = open(theme_path, 'w')
   theme_xmldoc.writexml(theme_file, encoding='utf-8')
   theme_file.close()
 

--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -63,11 +63,11 @@ def CopyDrawables(image_dict, orientation, sanitized_name, name, app_root):
   # If no supported images found, find the closest one as 1x.
   if not has_image:
     closest = ''
-    delta = sys.maxint
-    for (k , v) in  image_dict.items():
+    delta = sys.maxsize
+    for(k, v) in image_dict.items():
       items = k.split('x')
       if len(items) == 2:
-        float_value = sys.maxint
+        float_value = sys.maxsize
         try:
           float_value = float(items[0])
         except ValueError:


### PR DESCRIPTION
- Fix the open file mode which will cause str type error in Python 3
- Use sys.maxsize instead of sys.maxint since sys.maxint is remove in Python 3

Cherry-Pick: e74d798796974081081eafb00da15ce526c3ce2e

BUG=https://crosswalk-project.org/jira/browse/XWALK-1721
