### PR TITLE
Update DEPS.xwalk to include blink::ScreenOrientation enabling

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -7,8 +7,8 @@
 # Use 'Trunk' for trunk.
 # If using trunk, will use '.DEPS.git' for gclient.
 chromium_version = '36.0.1985.18'
-chromium_crosswalk_point = 'c282374abcd161a82bbcd5a51e02e33b1be0b1c4'
-blink_crosswalk_point = '7425f4985931cbd48e669c205a707cf1ff4ff6c6'
+chromium_crosswalk_point = '00026639160639f24b3fc3e0d29b6540ba0dcb0a'
+blink_crosswalk_point = '07920aa9d1a9ae404ba8fb574ae1a9b109b22083'
 v8_crosswalk_point = '535cd006e5174ff00fd7b745a581980b1d371a9f'
 ozone_wayland_point = 'a5ca2e9203e6a0567751cc0400995982b703dde4'
 


### PR DESCRIPTION
Update DEPS.xwalk to include blink::ScreenOrientation enabling:
https://github.com/crosswalk-project/blink-crosswalk/pull/15
and
https://github.com/crosswalk-project/chromium-crosswalk/pull/168

BUG=XWALK-1820
