### PR TITLE
Remove application events related code from application storage

### DIFF
--- a/application/browser/application_storage_impl.h
+++ b/application/browser/application_storage_impl.h
@@ -40,15 +40,6 @@ class ApplicationStorageImpl {
   bool SetApplicationValue(const ApplicationData* application,
                            const base::Time& install_time,
                            const std::string& operation);
-  // Events helper functions
-  bool SetEventsValue(const std::string& id,
-                      const std::set<std::string>& events,
-                      const std::string& operation);
-  bool SetEvents(const std::string& id,
-                 const std::set<std::string>& events);
-  bool UpdateEvents(const std::string& id,
-                    const std::set<std::string>& events);
-  bool DeleteEvents(const std::string& id);
   // Permissions helper functions
   bool SetPermissionsValue(const std::string& id,
                            const StoredPermissionMap& permissions,

--- a/application/browser/application_storage_impl_unittest.cc
+++ b/application/browser/application_storage_impl_unittest.cc
@@ -56,17 +56,12 @@ TEST_F(ApplicationStorageImplTest, DBInsert) {
       &error);
   ASSERT_TRUE(error.empty());
   ASSERT_TRUE(application);
-  std::set<std::string> events;
-  events.insert("test_events");
-  application->SetEvents(events);
   EXPECT_TRUE(app_storage_impl_->AddApplication(application.get(),
                                                 base::Time::FromDoubleT(0)));
   ApplicationData::ApplicationDataMap applications;
   ASSERT_TRUE(app_storage_impl_->GetInstalledApplications(applications));
   EXPECT_EQ(applications.size(), 1);
   EXPECT_TRUE(applications[application->ID()]);
-  EXPECT_EQ(applications[application->ID()]
-            ->GetEvents().count("test_events"), 1);
 }
 
 TEST_F(ApplicationStorageImplTest, DBDelete) {

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -314,15 +314,6 @@ bool ApplicationData::LoadManifestVersion(base::string16* error) {
   return true;
 }
 
-void ApplicationData::SetEvents(const std::set<std::string>& events) {
-  events_ = events;
-  is_dirty_ = true;
-}
-
-const std::set<std::string>& ApplicationData::GetEvents() const {
-  return events_;
-}
-
 StoredPermission ApplicationData::GetPermission(
     std::string& permission_name) const {
   StoredPermissionMap::const_iterator iter =

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -111,10 +111,6 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
     return manifest_.get();
   }
 
-  // System events
-  void SetEvents(const std::set<std::string>& events);
-  const std::set<std::string>& GetEvents() const;
-
   bool IsDirty() const { return is_dirty_; }
 
   const base::Time& install_time() const { return install_time_; }

--- a/application/common/application_storage_constants.cc
+++ b/application/common/application_storage_constants.cc
@@ -9,7 +9,6 @@ namespace xwalk {
 namespace application_storage_constants {
 
 const char kAppTableName[] = "applications";
-const char kEventTableName[] = "registered_events";
 const char kPermissionTableName[] = "stored_permissions";
 const char kGarbageCollectionTableName[] = "garbage_collection";
 
@@ -19,14 +18,6 @@ const char kCreateAppTableOp[] =
     "manifest TEXT NOT NULL,"
     "path TEXT NOT NULL,"
     "install_time REAL)";
-
-const char kCreateEventTableOp[] =
-    "CREATE TABLE registered_events ("
-    "id TEXT NOT NULL,"
-    "event_names TEXT NOT NULL,"
-    "PRIMARY KEY (id),"
-    "FOREIGN KEY (id) REFERENCES applications(id)"
-    "ON DELETE CASCADE)";
 
 const char kCreatePermissionTableOp[] =
     "CREATE TABLE stored_permissions ("
@@ -46,12 +37,9 @@ const char kCreateGarbageCollectionTriggersOp[] =
     "CREATE TRIGGER IF NOT EXISTS del_garbage_app AFTER INSERT ON applications"
     " BEGIN DELETE FROM garbage_collection WHERE app_id = NEW.id; END";
 
-const char kGetAllRowsFromAppEventTableOp[] =
+const char kGetAllRowsFromAppTableOp[] =
     "SELECT A.id, A.manifest, A.path, A.install_time, "
-    "B.event_names, C.permission_names "
-    "FROM applications as A "
-    "LEFT JOIN registered_events as B "
-    "ON A.id = B.id "
+    "C.permission_names FROM applications as A "
     "LEFT JOIN stored_permissions as C "
     "ON A.id = C.id";
 
@@ -65,16 +53,6 @@ const char kUpdateApplicationWithBindOp[] =
 
 const char kDeleteApplicationWithBindOp[] =
     "DELETE FROM applications WHERE id = ?";
-
-const char kInsertEventsWithBindOp[] =
-    "INSERT INTO registered_events (event_names, id) "
-    "VALUES(?,?)";
-
-const char kUpdateEventsWithBindOp[] =
-    "UPDATE registered_events SET event_names = ? WHERE id = ?";
-
-const char kDeleteEventsWithBindOp[] =
-    "DELETE FROM registered_events WHERE id = ?";
 
 const char kInsertPermissionsWithBindOp[] =
     "INSERT INTO stored_permissions (permission_names, id) "

--- a/application/common/application_storage_constants.h
+++ b/application/common/application_storage_constants.h
@@ -11,22 +11,17 @@
 namespace xwalk {
 namespace application_storage_constants {
   extern const char kAppTableName[];
-  extern const char kEventTableName[];
   extern const char kPermissionTableName[];
   extern const char kGarbageCollectionTableName[];
 
   extern const char kCreateAppTableOp[];
-  extern const char kCreateEventTableOp[];
   extern const char kCreatePermissionTableOp[];
   extern const char kCreateGarbageCollectionTableOp[];
   extern const char kCreateGarbageCollectionTriggersOp[];
-  extern const char kGetAllRowsFromAppEventTableOp[];
+  extern const char kGetAllRowsFromAppTableOp[];
   extern const char kSetApplicationWithBindOp[];
   extern const char kUpdateApplicationWithBindOp[];
   extern const char kDeleteApplicationWithBindOp[];
-  extern const char kInsertEventsWithBindOp[];
-  extern const char kUpdateEventsWithBindOp[];
-  extern const char kDeleteEventsWithBindOp[];
   extern const char kInsertPermissionsWithBindOp[];
   extern const char kUpdatePermissionsWithBindOp[];
   extern const char kDeletePermissionsWithBindOp[];


### PR DESCRIPTION
SSIA. This code is not used since we dropped Main document support.
