### PR TITLE
[Tizen][Runtime] Enable the application URL for using Tizen app id.

### DIFF
--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -88,6 +88,8 @@ class ApplicationService : public Application::Observer {
       const std::string& extension_name,
       const std::string& perm_table);
 
+  ApplicationStorage* application_storage() { return application_storage_; }
+
  private:
   // Implementation of Application::Observer.
   virtual void OnApplicationTerminated(Application* app) OVERRIDE;

--- a/application/browser/application_storage.cc
+++ b/application/browser/application_storage.cc
@@ -24,7 +24,8 @@ ApplicationStorage::~ApplicationStorage() {
 
 bool ApplicationStorage::AddApplication(
     scoped_refptr<ApplicationData> app_data) {
-  if (Contains(app_data->ID())) {
+  base::AutoLock lock(lock_);
+  if (applications_.find(app_data->ID()) != applications_.end()) {
     LOG(WARNING) << "Application " << app_data->ID()
                  << " has been already installed";
     return false;
@@ -38,6 +39,7 @@ bool ApplicationStorage::AddApplication(
 }
 
 bool ApplicationStorage::RemoveApplication(const std::string& id) {
+  base::AutoLock lock(lock_);
   if (applications_.erase(id) != 1) {
     LOG(ERROR) << "Application " << id << " is invalid.";
     return false;
@@ -55,6 +57,7 @@ bool ApplicationStorage::RemoveApplication(const std::string& id) {
 
 bool ApplicationStorage::UpdateApplication(
     scoped_refptr<ApplicationData> app_data) {
+  base::AutoLock lock(lock_);
   ApplicationData::ApplicationDataMapIterator it =
       applications_.find(app_data->ID());
   if (it == applications_.end()) {
@@ -70,11 +73,13 @@ bool ApplicationStorage::UpdateApplication(
 }
 
 bool ApplicationStorage::Contains(const std::string& app_id) const {
+  base::AutoLock lock(lock_);
   return applications_.find(app_id) != applications_.end();
 }
 
 scoped_refptr<ApplicationData> ApplicationStorage::GetApplicationData(
     const std::string& application_id) const {
+  base::AutoLock lock(lock_);
   ApplicationData::ApplicationDataMap::const_iterator it =
       applications_.find(application_id);
   if (it != applications_.end()) {

--- a/application/browser/application_storage.h
+++ b/application/browser/application_storage.h
@@ -39,6 +39,7 @@ class ApplicationStorage {
   base::FilePath data_path_;
   scoped_ptr<class ApplicationStorageImpl> impl_;
   ApplicationData::ApplicationDataMap applications_;
+  mutable base::Lock lock_;
   DISALLOW_COPY_AND_ASSIGN(ApplicationStorage);
 };
 

--- a/application/browser/installer/wgt_package.cc
+++ b/application/browser/installer/wgt_package.cc
@@ -5,6 +5,7 @@
 #include "xwalk/application/browser/installer/wgt_package.h"
 
 #include "base/file_util.h"
+#include "base/strings/string_util.h"
 #include "third_party/libxml/chromium/libxml_utils.h"
 #include "xwalk/application/common/id_util.h"
 
@@ -54,7 +55,13 @@ WGTPackage::WGTPackage(const base::FilePath& path)
   }
 
   if (!value.empty())
+#if defined(OS_TIZEN)
+    // For app scheme, only support lower cases, so need to convert
+    // here, so that we can get the right app id.
+    id_ = GenerateId(StringToLowerASCII(value));
+#else
     id_ = GenerateId(value);
+#endif
 
   is_valid_ = true;
 


### PR DESCRIPTION
For Tizen WRT, the app url like app://tizen.appid could be used to load
resources belong to other web application. Crosswalk runtime on Tizen
should follow what Tizen WRT does. The patch will enable to support the
url like app://tizen.appid in Crosswalk runtime model, and the crosswalk
application url like app://crosswalk.appid will be enabled as well.

BUG=XWALK-1762
