### PR TITLE
[Android] Decouple url loading and onReadyToRender callback

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkContent.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkContent.java
@@ -58,9 +58,6 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
 
     long mXWalkContent;
     long mWebContents;
-    boolean mReadyToLoad = false;
-    String mPendingUrl = null;
-    String mPendingData = null;
 
     public XWalkContent(Context context, AttributeSet attrs, XWalkView xwView) {
         super(context, attrs);
@@ -81,13 +78,8 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
                 animated ? CompositingSurfaceType.TEXTURE_VIEW : CompositingSurfaceType.SURFACE_VIEW;
         mContentViewRenderView = new ContentViewRenderView(context, mWindow, surfaceType) {
             protected void onReadyToRender() {
-                if (mPendingUrl != null) {
-                    doLoadUrl(mPendingUrl, mPendingData);
-                    mPendingUrl = null;
-                    mPendingData = null;
-                }
-
-                mReadyToLoad = true;
+                // Anything depending on the underlying Surface readiness should
+                // be placed here.
             }
         };
         mLaunchScreenManager = new XWalkLaunchScreenManager(context, mXWalkView);
@@ -160,25 +152,17 @@ class XWalkContent extends FrameLayout implements XWalkPreferences.KeyValueChang
             return;
         }
 
-        if (mReadyToLoad) {
-            doLoadUrl(url, data);
-        } else {
-            mPendingUrl = url;
-            mPendingData = data;
-        }
+        doLoadUrl(url, data);
     }
 
     public void reload(int mode) {
-        if (mReadyToLoad) {
-            switch (mode) {
-                case XWalkView.RELOAD_IGNORE_CACHE:
-                    mContentViewCore.reloadIgnoringCache(true);
-                    break;
-                case XWalkView.RELOAD_NORMAL:
-                default:
-                    mContentViewCore.reload(true);
-
-            }
+        switch (mode) {
+            case XWalkView.RELOAD_IGNORE_CACHE:
+                mContentViewCore.reloadIgnoringCache(true);
+                break;
+            case XWalkView.RELOAD_NORMAL:
+            default:
+                mContentViewCore.reload(true);
         }
     }
 


### PR DESCRIPTION
The url loading should not depend on the readiness of compositing
surface. Otherwise, it will cause 'deadlock' between loading url and
surface availability in some cases.

For example, to support splash screen in cordova, the XWalkView should
be initially invisible and waits for a signal from web page to become
visible. However, Android framework may not create the underlying Surface
for an invisibile View, which causes the url won't be loaded.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1884
