### PR TITLE
[Tizen] Correct default TEC path for 64-bit

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -139,9 +139,14 @@ void XWalkBrowserMainParts::RegisterExternalExtensions() {
   CommandLine* cmd_line = CommandLine::ForCurrentProcess();
 
 #if defined(OS_TIZEN)
-  static const std::string tec_path = "/usr/lib/tizen-extensions-crosswalk";
   std::string value = cmd_line->GetSwitchValueASCII(
       switches::kXWalkExternalExtensionsPath);
+
+#if defined(ARCH_CPU_64_BITS)
+  const char tec_path[] = "/usr/lib64/tizen-extensions-crosswalk";
+#else
+  const char tec_path[] = "/usr/lib/tizen-extensions-crosswalk";
+#endif
 
   if (value.empty())
     cmd_line->AppendSwitchASCII(switches::kXWalkExternalExtensionsPath,


### PR DESCRIPTION
The TEC extensions libraries are delivered into different directory
varies 32-bit (/usr/lib) and 64-bit (/usr/lib64), the default path need
to aware this difference. And use char[] instead of static std::string.

BUG=XWALK-1624
