### PR TITLE
[Runtime] Make application running with isolated storage partition

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -14,6 +14,7 @@
 #include "base/values.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/render_process_host.h"
+#include "content/public/browser/site_instance.h"
 #include "net/base/net_util.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_storage.h"
@@ -80,7 +81,9 @@ bool Application::Launch(const LaunchParams& launch_params) {
   if (!url.is_valid())
     return false;
 
-  Runtime* runtime = Runtime::Create(runtime_context_, this);
+  Runtime* runtime = Runtime::Create(
+      runtime_context_,
+      this, content::SiteInstance::CreateForURL(runtime_context_, url));
   render_process_host_ = runtime->GetRenderProcessHost();
   render_process_host_->AddObserver(this);
   InitSecurityPolicy();
@@ -159,6 +162,7 @@ GURL Application::GetURLFromRelativePathKey(const std::string& key) {
     if (data_->GetPackageType() == Package::XPK)
       return GURL();
 
+    base::ThreadRestrictions::SetIOAllowed(true);
     base::FileEnumerator iter(data_->Path(), true,
                               base::FileEnumerator::FILES,
                               FILE_PATH_LITERAL("index.*"));

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -331,18 +331,12 @@ bool ApplicationService::Uninstall(const std::string& id) {
     result = false;
   }
 
-  content::StoragePartition* partition =
-      content::BrowserContext::GetStoragePartitionForSite(
-          runtime_context_, application->GetBaseURLFromApplicationId(id));
-  partition->ClearDataForOrigin(
-      content::StoragePartition::REMOVE_DATA_MASK_ALL,
-      content::StoragePartition::QUOTA_MANAGED_STORAGE_MASK_ALL,
-      application->URL(),
-      partition->GetURLRequestContext());
-
-  base::FilePath path;
-  PathService::Get(xwalk::DIR_WGT_STORAGE_PATH, &path);
-  RemoveWidgetStorageFiles(path, id);
+  // Clear databases, the directory clean up will happen next time Crosswalk
+  // startup by ApplicationStorageImpl::CollectGarbageApplications.
+  content::BrowserContext::AsyncObliterateStoragePartition(
+      runtime_context_,
+      application->GetBaseURLFromApplicationId(id),
+      base::Bind(&base::DoNothing));
 
   FOR_EACH_OBSERVER(Observer, observers_, OnApplicationUninstalled(id));
 

--- a/application/browser/application_storage_impl.cc
+++ b/application/browser/application_storage_impl.cc
@@ -40,6 +40,9 @@ const std::string StoredPermissionStr[] = {
     "PROMPT",
 };
 
+const base::FilePath::CharType kApplicationDataDirName[] =
+    FILE_PATH_LITERAL("Storage/ext");
+
 std::string ToString(StoredPermission permission) {
   if (permission == UNDEFINED_STORED_PERM)
     return std::string("");
@@ -123,11 +126,29 @@ bool InitPermissionsTable(sql::Connection* db) {
   return transaction.Commit();
 }
 
+
+bool InitGarbageCollectionTable(sql::Connection* db) {
+  sql::Transaction transaction(db);
+  transaction.Begin();
+  if (!db->DoesTableExist(db_fields::kGarbageCollectionTableName)) {
+    if (!db->Execute(db_fields::kCreateGarbageCollectionTableOp) ||
+        !db->Execute(db_fields::kCreateGarbageCollectionTriggersOp))
+     return false;
+  }
+
+  return transaction.Commit();
+}
+
 bool Insert(scoped_refptr<ApplicationData> application,
             ApplicationData::ApplicationDataMap& applications) {
   return applications.insert(
       std::pair<std::string, scoped_refptr<ApplicationData> >(
           application->ID(), application)).second;
+}
+
+base::FilePath GetAppDataPath(
+    const base::FilePath& base_path, const std::string& app_id) {
+  return base_path.Append(kApplicationDataDirName).Append(app_id);
 }
 
 }  // namespace
@@ -218,6 +239,11 @@ bool ApplicationStorageImpl::Init(
     return false;
   }
 
+  if (!InitGarbageCollectionTable(sqlite_db.get())) {
+    LOG(ERROR) << "Unable to open garbage collection table.";
+    return false;
+  }
+
   if (!sqlite_db->Execute("PRAGMA foreign_keys=ON")) {
     LOG(ERROR) << "Unable to enforce foreign key contraints.";
     return false;
@@ -244,6 +270,11 @@ bool ApplicationStorageImpl::Init(
   }
 
   db_initialized_ = GetInstalledApplications(applications);
+
+  // TODO(xiang): move this to file thread and only enable application install
+  // after this garbage collection finished.
+  if (!CollectGarbageApplications())
+    LOG(ERROR) << "Unable to collection garbage applications.";
 
   return db_initialized_;
 }
@@ -522,6 +553,37 @@ bool ApplicationStorageImpl::SetPermissionsValue(
         "An error occurred while inserting permissions.";
     return false;
   }
+  return transaction.Commit();
+}
+
+bool ApplicationStorageImpl::CollectGarbageApplications() {
+  sql::Transaction transaction(sqlite_db_.get());
+  if (!transaction.Begin())
+    return false;
+
+  sql::Statement smt(sqlite_db_->GetUniqueStatement(
+      db_fields::kGetAllRowsFromGarbageCollectionTableOp));
+  if (!smt.is_valid())
+    return false;
+
+  while (smt.Step()) {
+    const std::string app_id = smt.ColumnString(0);
+    base::FilePath app_data_path = GetAppDataPath(data_path_, app_id);
+    if (base::DirectoryExists(app_data_path) &&
+        !base::DeleteFile(app_data_path, true)) {
+      LOG(ERROR) << "Error occurred while trying to remove application data.";
+      return false;
+    }
+
+    sql::Statement del_smt(sqlite_db_->GetUniqueStatement(
+        db_fields::kDeleteGarbageAppIdWithBindOp));
+    del_smt.BindString(0, app_id);
+    if (!del_smt.Run()) {
+      LOG(ERROR) << "Could not delete app_id from garbage table.";
+      return false;
+    }
+  }
+
   return transaction.Commit();
 }
 

--- a/application/browser/application_storage_impl.h
+++ b/application/browser/application_storage_impl.h
@@ -59,6 +59,8 @@ class ApplicationStorageImpl {
                          const StoredPermissionMap& permissions);
   bool RevokePermissions(const std::string& id);
 
+  bool CollectGarbageApplications();
+
   scoped_ptr<sql::Connection> sqlite_db_;
   sql::MetaTable meta_table_;
   base::FilePath data_path_;

--- a/application/common/application_storage_constants.cc
+++ b/application/common/application_storage_constants.cc
@@ -11,6 +11,7 @@ namespace application_storage_constants {
 const char kAppTableName[] = "applications";
 const char kEventTableName[] = "registered_events";
 const char kPermissionTableName[] = "stored_permissions";
+const char kGarbageCollectionTableName[] = "garbage_collection";
 
 const char kCreateAppTableOp[] =
     "CREATE TABLE applications ("
@@ -34,6 +35,16 @@ const char kCreatePermissionTableOp[] =
     "PRIMARY KEY (id),"
     "FOREIGN KEY (id) REFERENCES applications(id)"
     "ON DELETE CASCADE)";
+
+const char kCreateGarbageCollectionTableOp[] =
+    "CREATE TABLE garbage_collection ("
+    "app_id TEXT NOT NULL PRIMARY KEY)";
+
+const char kCreateGarbageCollectionTriggersOp[] =
+    "CREATE TRIGGER IF NOT EXISTS add_garbage_app AFTER DELETE ON applications"
+    " BEGIN INSERT INTO garbage_collection VALUES (OLD.id); END;"
+    "CREATE TRIGGER IF NOT EXISTS del_garbage_app AFTER INSERT ON applications"
+    " BEGIN DELETE FROM garbage_collection WHERE app_id = NEW.id; END";
 
 const char kGetAllRowsFromAppEventTableOp[] =
     "SELECT A.id, A.manifest, A.path, A.install_time, "
@@ -74,6 +85,12 @@ const char kUpdatePermissionsWithBindOp[] =
 
 const char kDeletePermissionsWithBindOp[] =
     "DELETE FROM stored_permissions WHERE id = ?";
+
+const char kGetAllRowsFromGarbageCollectionTableOp[] =
+    "SELECT app_id FROM garbage_collection";
+
+const char kDeleteGarbageAppIdWithBindOp[] =
+    "DELETE FROM garbage_collection WHERE app_id = ?";
 
 }  // namespace application_storage_constants
 }  // namespace xwalk

