### PR TITLE
[Runtime] WARP security mode should be enabled by default.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -327,9 +327,16 @@ void Application::InitSecurityPolicy() {
 
   const WARPInfo* info = static_cast<WARPInfo*>(
       data_->GetManifestData(widget_keys::kAccessKey));
-  // FIXME(xinchao): Need to enable WARP mode by default.
-  if (!info)
+  // Need to enable WARP mode by default.
+  if (!info) {
+    security_mode_enabled_ = true;
+    DCHECK(render_process_host_);
+    render_process_host_->Send(
+        new ViewMsg_EnableSecurityMode(
+            ApplicationData::GetBaseURLFromApplicationId(id()),
+            SecurityPolicy::WARP));
     return;
+  }
 
   const base::ListValue* whitelist = info->GetWARP();
   for (base::ListValue::const_iterator it = whitelist->begin();


### PR DESCRIPTION
According to the W3C widget spec, http://www.w3.org/TR/widgets-access/,
"In the default policy, a user agent must deny access to network resources external to the widget by default, whether this access is requested through APIs (e.g. XMLHttpRequest) or through markup (e.g. iframe, script, img)." Means if there's no access tag in config.xml, all external requests should be blocked.

BUG=XWALK-1772
