### PR TITLE
[Android] Include "-DOS=android" in xwalk_android_gyp by default

### DIFF
--- a/build/android/envsetup.sh
+++ b/build/android/envsetup.sh
@@ -12,5 +12,5 @@ export PATH=$PATH:${ENVSETUP_GYP_CHROME_SRC}/xwalk/build/android
 # The purpose of this function is to do the same as android_gyp(), but calling
 # gyp_xwalk instead.
 xwalk_android_gyp() {
-  "${ENVSETUP_GYP_CHROME_SRC}/xwalk/gyp_xwalk" --check "$@"
+  "${ENVSETUP_GYP_CHROME_SRC}/xwalk/gyp_xwalk" --check -DOS=android "$@"
 }


### PR DESCRIPTION
In M36, android_gyp is still available in upstream, but it is
going to be removed in recent future.
We can still use it for crosswalk 7 with appending "-DOS=android"
by default in xwalk_android_gyp.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1803
