### PR TITLE
DO NOT MERGE [Extensions] Send large messages out of line

### DIFF
--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include "base/memory/shared_memory.h"
 #include "base/values.h"
 #include "ipc/ipc_channel_handle.h"
 #include "ipc/ipc_message_macros.h"
@@ -74,6 +75,10 @@ IPC_MESSAGE_CONTROL2(XWalkExtensionServerMsg_PostMessageToNative,  // NOLINT(*)
 IPC_MESSAGE_CONTROL2(XWalkExtensionClientMsg_PostMessageToJS,  // NOLINT(*)
                      int64_t /* instance id */,
                      base::ListValue /* contents */)
+
+IPC_MESSAGE_CONTROL2(XWalkExtensionClientMsg_PostOOLMessageToJS,  // NOLINT(*)
+                     base::SharedMemoryHandle /* message buffer */,
+                     size_t /* buffer size */)
 
 IPC_SYNC_MESSAGE_CONTROL2_1(XWalkExtensionServerMsg_SendSyncMessageToNative,  // NOLINT(*)
                             int64_t /* instance id */,

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -51,6 +51,7 @@ class XWalkExtensionServer : public IPC::Listener,
 
   // IPC::Listener Implementation.
   virtual bool OnMessageReceived(const IPC::Message& message) OVERRIDE;
+  virtual void OnChannelConnected(int32 peer_pid) OVERRIDE;
 
   // Different types of ExtensionServers are initialized with different
   // permission delegates: For out-of-process extensions the extension
@@ -113,6 +114,8 @@ class XWalkExtensionServer : public IPC::Listener,
   // The exported symbols for extensions already registered.
   typedef std::set<std::string> ExtensionSymbolsSet;
   ExtensionSymbolsSet extension_symbols_;
+
+  base::ProcessHandle renderer_process_handle_;
 
   XWalkExtension::PermissionsDelegate* permissions_delegate_;
 };

--- a/extensions/renderer/xwalk_extension_client.h
+++ b/extensions/renderer/xwalk_extension_client.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/memory/scoped_ptr.h"
+#include "base/memory/shared_memory.h"
 #include "base/values.h"
 #include "ipc/ipc_listener.h"
 
@@ -73,6 +74,7 @@ class XWalkExtensionClient : public IPC::Listener {
   // Message Handlers.
   void OnInstanceDestroyed(int64_t instance_id);
   void OnPostMessageToJS(int64_t instance_id, const base::ListValue& msg);
+  void OnPostOOLMessageToJS(base::SharedMemoryHandle handle, size_t size);
 
   IPC::Sender* sender_;
   ExtensionAPIMap extension_apis_;


### PR DESCRIPTION
Use a shared memory handler to send messages bigger than 4096 bytes and
possibly optimize the data transfer.
