### PR TITLE
[Android] Add color message output for package tools.

### DIFF
--- a/app/tools/android/console_log.py
+++ b/app/tools/android/console_log.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import sys
+
+# For tty that supports ANSI color, define the color value.
+# For window console, the win32 API `SetConsoleTextAttribute` has to be
+# used to set the console color.
+class AnsiColor:
+  BLACK   = '\033[' + str(30) + 'm'
+  RED     = '\033[' + str(31) + 'm'
+  GREEN   = '\033[' + str(32) + 'm'
+  YELLOW  = '\033[' + str(33) + 'm'
+  BLUE    = '\033[' + str(34) + 'm'
+  MAGENTA = '\033[' + str(35) + 'm'
+  CYAN    = '\033[' + str(36) + 'm'
+  WHITE   = '\033[' + str(37) + 'm'
+  RESET   = '\033[' + str(39) + 'm'
+
+  def __init__(self):
+    pass
+
+
+def TtySupportAnsiColor():
+  if sys.platform == 'win32':
+    return False
+  is_a_tty = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+  return is_a_tty
+
+
+def PrintError(message):
+  color_message = message
+  if TtySupportAnsiColor():
+    color_message = AnsiColor.RED + message + AnsiColor.RESET
+  print(color_message)
+
+
+def PrintWarning(message):
+  color_message = message
+  if TtySupportAnsiColor():
+    color_message = AnsiColor.CYAN + message + AnsiColor.RESET
+  print(color_message)
+
+
+def PrintSuccess(message):
+  color_message = message
+  if TtySupportAnsiColor():
+    color_message = AnsiColor.GREEN + message + AnsiColor.RESET
+  print(color_message)
+
+
+if __name__ == '__main__':
+  PrintError('Error')
+  PrintWarning('Warning')
+  PrintSuccess('Success')

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -17,6 +17,8 @@ sys.path.append('scripts/gyp')
 
 from customize import VerifyAppName, CustomizeAll, \
                       ParseParameterForCompressor
+from console_log import PrintError, PrintWarning, \
+                        PrintSuccess
 from dex import AddExeExtensions
 from handle_permissions import permission_mapping_table
 from manifest_json_parser import HandlePermissionList
@@ -499,17 +501,17 @@ def PrintPackageInfo(target_dir, app_name, app_version,
            'Runtime to be present.'
            % (app_name, package_name_version))
   else:
-    print ('An APK for the web application "%s" including the Crosswalk '
+    PrintSuccess ('An APK for the web application "%s" including the Crosswalk '
            'Runtime built for %s was generated successfully, which can be '
            'found at\n%s_%s.apk.'
            % (app_name, arch, package_name_version, arch))
     if multi_arch is False:
       if arch == 'x86':
-        print ('WARNING: This APK will only work on x86 based Android devices. '
-               'Consider building for ARM as well.')
+        PrintWarning ('WARNING: This APK will only work on x86 based Android '
+               'devices. Consider building for ARM as well.')
       elif arch == 'arm':
-        print ('WARNING: This APK will only work on ARM based Android devices. '
-               'Consider building for x86 as well.')
+        PrintWarning ('WARNING: This APK will only work on ARM based Android '
+               'devices. Consider building for x86 as well.')
 
 
 def MakeApk(options):
@@ -541,7 +543,7 @@ def MakeApk(options):
           Execution(options, name)
           packaged_archs.append(options.arch)
         else:
-          print('Warning: failed to create package for arch "%s" '
+          PrintWarning('WARNING: failed to create package for arch "%s" '
                 'due to missing library %s' %
                 (arch, lib_path))
 
@@ -556,7 +558,7 @@ def MakeApk(options):
         PrintPackageInfo(options.target_dir, name, app_version, arch,
                          multi_arch)
   else:
-    print('Unknown mode for packaging the application. Abort!')
+    PrintError('Unknown mode for packaging the application. Abort!')
     sys.exit(11)
 
 
@@ -725,8 +727,8 @@ def main(argv):
     if options.permissions:
       permission_list = options.permissions.split(':')
     else:
-      print('Warning: all supported permissions on Android port are added. '
-            'Refer to https://github.com/crosswalk-project/'
+      PrintWarning('Warning: all supported permissions on Android port are '
+            'added. Refer to https://github.com/crosswalk-project/'
             'crosswalk-website/wiki/Crosswalk-manifest')
       permission_list = permission_mapping_table.keys()
     options.permissions = HandlePermissionList(permission_list)
@@ -740,7 +742,7 @@ def main(argv):
   if (options.app_root and options.app_local_path and
       not os.path.isfile(os.path.join(options.app_root,
                                       options.app_local_path))):
-    print('Please make sure that the local path file of launching app '
+    PrintError('Please make sure that the local path file of launching app '
           'does exist.')
     sys.exit(7)
 

--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -125,6 +125,7 @@ def PrepareFromXwalk(src_dir, target_dir):
     (os.path.join(tools_src_dir, 'ant'),
      os.path.join(target_dir, 'scripts/ant')),
     (os.path.join(tools_src_dir, 'compress_js_and_css.py'), target_dir),
+    (os.path.join(tools_src_dir, 'console_log.py'), target_dir),
     (os.path.join(tools_src_dir, 'customize.py'), target_dir),
     (os.path.join(tools_src_dir, 'customize_launch_screen.py'), target_dir),
     (os.path.join(tools_src_dir, 'handle_permissions.py'), target_dir),


### PR DESCRIPTION
The package tool outputs many messages, add color support for different
message level (error, warning).
Currently only ANSI color is added, the support for Win32 console uses
`SetConsoleTextAttribute` API to be implemented.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1648