### PR TITLE
DEPS.xwalk: Roll v8-crosswalk (262b54e -> c4640c3).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -9,7 +9,7 @@
 chromium_version = '36.0.1985.18'
 chromium_crosswalk_point = 'b2129f32fc231edc2eb401cf56a858dcb1477031'
 blink_crosswalk_point = '7425f4985931cbd48e669c205a707cf1ff4ff6c6'
-v8_crosswalk_point = '262b54e087a73708031d42deb8a076fd36ae6ec2'
+v8_crosswalk_point = 'c4640c389b044e377d905579c6b01da3354d0f59'
 ozone_wayland_point = 'a5ca2e9203e6a0567751cc0400995982b703dde4'
 
 deps_xwalk = {


### PR DESCRIPTION
c4640c3 Merge pull request #32 from dp7/master
9f30235 Merge pull request #34 from fenghaitao/setTruncatingFlag
69be78f Set kTruncatingToInt32 flag if one of the SIMD operand requires Integer32
773c161 Merge pull request #33 from fenghaitao/master
ca3023f Fixed a typo: psrlq -> psrldq.
2a06d56 V8 profiling patch rebased on Chromium v36
6756718 Merge pull request #31 from huningxin/fix_int32x4_select
c537192 Merge pull request #30 from huningxin/fix_ia32_debug
2daf654 Fix SIMD.int32x4.select to return and accept input type as float32x4
03a03f2 Fix ia32 debug build issue.
a0f0edc Merge pull request #22 from rakuco/backport-urlretrieve-fix
c2d1700 Backport r21402 from the bleeding_edge branch.
