### PR TITLE
[Android] Expand the path of app_root in LaunchScreen

### DIFF
--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -164,7 +164,7 @@ def CustomizeLaunchScreen(app_manifest, sanitized_name):
   if not app_manifest:
     return False
   parser = ManifestJsonParser(os.path.expanduser(app_manifest))
-  app_root = os.path.dirname(app_manifest)
+  app_root = os.path.dirname(parser.input_path)
   default = CustomizeByOrientation(parser, 'default',
                                    sanitized_name, app_root)
   portrait = CustomizeByOrientation(parser, 'portrait',


### PR DESCRIPTION
If the provided path of manifest.json is not absolute, the launch screen image can not be found 
and will cause build fail.
Need to expand the path of app_root.

BUG=XWALK-1795
