### PR TITLE
[Android] Use const int value for Embedding APIs

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContentsClientBridge.java
@@ -512,7 +512,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         if (isOwnerActivityRunning()) {
             XWalkJavascriptResultHandler result = new XWalkJavascriptResultHandler(this, id);
             mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
-                    XWalkUIClient.JavascriptMessageType.JAVASCRIPT_ALERT, url, message, "", result);
+                    XWalkUIClient.JAVASCRIPT_MESSAGE_ALERT, url, message, "", result);
         }
     }
 
@@ -521,7 +521,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         if (isOwnerActivityRunning()) {
             XWalkJavascriptResultHandler result = new XWalkJavascriptResultHandler(this, id);
             mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
-                    XWalkUIClient.JavascriptMessageType.JAVASCRIPT_CONFIRM, url, message, "", result);
+                    XWalkUIClient.JAVASCRIPT_MESSAGE_CONFIRM, url, message, "", result);
         }
     }
 
@@ -530,7 +530,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         if (isOwnerActivityRunning()) {
             XWalkJavascriptResultHandler result = new XWalkJavascriptResultHandler(this, id);
             mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
-                    XWalkUIClient.JavascriptMessageType.JAVASCRIPT_PROMPT, url, message, defaultValue,
+                    XWalkUIClient.JAVASCRIPT_MESSAGE_PROMPT, url, message, defaultValue,
                             result);
         }
     }
@@ -540,7 +540,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         if (isOwnerActivityRunning()) {
             XWalkJavascriptResultHandler result = new XWalkJavascriptResultHandler(this, id);
             mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
-                    XWalkUIClient.JavascriptMessageType.JAVASCRIPT_BEFOREUNLOAD, url, message, "",
+                    XWalkUIClient.JAVASCRIPT_MESSAGE_BEFOREUNLOAD, url, message, "",
                             result);
         }
     }

