### PR TITLE
DEPS.xwalk: Re-roll ozone-wayland to 55f39c6.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -10,7 +10,7 @@ chromium_version = '35.0.1916.114'
 chromium_crosswalk_point = 'e76fa1eeaea6745b72a693cf746e5d3d8ece1bef'
 blink_crosswalk_point = '3cf743afc1a77a1141f08897c4f2c3b805124f25'
 v8_crosswalk_point = '64b8b78dee87a9d465f9d095e2021bdb9d45d37d'
-ozone_wayland_point = 'f4faec532d7d2f482b3ffe1e52be6fa3e6fc8629'
+ozone_wayland_point = '55f39c62b461b92d3b0b912c7c80ae98d866b5a6'
 
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
When we moved to Chromium 35.0.1916.114 (83d22586), we accidentally reverted
ozone-wayland back to f4faec5, thus losing the fix to XWALK-1673.
