### PR TITLE
[Tizen][Runtime] Add simple error page for net error.

### DIFF
--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
@@ -7,9 +7,12 @@
 #include <string>
 
 #include "base/files/file_path.h"
+#include "base/strings/stringprintf.h"
 #include "net/base/filename_util.h"
+#include "net/base/net_errors.h"
 #include "url/gurl.h"
 #include "xwalk/application/common/constants.h"
+#include "third_party/WebKit/public/platform/WebURLError.h"
 #include "third_party/WebKit/public/web/WebFrame.h"
 #include "third_party/WebKit/public/web/WebDocument.h"
 
@@ -86,6 +89,26 @@ bool XWalkContentRendererClientTizen::WillSendRequest(
 
   new_url->Swap(&replacement_url);
   return true;
+}
+
+bool XWalkContentRendererClientTizen::HasErrorPage(int http_status_code,
+                                                   std::string* error_domain) {
+  return true;
+}
+
+void XWalkContentRendererClientTizen::GetNavigationErrorStrings(
+    content::RenderView* render_view,
+    blink::WebFrame* frame,
+    const blink::WebURLRequest& failed_request,
+    const blink::WebURLError& error,
+    std::string* error_html,
+    base::string16* error_description) {
+  if (error_html) {
+    *error_html =
+        base::StringPrintf("<html><body style=\"text-align: center;\">"
+                           "<h1>NET ERROR : %s</h1></body></html>",
+                           net::ErrorToString(error.reason));
+  }
 }
 
 }  // namespace xwalk

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_RUNTIME_RENDERER_TIZEN_XWALK_CONTENT_RENDERER_CLIENT_TIZEN_H_
 #define XWALK_RUNTIME_RENDERER_TIZEN_XWALK_CONTENT_RENDERER_CLIENT_TIZEN_H_
 
+#include <string>
+
 #include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
 
 namespace xwalk {
@@ -18,6 +20,18 @@ class XWalkContentRendererClientTizen : public XWalkContentRendererClient {
                                const GURL& url,
                                const GURL& first_party_for_cookies,
                                GURL* new_url) OVERRIDE;
+
+  virtual bool HasErrorPage(int http_status_code,
+                            std::string* error_domain) OVERRIDE;
+
+  virtual void GetNavigationErrorStrings(
+      content::RenderView* render_view,
+      blink::WebFrame* frame,
+      const blink::WebURLRequest& failed_request,
+      const blink::WebURLError& error,
+      std::string* error_html,
+      base::string16* error_description) OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkContentRendererClientTizen);
 };


### PR DESCRIPTION
After we have support allow-navigation on tizen, QA will test
for this. But if we do not have a net error page, QA might can
not identify whether some issues caused by crosswalk or other
net errors.