--- a/runtime/android/core/src/org/xwalk/core/XWalkNavigationHistory.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNavigationHistory.java
@@ -78,6 +78,7 @@ public final class XWalkNavigationHistory implements Cloneable, Serializable {
 
     /**
      * The direction for web page navigation.
+     * @deprecated use const int value instead.
      */
     public enum Direction {
         /** The backward direction for web page navigation. */
@@ -86,11 +87,17 @@ public final class XWalkNavigationHistory implements Cloneable, Serializable {
         FORWARD
     }
 
+    /** The backward direction for web page navigation. */
+    public final static int NAVIGATION_BACKWARD = 1;
+    /** The forward direction for web page navigation. */
+    public final static int NAVIGATION_FORWARD = 2;
+
     /**
      * Navigates to the specified step from the current navigation item.
      * Do nothing if the offset is out of bound.
      * @param direction the direction of navigation.
      * @param steps go back or foward with a given steps.
+     * @deprecated use navigate(int direction, int steps) instead.
      */
     public void navigate(Direction direction, int steps) {
         switch(direction) {
@@ -98,6 +105,25 @@ public final class XWalkNavigationHistory implements Cloneable, Serializable {
                 mXWalkView.navigateTo(steps);
                 break;
             case BACKWARD:
+                mXWalkView.navigateTo(-steps);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Navigates to the specified step from the current navigation item.
+     * Do nothing if the offset is out of bound.
+     * @param direction the direction of navigation.
+     * @param steps go back or foward with a given steps.
+     */
+    public void navigate(int direction, int steps) {
+        switch(direction) {
+            case NAVIGATION_FORWARD:
+                mXWalkView.navigateTo(steps);
+                break;
+            case NAVIGATION_BACKWARD:
                 mXWalkView.navigateTo(-steps);
                 break;
             default:

--- a/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
@@ -81,6 +81,7 @@ public class XWalkUIClient {
 
     /**
      * The type of JavaScript modal dialog.
+     * @deprecated use const int value instead.
      */
     public enum JavascriptMessageType {
         /** JavaScript alert dialog. */
@@ -93,6 +94,15 @@ public class XWalkUIClient {
         JAVASCRIPT_BEFOREUNLOAD
     }
 
+    /** JavaScript alert dialog. */
+    public final static int JAVASCRIPT_MESSAGE_ALERT = 1;
+    /** JavaScript confirm dialog. */
+    public final static int JAVASCRIPT_MESSAGE_CONFIRM = 2;
+    /** JavaScript prompt dialog. */
+    public final static int JAVASCRIPT_MESSAGE_PROMPT = 3;
+    /** JavaScript dialog for a window-before-unload notification. */
+    public final static int JAVASCRIPT_MESSAGE_BEFOREUNLOAD = 4;
+
     /**
      * Tell the client to display a prompt dialog to the user.
      * @param view the owner XWalkView instance.
@@ -101,6 +111,8 @@ public class XWalkUIClient {
      * @param message the message to be shown.
      * @param defaultValue the default value string. Only valid for Prompt dialog.
      * @param result the callback to handle the result from caller.
+     * @deprecated use onJavascriptModalDialog(XWalkView, int, String,
+     *             String, String, XWalkJavascriptResult) instead.
      */
     public boolean onJavascriptModalDialog(XWalkView view, JavascriptMessageType type, String url,
             String message, String defaultValue, XWalkJavascriptResult result) {
@@ -119,6 +131,38 @@ public class XWalkUIClient {
         }
         assert(false);
         return false;
+    }
+
+    /**
+     * Tell the client to display a prompt dialog to the user.
+     * @param view the owner XWalkView instance.
+     * @param type the type of JavaScript modal dialog.
+     * @param url the url of the web page which wants to show this dialog.
+     * @param message the message to be shown.
+     * @param defaultValue the default value string. Only valid for Prompt dialog.
+     * @param result the callback to handle the result from caller.
+     */
+    public boolean onJavascriptModalDialog(XWalkView view, int type, String url,
+            String message, String defaultValue, XWalkJavascriptResult result) {
+        JavascriptMessageType enumType = JavascriptMessageType.JAVASCRIPT_ALERT;
+        switch(type) {
+            case JAVASCRIPT_MESSAGE_ALERT:
+                enumType = JavascriptMessageType.JAVASCRIPT_ALERT;
+                break;
+            case JAVASCRIPT_MESSAGE_CONFIRM:
+                enumType = JavascriptMessageType.JAVASCRIPT_CONFIRM;
+                break;
+            case JAVASCRIPT_MESSAGE_PROMPT:
+                enumType = JavascriptMessageType.JAVASCRIPT_PROMPT;
+                break;
+            case JAVASCRIPT_MESSAGE_BEFOREUNLOAD:
+                enumType = JavascriptMessageType.JAVASCRIPT_BEFOREUNLOAD;
+                break;
+            default:
+                assert(false);
+                break;
+        }
+        return onJavascriptModalDialog(view, enumType, url, message, defaultValue, result);
     }
 
     /**

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -269,7 +269,7 @@ public class XWalkViewShellActivity extends FragmentActivity
                 if (mActiveView != null &&
                         mActiveView.getNavigationHistory().canGoBack()) {
                     mActiveView.getNavigationHistory().navigate(
-                            XWalkNavigationHistory.Direction.BACKWARD, 1);
+                            XWalkNavigationHistory.NAVIGATION_BACKWARD, 1);
                 }
             }
         });
@@ -281,7 +281,7 @@ public class XWalkViewShellActivity extends FragmentActivity
                 if (mActiveView != null &&
                         mActiveView.getNavigationHistory().canGoForward()) {
                     mActiveView.getNavigationHistory().navigate(
-                            XWalkNavigationHistory.Direction.FORWARD, 1);
+                            XWalkNavigationHistory.NAVIGATION_FORWARD, 1);
                 }
             }
         });

--- a/runtime/android/sample/src/org/xwalk/core/sample/ResourceAndUIClientsActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/ResourceAndUIClientsActivity.java
@@ -63,8 +63,7 @@ public class ResourceAndUIClientsActivity extends XWalkBaseActivity {
             Log.d(TAG, "Window closed.");
         }
 
-        public boolean onJavascriptModalDialog(XWalkView view, JavascriptMessageType type,
-                String url,
+        public boolean onJavascriptModalDialog(XWalkView view, int type, String url,
                 String message, String defaultValue, XWalkJavascriptResult result) {
             Log.d(TAG, "Show JS dialog.");
             return super.onJavascriptModalDialog(view, type, url, message, defaultValue, result);

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkNavigationActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkNavigationActivity.java
@@ -41,7 +41,7 @@ public class XWalkNavigationActivity extends XWalkBaseActivity {
                 if (mXWalkView != null &&
                         mXWalkView.getNavigationHistory().canGoBack()) {
                     mXWalkView.getNavigationHistory().navigate(
-                            XWalkNavigationHistory.Direction.BACKWARD, 1);
+                            XWalkNavigationHistory.NAVIGATION_BACKWARD, 1);
                 }
                 XWalkNavigationItem navigationItem = mXWalkView.getNavigationHistory().getCurrentItem();
                 showNavigationItemInfo(navigationItem);
@@ -55,7 +55,7 @@ public class XWalkNavigationActivity extends XWalkBaseActivity {
                 if (mXWalkView != null &&
                         mXWalkView.getNavigationHistory().canGoForward()) {
                     mXWalkView.getNavigationHistory().navigate(
-                            XWalkNavigationHistory.Direction.FORWARD, 1);
+                            XWalkNavigationHistory.NAVIGATION_FORWARD, 1);
                 }
                 XWalkNavigationItem navigationItem = mXWalkView.getNavigationHistory().getCurrentItem();
                 showNavigationItemInfo(navigationItem);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -419,7 +419,7 @@ public class XWalkViewTestBase
                     @Override
                     public void run() {
                         mXWalkView.getNavigationHistory().navigate(
-                            XWalkNavigationHistory.Direction.BACKWARD, 1);
+                            XWalkNavigationHistory.NAVIGATION_BACKWARD, 1);
                     }
                 });
             }
@@ -434,7 +434,7 @@ public class XWalkViewTestBase
                     @Override
                     public void run() {
                         mXWalkView.getNavigationHistory().navigate(
-                            XWalkNavigationHistory.Direction.FORWARD, 1);
+                            XWalkNavigationHistory.NAVIGATION_FORWARD, 1);
                     }
                 });
             }


### PR DESCRIPTION
As discussed in Embedding API documentation.
Const value + int params is better than enum type.
This commit deprecates the two remaining usages
of enum type in xwalk embedding API, and use const
integer value instead.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1869
