### PR TITLE
[Android] Add test case for canGoBack().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/CanGoBackTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/CanGoBackTest.java
@@ -1,0 +1,34 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for CanGoBack().
+ */
+public class CanGoBackTest extends XWalkViewTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"CanGoBack"})
+    public void testCanGoBack() throws Throwable {
+        final String url1 = "about:blank";
+        final String url2 = "file:///android_asset/www/index.html";
+        assertFalse(canGoBackOnUiThread());
+        loadUrlSync(url1);
+        assertFalse(canGoBackOnUiThread());
+        loadUrlSync(url2);
+        assertTrue(canGoBackOnUiThread());
+    }
+}


### PR DESCRIPTION
This patch is to add test case for canGoBack().
Before load any url, canGoBack should be false.
Load the first url, canGoBack should be false.
Load the second url, canGoBack should be true.
