### PR TITLE
[Tizen] Further implementation of Blink-based orientation code

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,7 +7,7 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '36.0.1985.18'
-chromium_crosswalk_point = 'b2129f32fc231edc2eb401cf56a858dcb1477031'
+chromium_crosswalk_point = 'c282374abcd161a82bbcd5a51e02e33b1be0b1c4'
 blink_crosswalk_point = '7425f4985931cbd48e669c205a707cf1ff4ff6c6'
 v8_crosswalk_point = '262b54e087a73708031d42deb8a076fd36ae6ec2'
 ozone_wayland_point = 'a5ca2e9203e6a0567751cc0400995982b703dde4'

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -127,7 +127,7 @@ class Application : public Runtime::Observer,
   Application(scoped_refptr<ApplicationData> data,
               RuntimeContext* context,
               Observer* observer);
-
+  virtual bool Launch(const LaunchParams& launch_params);
   virtual void InitSecurityPolicy();
   void AddSecurityPolicy(const GURL& url, bool subdomains);
 
@@ -149,9 +149,6 @@ class Application : public Runtime::Observer,
                                    int exit_code) OVERRIDE;
   virtual void RenderProcessHostDestroyed(
       content::RenderProcessHost* host) OVERRIDE;
-
-
-  bool Launch(const LaunchParams& launch_params);
 
   // Try to extract the URL from different possible keys for entry points in the
   // manifest, returns it and the entry point used.

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -5,6 +5,7 @@
 #define XWALK_APPLICATION_BROWSER_APPLICATION_TIZEN_H_
 
 #include "base/event_types.h"
+#include "content/browser/screen_orientation/screen_orientation_provider.h"
 #include "xwalk/application/browser/application.h"
 
 #if defined(USE_OZONE)
@@ -19,7 +20,7 @@ class ApplicationTizen :  // NOLINT
 #if defined(USE_OZONE)
   public ui::PlatformEventObserver,
 #endif
-  public Application {
+  public Application, public content::ScreenOrientationProvider {
  public:
   virtual ~ApplicationTizen();
   void Hide();
@@ -30,13 +31,18 @@ class ApplicationTizen :  // NOLINT
   ApplicationTizen(scoped_refptr<ApplicationData> data,
                    RuntimeContext* context,
                    Application::Observer* observer);
-
+  virtual bool Launch(const LaunchParams& launch_params) OVERRIDE;
   virtual void InitSecurityPolicy() OVERRIDE;
 
 #if defined(USE_OZONE)
   virtual void WillProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
   virtual void DidProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
 #endif
+
+  // content::ScreenOrientationProvider overrides:
+  virtual void LockOrientation(
+      blink::WebScreenOrientationLockType orientations) OVERRIDE;
+  virtual void UnlockOrientation() OVERRIDE;
 };
 
 inline ApplicationTizen* ToApplicationTizen(Application* app) {

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -5,6 +5,7 @@
       'type': 'static_library',
       'dependencies': [
         '../base/base.gyp:base',
+        '../content/content.gyp:content_browser',
         '../crypto/crypto.gyp:crypto',
         '../ipc/ipc.gyp:ipc',
         '../sql/sql.gyp:sql',
@@ -125,6 +126,7 @@
         }],
       ],
       'include_dirs': [
+        '..',
         '../..',
       ],
     },

--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -119,6 +119,13 @@ NativeAppWindowTizen::~NativeAppWindowTizen() {
     SensorProvider::GetInstance()->RemoveObserver(this);
 }
 
+void NativeAppWindowTizen::LockOrientation(
+      blink::WebScreenOrientationLockType lock) {
+  orientation_lock_ = lock;
+  if (SensorProvider* sensor = SensorProvider::GetInstance())
+    OnScreenOrientationChanged(sensor->GetScreenOrientation());
+}
+
 void NativeAppWindowTizen::ViewHierarchyChanged(
     const ViewHierarchyChangedDetails& details) {
   if (details.is_add && details.child == this) {
@@ -198,17 +205,6 @@ blink::WebScreenOrientationType
       NOTREACHED();
   }
   return orientation;
-}
-
-void NativeAppWindowTizen::LockOrientation(
-      blink::WebScreenOrientationLockType lock) {
-  orientation_lock_ = lock;
-  if (SensorProvider* sensor = SensorProvider::GetInstance())
-    OnScreenOrientationChanged(sensor->GetScreenOrientation());
-}
-
-void NativeAppWindowTizen::UnlockOrientation() {
-  LockOrientation(blink::WebScreenOrientationLockDefault);
 }
 
 void NativeAppWindowTizen::OnScreenOrientationChanged(

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -5,13 +5,13 @@
 #ifndef XWALK_RUNTIME_BROWSER_UI_NATIVE_APP_WINDOW_TIZEN_H_
 #define XWALK_RUNTIME_BROWSER_UI_NATIVE_APP_WINDOW_TIZEN_H_
 
+#include "content/browser/screen_orientation/screen_orientation_provider.h"
 #include "xwalk/runtime/browser/ui/screen_orientation.h"
 #include "xwalk/runtime/browser/ui/native_app_window_views.h"
 #include "xwalk/tizen/mobile/sensor/sensor_provider.h"
 #include "xwalk/tizen/mobile/ui/tizen_system_indicator_widget.h"
 #include "xwalk/tizen/mobile/ui/widget_container_view.h"
 #include "ui/aura/window_observer.h"
-#include "content/browser/screen_orientation/screen_orientation_provider.h"
 
 namespace xwalk {
 
@@ -20,11 +20,13 @@ namespace xwalk {
 class NativeAppWindowTizen
     : public aura::WindowObserver,
       public NativeAppWindowViews,
-      public SensorProvider::Observer,
-      public content::ScreenOrientationProvider {
+      public SensorProvider::Observer {
  public:
   explicit NativeAppWindowTizen(const NativeAppWindow::CreateParams& params);
   virtual ~NativeAppWindowTizen();
+
+  void LockOrientation(
+      blink::WebScreenOrientationLockType orientations);
 
  private:
   blink::WebScreenOrientationType FindNearestAllowedOrientation(
@@ -35,11 +37,6 @@ class NativeAppWindowTizen
   // SensorProvider::Observer overrides:
   virtual void OnScreenOrientationChanged(
       blink::WebScreenOrientationType orientation) OVERRIDE;
-
-  // content::ScreenOrientationProvider overrides:
-  virtual void LockOrientation(
-      blink::WebScreenOrientationLockType orientations) OVERRIDE;
-  virtual void UnlockOrientation() OVERRIDE;
 
   // NativeAppWindowViews overrides:
   virtual void Initialize() OVERRIDE;
@@ -73,6 +70,10 @@ class NativeAppWindowTizen
 
   DISALLOW_COPY_AND_ASSIGN(NativeAppWindowTizen);
 };
+
+inline NativeAppWindowTizen* ToNativeAppWindowTizen(NativeAppWindow* window) {
+  return static_cast<NativeAppWindowTizen*>(window);
+}
 
 }  // namespace xwalk
 


### PR DESCRIPTION
The ApplicationTizen class is now inherited from 'content::ScreenOrientationProvider'
since both Application and ScreenOrientationDispatcherHost correspond to a single
renderer process.
Also ScreenOrientationProvider initialization code is added to ApplicationTizen::Launch
method.
