### PR TITLE
[Android] Remove some useless statements inside `finally' clauses.

### DIFF
--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -61,8 +61,6 @@ class ManifestJsonParser(object):
     except KeyError as error:
       print('There is a field error in manifest.json file: %s' % error)
       sys.exit(1)
-    finally:
-      input_file.close()
 
   def _output_items(self):
     """ The manifest field items are reorganized and returned as a

--- a/app/tools/android/parse_xpk.py
+++ b/app/tools/android/parse_xpk.py
@@ -115,7 +115,6 @@ def main():
     except IOError:
       HandleError(EXIT_CODE_XPK_FILE_IO_ERROR)
     finally:
-      xpk_file.close()
       if zip_path and os.path.isfile(zip_path):
         os.remove(zip_path)
   else:


### PR DESCRIPTION
This is Python, so there's no need to manually call close() in files most of
the time.