--- a/application/common/application_storage_constants.h
+++ b/application/common/application_storage_constants.h
@@ -13,10 +13,13 @@ namespace application_storage_constants {
   extern const char kAppTableName[];
   extern const char kEventTableName[];
   extern const char kPermissionTableName[];
+  extern const char kGarbageCollectionTableName[];
 
   extern const char kCreateAppTableOp[];
   extern const char kCreateEventTableOp[];
   extern const char kCreatePermissionTableOp[];
+  extern const char kCreateGarbageCollectionTableOp[];
+  extern const char kCreateGarbageCollectionTriggersOp[];
   extern const char kGetAllRowsFromAppEventTableOp[];
   extern const char kSetApplicationWithBindOp[];
   extern const char kUpdateApplicationWithBindOp[];
@@ -27,6 +30,8 @@ namespace application_storage_constants {
   extern const char kInsertPermissionsWithBindOp[];
   extern const char kUpdatePermissionsWithBindOp[];
   extern const char kDeletePermissionsWithBindOp[];
+  extern const char kGetAllRowsFromGarbageCollectionTableOp[];
+  extern const char kDeleteGarbageAppIdWithBindOp[];
 
 }  // namespace application_storage_constants
 }  // namespace xwalk

--- a/application/extension/application_widget_extension.cc
+++ b/application/extension/application_widget_extension.cc
@@ -8,6 +8,8 @@
 #include "base/path_service.h"
 #include "base/strings/string_util.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
 #include "ipc/ipc_message.h"
 #include "grit/xwalk_application_resources.h"
