### PR TITLE
[Tools] Fixed xwalk_android_gyp issue

### DIFF
--- a/build/android/envsetup.sh
+++ b/build/android/envsetup.sh
@@ -7,10 +7,10 @@ SCRIPT_DIR="$(dirname "${BASH_SOURCE:-$0}")"
 
 . ${SCRIPT_DIR}/../../../build/android/envsetup.sh "$@"
 
-export PATH=$PATH:${ENVSETUP_GYP_CHROME_SRC}/xwalk/build/android
+export PATH=$PATH:${SCRIPT_DIR}/../../../xwalk/build/android
 
 # The purpose of this function is to do the same as android_gyp(), but calling
 # gyp_xwalk instead.
 xwalk_android_gyp() {
-  "${ENVSETUP_GYP_CHROME_SRC}/xwalk/gyp_xwalk" --check "$@"
+  "${SCRIPT_DIR}/../../../xwalk/gyp_xwalk" --check "$@"
 }


### PR DESCRIPTION
according to the chromium upstream patch d9584323 and 50f36a01,
the comunity decided to stop exporting CHROME_SRC and
ENVSETUP_GYP_CHROME_SRC out of build/android/envsetup.sh, which
will break xwalk_android_gyp.
So we need to get rid of the dependency on those exported variables
in our own script.
