### PR TITLE
[DO NOT MERGE][Runtime] Reconstruct load config xml.

### DIFF
--- a/application/common/application_config_xml_loader.cc
+++ b/application/common/application_config_xml_loader.cc
@@ -1,0 +1,163 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/application_config_xml_loader.h"
+
+#include <set>
+
+#include "base/files/file_path.h"
+#include "base/file_util.h"
+#include "base/strings/stringprintf.h"
+#include "base/values.h"
+#include "third_party/libxml/src/include/libxml/tree.h"
+#include "xwalk/application/common/application_config_xml_loader_util.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+namespace application {
+
+using namespace config_xml_loader; // NOLINT
+
+base::DictionaryValue* ConfigXMLLoader::Load(const base::FilePath& xml_path,
+                                             std::string* error) {
+  Reset();
+  xmlDoc * doc = NULL;
+  doc = xmlReadFile(xml_path.MaybeAsASCII().c_str(), NULL, 0);
+  if (doc == NULL) {
+    *error = base::StringPrintf("%s",
+        application_manifest_errors::kManifestUnreadable);
+    return NULL;
+  }
+  root_ = xmlDocGetRootElement(doc);
+  if (root_->type != XML_ELEMENT_NODE) {
+    *error = "Root node of config.xml is not an element node.";
+    return NULL;
+  }
+  if (xmlStrEqual(kWidgetNameKey, root_->name)) {
+    *error = "Root node name of config.xml should be widget.";
+    return NULL;
+  }
+
+  if (!LoadWidgetNamesapce()) {
+    *error = error_;
+    return NULL;
+  }
+
+  if (!LoadWidgetAttribute()) {
+    *error = error_;
+    return NULL;
+  }
+
+  for (xmlNodePtr node = root_->children; node; node = node->next) {
+    if (!LoadWidgetEachChildElement(node))
+      InsertElement(widget_.get(), node, LoadExtensionsXMLNode(node), true);
+  }
+
+  scoped_ptr<base::DictionaryValue> result(new base::DictionaryValue);
+  result->Set(ToString(root_->name), widget_.release());
+  return result.release();
+}
+
+void ConfigXMLLoader::Reset() {
+  error_.clear();
+  root_ = NULL;
+  widget_.reset(new base::DictionaryValue);
+  preference_names_.clear();
+}
+
+bool ConfigXMLLoader::LoadWidgetNamesapce() {
+  for (xmlNsPtr ns = root_->ns; ns; ns= ns->next) {
+    if (xmlStrEqual(kNamespaceValue, ns->href))
+      return true;
+  }
+  error_ = base::StringPrintf("There is no namespace %s.", kNamespaceValue);
+  return false;
+}
+
+bool ConfigXMLLoader::LoadWidgetAttribute() {
+  SetAttribute(widget_.get(), root_, kAttributeDefaultlocaleKey);
+  SetAttribute(widget_.get(), root_, kAttributeIdKey, IRI);
+  SetAttribute(widget_.get(), root_, kAttributeVersionKey, DIR);
+  SetAttribute(widget_.get(), root_, kAttributeHeightKey);
+  SetAttribute(widget_.get(), root_, kAttributeWidthKey);
+  SetAttribute(widget_.get(), root_, kAttributeViewmodesKey);
+  return true;
+}
+
+bool ConfigXMLLoader::LoadWidgetEachChildElement(xmlNodePtr node) {
+  scoped_ptr<base::DictionaryValue> element(new base::DictionaryValue);
+
+  if (xmlStrEqual(kNameNameKey, node->name)) {
+    SetAttribute(element.get(), node, kAttributeLangKey);
+    SetAttribute(element.get(), node, kAttributeShortKey, DIR);
+    element->SetString(
+        kTextKey, base::CollapseWhitespace(GetNodeText(node), false));
+    InsertElement(widget_.get(), node, element.release(), true);
+    return true;
+  }
+
+  if (xmlStrEqual(kDescriptionNameKey, node->name)) {
+    SetAttribute(element.get(), node, kAttributeLangKey);
+    element->SetString(kTextKey, GetNodeText(node));
+    InsertElement(widget_.get(), node, element.release(), true);
+    return true;
+  }
+
+  if (xmlStrEqual(kAuthorNameKey, node->name)) {
+    SetAttribute(element.get(), node, kAttributeHrefKey, IRI);
+    SetAttribute(element.get(), node, kAttributeEmailKey);
+    element->SetString(
+        kTextKey, base::CollapseWhitespace(GetNodeText(node), false));
+    InsertElement(widget_.get(), node, element.release(), false);
+    return true;
+  }
+
+  if (xmlStrEqual(kLicenseNameKey, node->name)) {
+    SetAttribute(element.get(), node, kAttributeHrefKey, IRI);
+    element->SetString(kTextKey, GetNodeText(node));
+    InsertElement(widget_.get(), node, element.release(), false);
+    return true;
+  }
+
+  if (xmlStrEqual(kIconNameKey, node->name)) {
+    if (!SetAttribute(element.get(), node, kAttributeSrcKey))
+      return true;
+    SetAttribute(element.get(), node, kAttributeWidthKey);
+    SetAttribute(element.get(), node, kAttributeHeightKey);
+    InsertElement(widget_.get(), node, element.release(), true);
+    return true;
+  }
+
+  if (xmlStrEqual(kContentNameKey, node->name)) {
+    if (!SetAttribute(element.get(), node, kAttributeSrcKey))
+      return true;
+    SetAttribute(element.get(), node, kAttributeTypeKey);
+    SetAttribute(element.get(), node, kAttributeEncodingKey);
+    InsertElement(widget_.get(), node, element.release(), false);
+    return true;
+  }
+
+  if (xmlStrEqual(kFeatureNameKey, node->name)) {
+    // TODO(hongzhang) : Load feature element according to widget_ process
+    // rules.
+    InsertElement(widget_.get(), node, LoadExtensionsXMLNode(node), true);
+    return true;
+  }
+
+  if (xmlStrEqual(kPreferenceNameKey, node->name)) {
+    base::string16 preference_name = GetAttribute(node, kAttributeNameKey);
+    if (preference_names_.find(preference_name) != preference_names_.end())
+      return true;
+    SetAttribute(element.get(), node, kAttributeNameKey);
+    SetAttribute(element.get(), node, kAttributeValueKey);
+    SetAttribute(element.get(), node, kAttributeReadonlyKey);
+    InsertElement(widget_.get(), node, element.release(), true);
+    return false;
+  }
+
+  return false;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/application_config_xml_loader.h
+++ b/application/common/application_config_xml_loader.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_APPLICATION_CONFIG_XML_LOADER_H_
+#define XWALK_APPLICATION_COMMON_APPLICATION_CONFIG_XML_LOADER_H_
+
+#include <string>
+#include <set>
+
+#include "base/files/file_path.h"
+#include "base/memory/scoped_ptr.h"
+#include "base/strings/string16.h"
+#include "base/values.h"
+#include "third_party/libxml/src/include/libxml/tree.h"
+
+namespace xwalk {
+namespace application {
+// Load config.xml into a DictionaryValue with rules according to
+// http://www.w3.org/TR/widgets/#step-7-process-the-configuration-document
+// For example config.xml
+// <?xml version="1.0" encoding="UTF-8"?>
+// <widget id="example:" xmlns="http://www.w3.org/ns/widgets"
+//     xmlns:tizen="http://tizen.org/ns/widgets">
+//  <name>English</name>
+//  <name xml:lang="zh-cn">Chinese</name>
+//  <author>example author</author>
+//  <author>author is zero or one, so this element will be ignored</author>
+//  <tizen:application id="UM93QrpfK6.example" package="UM93QrpfK6"
+//     required_version="2.1"/>
+// </widget>
+// DictionaryValue :
+// widget : {
+//   "@namespace" : "http://www.w3.org/ns/widgets",
+//   "@id" : "example:",
+//   "name" : [
+//     {
+//       "#text" : "English"
+//     },
+//     {
+//       "@lang" : "zh-cn"
+//       "#text" : "Chinese"
+//     }
+//   ],
+//   "author" : {
+//     "#text" : "example author"
+//   },
+//   "tizen:application" {
+//     "@namespace" : "http://tizen.org/ns/widgets",
+//     "@id" : "UM93QrpfK6.example",
+//     "@package" : "UM93QrpfK6",
+//     "@required_version" : "2.1"
+//   }
+// }
+// Note : all user defined element(for example <tizen:application>) will
+// be a list if there are more than one element in document.
+class ConfigXMLLoader {
+ public:
+  base::DictionaryValue* Load(const base::FilePath& xml_path,
+                              std::string* error);
+
+ protected:
+  virtual void Reset();
+  virtual bool LoadWidgetNamesapce();
+  virtual bool LoadWidgetAttribute();
+  virtual bool LoadWidgetEachChildElement(xmlNodePtr node);
+
+  std::string error_;
+  xmlNodePtr root_;
+  scoped_ptr<base::DictionaryValue> widget_;
+  std::set<base::string16> preference_names_;
+};
+
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_APPLICATION_CONFIG_XML_LOADER_H_

--- a/application/common/application_config_xml_loader_util.cc
+++ b/application/common/application_config_xml_loader_util.cc
@@ -1,0 +1,210 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/application_config_xml_loader_util.h"
+
+#include "base/i18n/rtl.h"
+#include "base/strings/string16.h"
+#include "base/strings/utf_string_conversions.h"
+#include "url/gurl.h"
+
+namespace xwalk {
+namespace application {
+namespace {
+const char kDirLTRValue[] = "ltr";
+const char kDirRTLValue[] = "rtl";
+const char kDirLROValue[] = "lro";
+const char kDirRLOValue[] = "rlo";
+const base::char16 kLRE = base::i18n::kLeftToRightEmbeddingMark;
+const base::char16 kRLE = base::i18n::kRightToLeftEmbeddingMark;
+const base::char16 kLRO = base::i18n::kLeftToRightOverride;
+const base::char16 kRLO = base::i18n::kRightToLeftOverride;
+const base::char16 kPDF = base::i18n::kPopDirectionalFormatting;
+}  // namespace
+namespace config_xml_loader {
+const char kAttributePrefix[] = "@";
+const char kNamespaceKey[] = "@namespace";
+const char kNamespaceNameConnectKey[] = ":";
+const char kTextKey[] = "#text";
+
+// Element name keys.
+const xmlChar kWidgetNameKey[] = "widget";
+const xmlChar kNameNameKey[] = "name";
+const xmlChar kDescriptionNameKey[] = "description";
+const xmlChar kAuthorNameKey[] = "author";
+const xmlChar kLicenseNameKey[] = "license";
+const xmlChar kIconNameKey[] = "icon";
+const xmlChar kContentNameKey[] = "content";
+const xmlChar kFeatureNameKey[] = "feature";
+const xmlChar kPreferenceNameKey[] = "preference";
+const xmlChar kParamNameKey[] = "param";
+const xmlChar kSpanNameKey[] = "span";
+
+// Namespace value.
+const xmlChar kNamespaceValue[] = "http://www.w3.org/ns/widgets";
+
+// Attribute keys.
+const xmlChar kAttributeDirKey[] = "dir";
+const xmlChar kAttributeLangKey[] = "lang";
+const xmlChar kAttributeIdKey[] = "id";
+const xmlChar kAttributeVersionKey[] = "version";
+const xmlChar kAttributeHeightKey[] = "height";
+const xmlChar kAttributeWidthKey[] = "width";
+const xmlChar kAttributeViewmodesKey[] = "viewmodes";
+const xmlChar kAttributeDefaultlocaleKey[] = "defaultlocale";
+const xmlChar kAttributeShortKey[] = "short";
+const xmlChar kAttributeHrefKey[] = "href";
+const xmlChar kAttributeEmailKey[] = "email";
+const xmlChar kAttributeSrcKey[] = "src";
+const xmlChar kAttributeTypeKey[] = "type";
+const xmlChar kAttributeEncodingKey[] = "encoding";
+const xmlChar kAttributeRequiredKey[] = "required";
+const xmlChar kAttributeNameKey[] = "name";
+const xmlChar kAttributeValueKey[] = "value";
+const xmlChar kAttributeReadonlyKey[] = "readonly";
+
+inline base::string16 ToString16(const xmlChar* string_ptr) {
+  return base::UTF8ToUTF16(ToString(string_ptr));
+}
+
+// To attritube key in DictionaryValue
+inline std::string ToDVAttrKey(const xmlChar* string_ptr) {
+  return kAttributePrefix + ToString(string_ptr);
+}
+
+// Get a dir text, and this text is from node(maybe a attribute)
+base::string16 GetDirText(const base::string16& text, xmlNodePtr node) {
+  std::string dir;
+  for (; node; node = node->parent) {
+    xmlChar* value_ptr = xmlGetProp(node, kAttributeDirKey);
+    if (value_ptr) {
+      dir = ToString(value_ptr);
+      xmlFree(value_ptr);
+      break;
+    }
+  }
+  if (dir == kDirLTRValue)
+    return kLRE + text + kPDF;
+  if (dir == kDirRTLValue)
+    return kRLE + text + kPDF;
+  if (dir == kDirLROValue)
+    return kLRO + text + kPDF;
+  if (dir == kDirRLOValue)
+    return kRLO + text + kPDF;
+  return text;
+}
+
+// Get a node text when the node may support span and dir.
+// For example :
+// <name dir="ltr">n<span dir="lro">a<span dir="rlo">m</span></span>e</name>
+// we will get value => "n[LRO]a[RLO]m[PDF][PDF]e"
+base::string16 GetNodeText(xmlNodePtr root) {
+  DCHECK(root);
+  if (root->type != XML_ELEMENT_NODE)
+    return base::string16();
+
+  base::string16 text;
+  for (xmlNode* node = root->children; node; node = node->next) {
+    if (node->type == XML_TEXT_NODE || node->type == XML_CDATA_SECTION_NODE) {
+      text = text + base::i18n::StripWrappingBidiControlCharacters(
+                        ToString16(node->content));
+    } else {
+      text = text + GetNodeText(node);
+    }
+  }
+  return GetDirText(text, root);
+}
+
+std::string GetNamespacePrefix(xmlNode* root) {
+  DCHECK(root);
+  if (!root->ns || !root->ns->prefix)
+    return base::EmptyString();
+  return ToString(root->ns->prefix) + kNamespaceNameConnectKey;
+}
+
+// Insert an DictionaryValue of element to parent element DictionaryValue,
+// if the element is already exist(same name) and can_be_list is true, we will
+// have a ListValue in element_name dictionary of parent element, or if
+// can_be_list if false, the element will be ignored.
+bool InsertElement(base::DictionaryValue* parent_value,
+                   xmlNodePtr node,
+                   base::DictionaryValue* element_value,
+                   bool can_be_list) {
+  if (!parent_value || !element_value || !node)
+    return false;
+  std::string element_name = ToString(node->name);
+  if (!parent_value->HasKey(element_name)) {
+    parent_value->Set(element_name, element_value);
+    return true;
+  } else if (!can_be_list) {
+    return false;
+  }
+
+  base::Value* temp;
+  parent_value->Get(element_name, &temp);
+  DCHECK(temp);
+
+  base::ListValue* list;
+  base::DictionaryValue* dict;
+  if (temp->GetAsList(&list)) {
+    list->Append(element_value);
+  } else if (temp->GetAsDictionary(&dict)) {
+    list = new base::ListValue();
+    list->Append(dict->DeepCopy());
+    list->Append(element_value);
+    parent_value->Set(element_name, list);
+  }
+  return true;
+}
+
+base::string16 NodeListGetString(xmlDocPtr doc, xmlNodePtr children) {
+  xmlChar* value_ptr = xmlNodeListGetString(doc, children, 1);
+  base::string16 value(ToString16(value_ptr));
+  xmlFree(value_ptr);
+  return value;
+}
+
+// Load extensions XML node into Dictionary structure.
+base::DictionaryValue* LoadExtensionsXMLNode(xmlNode* root) {
+  DCHECK(root);
+  scoped_ptr<base::DictionaryValue> value(new base::DictionaryValue);
+  if (root->type != XML_ELEMENT_NODE)
+    return NULL;
+  if (root->ns)
+    value->SetString(kNamespaceKey, ToString(root->ns->href));
+  for (xmlAttr* attr = root->properties; attr; attr = attr->next) {
+    value->SetString(ToDVAttrKey(attr->name),
+                     NodeListGetString(root->doc, attr->children));
+  }
+  for (xmlNode* node = root->children; node; node = node->next) {
+    InsertElement(value.get(), node, LoadExtensionsXMLNode(node), true);
+  }
+  value->SetString(kTextKey, NodeListGetString(root->doc, root->children));
+  return value.release();
+}
+
+base::string16 GetAttribute(xmlNodePtr node,
+                            const xmlChar* key,
+                            bool is_dir_attr) {
+  xmlChar* value_ptr = xmlGetProp(node, key);
+  base::string16 value(base::CollapseWhitespace(ToString16(value_ptr), false));
+  xmlFree(value_ptr);
+  if (is_dir_attr)
+    return GetDirText(value, node);
+  return value;
+}
+
+bool SetAttribute(base::DictionaryValue* element_value,
+                  xmlNodePtr node,
+                  const xmlChar* key,
+                  AttributeType attribute_type) {
+  base::string16 value(GetAttribute(node, key, attribute_type == DIR));
+  if (value.empty() || (attribute_type == IRI && !GURL(value).is_valid()))
+    return false;
+  element_value->SetString(ToDVAttrKey(key), value);
+  return true;
+}
+}  // namespace config_xml_loader
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/application_config_xml_loader_util.h
+++ b/application/common/application_config_xml_loader_util.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_APPLICATION_CONFIG_XML_LOADER_UTIL_H_
+#define XWALK_APPLICATION_COMMON_APPLICATION_CONFIG_XML_LOADER_UTIL_H_
+
+#include <string>
+
+#include "base/strings/string_util.h"
+#include "base/values.h"
+#include "third_party/libxml/src/include/libxml/tree.h"
+
+namespace xwalk {
+namespace application {
+namespace config_xml_loader {
+extern const char kAttributePrefix[];
+extern const char kNamespaceKey[];
+extern const char kNamespaceNameConnectKey[];
+extern const char kTextKey[];
+
+// Element name keys.
+extern const xmlChar kWidgetNameKey[];
+extern const xmlChar kNameNameKey[];
+extern const xmlChar kDescriptionNameKey[];
+extern const xmlChar kAuthorNameKey[];
+extern const xmlChar kLicenseNameKey[];
+extern const xmlChar kIconNameKey[];
+extern const xmlChar kContentNameKey[];
+extern const xmlChar kFeatureNameKey[];
+extern const xmlChar kPreferenceNameKey[];
+extern const xmlChar kParamNameKey[];
+extern const xmlChar kSpanNameKey[];
+
+// Namespace value.
+extern const xmlChar kNamespaceValue[];
+
+// Attribute keys.
+extern const xmlChar kAttributeDirKey[];
+extern const xmlChar kAttributeLangKey[];
+extern const xmlChar kAttributeIdKey[];
+extern const xmlChar kAttributeVersionKey[];
+extern const xmlChar kAttributeHeightKey[];
+extern const xmlChar kAttributeWidthKey[];
+extern const xmlChar kAttributeViewmodesKey[];
+extern const xmlChar kAttributeDefaultlocaleKey[];
+extern const xmlChar kAttributeShortKey[];
+extern const xmlChar kAttributeHrefKey[];
+extern const xmlChar kAttributeEmailKey[];
+extern const xmlChar kAttributeSrcKey[];
+extern const xmlChar kAttributeTypeKey[];
+extern const xmlChar kAttributeEncodingKey[];
+extern const xmlChar kAttributeRequiredKey[];
+extern const xmlChar kAttributeNameKey[];
+extern const xmlChar kAttributeValueKey[];
+extern const xmlChar kAttributeReadonlyKey[];
+
+inline std::string ToString(const xmlChar* string_ptr) {
+  if (!string_ptr)
+    return base::EmptyString();
+  return std::string(reinterpret_cast<const char*>(string_ptr));
+}
+
+// Get a dir text, and this text is from node(maybe a attribute)
+base::string16 GetDirText(const base::string16& text, xmlNodePtr node);
+
+// Get a node text when the node may support span and dir.
+// For example :
+// <name dir="ltr">n<span dir="lro">a<span dir="rlo">m</span></span>e</name>
+// we will get value => "n[LRO]a[RLO]m[PDF][PDF]e"
+base::string16 GetNodeText(xmlNodePtr root);
+
+// Insert an DictionaryValue of element to parent element DictionaryValue,
+// if the element is already exist(same name) and can_be_list is true, we will
+// have a ListValue in element_name dictionary of parent element, or if
+// can_be_list if false, the element will be ignored.
+bool InsertElement(base::DictionaryValue* parent_value,
+                   xmlNodePtr node,
+                   base::DictionaryValue* element_value,
+                   bool can_be_list);
+
+// Load extensions XML node into Dictionary structure.
+base::DictionaryValue* LoadExtensionsXMLNode(xmlNode* root);
+
+base::string16 GetAttribute(xmlNodePtr node,
+                            const xmlChar* key,
+                            bool is_dir_attr = false);
+
+enum AttributeType {
+  NORMAL,
+  DIR,
+  IRI
+};
+
+bool SetAttribute(base::DictionaryValue* element_value,
+                  xmlNodePtr node,
+                  const xmlChar* key,
+                  AttributeType attribute_type = NORMAL);
+
+}  // namespace config_xml_loader
+}  // namespace application
+}  // namespace xwalk
+
+
+#endif  // XWALK_APPLICATION_COMMON_APPLICATION_CONFIG_XML_LOADER_UTIL_H_

--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -12,19 +12,16 @@
 #include "base/files/file_path.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/file_util.h"
-#include "base/i18n/rtl.h"
 #include "base/json/json_file_value_serializer.h"
+#include "base/lazy_instance.h"
 #include "base/logging.h"
 #include "base/metrics/histogram.h"
 #include "base/path_service.h"
-#include "base/strings/string16.h"
 #include "base/strings/stringprintf.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_restrictions.h"
 #include "net/base/escape.h"
 #include "net/base/file_stream.h"
-#include "third_party/libxml/src/include/libxml/tree.h"
-#include "ui/base/l10n/l10n_util.h"
+#include "xwalk/application/common/application_config_xml_loader.h"
 #include "xwalk/application/browser/installer/package.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/application_manifest_constants.h"
@@ -38,120 +35,6 @@ namespace keys = xwalk::application_manifest_keys;
 namespace widget_keys = xwalk::application_widget_keys;
 
 namespace {
-const char kAttributePrefix[] = "@";
-const char kNamespaceKey[] = "@namespace";
-const char kTextKey[] = "#text";
-
-const xmlChar kWidgetNodeKey[] = "widget";
-const xmlChar kNameNodeKey[] = "name";
-const xmlChar kDescriptionNodeKey[] = "description";
-const xmlChar kAuthorNodeKey[] = "author";
-const xmlChar kLicenseNodeKey[] = "license";
-const xmlChar kVersionAttributeKey[] = "version";
-const xmlChar kShortAttributeKey[] = "short";
-const xmlChar kDirAttributeKey[] = "dir";
-
-const char kDirLTRKey[] = "ltr";
-const char kDirRTLKey[] = "rtl";
-const char kDirLROKey[] = "lro";
-const char kDirRLOKey[] = "rlo";
-
-inline char* ToCharPointer(void* ptr) {
-  return reinterpret_cast<char *>(ptr);
-}
-
-inline const char* ToConstCharPointer(const void* ptr) {
-  return reinterpret_cast<const char*>(ptr);
-}
-
-base::string16 ToSting16(const xmlChar* string_ptr) {
-  return base::UTF8ToUTF16(std::string(ToConstCharPointer(string_ptr)));
-}
-
-base::string16 GetDirText(const base::string16& text, const std::string& dir) {
-  if (dir == kDirLTRKey)
-    return base::i18n::kLeftToRightEmbeddingMark
-           + text
-           + base::i18n::kPopDirectionalFormatting;
-
-  if (dir == kDirRTLKey)
-    return base::i18n::kRightToLeftEmbeddingMark
-           + text
-           + base::i18n::kPopDirectionalFormatting;
-
-  if (dir == kDirLROKey)
-    return base::i18n::kLeftToRightOverride
-           + text
-           + base::i18n::kPopDirectionalFormatting;
-
-  if (dir == kDirRLOKey)
-    return base::i18n::kRightToLeftOverride
-           + text
-           + base::i18n::kPopDirectionalFormatting;
-
-  return text;
-}
-
-std::string GetNodeDir(xmlNode* node, const std::string& inherit_dir) {
-  DCHECK(node);
-  std::string dir(inherit_dir);
-
-  xmlAttr* prop = NULL;
-  for (prop = node->properties; prop; prop = prop->next) {
-    if (xmlStrEqual(prop->name, kDirAttributeKey)) {
-      char* prop_value = ToCharPointer(xmlNodeListGetString(
-          node->doc, prop->children, 1));
-      dir = prop_value;
-      xmlFree(prop_value);
-      break;
-    }
-  }
-
-  return dir;
-}
-
-base::string16 GetNodeText(xmlNode* root, const std::string& inherit_dir) {
-  DCHECK(root);
-  if (root->type != XML_ELEMENT_NODE)
-    return base::string16();
-
-  std::string current_dir(GetNodeDir(root, inherit_dir));
-  base::string16 text;
-  for (xmlNode* node = root->children; node; node = node->next) {
-    if (node->type == XML_TEXT_NODE || node->type == XML_CDATA_SECTION_NODE) {
-      text = text + base::i18n::StripWrappingBidiControlCharacters(
-                        ToSting16(node->content));
-    } else {
-      text = text + GetNodeText(node, current_dir);
-    }
-  }
-  return GetDirText(text, current_dir);
-}
-
-// According to widget specification, this two prop need to support dir.
-// see detail on http://www.w3.org/TR/widgets/#the-dir-attribute
-inline bool IsPropSupportDir(xmlNode* root, xmlAttr* prop) {
-  if (xmlStrEqual(root->name, kWidgetNodeKey)
-     && xmlStrEqual(prop->name, kVersionAttributeKey))
-    return true;
-  if (xmlStrEqual(root->name, kNameNodeKey)
-     && xmlStrEqual(prop->name, kShortAttributeKey))
-    return true;
-  return false;
-}
-
-// Only this four items need to support span and ignore other element.
-// Besides xmlNodeListGetString can not support dir prop of span.
-// See http://www.w3.org/TR/widgets/#the-span-element-and-its-attributes
-inline bool IsElementSupportSpanAndDir(xmlNode* root) {
-  if (xmlStrEqual(root->name, kNameNodeKey)
-     || xmlStrEqual(root->name, kDescriptionNodeKey)
-     || xmlStrEqual(root->name, kAuthorNodeKey)
-     || xmlStrEqual(root->name, kLicenseNodeKey))
-    return true;
-  return false;
-}
-
 bool GetPackageType(const base::FilePath& path,
                     xwalk::application::Package::Type* package_type,
                     std::string* error) {
@@ -178,118 +61,8 @@ bool GetPackageType(const base::FilePath& path,
 namespace xwalk {
 namespace application {
 
-// Load XML node into Dictionary structure.
-// The keys for the XML node to Dictionary mapping are described below:
-// XML                                 Dictionary
-// <e></e>                             "e":{"#text": ""}
-// <e>textA</e>                        "e":{"#text":"textA"}
-// <e attr="val">textA</e>             "e":{ "@attr":"val", "#text": "textA"}
-// <e> <a>textA</a> <b>textB</b> </e>  "e":{
-//                                       "a":{"#text":"textA"}
-//                                       "b":{"#text":"textB"}
-//                                     }
-// <e> <a>textX</a> <a>textY</a> </e>  "e":{
-//                                       "a":[ {"#text":"textX"},
-//                                             {"#text":"textY"}]
-//                                     }
-// <e> textX <a>textY</a> </e>         "e":{ "#text":"textX",
-//                                           "a":{"#text":"textY"}
-//                                     }
-//
-// For elements that are specified under a namespace, the dictionary
-// will add '@namespace' key for them, e.g.,
-// XML:
-// <e xmln="linkA" xmlns:N="LinkB">
-//   <sub-e1> text1 </sub-e>
-//   <N:sub-e2 text2 />
-// </e>
-// will be saved in Dictionary as,
-// "e":{
-//   "#text": "",
-//   "@namespace": "linkA"
-//   "sub-e1": {
-//     "#text": "text1",
-//     "@namespace": "linkA"
-//   },
-//   "sub-e2": {
-//     "#text":"text2"
-//     "@namespace": "linkB"
-//   }
-// }
-base::DictionaryValue* LoadXMLNode(
-    xmlNode* root, const std::string& inherit_dir = "") {
-  scoped_ptr<base::DictionaryValue> value(new base::DictionaryValue);
-  if (root->type != XML_ELEMENT_NODE)
-    return NULL;
-
-  std::string current_dir(GetNodeDir(root, inherit_dir));
-
-  xmlAttr* prop = NULL;
-  for (prop = root->properties; prop; prop = prop->next) {
-    xmlChar* value_ptr = xmlNodeListGetString(root->doc, prop->children, 1);
-    base::string16 prop_value(ToSting16(value_ptr));
-    xmlFree(value_ptr);
-
-    if (IsPropSupportDir(root, prop))
-      prop_value = GetDirText(prop_value, current_dir);
-
-    value->SetString(
-        std::string(kAttributePrefix) + ToConstCharPointer(prop->name),
-        prop_value);
-  }
-
-  if (root->ns)
-    value->SetString(kNamespaceKey, ToConstCharPointer(root->ns->href));
-
-  for (xmlNode* node = root->children; node; node = node->next) {
-    std::string sub_node_name(ToConstCharPointer(node->name));
-    base::DictionaryValue* sub_value = LoadXMLNode(node, current_dir);
-    if (!sub_value)
-      continue;
-
-    if (!value->HasKey(sub_node_name)) {
-      value->Set(sub_node_name, sub_value);
-      continue;
-    }
-
-    base::Value* temp;
-    value->Get(sub_node_name, &temp);
-    DCHECK(temp);
-
-    if (temp->IsType(base::Value::TYPE_LIST)) {
-      base::ListValue* list;
-      temp->GetAsList(&list);
-      list->Append(sub_value);
-    } else {
-      DCHECK(temp->IsType(base::Value::TYPE_DICTIONARY));
-      base::DictionaryValue* dict;
-      temp->GetAsDictionary(&dict);
-      base::DictionaryValue* prev_value(new base::DictionaryValue());
-      prev_value = dict->DeepCopy();
-
-      base::ListValue* list = new base::ListValue();
-      list->Append(prev_value);
-      list->Append(sub_value);
-      value->Set(sub_node_name, list);
-    }
-  }
-
-  base::string16 text;
-  if (IsElementSupportSpanAndDir(root)) {
-    text = GetNodeText(root, current_dir);
-  } else {
-    xmlChar* text_ptr = xmlNodeListGetString(root->doc, root->children, 1);
-    if (text_ptr) {
-      text = ToSting16(text_ptr);
-      xmlFree(text_ptr);
-    }
-  }
-
-  if (!text.empty())
-    value->SetString(kTextKey, text);
-
-  return value.release();
-}
+static base::LazyInstance<ConfigXMLLoader> config_xml_loader =
+    LAZY_INSTANCE_INITIALIZER;
 
 scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_path,
@@ -378,20 +151,7 @@ static base::DictionaryValue* LoadManifestXpk(
 static base::DictionaryValue* LoadManifestWgt(
     const base::FilePath& manifest_path,
     std::string* error) {
-  xmlDoc * doc = NULL;
-  xmlNode* root_node = NULL;
-  doc = xmlReadFile(manifest_path.MaybeAsASCII().c_str(), NULL, 0);
-  if (doc == NULL) {
-    *error = base::StringPrintf("%s", errors::kManifestUnreadable);
-    return NULL;
-  }
-  root_node = xmlDocGetRootElement(doc);
-  base::DictionaryValue* dv = LoadXMLNode(root_node);
-  scoped_ptr<base::DictionaryValue> result(new base::DictionaryValue);
-  if (dv)
-    result->Set(ToConstCharPointer(root_node->name), dv);
-
-  return result.release();
+  return config_xml_loader.Get().Load(manifest_path, error);
 }
 
 base::DictionaryValue* LoadManifest(const base::FilePath& application_path,

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -35,6 +35,10 @@
         'browser/installer/xpk_package.cc',
         'browser/installer/xpk_package.h',
 
+        'common/application_config_xml_loader.cc',
+        'common/application_config_xml_loader.h',
+        'common/application_config_xml_loader_util.cc',
+        'common/application_config_xml_loader_util.h',
         'common/application_data.cc',
         'common/application_data.h',
         'common/application_file_util.cc',


### PR DESCRIPTION
In old logic we use a simple depth traversal to load xml, but it
hard to apply all rules according to
http://www.w3.org/TR/widgets/#step-7-process-the-configuration-document
So I reconstruct the logic of load config, and now it was more
comply with the standard process rule.

Besides this process will make the value we storage in DB
clearly.
