### PR TITLE
Preliminary work before manifest `csp` member implementation

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -97,6 +97,8 @@ class Application : public Runtime::Observer,
   // (ApplicationData objects).
   std::string id() const { return data_->ID(); }
   int GetRenderProcessHostID() const;
+  content::RenderProcessHost* render_process_host() {
+    return render_process_host_; }
 
   const ApplicationData* data() const { return data_; }
   ApplicationData* data() { return data_; }
@@ -129,7 +131,6 @@ class Application : public Runtime::Observer,
               Observer* observer);
   virtual bool Launch(const LaunchParams& launch_params);
   virtual void InitSecurityPolicy();
-  void AddSecurityPolicy(const GURL& url, bool subdomains);
 
   std::set<Runtime*> runtimes_;
   scoped_refptr<ApplicationData> const data_;
@@ -169,8 +170,8 @@ class Application : public Runtime::Observer,
   std::map<std::string, std::string> name_perm_map_;
   // Application's session permissions.
   StoredPermissionMap permission_map_;
-  // Security policy set.
-  ScopedVector<SecurityPolicy> security_policy_;
+  // Security policy.
+  scoped_ptr<SecurityPolicy> security_policy_;
   // WeakPtrFactory should be always declared the last.
   base::WeakPtrFactory<Application> weak_factory_;
   DISALLOW_COPY_AND_ASSIGN(Application);

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -32,7 +32,6 @@ class ApplicationTizen :  // NOLINT
                    RuntimeContext* context,
                    Application::Observer* observer);
   virtual bool Launch(const LaunchParams& launch_params) OVERRIDE;
-  virtual void InitSecurityPolicy() OVERRIDE;
 
 #if defined(USE_OZONE)
   virtual void WillProcessEvent(const ui::PlatformEvent& event) OVERRIDE;

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -347,13 +347,15 @@ PermissionSet ApplicationData::GetManifestPermissions() const {
   return permissions;
 }
 
-#if defined(OS_TIZEN)
 bool ApplicationData::HasCSPDefined() const {
-  return (manifest_->HasPath(widget_keys::kCSPKey) ||
+#if defined(OS_TIZEN)
+  return  manifest_->HasPath(GetCSPKey(package_type_)) ||
           manifest_->HasPath(widget_keys::kCSPReportOnlyKey) ||
-          manifest_->HasPath(widget_keys::kAllowNavigationKey));
-}
+          manifest_->HasPath(widget_keys::kAllowNavigationKey);
+#else
+  return manifest_->HasPath(GetCSPKey(package_type_));
 #endif
