### PR TITLE
Revert "[Tizen] Prepare the screen orientation code to use the Blink impl"

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -15,75 +15,6 @@
 #include "xwalk/runtime/browser/ui/top_view_layout_views.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 
-namespace {
-
-static gfx::Display::Rotation ToDisplayRotation(gfx::Display display,
-    blink::WebScreenOrientationType orientation) {
-  gfx::Display::Rotation rot = gfx::Display::ROTATE_0;
-  switch (orientation) {
-    case blink::WebScreenOrientationUndefined:
-    case blink::WebScreenOrientationPortraitPrimary:
-      rot = gfx::Display::ROTATE_0;
-      break;
-    case blink::WebScreenOrientationLandscapeSecondary:
-      rot = gfx::Display::ROTATE_90;
-      break;
-    case blink::WebScreenOrientationPortraitSecondary:
-      rot = gfx::Display::ROTATE_180;
-      break;
-    case blink::WebScreenOrientationLandscapePrimary:
-      rot = gfx::Display::ROTATE_270;
-      break;
-  default:
-      NOTREACHED();
-  }
-
-  if (display.bounds().width() > display.bounds().height()) {
-    // Landscape devices have landscape-primary as default.
-    rot = static_cast<gfx::Display::Rotation>((rot - 1) % 4);
-  }
-
-  return rot;
-}
-
-static void SetWindowRotation(aura::Window* window, gfx::Display display) {
-  // This methods assumes that window is fullscreen.
-
-#if defined(OS_TIZEN_MOBILE)
-  // Assumes portrait display; shows overlay indicator in landscape only.
-  bool useOverlay = display.rotation() == gfx::Display::ROTATE_90 ||
-      display.rotation() == gfx::Display::ROTATE_180);
-  top_view_layout()->SetUseOverlay(enableOverlay);
-  indicator_widget_->SetDisplay(display);
-#endif
-
-  // As everything is calculated from the fixed position we do
-  // not update the display bounds after rotation change.
-  gfx::Transform rotate;
-  float one_pixel = 1.0f / display.device_scale_factor();
-  switch (display.rotation()) {
-    case gfx::Display::ROTATE_0:
-      break;
-    case gfx::Display::ROTATE_90:
-      rotate.Translate(display.bounds().width() - one_pixel, 0);
-      rotate.Rotate(90);
-      break;
-    case gfx::Display::ROTATE_270:
-      rotate.Translate(0, display.bounds().height() - one_pixel);
-      rotate.Rotate(270);
-      break;
-    case gfx::Display::ROTATE_180:
-      rotate.Translate(display.bounds().width() - one_pixel,
-                       display.bounds().height() - one_pixel);
-      rotate.Rotate(180);
-      break;
-  }
-
-  window->SetTransform(rotate);
-}
-
-}  // namespace.
-
 namespace xwalk {
 
 NativeAppWindowTizen::NativeAppWindowTizen(
@@ -93,24 +24,30 @@ NativeAppWindowTizen::NativeAppWindowTizen(
       indicator_widget_(new TizenSystemIndicatorWidget()),
       indicator_container_(new WidgetContainerView(indicator_widget_)),
 #endif
-      orientation_lock_(blink::WebScreenOrientationLockAny) {
+      allowed_orientations_(ANY) {
 }
 
 void NativeAppWindowTizen::Initialize() {
   NativeAppWindowViews::Initialize();
 
   // Get display info such as device_scale_factor, and current
-  // rotation (orientation).
-  // NOTE: This is a local copy of the info.
+  // rotation (orientation). NOTE: This is a local copy of the info.
   display_ = gfx::Screen::GetNativeScreen()->GetPrimaryDisplay();
 
   aura::Window* root_window = GetNativeWindow()->GetRootWindow();
   DCHECK(root_window);
   root_window->AddObserver(this);
 
+  OrientationMask ua_default =
+      XWalkBrowserMainPartsTizen::GetAllowedUAOrientations();
+  OnAllowedOrientationsChanged(ua_default);
+
   if (SensorProvider* sensor = SensorProvider::GetInstance()) {
+    gfx::Display::Rotation rotation
+      = GetClosestAllowedRotation(sensor->GetCurrentRotation());
+    display_.set_rotation(rotation);
+    ApplyDisplayRotation();
     sensor->AddObserver(this);
-    OnScreenOrientationChanged(sensor->GetScreenOrientation());
   }
 }
 
@@ -123,7 +60,6 @@ void NativeAppWindowTizen::ViewHierarchyChanged(
     const ViewHierarchyChangedDetails& details) {
   if (details.is_add && details.child == this) {
     NativeAppWindowViews::ViewHierarchyChanged(details);
-
 #if defined(OS_TIZEN_MOBILE)
     indicator_widget_->Initialize(GetNativeWindow());
     top_view_layout()->set_top_view(indicator_container_.get());
@@ -154,83 +90,161 @@ void NativeAppWindowTizen::OnWindowDestroying(aura::Window* window) {
 
 void NativeAppWindowTizen::OnWindowVisibilityChanging(
     aura::Window* window, bool visible) {
-  if (!visible)
-    return;
-  SetDisplayRotation(display_);
+  if (visible)
+    ApplyDisplayRotation();
 }
 
-blink::WebScreenOrientationType
-    NativeAppWindowTizen::FindNearestAllowedOrientation(
-        blink::WebScreenOrientationType orientation) const {
-  switch (orientation_lock_) {
-    case blink::WebScreenOrientationLockDefault:
-    case blink::WebScreenOrientationLockAny:
-      return orientation;
-    case blink::WebScreenOrientationLockLandscape: {
-      switch (orientation) {
-        case blink::WebScreenOrientationLandscapePrimary:
-        case blink::WebScreenOrientationLandscapeSecondary:
-          return orientation;
-        default:
-          return blink::WebScreenOrientationLandscapePrimary;
-      }
+gfx::Transform NativeAppWindowTizen::GetRotationTransform() const {
+  // This method assumed a fixed portrait device. As everything
+  // is calculated from the fixed position we do not update the
+  // display bounds after rotation change.
+  // FIXME : Add proper support for landscape devices.
+  gfx::Transform rotate;
+  float one_pixel = 1.0f / display_.device_scale_factor();
+  switch (display_.rotation()) {
+    case gfx::Display::ROTATE_0:
       break;
-    }
-    case blink::WebScreenOrientationLockPortrait: {
-      switch (orientation) {
-        case blink::WebScreenOrientationPortraitPrimary:
-        case blink::WebScreenOrientationPortraitSecondary:
-          return orientation;
-        default:
-          return blink::WebScreenOrientationPortraitPrimary;
-      }
+    case gfx::Display::ROTATE_90:
+      rotate.Translate(display_.bounds().width() - one_pixel, 0);
+      rotate.Rotate(90);
       break;
-    }
-    case blink::WebScreenOrientationLockPortraitPrimary:
-      return blink::WebScreenOrientationPortraitPrimary;
-    case blink::WebScreenOrientationLockPortraitSecondary:
-      return blink::WebScreenOrientationPortraitSecondary;
-    case blink::WebScreenOrientationLockLandscapePrimary:
-      return blink::WebScreenOrientationLandscapePrimary;
-    case blink::WebScreenOrientationLockLandscapeSecondary:
-      return blink::WebScreenOrientationLandscapeSecondary;
-  default:
+    case gfx::Display::ROTATE_270:
+      rotate.Translate(0, display_.bounds().height() - one_pixel);
+      rotate.Rotate(270);
+      break;
+    case gfx::Display::ROTATE_180:
+      rotate.Translate(display_.bounds().width() - one_pixel,
+                       display_.bounds().height() - one_pixel);
+      rotate.Rotate(180);
+      break;
+  }
+
+  return rotate;
+}
+
+namespace {
+
+#if defined(OS_TIZEN_MOBILE)
+Orientation ToOrientation(const gfx::Display::Rotation& rotation) {
+  switch (rotation) {
+    case gfx::Display::ROTATE_0:
+      return PORTRAIT_PRIMARY;
+    case gfx::Display::ROTATE_90:
+      return LANDSCAPE_PRIMARY;
+    case gfx::Display::ROTATE_180:
+      return PORTRAIT_SECONDARY;
+    case gfx::Display::ROTATE_270:
+      return LANDSCAPE_SECONDARY;
+    default:
       NOTREACHED();
   }
-  return orientation;
+  return PORTRAIT_PRIMARY;
+}
+#else
+Orientation ToOrientation(const gfx::Display::Rotation& rotation) {
+  switch (rotation) {
+    case gfx::Display::ROTATE_0:
+      return LANDSCAPE_PRIMARY;
+    case gfx::Display::ROTATE_90:
+      return PORTRAIT_PRIMARY;
+    case gfx::Display::ROTATE_180:
+      return LANDSCAPE_SECONDARY;
+    case gfx::Display::ROTATE_270:
+      return PORTRAIT_SECONDARY;
+    default:
+      NOTREACHED();
+  }
+  return LANDSCAPE_PRIMARY;
+}
+#endif
+
+inline gfx::Display::Rotation ToRotation(unsigned rotation) {
+  return static_cast<gfx::Display::Rotation>(rotation % 4);
 }
 
-void NativeAppWindowTizen::LockOrientation(
-      blink::WebScreenOrientationLockType lock) {
-  orientation_lock_ = lock;
+bool IsLandscapeOrientation(const gfx::Display::Rotation& rotation) {
+  return ToOrientation(rotation) & LANDSCAPE;
+}
+
+}  // namespace.
+
+gfx::Display::Rotation NativeAppWindowTizen::GetClosestAllowedRotation(
+    gfx::Display::Rotation rotation) const {
+
+  // Test current orientation
+  if (allowed_orientations_ & ToOrientation(rotation))
+    return rotation;
+
+  // Test orientation right of current one.
+  if (allowed_orientations_ & ToOrientation(ToRotation(rotation + 1)))
+    return ToRotation(rotation + 1);
+
+  // Test orientation left of current one.
+  if (allowed_orientations_ & ToOrientation(ToRotation(rotation + 3)))
+    return ToRotation(rotation + 3);
+
+  // Test orientation opposite of current one.
+  if (allowed_orientations_ & ToOrientation(ToRotation(rotation + 1)))
+    return ToRotation(rotation + 1);
+
+  NOTREACHED();
+  return rotation;
+}
+
+Orientation NativeAppWindowTizen::GetCurrentOrientation() const {
+  return ToOrientation(display_.rotation());
+}
+
+void NativeAppWindowTizen::OnAllowedOrientationsChanged(
+    OrientationMask orientations) {
+  allowed_orientations_ = orientations;
+
+  // As we might have been locked before our current orientation
+  // might not fit with the sensor orienation.
+  gfx::Display::Rotation rotation = display_.rotation();
   if (SensorProvider* sensor = SensorProvider::GetInstance())
-    OnScreenOrientationChanged(sensor->GetScreenOrientation());
+    rotation = sensor->GetCurrentRotation();
+
+  rotation = GetClosestAllowedRotation(rotation);
+  if (display_.rotation() == rotation)
+    return;
+
+  display_.set_rotation(rotation);
+  ApplyDisplayRotation();
 }
 
-void NativeAppWindowTizen::UnlockOrientation() {
-  LockOrientation(blink::WebScreenOrientationLockDefault);
-}
-
-void NativeAppWindowTizen::OnScreenOrientationChanged(
-    blink::WebScreenOrientationType orientation) {
-
+void NativeAppWindowTizen::OnRotationChanged(
+    gfx::Display::Rotation rotation) {
   // We always store the current sensor position, even if we do not
   // apply it in case the window is invisible.
-  gfx::Display::Rotation rot = ToDisplayRotation(display_,
-      FindNearestAllowedOrientation(orientation));
-  if (display_.rotation() == rot)
+
+  rotation = GetClosestAllowedRotation(rotation);
+  if (display_.rotation() == rotation)
     return;
 
-  display_.set_rotation(rot);
-  SetDisplayRotation(display_);
+  display_.set_rotation(rotation);
+
+  ApplyDisplayRotation();
 }
 
-void NativeAppWindowTizen::SetDisplayRotation(gfx::Display display) {
-  aura::Window* window = GetNativeWindow()->GetRootWindow();
-  if (!window->IsVisible())
-    return;
+void NativeAppWindowTizen::UpdateTopViewOverlay() {
+  top_view_layout()->SetUseOverlay(
+      IsLandscapeOrientation(display_.rotation()));
+}
 
-  SetWindowRotation(window, display);
+void NativeAppWindowTizen::ApplyDisplayRotation() {
+  if (observer())
+    observer()->OnOrientationChanged(GetCurrentOrientation());
+
+  aura::Window* root_window = GetNativeWindow()->GetRootWindow();
+  if (!root_window->IsVisible())
+    return;
+  UpdateTopViewOverlay();
+
+#if defined(OS_TIZEN_MOBILE)
+  indicator_widget_->SetDisplay(display_);
+#endif
+  root_window->SetTransform(GetRotationTransform());
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts_tizen.h
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.h
@@ -20,6 +20,11 @@ class XWalkBrowserMainPartsTizen : public XWalkBrowserMainParts {
   virtual void PreMainMessageLoopStart() OVERRIDE;
   virtual void PreMainMessageLoopRun() OVERRIDE;
 
+  virtual void CreateInternalExtensionsForUIThread(
+      content::RenderProcessHost* host,
+      extensions::XWalkExtensionVector* extensions) OVERRIDE;
+
+  static OrientationMask GetAllowedUAOrientations();
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkBrowserMainPartsTizen);
 };

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -76,8 +76,8 @@ class XWalkRunner {
   bool is_running_as_service() const { return is_running_as_service_; }
 
   // Stages of main parts. See content/browser_main_parts.h for description.
-  virtual void PreMainMessageLoopRun();
-  virtual void PostMainMessageLoopRun();
+  void PreMainMessageLoopRun();
+  void PostMainMessageLoopRun();
 
   // Get the latest application locale from system.
   // locale is a langtag defined in [BCP47]

--- a/runtime/browser/xwalk_runner_tizen.cc
+++ b/runtime/browser/xwalk_runner_tizen.cc
@@ -19,10 +19,6 @@ XWalkRunnerTizen* XWalkRunnerTizen::GetInstance() {
   return static_cast<XWalkRunnerTizen*>(XWalkRunner::GetInstance());
 }
 
-void XWalkRunnerTizen::PreMainMessageLoopRun() {
-  XWalkRunner::PreMainMessageLoopRun();
-}
-
 std::string XWalkRunnerTizen::GetLocale() const {
   return tizen_locale_listener_.GetLocale();
 }

--- a/runtime/browser/xwalk_runner_tizen.h
+++ b/runtime/browser/xwalk_runner_tizen.h
@@ -23,8 +23,6 @@ class XWalkRunnerTizen : public XWalkRunner {
 
   virtual ~XWalkRunnerTizen();
 
-  virtual void PreMainMessageLoopRun() OVERRIDE;
-
   // Get the latest application locale from system.
   // locale is a langtag defined in [BCP47]
   virtual std::string GetLocale() const OVERRIDE;

--- a/runtime/extension/screen_orientation_extension.cc
+++ b/runtime/extension/screen_orientation_extension.cc
@@ -26,9 +26,23 @@ using application::Application;
 
 namespace {
 
-MultiOrientationScreen* GetMultiOrientationScreen(Application*) {  // NOLINT
-  NOTREACHED();
-  return NULL;
+MultiOrientationScreen* GetMultiOrientationScreen(Application* app) {
+  // FIXME(Mikhail): handle multi-windowed applications properly.
+  // At the moment app has two runtimes: main (without window)
+  // and a runtime with window.
+  NativeAppWindowTizen* window = NULL;
+  const std::set<Runtime*>& runtimes = app->runtimes();
+  std::set<Runtime*>::const_iterator it = runtimes.begin();
+  for (; it != runtimes.end(); ++it) {
+    if (NativeAppWindow* native_window = (*it)->window()) {
+      // FIXME: Let NativeAppWindow inherit the interface.
+      window = static_cast<NativeAppWindowTizen*>(native_window);
+      break;
+    }
+  }
+
+  DCHECK(window);
+  return static_cast<MultiOrientationScreen*>(window);
 }
 
 }  // namespace.

--- a/runtime/extension/screen_orientation_extension.h
+++ b/runtime/extension/screen_orientation_extension.h
@@ -26,8 +26,6 @@ using extensions::XWalkExtensionFunctionHandler;
 using extensions::XWalkExtensionFunctionInfo;
 using extensions::XWalkExtensionInstance;
 
-// NOTE : This class will be removed (and content::ScreenOrientationProvider
-// used instead).
 class ScreenOrientationExtension : public XWalkExtension {
  public:
   explicit ScreenOrientationExtension(

--- a/tizen/mobile/sensor/sensor_provider.cc
+++ b/tizen/mobile/sensor/sensor_provider.cc
@@ -22,7 +22,7 @@ SensorProvider* SensorProvider::GetInstance() {
 }
 
 SensorProvider::SensorProvider()
-    : last_orientation_(blink::WebScreenOrientationUndefined) {
+    : last_rotation_(gfx::Display::ROTATE_0) {
 }
 
 SensorProvider::~SensorProvider() {
@@ -37,13 +37,12 @@ void SensorProvider::RemoveObserver(Observer* observer) {
   observers_.erase(observer);
 }
 
-void SensorProvider::OnScreenOrientationChanged(
-    blink::WebScreenOrientationType orientation) {
-  last_orientation_ = orientation;
+void SensorProvider::OnRotationChanged(gfx::Display::Rotation rotation) {
+  last_rotation_ = rotation;
 
   std::set<Observer*>::iterator it;
   for (it = observers_.begin(); it != observers_.end(); ++it)
-    (*it)->OnScreenOrientationChanged(orientation);
+    (*it)->OnRotationChanged(rotation);
 }
 
 void SensorProvider::OnOrientationChanged(float alpha,

--- a/tizen/mobile/sensor/sensor_provider.h
+++ b/tizen/mobile/sensor/sensor_provider.h
@@ -9,33 +9,31 @@
 
 #include "base/memory/scoped_ptr.h"
 #include "ui/gfx/display.h"
-#include "third_party/WebKit/public/platform/WebScreenOrientationType.h"
 
 namespace xwalk {
 
 class SensorProvider {
  public:
-  static SensorProvider* GetInstance();
-  virtual ~SensorProvider();
-
   class Observer {
    public:
     virtual ~Observer() {}
 
-    virtual void OnScreenOrientationChanged(
-        blink::WebScreenOrientationType orientation) {}
-
+    virtual void OnRotationChanged(gfx::Display::Rotation r) {}
     virtual void OnOrientationChanged(float alpha, float beta, float gamma) {}
     virtual void OnAccelerationChanged(float raw_x, float raw_y, float raw_z,
                                        float x, float y, float z) {}
     virtual void OnRotationRateChanged(float alpha, float beta, float gamma) {}
   };
 
+  static SensorProvider* GetInstance();
+
+  virtual ~SensorProvider();
+
   virtual void AddObserver(Observer* observer);
   virtual void RemoveObserver(Observer* observer);
 
-  virtual blink::WebScreenOrientationType GetScreenOrientation() const {
-    return last_orientation_;
+  virtual gfx::Display::Rotation GetCurrentRotation() const {
+    return last_rotation_;
   }
 
   static bool initialized_;
@@ -46,16 +44,14 @@ class SensorProvider {
   virtual bool Initialize() = 0;
   virtual void Finish() {}
 
-  virtual void OnScreenOrientationChanged(
-      blink::WebScreenOrientationType orientation);
-
+  virtual void OnRotationChanged(gfx::Display::Rotation rotation);
   virtual void OnOrientationChanged(float alpha, float beta, float gamma);
   virtual void OnAccelerationChanged(float raw_x, float raw_y, float raw_z,
                                      float x, float y, float z);
   virtual void OnRotationRateChanged(float alpha, float beta, float gamma);
 
   std::set<Observer*> observers_;
-  blink::WebScreenOrientationType last_orientation_;
+  gfx::Display::Rotation last_rotation_;
 
  private:
   static scoped_ptr<SensorProvider> instance_;

--- a/tizen/mobile/sensor/tizen_platform_sensor.cc
+++ b/tizen/mobile/sensor/tizen_platform_sensor.cc
@@ -10,40 +10,6 @@
 #include "base/files/file_path.h"
 #include "base/logging.h"
 
-namespace  {
-
-// Make the class depend on gfx::Display to avoid the hack below:
-
-#if defined(OS_TIZEN_MOBILE)
-int rotation_start = 0;  // Default is portrait primary.
-#else
-int rotation_start = -1;  // Default is landscape primary.
-#endif
-
-blink::WebScreenOrientationType ToScreenOrientation(
-    int rotation) {
-  rotation = (rotation + rotation_start) % 4;
-
-  blink::WebScreenOrientationType r = blink::WebScreenOrientationUndefined;
-  switch (rotation) {
-    case ROTATION_EVENT_0:
-      r = blink::WebScreenOrientationPortraitPrimary;
-      break;
-    case ROTATION_EVENT_90:
-      r = blink::WebScreenOrientationLandscapeSecondary;
-      break;
-    case ROTATION_EVENT_180:
-      r = blink::WebScreenOrientationPortraitSecondary;
-      break;
-    case ROTATION_EVENT_270:
-      r = blink::WebScreenOrientationLandscapePrimary;
-      break;
-  }
-  return r;
-}
-
-}  // namespace
-
 namespace xwalk {
 
 TizenPlatformSensor::TizenPlatformSensor()
@@ -64,7 +30,7 @@ bool TizenPlatformSensor::Initialize() {
 
   unsigned long rotation;  // NOLINT
   if (!sf_check_rotation(&rotation)) {
-    last_orientation_ = ToScreenOrientation(static_cast<int>(rotation));
+    last_rotation_ = ToDisplayRotation(static_cast<int>(rotation));
   }
 
   int value;
@@ -76,15 +42,13 @@ bool TizenPlatformSensor::Initialize() {
 
   accel_handle_ = sf_connect(ACCELEROMETER_SENSOR);
   if (accel_handle_ >= 0) {
-    if (sf_register_event(accel_handle_,
-            ACCELEROMETER_EVENT_ROTATION_CHECK, NULL,
-            OnEventReceived, this) < 0 ||
+    if (sf_register_event(accel_handle_, ACCELEROMETER_EVENT_ROTATION_CHECK,
+                          NULL, OnEventReceived, this) < 0 ||
         sf_register_event(accel_handle_,
-            ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME, NULL,
-            OnEventReceived, this) < 0 ||
+                          ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME,
+                          NULL, OnEventReceived, this) < 0 ||
         sf_start(accel_handle_, 0) < 0) {
       LOG(ERROR) << "Register accelerometer sensor event failed";
-
       sf_unregister_event(accel_handle_, ACCELEROMETER_EVENT_ROTATION_CHECK);
       sf_unregister_event(accel_handle_,
                           ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME);
@@ -98,10 +62,11 @@ bool TizenPlatformSensor::Initialize() {
   gyro_handle_ = sf_connect(GYROSCOPE_SENSOR);
   if (gyro_handle_ >= 0) {
     if (sf_register_event(gyro_handle_, GYROSCOPE_EVENT_RAW_DATA_REPORT_ON_TIME,
-            NULL, OnEventReceived, this) < 0 || sf_start(gyro_handle_, 0) < 0) {
+                          NULL, OnEventReceived, this) < 0 ||
+        sf_start(gyro_handle_, 0) < 0) {
       LOG(ERROR) << "Register gyroscope sensor event failed";
       sf_unregister_event(gyro_handle_,
-          GYROSCOPE_EVENT_RAW_DATA_REPORT_ON_TIME);
+                          GYROSCOPE_EVENT_RAW_DATA_REPORT_ON_TIME);
       sf_disconnect(gyro_handle_);
       gyro_handle_ = -1;
     }
@@ -117,7 +82,7 @@ void TizenPlatformSensor::Finish() {
     sf_stop(accel_handle_);
     sf_unregister_event(accel_handle_, ACCELEROMETER_EVENT_ROTATION_CHECK);
     sf_unregister_event(accel_handle_,
-        ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME);
+                        ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME);
     sf_disconnect(accel_handle_);
     accel_handle_ = -1;
   }
@@ -130,64 +95,93 @@ void TizenPlatformSensor::Finish() {
   }
 
   vconf_ignore_key_changed(VCONFKEY_SETAPPL_AUTO_ROTATE_SCREEN_BOOL,
-      OnAutoRotationEnabledChanged);
+                           OnAutoRotationEnabledChanged);
+}
+
+gfx::Display::Rotation TizenPlatformSensor::ToDisplayRotation(
+    int rotation) const {
+  gfx::Display::Rotation r = gfx::Display::ROTATE_0;
+  switch (rotation) {
+    case ROTATION_EVENT_0:
+      r = gfx::Display::ROTATE_0;
+      break;
+    case ROTATION_EVENT_90:
+      r = gfx::Display::ROTATE_90;
+      break;
+    case ROTATION_EVENT_180:
+      r = gfx::Display::ROTATE_180;
+      break;
+    case ROTATION_EVENT_270:
+      r = gfx::Display::ROTATE_270;
+      break;
+  }
+  return r;
 }
 
 void TizenPlatformSensor::OnEventReceived(unsigned int event_type,
                                           sensor_event_data_t* event_data,
                                           void* udata) {
-  TizenPlatformSensor* self = reinterpret_cast<TizenPlatformSensor*>(udata);
-
+  TizenPlatformSensor* sensor = reinterpret_cast<TizenPlatformSensor*>(udata);
   sensor_data_t* data =
       reinterpret_cast<sensor_data_t*>(event_data->event_data);
   size_t last = event_data->event_data_size / sizeof(sensor_data_t) - 1;
 
   switch (event_type) {
     case ACCELEROMETER_EVENT_ROTATION_CHECK: {
-      if (!self->auto_rotation_enabled_)
-        return;
-      int value = *reinterpret_cast<int*>(event_data->event_data);
-      self->OnScreenOrientationChanged(ToScreenOrientation(value));
+      gfx::Display::Rotation r = sensor->ToDisplayRotation(
+          *reinterpret_cast<int*>(event_data->event_data));
+      if (sensor->auto_rotation_enabled_)
+        sensor->OnRotationChanged(r);
       break;
     }
     case ACCELEROMETER_EVENT_RAW_DATA_REPORT_ON_TIME: {
       sensor_data_t linear;
       linear.values[0] = linear.values[1] = linear.values[2] = FP_NAN;
-      sf_get_data(self->accel_handle_,
-          ACCELEROMETER_LINEAR_ACCELERATION_DATA_SET, &linear);
-      self->OnAccelerationChanged(
-          data[last].values[0], data[last].values[1], data[last].values[2],
-          linear.values[0], linear.values[1], linear.values[2]);
+      sf_get_data(sensor->accel_handle_,
+                  ACCELEROMETER_LINEAR_ACCELERATION_DATA_SET,
+                  &linear);
+      sensor->OnAccelerationChanged(data[last].values[0],
+                                    data[last].values[1],
+                                    data[last].values[2],
+                                    linear.values[0],
+                                    linear.values[1],
+                                    linear.values[2]);
 
       sensor_data_t orient;
-      if (sf_get_data(self->accel_handle_,
-              ACCELEROMETER_ORIENTATION_DATA_SET, &orient) >= 0) {
-        self->OnOrientationChanged(
-            orient.values[0], orient.values[1], orient.values[2]);
+      if (sf_get_data(sensor->accel_handle_,
+                      ACCELEROMETER_ORIENTATION_DATA_SET,
+                      &orient) >= 0) {
+        sensor->OnOrientationChanged(orient.values[0],
+                                     orient.values[1],
+                                     orient.values[2]);
       }
       break;
     }
     case GYROSCOPE_EVENT_RAW_DATA_REPORT_ON_TIME: {
-      self->OnRotationRateChanged(
-          data[last].values[0], data[last].values[1], data[last].values[2]);
+      sensor->OnRotationRateChanged(data[last].values[0],
+                                    data[last].values[1],
+                                    data[last].values[2]);
     }
   }
 }
 
-void TizenPlatformSensor::OnAutoRotationEnabledChanged(
-    keynode_t* node, void* udata) {
-  TizenPlatformSensor* self = reinterpret_cast<TizenPlatformSensor*>(udata);
-
-  self->auto_rotation_enabled_ = (vconf_keynode_get_bool(node) != 0);
+void TizenPlatformSensor::OnAutoRotationEnabledChanged(keynode_t* node,
+                                                       void* udata) {
+  TizenPlatformSensor* sensor = reinterpret_cast<TizenPlatformSensor*>(udata);
+  sensor->auto_rotation_enabled_ = (vconf_keynode_get_bool(node) != 0);
 
   unsigned long value;  // NOLINT
-  if (!self->auto_rotation_enabled_) {
-    // Change orientation to initial platform orientation when disabled.
-    self->OnScreenOrientationChanged(
-        ToScreenOrientation(ROTATION_EVENT_0));
-  } else if (self->auto_rotation_enabled_ && !sf_check_rotation(&value)) {
-    self->OnScreenOrientationChanged(
-        ToScreenOrientation(static_cast<int>(value)));
+  if (!sensor->auto_rotation_enabled_ &&
+      sensor->GetCurrentRotation() != gfx::Display::ROTATE_0) {
+    // Change orientation to initial platform orientation when
+    // auto rotation is disabled.
+    sensor->OnRotationChanged(gfx::Display::ROTATE_0);
+  } else if (sensor->auto_rotation_enabled_ && !sf_check_rotation(&value)) {
+    // Notify observers the current orientation.
+    gfx::Display::Rotation rotation =
+          sensor->ToDisplayRotation(static_cast<int>(value));
+    if (rotation != sensor->GetCurrentRotation())
+      sensor->OnRotationChanged(rotation);
   }
 }
 

--- a/tizen/mobile/sensor/tizen_platform_sensor.h
+++ b/tizen/mobile/sensor/tizen_platform_sensor.h
@@ -33,12 +33,15 @@ class TizenPlatformSensor : public SensorProvider {
   virtual void Finish() OVERRIDE;
 
  private:
+  gfx::Display::Rotation ToDisplayRotation(int rotation) const;
+
   bool auto_rotation_enabled_;
   int accel_handle_;
   int gyro_handle_;
 
   static void OnEventReceived(unsigned int event_type,
-      sensor_event_data_t* event_data, void* udata);
+                              sensor_event_data_t* event_data,
+                              void* udata);
   static void OnAutoRotationEnabledChanged(keynode_t* node, void* udata);
 
   DISALLOW_COPY_AND_ASSIGN(TizenPlatformSensor);

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -285,6 +285,9 @@
             '<(DEPTH)/third_party/jsoncpp/jsoncpp.gyp:jsoncpp',
           ],
           'sources': [
+            'runtime/browser/ui/screen_orientation.h',
+            'runtime/extension/screen_orientation_extension.cc',
+            'runtime/extension/screen_orientation_extension.h',
             'runtime/browser/tizen/tizen_locale_listener.cc',
             'runtime/browser/tizen/tizen_locale_listener.h',
           ],


### PR DESCRIPTION
This commit is not a requirement for moving to M36, so we can revert it
for now, have a much smaller squashed commit rolling DEPS.xwalk to M36
and then land it again.
