### PR TITLE
[Android] Deprecate xwalk_android_gyp

### DIFF
--- a/build/android/envsetup.sh
+++ b/build/android/envsetup.sh
@@ -12,5 +12,9 @@ export PATH=$PATH:${SCRIPT_DIR}/../../../xwalk/build/android
 # The purpose of this function is to do the same as android_gyp(), but calling
 # gyp_xwalk instead.
 xwalk_android_gyp() {
+  echo "Deprecated: Please use xwalk/gyp_xwalk instead. xwalk_android_gyp \
+is going away."
+  echo "Notice: Add '-DOS=android' explicity to generate android building \
+environment."
   "${SCRIPT_DIR}/../../../xwalk/gyp_xwalk" --check "$@"
 }


### PR DESCRIPTION
In M36, android_gyp is still available in upstream, but it is
going to be removed in recent future.
We need to deprecate xwalk_android_gyp together with upstream's
change, and we need to pass '-DOS=android' explicity to it to
generate android building environment.

This change based on the discussion in pull request:
https://github.com/crosswalk-project/crosswalk/pull/2015

BUG=https://crosswalk-project.org/jira/browse/XWALK-1803
