### PR TITLE
[Tizen] Fix Sensor provider initialization issue.

### DIFF
--- a/tizen/mobile/sensor/sensor_provider.cc
+++ b/tizen/mobile/sensor/sensor_provider.cc
@@ -9,8 +9,11 @@
 
 namespace xwalk {
 
+// static
+bool SensorProvider::initialized_ = false;
+
 SensorProvider* SensorProvider::GetInstance() {
-  if (!instance_) {
+  if (!initialized_) {
     instance_.reset(new TizenPlatformSensor());
     if (!instance_->Initialize())
       instance_.reset();

--- a/tizen/mobile/sensor/sensor_provider.h
+++ b/tizen/mobile/sensor/sensor_provider.h
@@ -36,6 +36,8 @@ class SensorProvider {
     return last_rotation_;
   }
 
+  static bool initialized_;
+
  protected:
   SensorProvider();
 

--- a/tizen/mobile/sensor/tizen_platform_sensor.cc
+++ b/tizen/mobile/sensor/tizen_platform_sensor.cc
@@ -22,6 +22,12 @@ TizenPlatformSensor::~TizenPlatformSensor() {
 }
 
 bool TizenPlatformSensor::Initialize() {
+  // If the sensors couldn't be able to connect normally for the first time,
+  // it indicates that the platform doesn't support these sensors.
+  // Set |initialized_| true to make this function is called only
+  // once and avoid connecting to platform sensors repeatedly.
+  initialized_ = true;
+
   unsigned long rotation;  // NOLINT
   if (!sf_check_rotation(&rotation)) {
     last_rotation_ = ToDisplayRotation(static_cast<int>(rotation));


### PR DESCRIPTION
On platforms without acceleration and gyroscope sensors, the
TizenPlatformSensor intialization costs more than 200ms and returns
NULL, due to Tizen framework keeps trying to connect the sensors
until timeout.

As a result, currently SensorProvider::GetInstance() will always call
above function and waste plenty of time.

To fix the issue, this PR connects to the sensors only once, if it
fails, it returns NULL immediately when getting the SensorProvider instance again.

BUG=XWALK-1770