+}
 
 bool ApplicationData::SetApplicationLocale(const std::string& locale,
                                            base::string16* error) {

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -129,9 +129,7 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   Package::Type GetPackageType() const { return package_type_; }
 
-#if defined(OS_TIZEN)
   bool HasCSPDefined() const;
-#endif
 
   bool SetApplicationLocale(const std::string& locale, base::string16* error);
 

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -8,7 +8,7 @@ namespace xwalk {
 
 namespace application_manifest_keys {
 const char kAppKey[] = "app";
-const char kCSPKey[] = "content_security_policy";
+const char kCSPKey[] = "csp";
 const char kDescriptionKey[] = "description";
 const char kDisplay[] = "display";
 const char kLaunchLocalPathKey[] = "app.launch.local_path";

--- a/application/common/security_policy.cc
+++ b/application/common/security_policy.cc
@@ -4,12 +4,209 @@
 
 #include "xwalk/application/common/security_policy.h"
 
+#include <string>
+
+#include "content/public/browser/render_process_host.h"
+#include "xwalk/application/browser/application.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/constants.h"
+#include "xwalk/application/common/manifest_handlers/csp_handler.h"
+#include "xwalk/application/common/manifest_handlers/navigation_handler.h"
+#include "xwalk/application/common/manifest_handlers/warp_handler.h"
+#include "xwalk/runtime/common/xwalk_common_messages.h"
+
 namespace xwalk {
+
+namespace keys = application_manifest_keys;
+namespace widget_keys = application_widget_keys;
+
 namespace application {
 
-SecurityPolicy::SecurityPolicy(const GURL& url, bool subdomains)
-    : url_(url),
-      subdomains_(subdomains) {
+namespace {
+const char kAsterisk[] = "*";
+
+const char kDirectiveValueSelf[] = "'self'";
+const char kDirectiveValueNone[] = "'none'";
+
+const char kDirectiveNameDefault[] = "default-src";
+const char kDirectiveNameScript[] = "script-src";
+const char kDirectiveNameStyle[] = "style-src";
+const char kDirectiveNameObject[] = "object-src";
+
+// By default:
+// default-src * ; script-src 'self' ; style-src 'self' ; object-src 'none'
+CSPInfo* GetDefaultCSPInfo() {
+  static CSPInfo default_csp_info;
+  if (default_csp_info.GetDirectives().empty()) {
+    std::vector<std::string> directive_all;
+    std::vector<std::string> directive_self;
+    std::vector<std::string> directive_none;
+    directive_all.push_back(kAsterisk);
+    directive_self.push_back(kDirectiveValueSelf);
+    directive_none.push_back(kDirectiveValueNone);
+
+    default_csp_info.SetDirective(kDirectiveNameDefault, directive_all);
+    default_csp_info.SetDirective(kDirectiveNameScript, directive_self);
+    default_csp_info.SetDirective(kDirectiveNameStyle, directive_self);
+    default_csp_info.SetDirective(kDirectiveNameObject, directive_none);
+  }
+
+  return (new CSPInfo(default_csp_info));
+}
+
+}  // namespace
+
+SecurityPolicy::WhitelistEntry::WhitelistEntry(const GURL& url, bool subdomains)
+  : url(url),
+    subdomains(subdomains) {
+}
+
+SecurityPolicy::SecurityPolicy(Application* app)
+  : app_(app),
+    enabled_(false) {
+}
+
+SecurityPolicy::~SecurityPolicy() {
+}
+
+bool SecurityPolicy::IsAccessAllowed(const GURL& url) const {
+  if (!enabled_)
+    return true;
+
+  // Accessing own resources is always allowed.
+  if (url.SchemeIs(application::kApplicationScheme) &&
+      url.host() == app_->id())
+    return true;
+
+  for (std::vector<WhitelistEntry>::const_iterator it =
+      whitelist_entries_.begin(); it != whitelist_entries_.end(); ++it) {
+    const GURL& policy = it->url;
+    bool subdomains = it->subdomains;
+    bool is_host_matched = subdomains ?
+        url.DomainIs(policy.host().c_str()) : url.host() == policy.host();
+    if (url.scheme() == policy.scheme() && is_host_matched)
+      return true;
+  }
+  return false;
+}
+
+void SecurityPolicy::Enforce() {
+}
+
+void SecurityPolicy::AddWhitelistEntry(const GURL& url, bool subdomains) {
+  GURL app_url = app_->data()->URL();
+  DCHECK(app_->render_process_host());
+  app_->render_process_host()->Send(
+      new ViewMsg_SetAccessWhiteList(
+          app_url, url, subdomains));
+  whitelist_entries_.push_back(WhitelistEntry(url, subdomains));
+}
+
+SecurityPolicyWARP::SecurityPolicyWARP(Application* app)
+  : SecurityPolicy(app) {
+}
+
+SecurityPolicyWARP::~SecurityPolicyWARP() {
+}
+
+void SecurityPolicyWARP::Enforce() {
+  const WARPInfo* info = static_cast<WARPInfo*>(
+      app_->data()->GetManifestData(widget_keys::kAccessKey));
+  if (!info) {
+    enabled_ = true;
+    DCHECK(app_->render_process_host());
+    app_->render_process_host()->Send(
+        new ViewMsg_EnableSecurityMode(
+            ApplicationData::GetBaseURLFromApplicationId(app_->id()),
+            SecurityPolicy::WARP));
+    return;
+  }
+
+  const base::ListValue* whitelist = info->GetWARP();
+  for (base::ListValue::const_iterator it = whitelist->begin();
+       it != whitelist->end(); ++it) {
+    base::DictionaryValue* value = NULL;
+    (*it)->GetAsDictionary(&value);
+    std::string dest;
+    if (!value || !value->GetString(widget_keys::kAccessOriginKey, &dest) ||
+        dest.empty())
+      continue;
+    if (dest == "*") {
+      enabled_ = false;
+      break;
+    }
+
+    GURL dest_url(dest);
+    // The default subdomains attribute should be "false".
+    std::string subdomains = "false";
+    value->GetString(widget_keys::kAccessSubdomainsKey, &subdomains);
+    AddWhitelistEntry(dest_url, (subdomains == "true"));
+    enabled_ = true;
+  }
+
+  if (enabled_) {
+    DCHECK(app_->render_process_host());
+    app_->render_process_host()->Send(
+        new ViewMsg_EnableSecurityMode(
+            ApplicationData::GetBaseURLFromApplicationId(app_->id()),
+            SecurityPolicy::WARP));
+  }
+}
+
+SecurityPolicyCSP::SecurityPolicyCSP(Application* app)
+  : SecurityPolicy(app) {
+}
+
+SecurityPolicyCSP::~SecurityPolicyCSP() {
+}
+
+void SecurityPolicyCSP::Enforce() {
+#if defined(OS_TIZEN)
+  Package::Type package_type = app_->data()->GetPackageType();
+  const char* scp_key = GetCSPKey(package_type);
+
+  CSPInfo* csp_info =
+      static_cast<CSPInfo*>(app_->data()->GetManifestData(scp_key));
+  if (!csp_info || csp_info->GetDirectives().empty())
+    app_->data()->SetManifestData(scp_key, GetDefaultCSPInfo());
+
+  // Always enable security mode when under CSP mode.
+  enabled_ = true;
+
+  if (package_type = Package::WGT) {
+    NavigationInfo* info = static_cast<NavigationInfo*>(
+        app_->data()->GetManifestData(widget_keys::kAllowNavigationKey));
+    if (info) {
+      const std::vector<std::string>& allowed_list = info->GetAllowedDomains();
+      for (std::vector<std::string>::const_iterator it = allowed_list.begin();
+           it != allowed_list.end(); ++it) {
+        // If the policy is "*", it represents that any external link is allowed
+        // to navigate to.
+        if ((*it) == kAsterisk) {
+          enabled_ = false;
+          return;
+        }
+
+        // If the policy start with "*.", like this: *.domain,
+        // means that can access to all subdomains for 'domain',
+        // otherwise, the host of request url should exactly the same
+        // as policy.
+        bool subdomains = ((*it).find("*.") == 0);
+        std::string host = subdomains ? (*it).substr(2) : (*it);
+        AddWhitelistEntry(GURL("http://" + host), subdomains);
+        AddWhitelistEntry(GURL("https://" + host), subdomains);
+      }
+    }
+  } else {
+    // FIXME: Implement http://w3c.github.io/manifest-csp/ here.
+  }
+
+  DCHECK(app_->render_process_host());
+  app_->render_process_host()->Send(
+      new ViewMsg_EnableSecurityMode(
+          ApplicationData::GetBaseURLFromApplicationId(app_->id()),
+          SecurityPolicy::CSP));
+#endif
 }
 
 }  // namespace application

--- a/application/common/security_policy.h
+++ b/application/common/security_policy.h
@@ -4,11 +4,18 @@
 
 #ifndef XWALK_APPLICATION_COMMON_SECURITY_POLICY_H_
 #define XWALK_APPLICATION_COMMON_SECURITY_POLICY_H_
+
+#include <vector>
+
 #include "url/gurl.h"
 
 namespace xwalk {
 namespace application {
 
+class Application;
+
+// FIXME(Mikhail): Move to application/browser folder.
+// Rename to ApplicationSecurityPolicy.
 class SecurityPolicy {
  public:
   enum SecurityMode {
@@ -16,13 +23,42 @@ class SecurityPolicy {
     CSP,
     WARP
   };
-  SecurityPolicy(const GURL& url, bool subdomains);
-  const GURL& url() const { return url_; }
-  bool subdomains() const { return subdomains_; }
 
- private:
-  GURL url_;
-  bool subdomains_;
+  explicit SecurityPolicy(Application* app);
+  virtual ~SecurityPolicy();
+
+  bool IsAccessAllowed(const GURL& url) const;
+
+  virtual void Enforce() = 0;
+
+ protected:
+  struct WhitelistEntry {
+    WhitelistEntry(const GURL& url, bool subdomains);
+    GURL url;
+    bool subdomains;
+  };
+
+  void AddWhitelistEntry(const GURL& url, bool subdomains);
+
+  std::vector<WhitelistEntry> whitelist_entries_;
+  Application* app_;
+  bool enabled_;
+};
+
+class SecurityPolicyWARP : public SecurityPolicy {
+ public:
+  explicit SecurityPolicyWARP(Application* app);
+  virtual ~SecurityPolicyWARP();
+
+  virtual void Enforce() OVERRIDE;
+};
+
+class SecurityPolicyCSP : public SecurityPolicy {
+ public:
+  explicit SecurityPolicyCSP(Application* app);
+  virtual ~SecurityPolicyCSP();
+
+  virtual void Enforce() OVERRIDE;
 };
 
 }  // namespace application


### PR DESCRIPTION
This patch re-organizes the existing WARP and CSP code
so that it is accessible not only for Tizen and encapsulated
within SecurityPolicy classes family.
