### PR TITLE
[Android] Add test case for onActivityResult() and onNewIntent().

### DIFF
--- a/runtime/android/sample/AndroidManifest.xml
+++ b/runtime/android/sample/AndroidManifest.xml
@@ -138,6 +138,32 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".OnActivityResultActivity"
+            android:label="OnActivityResult"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+        <activity android:name="org.xwalk.core.sample.AuxiliaryActivity"
+            android:label="AuxiliaryActivity">
+        </activity>
+
+        <activity
+            android:name=".OnNewIntentActivity"
+            android:label="OnNewIntent"
+            android:parentActivityName=".XWalkEmbeddedAPISample"
+            android:launchMode="singleTask" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+        <activity android:name="org.xwalk.core.sample.AuxiliaryActivityForNewIntent"
+            android:label="AuxiliaryActivity" >
+        </activity>
     </application>
 
 </manifest>

--- a/runtime/android/sample/res/layout/result_layout.xml
+++ b/runtime/android/sample/res/layout/result_layout.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <TextView
+        android:id="@+id/result_text1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="#FDF5E6" />
+    <TextView
+        android:id="@+id/result_text2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="#FDF5E6" />
+    <TextView
+        android:id="@+id/result_text3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="#FDF5E6" />
+
+    <LinearLayout
+        android:id="@+id/linearlayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal" >
+    </LinearLayout>
+</LinearLayout>

--- a/runtime/android/sample/src/org/xwalk/core/sample/AuxiliaryActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/AuxiliaryActivity.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.sample;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class AuxiliaryActivity extends Activity
+{
+    private String mExtra = "Auxiliary";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        final Class clazz = (Class)intent.getSerializableExtra("From");
+        Intent newIntent = new Intent(AuxiliaryActivity.this, clazz);
+        intent.putExtra("From", mExtra);
+        setResult(RESULT_OK, intent);
+        finish();
+    }
+}

--- a/runtime/android/sample/src/org/xwalk/core/sample/AuxiliaryActivityForNewIntent.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/AuxiliaryActivityForNewIntent.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.sample;
+
+import org.xwalk.core.sample.util.XWalkCommonFunctions;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.LinearLayout;
+
+public class AuxiliaryActivityForNewIntent extends XWalkBaseActivity
+{
+    @Override
+    public void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.result_layout);
+
+        LinearLayout ll = (LinearLayout)findViewById(R.id.linearlayout);
+        XWalkCommonFunctions commonFun = new XWalkCommonFunctions();
+        commonFun.createComponentsAndAddView(ll, this, OnNewIntentActivity.class, "Second");
+    }
+}

--- a/runtime/android/sample/src/org/xwalk/core/sample/OnActivityResultActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/OnActivityResultActivity.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.sample;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.TextView;
+
+public class OnActivityResultActivity extends XWalkBaseActivity {
+    TextView mRequestCode;
+    TextView mResultCode;
+    TextView mData;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.result_layout);
+        mRequestCode = (TextView) findViewById(R.id.result_text1);
+        mResultCode = (TextView) findViewById(R.id.result_text2);
+        mData = (TextView) findViewById(R.id.result_text3);
+
+        Intent newIntent = new Intent(this, AuxiliaryActivity.class);
+        newIntent.putExtra("From", this.getClass());
+        this.startActivityForResult(newIntent, 2);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        String strRequest = "Request code should be '2': ";
+        String strResultCode = "Result code should be '-1': ";
+        String strExtra = "Extra data should be 'Auxiliary': ";
+        Bundle extras = data.getExtras();
+
+        strRequest += Integer.toString(requestCode);
+        strResultCode += Integer.toString(resultCode);
+        strExtra += extras.getString("From");
+        mRequestCode.setText(strRequest);
+        mResultCode.setText(strResultCode);
+        mData.setText(strExtra);
+    }
+}

--- a/runtime/android/sample/src/org/xwalk/core/sample/OnNewIntentActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/OnNewIntentActivity.java
@@ -1,0 +1,51 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.sample;
+
+import org.xwalk.core.sample.util.XWalkCommonFunctions;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+public class OnNewIntentActivity extends XWalkBaseActivity {
+    TextView mTextView1;
+    TextView mTextView2;
+    String mResult = "Test result: ";
+    String mText = "onNewIntent works well.";
+    String mStep = "Test step:\n1. Click the button(First) to next activity.\n" +
+            "2. Click the button(Second) to return.\nYou can see \"" + mText +
+                    "\" after" + mResult;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.result_layout);
+        mTextView1 = (TextView) findViewById(R.id.result_text1);
+        mTextView2 = (TextView) findViewById(R.id.result_text3);
+        mTextView1.setText(mStep);
+        mTextView2.setText(mResult);
+
+        LinearLayout ll = (LinearLayout)findViewById(R.id.linearlayout);
+        XWalkCommonFunctions commonFun = new XWalkCommonFunctions();
+        commonFun.createComponentsAndAddView(ll, this, AuxiliaryActivityForNewIntent.class, "First");
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        Bundle extras = intent.getExtras();
+        String name = extras.getString("name");
+
+        if (name.equals("crosswalk")) {
+            String text = mResult + mText;
+            mTextView2.setText(text);
+        } else {
+            mTextView2.setText(mResult);
+        }
+    }
+}

--- a/runtime/android/sample/src/org/xwalk/core/sample/util/XWalkCommonFunctions.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/util/XWalkCommonFunctions.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.sample.util;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
+
+public class XWalkCommonFunctions {
+    public void XWalkCommonFunctions() {
+    }
+
+    Button createButton(String text, final Activity activity, final Intent intent) {
+        Button btn = new Button(activity);
+        btn.setText(text);
+        btn.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View view) {
+                startActivityOnClick(activity, intent);
+            }
+        });
+        return btn;
+    }
+
+    Intent createNewIntent(Activity activity, Class<?> cls) {
+        Intent intent = new Intent(activity, cls);
+        intent.putExtra("name", "crosswalk");
+        return intent;
+    }
+
+    void startActivityOnClick(Activity activity, Intent intent) {
+        activity.startActivity(intent);
+    }
+
+    public void createComponentsAndAddView(LinearLayout ll, Activity activity, Class<?> cls, String text) {
+        Intent intent = createNewIntent(activity, cls);
+        Button btn = createButton(text, activity, intent);
+        ll.addView(btn);
+    }
+}


### PR DESCRIPTION
This patch is to add test case for onActivityResult() and onNewIntent().
For onActivityResult: In the main activity, call startActivityForResult()
with request code, then in auxiliary activity, set result with result code
and extra data. In main activity, verify the request code, result code and
extra data.
For onNewIntent: In AndroidManifest.xml, set the launch mode to "singleTask"
for main activity, then start activity to auxiliary activity, click button
to return to main activity, in onNewIntent(), verify the value and set text
result.
