### PR TITLE
[Runtime] Return a "NOT FOUND" message if the resource is invalid when using application scheme.

### DIFF
--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -235,6 +235,11 @@ ApplicationProtocolHandler::MaybeCreateJob(
   const std::string& application_id = request->url().host();
   scoped_refptr<ApplicationData> application =
       cache_.GetApplicationData(application_id);
+
+  if (!application)
+    return new net::URLRequestErrorJob(
+        request, network_delegate, net::ERR_FILE_NOT_FOUND);
+
   base::FilePath relative_path =
       ApplicationURLToRelativeFilePath(request->url());
   base::FilePath directory_path;


### PR DESCRIPTION
When using application scheme (app://), if loading a resource which does
not belong to an application, it should return the error message
directly, this patch will do this if the application can not found.

BUG=XWALK-1762
