### PR TITLE
[Android] Add test case for onLoadStarted() and onLoadFinished().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnLoadFinishedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnLoadFinishedTest.java
@@ -1,0 +1,35 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for onLoadFinished().
+ */
+public class OnLoadFinishedTest extends XWalkViewTestBase {
+    private TestHelperBridge.OnLoadFinishedHelper mOnLoadFinishedHelper;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        mOnLoadFinishedHelper = mTestHelperBridge.getOnLoadFinishedHelper();
+    }
+
+    @SmallTest
+    @Feature({"OnLoadFinished"})
+    public void testOnLoadFinished() throws Throwable {
+        final int callCount = mOnLoadFinishedHelper.getCallCount();
+        final String url = "file:///android_asset/www/frame.html";
+
+        loadUrlAsync(url);
+        mOnLoadFinishedHelper.waitForCallback(callCount);
+        assertEquals(url, mOnLoadFinishedHelper.getUrl());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnLoadStartedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnLoadStartedTest.java
@@ -1,0 +1,51 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.net.test.util.TestWebServer;
+
+/**
+ * Test suite for onLoadStarted().
+ */
+public class OnLoadStartedTest extends XWalkViewTestBase {
+    private TestHelperBridge.OnLoadStartedHelper mOnLoadStartedHelper;
+    private TestWebServer mWebServer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        mOnLoadStartedHelper = mTestHelperBridge.getOnLoadStartedHelper();
+        mWebServer = new TestWebServer(false);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (mWebServer != null) {
+            mWebServer.shutdown();
+        }
+        super.tearDown();
+    }
+
+    @SmallTest
+    @Feature({"OnLoadStarted"})
+    public void testOnLoadStarted() throws Throwable {
+        final int callCount = mOnLoadStartedHelper.getCallCount();
+        final String testHtml = "<html><head>Header</head><body>Body</body></html>";
+        final String testPath = "/test.html";
+        final String testUrl = mWebServer.setResponse(testPath, testHtml, null);
+
+        loadDataAsync(null, "<html><iframe src=\"" + testUrl + "\" /></html>",
+                      "text/html",
+                      false);
+
+        mOnLoadStartedHelper.waitForCallback(callCount);
+        assertEquals(testUrl, mOnLoadStartedHelper.getUrl());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
@@ -94,6 +94,19 @@ class TestHelperBridge {
         }
     }
 
+    public static class OnLoadFinishedHelper extends CallbackHelper {
+        private String mUrl;
+        public void notifyCalled(String url) {
+            mUrl = url;
+            notifyCalled();
+        }
+
+        public String getUrl() {
+            assert getCallCount() > 0;
+            return mUrl;
+        }
+    }
+
     class OnEvaluateJavaScriptResultHelper extends CallbackHelper {
         private String mJsonResult;
         public void evaluateJavascript(XWalkView xWalkView, String code) {
@@ -166,6 +179,7 @@ class TestHelperBridge {
     private final OnLoadStartedHelper mOnLoadStartedHelper;
     private final OnJavascriptCloseWindowHelper mOnJavascriptCloseWindowHelper;
     private final OnProgressChangedHelper mOnProgressChangedHelper;
+    private final OnLoadFinishedHelper mOnLoadFinishedHelper;
 
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -177,6 +191,7 @@ class TestHelperBridge {
         mOnLoadStartedHelper = new OnLoadStartedHelper();
         mOnJavascriptCloseWindowHelper = new OnJavascriptCloseWindowHelper();
         mOnProgressChangedHelper = new OnProgressChangedHelper();
+        mOnLoadFinishedHelper = new OnLoadFinishedHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -213,6 +228,10 @@ class TestHelperBridge {
 
     public OnProgressChangedHelper getOnProgressChangedHelper() {
         return mOnProgressChangedHelper;
+    }
+
+    public OnLoadFinishedHelper getOnLoadFinishedHelper() {
+        return mOnLoadFinishedHelper;
     }
 
     public void onTitleChanged(String title) {
@@ -252,5 +271,9 @@ class TestHelperBridge {
 
     public void onProgressChanged(int progress) {
         mOnProgressChangedHelper.notifyCalled(progress);
+    }
+
+    public void onLoadFinished(String url) {
+        mOnLoadFinishedHelper.notifyCalled(url);
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -86,6 +86,11 @@ public class XWalkViewTestBase
         }
 
         @Override
+        public void onLoadFinished(XWalkView view, String url) {
+            mTestHelperBridge.onLoadFinished(url);
+        }
+
+        @Override
         public void onReceivedLoadError(XWalkView view, int errorCode, String description, String failingUrl) {
             mInnerContentsClient.onReceivedLoadError(errorCode, description, failingUrl);
         }

--- a/test/android/data/frame.html
+++ b/test/android/data/frame.html
@@ -1,0 +1,1 @@
+<html><iframe src="index.html" /></html>

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -42,6 +42,7 @@
         'resource_dir': 'runtime/android/core_shell/res',
         'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/www/frame.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/www/index.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/xwalk.pak',
         ],
@@ -58,6 +59,7 @@
         {
           'destination': '<(PRODUCT_DIR)/xwalk_xwview/assets/www',
           'files': [
+            'test/android/data/frame.html',
             'test/android/data/index.html',
           ],
         }


### PR DESCRIPTION
This patch is to add test case about onLoadStarted() and onLoadFinished().
For onLoadStarted: Set url to iframe, load data from webserver, get the
url when onLoadStarted() was called, compare it with the expected value.
For onLoadFinished: Set up a url which contain iframe, load this url,
get the url when onLoadFinished() was called, compare it with the
expected value.