### PR TITLE
[Android] make_apk.py print exception message when search aapt.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -276,7 +276,7 @@ def Execution(options, name):
       print('Use %s in %s.' % (aapt_str, sdk_root_path))
       break
     except Exception:
-      print('There doesn\'t exist %s in %s.' % (aapt_str, sdk_root_path))
+      pass
   if not aapt_path:
     print('Your Android SDK may be ruined, please reinstall it.')
     sys.exit(2)


### PR DESCRIPTION
On Windows, PATHEXT may be set to something like ".COM;.EXE", which will make the code loop and print a message if, for example, "aapt.com" is not found. Just be silent instead.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1906
