### PR TITLE
[Tizen][Desktop] WebApp is able to access files via file:// protocol

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -350,13 +350,11 @@ bool Application::SetPermission(PermissionType type,
 }
 
 void Application::InitSecurityPolicy() {
-  if (data_->GetPackageType() == Package::WGT) {
-    // CSP policy takes precedence over WARP.
-    if (data_->HasCSPDefined())
-      security_policy_.reset(new SecurityPolicyCSP(this));
-    else
-      security_policy_.reset(new SecurityPolicyWARP(this));
-  }
+  // CSP policy takes precedence over WARP.
+  if (data_->HasCSPDefined())
+    security_policy_.reset(new SecurityPolicyCSP(this));
+  else if (data_->GetPackageType() == Package::WGT)
+    security_policy_.reset(new SecurityPolicyWARP(this));
 
   if (security_policy_)
     security_policy_->Enforce();

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -8,7 +8,8 @@ namespace xwalk {
 
 namespace application_manifest_keys {
 const char kAppKey[] = "app";
-const char kCSPKey[] = "content_security_policy";
+const char kCSPKey[] = "csp";
+const char kCSPKeyLegacy[] = "content_security_policy";
 const char kDescriptionKey[] = "description";
 const char kDisplay[] = "display";
 const char kLaunchLocalPathKey[] = "app.launch.local_path";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -11,6 +11,7 @@ namespace xwalk {
 namespace application_manifest_keys {
   extern const char kAppKey[];
   extern const char kCSPKey[];
+  extern const char kCSPKeyLegacy[];
   extern const char kDescriptionKey[];
   extern const char kDisplay[];
   extern const char kLaunchLocalPathKey[];

--- a/application/common/security_policy.h
+++ b/application/common/security_policy.h
@@ -36,6 +36,10 @@ class SecurityPolicy {
     WhitelistEntry(const GURL& url, bool subdomains);
     GURL url;
     bool subdomains;
+
+    bool operator==(const WhitelistEntry& o) const {
+      return o.url == url && o.subdomains == subdomains;
+    }
   };
 
   void AddWhitelistEntry(const GURL& url, bool subdomains);

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -235,7 +235,9 @@ jboolean XWalkContent::SetManifest(JNIEnv* env,
   render_view_host_ext_->SetOriginAccessWhitelist(url, match_patterns);
 
   std::string csp;
-  manifest.GetString(keys::kCSPKey, &csp);
+  // FIXME: Switch to 'csp' field, accordingly to
+  // http://w3c.github.io/manifest-csp/.
+  manifest.GetString(keys::kCSPKeyLegacy, &csp);
   RuntimeContext* runtime_context =
       XWalkRunner::GetInstance()->runtime_context();
   CHECK(runtime_context);


### PR DESCRIPTION
This change allows an application to access files via file:// protocol
if its manifest contains 'csp' field and the applied policy allows
fetching from 'localhost' (e.g. "csp": "default-src file://localhost").

The application should use the URLs in the following format:
file://localhost/path/to/the/local/file

BUG=XWALK-1840
