### PR TITLE
[Android] Add test case for onProgressChanged().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnProgressChangedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnProgressChangedTest.java
@@ -1,0 +1,51 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.net.test.util.TestWebServer;
+
+/**
+ * Test suite for onProgressChanged().
+ */
+public class OnProgressChangedTest extends XWalkViewTestBase {
+    private TestHelperBridge.OnProgressChangedHelper mOnProgressChangedHelper;
+    private TestWebServer mWebServer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        mOnProgressChangedHelper = mTestHelperBridge.getOnProgressChangedHelper();
+        mWebServer = new TestWebServer(false);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (mWebServer != null) {
+            mWebServer.shutdown();
+        }
+        super.tearDown();
+    }
+
+    @SmallTest
+    @Feature({"OnProgressChanged"})
+    public void testOnProgressChanged() throws Throwable {
+        final int callCount = mOnProgressChangedHelper.getCallCount();
+        final String testHtml = "<html><head>Header</head><body>Body</body></html>";
+        final String testPath = "/test.html";
+        final String testUrl = mWebServer.setResponse(testPath, testHtml, null);
+
+        loadDataAsync(null, "<html><iframe src=\"" + testUrl + "\" /></html>",
+                      "text/html",
+                      false);
+
+        mOnProgressChangedHelper.waitForCallback(callCount);
+        assertTrue(mOnProgressChangedHelper.getProgress() > 0);
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
@@ -80,6 +80,20 @@ class TestHelperBridge {
         }
     }
 
+    public class OnProgressChangedHelper extends CallbackHelper {
+        private int mProgress;
+
+        public int getProgress() {
+            assert getCallCount() > 0;
+            return mProgress;
+        }
+
+        public void notifyCalled(int progress) {
+            mProgress = progress;
+            notifyCalled();
+        }
+    }
+
     class OnEvaluateJavaScriptResultHelper extends CallbackHelper {
         private String mJsonResult;
         public void evaluateJavascript(XWalkView xWalkView, String code) {
@@ -151,6 +165,7 @@ class TestHelperBridge {
     private final ShouldInterceptLoadRequestHelper mShouldInterceptLoadRequestHelper;
     private final OnLoadStartedHelper mOnLoadStartedHelper;
     private final OnJavascriptCloseWindowHelper mOnJavascriptCloseWindowHelper;
+    private final OnProgressChangedHelper mOnProgressChangedHelper;
 
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -161,6 +176,7 @@ class TestHelperBridge {
         mShouldInterceptLoadRequestHelper = new ShouldInterceptLoadRequestHelper();
         mOnLoadStartedHelper = new OnLoadStartedHelper();
         mOnJavascriptCloseWindowHelper = new OnJavascriptCloseWindowHelper();
+        mOnProgressChangedHelper = new OnProgressChangedHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -193,6 +209,10 @@ class TestHelperBridge {
 
     public OnJavascriptCloseWindowHelper getOnJavascriptCloseWindowHelper() {
         return mOnJavascriptCloseWindowHelper;
+    }
+
+    public OnProgressChangedHelper getOnProgressChangedHelper() {
+        return mOnProgressChangedHelper;
     }
 
     public void onTitleChanged(String title) {
@@ -228,5 +248,9 @@ class TestHelperBridge {
 
     public void onJavascriptCloseWindow() {
         mOnJavascriptCloseWindowHelper.notifyCalled(true);
+    }
+
+    public void onProgressChanged(int progress) {
+        mOnProgressChangedHelper.notifyCalled(progress);
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -95,6 +95,11 @@ public class XWalkViewTestBase
                 String url) {
             return mInnerContentsClient.shouldInterceptLoadRequest(url);
         }
+
+        @Override
+        public void onProgressChanged(XWalkView view, int progressInPercent) {
+            mTestHelperBridge.onProgressChanged(progressInPercent);
+        }
     }
 
     class TestXWalkResourceClient extends TestXWalkResourceClientBase {


### PR DESCRIPTION
This patch is to add test case about onProgressChanged().
Load data which contains iframe from webserver, wait for a timer,
get the progress percent and compare it with the expected value.
