### PR TITLE
[Android] Add test case for size(), hasItemAt() and getItemAt().

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetItemAtTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetItemAtTest.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+import org.xwalk.core.XWalkNavigationItem;
+
+/**
+ * Test suite for GetItemAt().
+ */
+public class GetItemAtTest extends XWalkViewTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"GetItemAt"})
+    public void testGetItemAt() throws Throwable {
+        final String url1 = "about:blank";
+        final String url2 = "file:///android_asset/www/index.html";
+        final String title ="Crosswalk Sample Application";
+        assertTrue(getItemAtOnUiThread(-1) == null);
+        assertTrue(getItemAtOnUiThread(java.lang.Integer.MAX_VALUE) == null);
+        assertTrue(getItemAtOnUiThread(java.lang.Integer.MIN_VALUE) == null);
+        loadUrlSync(url1);
+        loadUrlSync(url2);
+        assertTrue(getItemAtOnUiThread(historySizeOnUiThread()) == null);
+        XWalkNavigationItem navigationItem1 = getItemAtOnUiThread(0);
+        assertEquals(url1, navigationItem1.getUrl());
+        XWalkNavigationItem navigationItem2 = getItemAtOnUiThread(1);
+        assertEquals(url2, navigationItem2.getUrl());
+        assertEquals(title, navigationItem2.getTitle());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/HasItemAtTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/HasItemAtTest.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+import org.xwalk.core.XWalkNavigationItem;
+
+/**
+ * Test suite for HasItemAt().
+ */
+public class HasItemAtTest extends XWalkViewTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"HasItemAt"})
+    public void testHasItemAt() throws Throwable {
+        final String url1 = "about:blank";
+        final String url2 = "file:///android_asset/www/index.html";
+        assertFalse(hasItemAtOnUiThread(-1));
+        assertFalse(hasItemAtOnUiThread(java.lang.Integer.MAX_VALUE));
+        assertFalse(hasItemAtOnUiThread(java.lang.Integer.MIN_VALUE));
+        assertFalse(hasItemAtOnUiThread(0));
+        loadUrlSync(url1);
+        assertTrue(hasItemAtOnUiThread(0));
+        assertFalse(hasItemAtOnUiThread(1));
+        loadUrlSync(url2);
+        assertTrue(hasItemAtOnUiThread(1));
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/HistorySizeTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/HistorySizeTest.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+import org.xwalk.core.XWalkNavigationItem;
+
+/**
+ * Test suite for HistorySize().
+ */
+public class HistorySizeTest extends XWalkViewTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+    }
+
+    @SmallTest
+    @Feature({"HistorySize"})
+    public void testHistorySize() throws Throwable {
+        final String url1 = "about:blank";
+        final String url2 = "file:///android_asset/www/index.html";
+        assertEquals(0, historySizeOnUiThread());
+        loadUrlSync(url1);
+        assertEquals(1, historySizeOnUiThread());
+        loadUrlSync(url2);
+        assertEquals(2, historySizeOnUiThread());
+        goBackSync();
+        assertEquals(2, historySizeOnUiThread());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -468,6 +468,33 @@ public class XWalkViewTestBase
         });
     }
 
+    protected int historySizeOnUiThread() throws Throwable {
+        return runTestOnUiThreadAndGetResult(new Callable<Integer>() {
+            @Override
+            public Integer call() {
+                return mXWalkView.getNavigationHistory().size();
+            }
+        });
+    }
+
+    protected boolean hasItemAtOnUiThread(final int index) throws Throwable {
+        return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() {
+                return mXWalkView.getNavigationHistory().hasItemAt(index);
+            }
+        });
+    }
+
+    protected XWalkNavigationItem getItemAtOnUiThread(final int index) throws Throwable {
+        return runTestOnUiThreadAndGetResult(new Callable<XWalkNavigationItem>() {
+            @Override
+            public XWalkNavigationItem call() {
+                return mXWalkView.getNavigationHistory().getItemAt(index);
+            }
+        });
+    }
+
     protected XWalkNavigationItem getCurrentItemOnUiThread() throws Throwable {
         return runTestOnUiThreadAndGetResult(new Callable<XWalkNavigationItem>() {
             @Override


### PR DESCRIPTION
This patch is to add test case for size(), hasItemAt() and getItemAt().
Load url and get history size, get item at specified index, compare them with the expected result.
Judge whether has item at specified index.
