### PR TITLE
[Runtime][Tizen] Fix hwkey issue after M36 rebase.

### DIFF
--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -19,6 +19,7 @@
 #include "ui/events/event.h"
 #include "ui/events/event_constants.h"
 #include "ui/events/keycodes/keyboard_codes_posix.h"
+#include "ui/events/platform/platform_event_source.h"
 #include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
 #endif
 
@@ -70,9 +71,15 @@ ApplicationTizen::ApplicationTizen(
     RuntimeContext* runtime_context,
     Application::Observer* observer)
     : Application(data, runtime_context, observer) {
+#if defined(USE_OZONE)
+  ui::PlatformEventSource::GetInstance()->AddPlatformEventObserver(this);
+#endif
 }
 
 ApplicationTizen::~ApplicationTizen() {
+#if defined(USE_OZONE)
+  ui::PlatformEventSource::GetInstance()->RemovePlatformEventObserver(this);
+#endif
 }
 
 void ApplicationTizen::Hide() {
@@ -133,8 +140,10 @@ void ApplicationTizen::InitSecurityPolicy() {
 }
 
 #if defined(USE_OZONE)
+void ApplicationTizen::WillProcessEvent(const ui::PlatformEvent& event) {}
+
 void ApplicationTizen::DidProcessEvent(
-    const base::NativeEvent& event) {
+    const ui::PlatformEvent& event) {
   ui::Event* ui_event = static_cast<ui::Event*>(event);
   if (!ui_event->IsKeyEvent() || ui_event->type() != ui::ET_KEY_PRESSED)
     return;

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -7,10 +7,19 @@
 #include "base/event_types.h"
 #include "xwalk/application/browser/application.h"
 
+#if defined(USE_OZONE)
+#include "ui/events/platform/platform_event_observer.h"
+#include "ui/events/platform/platform_event_types.h"
+#endif
+
 namespace xwalk {
 namespace application {
 
-class ApplicationTizen : public Application {
+class ApplicationTizen :  // NOLINT
+#if defined(USE_OZONE)
+  public ui::PlatformEventObserver,
+#endif
+  public Application {
  public:
   virtual ~ApplicationTizen();
   void Hide();
@@ -25,7 +34,8 @@ class ApplicationTizen : public Application {
   virtual void InitSecurityPolicy() OVERRIDE;
 
 #if defined(USE_OZONE)
-  virtual void DidProcessEvent(const base::NativeEvent& event);
+  virtual void WillProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
+  virtual void DidProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
 #endif
 };
 


### PR DESCRIPTION
Crosswalk fetches hardware key events from MessagePumpOzone before.
However, MessagePumpObserver is deprecated in M36, it is replaced by
PlatformEventObserver, which is installed on a PlatformEventSource.
Besides, the ozone message pump is also removed in M36 and is
substituted by the default message pump based on libevent instead.

This patch fixes above issue and now we support 'hwkey' feature again.

BUG = XWALK-1420
