### PR TITLE
[Android][Script] Fixes in XWalk debugging script

### DIFF
--- a/build/android/adb_gdb_xwalk_core_shell
+++ b/build/android/adb_gdb_xwalk_core_shell
@@ -7,12 +7,11 @@
 # Attach to or start a ContentShell process and debug it.
 # See --help for details.
 #
-cd ${CHROME_SRC}
+cd ${ENVSETUP_GYP_CHROME_SRC}
 
-PROGDIR=${CHROME_SRC}/build/android
 export ADB_GDB_PROGNAME=$(basename "$0")
 export ADB_GDB_ACTIVITY=.XWalkViewShellActivity
-"$PROGDIR"/adb_gdb \
+"${ENVSETUP_GYP_CHROME_SRC}"/build/android/adb_gdb \
     --program-name=XwViewShellActivity \
     --package-name=org.xwalk.core.xwview.shell \
     "$@"

--- a/build/android/adb_gdb_xwalk_runtime_client_embedded_shell
+++ b/build/android/adb_gdb_xwalk_runtime_client_embedded_shell
@@ -7,12 +7,11 @@
 # Attach to or start a ContentShell process and debug it.
 # See --help for details.
 #
-cd ${CHROME_SRC}
+cd ${ENVSETUP_GYP_CHROME_SRC}
 
-PROGDIR=${CHROME_SRC}/build/android
 export ADB_GDB_PROGNAME=$(basename "$0")
 export ADB_GDB_ACTIVITY=.XWalkRuntimeClientEmbeddedShellActivity
-"$PROGDIR"/adb_gdb \
+"${ENVSETUP_GYP_CHROME_SRC}"/build/android/adb_gdb \
     --program-name=XWalkRuntimeClientEmbeddedShellActivity \
     --package-name=org.xwalk.runtime.client.embedded.shell \
     "$@"


### PR DESCRIPTION
The env variable CHROME_SRC is not exposed, use ENVSETUP_GYP_CHROME_SRC
instead
