### PR TITLE
Use .DEPS.git instead of DEPS

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -2,10 +2,6 @@
     DO NOT use this DEPS to checkout code, it's for tools/generate_gclient-xwalk.py.
 '''
 
-# chromium_version is the version of chromium crosswalk based,
-# Usually it's major.minor.build.patch
-# Use 'Trunk' for trunk.
-# If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '36.0.1985.18'
 chromium_crosswalk_point = '00026639160639f24b3fc3e0d29b6540ba0dcb0a'
 blink_crosswalk_point = '07920aa9d1a9ae404ba8fb574ae1a9b109b22083'
@@ -20,5 +16,6 @@ deps_xwalk = {
   # Ozone-Wayland is required for Wayland support in Chromium.
   'src/ozone': 'https://github.com/01org/ozone-wayland.git@%s' % ozone_wayland_point,
 }
+
 vars_xwalk = {
 }


### PR DESCRIPTION
Use .DEPS.git instead of DEPS

This commit is allow developers get GIT version of dependencies.

 Most of dependencies in <release_dir>/DEPS are pointing to subversion.
 Unfortunately, svn command behind firewall randomly fails with error
 "501 Not Implemented". Instead, git repos are more stable to fetch.

Since upstream is switching SVN to GIT, it is time to switch to
 GIT(.DEPS.git) totally.

BUG=XWALK-1894
