### PR TITLE
[Tizen][Runtime] Should not check the package version for Tizen web application when updating.

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -223,7 +223,14 @@ bool ApplicationService::Update(const std::string& id,
     return false;
   }
 
-  if (old_application->Version()->CompareTo(
+  if (
+#if defined(OS_TIZEN)
+      // For Tizen WGT package, downgrade to a lower version or reinstall
+      // is permitted when using Tizen WRT, Crosswalk runtime need to follow
+      // this behavior on Tizen platform.
+      package->type() != Package::WGT &&
+#endif
+      old_application->Version()->CompareTo(
           *(new_application->Version())) >= 0) {
     LOG(INFO) << "The version number of new XPK/WGT package "
                  "should be higher than "


### PR DESCRIPTION
In Tizen platform, package version checking should be ignored when
updating, means that the downgrade and reinstall a package is
permitted, and this is the same behavior as Tizen WRT.

BUG=XWALK-1771
