### PR TITLE
[Tizen] [multi-users] remove setuid root in xwalk-pkg-helper

### DIFF
--- a/application/tools/tizen/xwalk_package_helper.cc
+++ b/application/tools/tizen/xwalk_package_helper.cc
@@ -33,14 +33,6 @@ int main(int argc, char *argv[]) {
   if (argc <= 2)
     return usage(argv[0]);
 
-  // When installing an application on Tizen, the libraries used require
-  // some steps to be run as root (UID 0) and fail otherwise, so we force
-  // this tool to assume the root UID.
-  if (setuid(0)) {
-    fprintf(stderr, "Make sure '%s' is set-user-ID-root\n", argv[0]);
-    return 1;;
-  }
-
   PackageInstallerHelper helper(argv[2]);
   if (!strcmp(argv[1], "--install")) {
     if (argc != 5)


### PR DESCRIPTION
xwalk-pkg-helper is always run by root user. It needs to be launched
by a user in order to retrieve User ID in application framework
and then install/remove applications in user's places.

related to XWALK-1649

Signed-off-by: Corentin Lecouvey corentin.lecouvey@open.eurogiciel.org
