### PR TITLE
[Android] Fail to create the webapp when the package option contain upper letter

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -41,7 +41,8 @@ def VerifyAppName(value, mode='default'):
   if not re.match(regex, value):
     print('Error: %s name should be started with letters and should not '
           'contain invalid characters.\n'
-          'It may contain letters, numbers, blank spaces and underscores\n'
+          'It may contain lowercase letters, numbers, blank spaces and '
+          'underscores\n'
           'Sample: %s' % (descrpt, sample))
     sys.exit(6)
 


### PR DESCRIPTION
According to Java naming conventions. Package should be lower case.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1681
