### PR TITLE
[Android] Fix null callback issue in XWalkView.evaluateJavaScript.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -201,12 +201,15 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
 
     public void evaluateJavascript(String script, ValueCallback<String> callback) {
         final ValueCallback<String>  fCallback = callback;
-        ContentViewCore.JavaScriptCallback coreCallback = new ContentViewCore.JavaScriptCallback() {
-            @Override
-            public void handleJavaScriptResult(String jsonResult) {
-                fCallback.onReceiveValue(jsonResult);
-            }
-        };
+        ContentViewCore.JavaScriptCallback coreCallback = null;
+        if (fCallback != null) {
+            coreCallback = new ContentViewCore.JavaScriptCallback() {
+                @Override
+                public void handleJavaScriptResult(String jsonResult) {
+                    fCallback.onReceiveValue(jsonResult);
+                }
+            };
+        }
         mContentViewCore.evaluateJavaScript(script, coreCallback);
     }
 


### PR DESCRIPTION
In case that the callback is a `null` value, XWalkView should behave normally and
same as Android WebView.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1815
