### PR TITLE
[Android] Create documentation for XWalk Embedding API at compile time

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -698,6 +698,7 @@
 
             # For external testing.
             'pack_xwalk_core_library',
+            'xwalk_core_library_documentation',
             'xwalk_runtime_lib_apk',
             'xwalk_app_hello_world_apk',
             'xwalk_app_template',

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -8,6 +8,40 @@
   },
   'targets': [
     {
+      'target_name': 'xwalk_core_library_documentation',
+      'type': 'none',
+      'variables': {
+        'api_files': [
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkJavascriptResult.java',
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkNavigationHistory.java',
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkNavigationItem.java',
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkPreferences.java',
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkResourceClient.java',
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java',
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkView.java',
+        ],
+        'docs': '<(PRODUCT_DIR)/xwalk_core_library_docs',
+      },
+      'actions': [
+        {
+          'action_name': 'javadoc_xwalk_core_library',
+          'message': 'Creating documentation for XWalk Core Library',
+          'inputs': [
+            '<@(api_files)',
+          ],
+          'outputs': [
+            '<(docs)/index.html',
+          ],
+          'action': [
+            'javadoc',
+            '-XDignore.symbol.file',
+            '-d', '<(docs)',
+            '<@(api_files)',
+          ],
+        },
+      ],
+    },
+    {
       'target_name': 'pack_xwalk_core_library',
       'type': 'none',
       'dependencies': [


### PR DESCRIPTION
Use javadoc to create API document based on Annotations
written in source code.
Need to use doclava to exclude the methods that are public
but not exposed as Embedding API.

The generated documents will be put in path
out/Debug(Release)/xwalk_core_library_docs/.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1856
