### PR TITLE
[Android] Ensure onPageStarted won't called for iframe loading

### DIFF
--- a/runtime/browser/runtime_resource_dispatcher_host_delegate_android.cc
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate_android.cc
@@ -220,20 +220,10 @@ void RuntimeResourceDispatcherHostDelegateAndroid::RequestBeginning(
     int child_id,
     int route_id,
     ScopedVector<content::ResourceThrottle>* throttles) {
-  bool allow_intercepting =
-      // We allow intercepting navigations within subframes, but only if the
-      // scheme other than http or https. This is because the embedder
-      // can't distinguish main frame and subframe callbacks (which could lead
-      // to broken content if the embedder decides to not ignore the main frame
-      // navigation, but ignores the subframe navigation).
-      // The reason this is supported at all is that certain JavaScript-based
-      // frameworks use iframe navigation as a form of communication with the
-      // embedder.
-      (resource_type == ResourceType::MAIN_FRAME ||
-       (resource_type == ResourceType::SUB_FRAME &&
-        !request->url().SchemeIs(url::kHttpScheme) &&
-        !request->url().SchemeIs(url::kHttpsScheme)));
-  if (allow_intercepting) {
+  // We allow intercepting only navigations within main frames. This
+  // is used to post onPageStarted. We handle shouldOverrideUrlLoading
+  // via a sync IPC for url loading in iframe.
+  if (resource_type == ResourceType::MAIN_FRAME) {
     throttles->push_back(InterceptNavigationDelegate::CreateThrottleFor(
         request));
   }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldInterceptLoadRequestTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldInterceptLoadRequestTest.java
@@ -468,4 +468,20 @@ public class ShouldInterceptLoadRequestTest extends XWalkViewTestBase {
     public void testCalledForNonexistentContentUrl() throws Throwable {
         calledForUrlTemplate("content://org.xwalk.core.test.NoSuchProvider/foo");
     }
+
+    @SmallTest
+    @Feature({"ShouldInterceptLoadRequest"})
+    public void testOnPageStartedOnlyOnMainFrame() throws Throwable {
+        final String aboutPageUrl = addAboutPageToTestServer(mWebServer);
+        final String pageWithIframe = addPageToTestServer(mWebServer, "/page_with_iframe.html",
+                CommonResources.makeHtmlPageFrom("",
+                    "<iframe src=\"" + aboutPageUrl + "\"/>"));
+        int onPageStartedCallCount = mTestHelperBridge.getOnPageStartedHelper().getCallCount();
+
+        loadUrlSync(pageWithIframe);
+
+        mTestHelperBridge.getOnPageStartedHelper().waitForCallback(onPageStartedCallCount);
+        assertEquals(onPageStartedCallCount + 1,
+                mTestHelperBridge.getOnPageStartedHelper().getCallCount());
+    }
 }


### PR DESCRIPTION
Even for http/https iframe, onPageStarted would not be called. To hook
up iframe url loading, the embedder is able to override
shouldOverrideUrlLoading defined in XWalkClient.

TODO:
Consider to expose shouldOverrideUrlLoading as a public API?

BUG=https://crosswalk-project.org/jira/browse/XWALK-1780