@@ -55,9 +57,10 @@ AppWidgetExtensionInstance::AppWidgetExtensionInstance(
   DCHECK(application_);
   base::ThreadRestrictions::SetIOAllowed(true);
 
-  base::FilePath path;
-  xwalk::RegisterPathProvider();
-  PathService::Get(xwalk::DIR_WGT_STORAGE_PATH, &path);
+  content::RenderProcessHost* rph =
+      content::RenderProcessHost::FromID(application->GetRenderProcessHostID());
+  content::StoragePartition* partition = rph->GetStoragePartition();
+  base::FilePath path = partition->GetPath().Append("WidgetStorage");
   widget_storage_.reset(new AppWidgetStorage(application_, path));
 }
 

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -22,9 +22,9 @@
 #include "content/public/browser/notification_service.h"
 #include "content/public/browser/notification_source.h"
 #include "content/public/browser/notification_types.h"
+#include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_contents.h"
-#include "content/public/browser/render_process_host.h"
 #include "grit/xwalk_resources.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/gfx/image/image_skia.h"
@@ -53,9 +53,10 @@ Runtime* Runtime::CreateWithDefaultWindow(
 }
 
 // static
-Runtime* Runtime::Create(
-    RuntimeContext* runtime_context, Observer* observer) {
-  WebContents::CreateParams params(runtime_context, NULL);
+Runtime* Runtime::Create(RuntimeContext* runtime_context,
+                         Observer* observer,
+                         content::SiteInstance* site) {
+  WebContents::CreateParams params(runtime_context, site);
   params.routing_id = MSG_ROUTING_NONE;
   WebContents* web_contents = WebContents::Create(params);
 

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -22,8 +22,9 @@
 namespace content {
 class ColorChooser;
 struct FileChooserParams;
-class WebContents;
 class RenderProcessHost;
+class SiteInstance;
+class WebContents;
 }
 
 namespace xwalk {
@@ -60,7 +61,8 @@ class Runtime : public content::WebContentsDelegate,
   static Runtime* CreateWithDefaultWindow(RuntimeContext*,
                                           const GURL&, Observer* = NULL);
   // Create a new Runtime instance with the given browsing context.
-  static Runtime* Create(RuntimeContext*, Observer* = NULL);
+  static Runtime* Create(RuntimeContext*,
+                         Observer* = NULL, content::SiteInstance* = NULL);
 
   // Attach to a default app window.
   void AttachDefaultWindow();

--- a/runtime/browser/runtime_context.h
+++ b/runtime/browser/runtime_context.h
@@ -9,6 +9,7 @@
 #include <string>
 #endif
 
+#include <map>
 #include <vector>
 
 #include "base/compiler_specific.h"
@@ -133,6 +134,10 @@ class RuntimeContext
   std::string csp_;
   scoped_ptr<visitedlink::VisitedLinkMaster> visitedlink_master_;
 #endif
+
+  typedef std::map<std::string, scoped_refptr<RuntimeURLRequestContextGetter> >
+      PartitionPathContextGetterMap;
+  PartitionPathContextGetterMap context_getters_;
 
   DISALLOW_COPY_AND_ASSIGN(RuntimeContext);
 };

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -29,6 +29,7 @@
 #include "net/url_request/url_request_context_getter.h"
 #include "ppapi/host/ppapi_host.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
+#include "xwalk/application/common/constants.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
 #include "xwalk/runtime/browser/geolocation/xwalk_access_token_store.h"
 #include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
@@ -62,7 +63,6 @@
 #if defined(OS_TIZEN)
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/manifest_handlers/navigation_handler.h"
-#include "xwalk/application/common/constants.h"
 #include "xwalk/runtime/browser/runtime_platform_util.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 #endif
@@ -368,5 +368,23 @@ bool XWalkContentBrowserClient::CanCreateWindow(const GURL& opener_url,
   return false;
 }
 #endif
+
+
+void XWalkContentBrowserClient::GetStoragePartitionConfigForSite(
+    content::BrowserContext* browser_context,
+    const GURL& site,
+    bool can_be_default,
+    std::string* partition_domain,
+    std::string* partition_name,
+    bool* in_memory) {
+  *in_memory = false;
+  partition_domain->clear();
+  partition_name->clear();
+
+#if !defined(OS_ANDROID)
+  if (site.SchemeIs(application::kApplicationScheme))
+    *partition_domain = site.host();
+#endif
+}
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -131,6 +131,16 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
 #if defined(OS_ANDROID)
   virtual void ResourceDispatcherHostCreated();
 #endif
+
+  virtual void GetStoragePartitionConfigForSite(
+      content::BrowserContext* browser_context,
+      const GURL& site,
+      bool can_be_default,
+      std::string* partition_domain,
+      std::string* partition_name,
+      bool* in_memory) OVERRIDE;
+
+
   XWalkBrowserMainParts* main_parts() { return main_parts_; }
 
  private:


### PR DESCRIPTION
Tizen WRT spec and Chrome both require applications running with private
storage. Which means the application running data like local storage,
cookies, app cache, GPU cache will move to a standalone storage directory.
This directory will be removed when application uninstalled.
