### PR TITLE
[Runtime][Tizen] Support to set app window view mode by configure config.xml.

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -156,7 +156,8 @@ class Application : public Runtime::Observer,
   // Try to extract the URL from different possible keys for entry points in the
   // manifest, returns it and the entry point used.
   GURL GetStartURL(const LaunchParams& params, LaunchEntryPoint* used);
-  ui::WindowShowState GetWindowShowState(const LaunchParams& params);
+  ui::WindowShowState GetWindowShowStateWGT(const LaunchParams& params);
+  ui::WindowShowState GetWindowShowStateXPK(const LaunchParams& params);
 
   GURL GetURLFromURLKey();
 

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -47,6 +47,7 @@ const char kXmlLangKey[] = "@lang";
 const char kDefaultLocaleKey[] = "widget.@defaultlocale";
 const char kNameKey[] = "widget.name.#text";
 const char kVersionKey[] = "widget.@version";
+const char kViewModesKey[] = "widget.@viewmodes";
 const char kWidgetKey[] = "widget";
 const char kLaunchLocalPathKey[] = "widget.content.@src";
 const char kWebURLsKey[] = "widget.@id";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -47,6 +47,7 @@ namespace application_widget_keys {
   extern const char kWebURLsKey[];
   extern const char kWidgetKey[];
   extern const char kVersionKey[];
+  extern const char kViewModesKey[];
   extern const char kAccessKey[];
   extern const char kAccessOriginKey[];
   extern const char kAccessSubdomainsKey[];


### PR DESCRIPTION
We support configuring application window display mode by 'display'
field in manifest.json for XPK packages. While this way is not enabled for widget format
packages.

The Widget Spec tells that 'viewmodes' attribute denotes the author's
preferred view mode.
http://www.w3.org/TR/2012/REC-widgets-20121127/#the-viewmodes-attribute

This CL enables the 'viewmodes' attribute for Widget applications.

BUG=XWALK-1732
