### PR TITLE
Transition from route_id to render_frame_id and child_id to render_proce...

### DIFF
--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -145,10 +145,10 @@ content::WebContents* XWalkContent::CreateWebContents(
       contents_client_bridge_.get());
   XWalkContentsIoThreadClientImpl::Associate(web_contents,
       ScopedJavaLocalRef<jobject>(env, io_thread_client));
-  int child_id = web_contents->GetRenderProcessHost()->GetID();
-  int route_id = web_contents->GetRoutingID();
+  int render_process_id = web_contents->GetRenderProcessHost()->GetID();
+  int render_frame_id = web_contents->GetRoutingID();
   RuntimeResourceDispatcherHostDelegateAndroid::OnIoThreadClientReady(
-      child_id, route_id);
+      render_process_id, render_frame_id);
   InterceptNavigationDelegate::Associate(web_contents,
       make_scoped_ptr(new InterceptNavigationDelegate(
           env, intercept_navigation_delegate)));

--- a/runtime/browser/runtime_resource_dispatcher_host_delegate_android.h
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate_android.h
@@ -65,21 +65,23 @@ class RuntimeResourceDispatcherHostDelegateAndroid
 
   void RemovePendingThrottleOnIoThread(IoThreadClientThrottle* throttle);
 
-  static void OnIoThreadClientReady(int new_child_id, int new_route_id);
-  static void AddPendingThrottle(int child_id,
-                                 int route_id,
+  static void OnIoThreadClientReady(int new_render_process_id,
+                                    int new_render_frame_id);
+  static void AddPendingThrottle(int render_process_id,
+                                 int render_frame_id,
                                  IoThreadClientThrottle* pending_throttle);
  private:
   friend struct base::DefaultLazyInstanceTraits<
       RuntimeResourceDispatcherHostDelegateAndroid>;
   // These methods must be called on IO thread.
-  void OnIoThreadClientReadyInternal(int child_id, int route_id);
-  void AddPendingThrottleOnIoThread(int child_id,
-                                    int route_id,
+  void OnIoThreadClientReadyInternal(int new_render_process_id,
+                                     int new_render_frame_id);
+  void AddPendingThrottleOnIoThread(int render_process_id,
+                                    int render_frame_id,
                                     IoThreadClientThrottle* pending_throttle);
 
-  typedef std::pair<int, int> ChildRouteIDPair;
-  typedef std::map<ChildRouteIDPair, IoThreadClientThrottle*>
+  typedef std::pair<int, int> FrameRouteIDPair;
+  typedef std::map<FrameRouteIDPair, IoThreadClientThrottle*>
       PendingThrottleMap;
 
   // Only accessed on the IO thread.


### PR DESCRIPTION
...ss_id.

This patch is to transform the route_id to render_frame_id and child_id
to render_process_id.
Set cache mode does not work without this patch.
The request was handled by the interfaces in "InterceptNavigationDelegate",
since the io client was got by the wrong id, so the interfaces in
"IoThreadClientThrottle" were not called.

BUG=XWALK-1908
