### PR TITLE
[Android] Pre-initialize the CPU information for ARM platform

### DIFF
--- a/runtime/app/android/xwalk_main_delegate_android.cc
+++ b/runtime/app/android/xwalk_main_delegate_android.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "base/command_line.h"
+#include "base/cpu.h"
 #include "base/file_util.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
@@ -37,6 +38,11 @@ bool XWalkMainDelegateAndroid::BasicStartupComplete(int* exit_code) {
 }
 
 void XWalkMainDelegateAndroid::PreSandboxStartup() {
+#if defined(ARCH_CPU_ARM_FAMILY)
+  // Create an instance of the CPU class to parse /proc/cpuinfo and cache
+  // cpu_brand info for ARM platform.
+  base::CPU cpu_info;
+#endif
   InitResourceBundle();
 }
 


### PR DESCRIPTION
On ARM platform, the cpu information is fetched from /proc/cpuinfo
which requires the right to allow accessing IO. Howerver, in Crosswalk,
the IO/IPC thread is not allowed to IO access unless
ThreadRestriction::SetIOAllowed(true) is called explicitly.

This fix is to pre-initialize the CPU info in advance to avoid thread
restrictions on reading /proc/cpuinfo.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1836
