### PR TITLE
[Android] make_apk.py error when Android SDK environment path contain whitespace

### DIFF
--- a/app/tools/android/gyp/javac.py
+++ b/app/tools/android/gyp/javac.py
@@ -17,7 +17,7 @@ from util import md5_check
 def DoJavac(options):
   output_dir = options.output_dir
 
-  src_dirs = options.src_dirs.split()
+  src_dirs = options.src_dirs.split('|')
   java_files = build_utils.FindInDirectories(src_dirs, '*.java')
   if options.javac_includes:
     javac_includes = options.javac_includes.split()
@@ -33,7 +33,7 @@ def DoJavac(options):
   # crash... Sorted order works, so use that.
   # See https://code.google.com/p/guava-libraries/issues/detail?id=950
   java_files.sort()
-  classpath = options.classpath.split()
+  classpath = options.classpath.split('|')
 
   jar_inputs = []
   for path in classpath:

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -362,16 +362,21 @@ def Execution(options, name):
     sys.exit(5)
 
   # Compile App source code with app runtime code.
-  classpath = '--classpath='
-  classpath += os.path.join(os.getcwd(), 'libs',
+  classpath = os.path.join(os.getcwd(), 'libs',
                             'xwalk_app_runtime_java.jar')
-  classpath += ' ' + sdk_jar_path
-  src_dirs = '--src-dirs=' + os.path.join(os.getcwd(), name, 'src') +\
-             ' ' + os.path.join(os.getcwd(), 'out', 'gen')
+  if ('|' in classpath):
+    print('Error: contain invalid characters \'|\' in %s.' % classpath)
+    sys.exit(6)
+  if ('|' in sdk_jar_path):
+    print('Error: contain invalid characters \'|\' in %s.' % sdk_jar_path)
+    sys.exit(6)
+  classpath += '|' + sdk_jar_path
+  src_dirs = os.path.join(os.getcwd(), name, 'src') +\
+             '|' + os.path.join(os.getcwd(), 'out', 'gen')
   cmd = ['python', os.path.join('scripts', 'gyp', 'javac.py'),
          '--output-dir=%s' % os.path.join('out', 'classes'),
-         classpath,
-         src_dirs,
+         '--classpath=%s' % classpath,
+         '--src-dirs=%s' % src_dirs,
          '--javac-includes=',
          '--chromium-code=0',
          '--stamp=compile.stam']


### PR DESCRIPTION
The javac.py option --classpath has 2 files, xwalk_app_runtime_java.jar and android.jar,
which paths joined by whitespace. But if one of paths contain whitespace. The javac.py
use options.classpath.split() will parse a error path. So change the 2 paths joined with '|'.
For contain '|' in file name is not recommended in Linux and invalid in Windows.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1905
