### PR TITLE
Runtime class should not contain/export RuntimeContext

### DIFF
--- a/extensions/test/external_extension_multi_process.cc
+++ b/extensions/test/external_extension_multi_process.cc
@@ -125,7 +125,7 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionMultiProcessTest,
   EXPECT_EQ(1, CountRegisterExtensions());
 
   Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
-      runtime()->runtime_context(), url, runtime_registry());
+      GetRuntimeContext(), url, runtime_registry());
   EXPECT_EQ(new_runtime, WaitForSingleNewRuntime());
   EXPECT_NE(runtime(), new_runtime);
   content::RunAllPendingInMessageLoop();

--- a/runtime/browser/devtools/xwalk_devtools_browsertest.cc
+++ b/runtime/browser/devtools/xwalk_devtools_browsertest.cc
@@ -31,7 +31,7 @@ class XWalkDevToolsTest : public InProcessBrowserTest {
 IN_PROC_BROWSER_TEST_F(XWalkDevToolsTest, RemoteDebugging) {
   GURL localhost_url("http://127.0.0.1:9222");
   Runtime* debugging_host = Runtime::CreateWithDefaultWindow(
-      runtime()->runtime_context(), localhost_url, runtime_registry());
+      GetRuntimeContext(), localhost_url, runtime_registry());
   content::WaitForLoadStop(debugging_host->web_contents());
   base::string16 real_title = debugging_host->web_contents()->GetTitle();
   base::string16 expected_title = base::ASCIIToUTF16("XWalk Remote Debugging");

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -76,7 +76,6 @@ Runtime::Runtime(content::WebContents* web_contents, Observer* observer)
       fullscreen_options_(NO_FULLSCREEN),
       observer_(observer) {
   web_contents_->SetDelegate(this);
-  runtime_context_ = RuntimeContext::FromWebContents(web_contents);
   content::NotificationService::current()->Notify(
        xwalk::NOTIFICATION_RUNTIME_OPENED,
        content::Source<Runtime>(this),

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -74,7 +74,6 @@ class Runtime : public content::WebContentsDelegate,
 
   content::WebContents* web_contents() const { return web_contents_.get(); }
   NativeAppWindow* window() const { return window_; }
-  RuntimeContext* runtime_context() const { return runtime_context_; }
   gfx::Image app_icon() const { return app_icon_; }
 
   content::RenderProcessHost* GetRenderProcessHost();
@@ -162,9 +161,6 @@ class Runtime : public content::WebContentsDelegate,
   void SetRootWindow(NativeAppWindow* window);
   void InitRootWindow();
 #endif
-
-  // The browsing context.
-  xwalk::RuntimeContext* runtime_context_;
 
   // Notification manager.
   content::NotificationRegistrar registrar_;

--- a/runtime/browser/xwalk_runtime_browsertest.cc
+++ b/runtime/browser/xwalk_runtime_browsertest.cc
@@ -110,7 +110,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CreateAndCloseRuntime) {
   // Create a new Runtime instance.
   GURL url(test_server()->GetURL("test.html"));
   Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
-      runtime()->runtime_context(), url, runtime_registry());
+      GetRuntimeContext(), url, runtime_registry());
   EXPECT_TRUE(url == new_runtime->web_contents()->GetURL());
   EXPECT_EQ(new_runtime, WaitForSingleNewRuntime());
   content::RunAllPendingInMessageLoop();
@@ -136,7 +136,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LoadURLAndClose) {
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CloseNativeWindow) {
   GURL url(test_server()->GetURL("test.html"));
   Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
-      runtime()->runtime_context(), url, runtime_registry());
+      GetRuntimeContext(), url, runtime_registry());
   size_t len = runtimes().size();
   new_runtime->window()->Close();
   content::RunAllPendingInMessageLoop();
@@ -147,7 +147,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CloseNativeWindow) {
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LaunchWithFullscreenWindow) {
   GURL url(test_server()->GetURL("test.html"));
   Runtime* new_runtime = Runtime::Create(
-      runtime()->runtime_context(), runtime_registry());
+      GetRuntimeContext(), runtime_registry());
 
   NativeAppWindow::CreateParams params;
   params.state = ui::SHOW_STATE_FULLSCREEN;

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -126,6 +126,10 @@ void InProcessBrowserTest::SetUp() {
   BrowserTestBase::SetUp();
 }
 
+xwalk::RuntimeContext* InProcessBrowserTest::GetRuntimeContext() const {
+  return XWalkRunner::GetInstance()->runtime_context();
+}
+
 void InProcessBrowserTest::PrepareTestCommandLine(
     base::CommandLine* command_line) {
   // Propagate commandline settings from test_launcher_utils.
@@ -145,7 +149,7 @@ void InProcessBrowserTest::RunTestOnMainThreadLoop() {
   // when needed and thus the 'runtime()' method should be removed
   // as well as 'runtime_' initialization below.
   runtime_ = Runtime::CreateWithDefaultWindow(
-      XWalkRunner::GetInstance()->runtime_context(),
+          GetRuntimeContext(),
           GURL(), runtime_registry_.get());
   content::WaitForLoadStop(runtime_->web_contents());
   content::RunAllPendingInMessageLoop();

--- a/test/base/in_process_browser_test.h
+++ b/test/base/in_process_browser_test.h
@@ -70,6 +70,8 @@ class InProcessBrowserTest : public content::BrowserTestBase {
   RuntimeRegistry* runtime_registry() const {
       return runtime_registry_.get(); }
 
+  xwalk::RuntimeContext* GetRuntimeContext() const;
+
   // Override this to add any custom cleanup code that needs to be done on the
   // main thread before the browser is torn down.
   virtual void ProperMainThreadCleanup() {}


### PR DESCRIPTION
SSIA. RuntimeContext is a global object owned by XWalkRunner.
