### PR TITLE
packaging: disable XDG-Shell for Tizen

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -160,7 +160,7 @@ if [ -n "${BUILDDIR_NAME}" ]; then
 fi
 
 %if %{with wayland}
-GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1 -Denable_ozone_wayland_vkb=1 -Denable_xdg_shell=1"
+GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1 -Denable_ozone_wayland_vkb=1 -Denable_xdg_shell=0"
 %endif
 
 GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Ddisable_nacl=%{_disable_nacl}"


### PR DESCRIPTION
Current implementation only worked with patched Weston 1.4 on Tizen,
and Ozone-Wayland disabled 1.5 support upstream anyway, so disable
it to avoid crashes when Tizen switches to Weston 1.5.

BUG=XWALK-1907

Signed-off-by: Manuel Bachmann manuel.bachmann@open.eurogiciel.org
