### PR TITLE
[Android] fixed android build issue

### DIFF
--- a/build/android/envsetup.sh
+++ b/build/android/envsetup.sh
@@ -12,5 +12,5 @@ export PATH=$PATH:${SCRIPT_DIR}/../../../xwalk/build/android
 # The purpose of this function is to do the same as android_gyp(), but calling
 # gyp_xwalk instead.
 xwalk_android_gyp() {
-  "${SCRIPT_DIR}/../../../xwalk/gyp_xwalk" --check "$@"
+  "${SCRIPT_DIR}/../../../xwalk/gyp_xwalk" "$@" "-DOS=android"
 }


### PR DESCRIPTION
As upstream bumps to version 36.0.1985.18, we found we always
failed to build xwalk android as we haven't pass -DOS=android to
gyp_xwalk. So added it into build/android/envsetup.sh.

Also removed '--check' because if we pass -DOS=android to
gyp_xwalk, the '--check' will be append into args.
