### PR TITLE
Revert "Fix build : Force ld.gold binary usage"

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -28,7 +28,6 @@ Source1003:     %{name}.png
 Patch9:         Blink-Add-GCC-flag-Wno-narrowing-fix-64bits-build.patch
 Patch10:        crosswalk-do-not-look-for-gtk-dependencies-on-x11.patch
 
-BuildRequires:  binutils-gold
 BuildRequires:  bison
 BuildRequires:  bzip2-devel
 BuildRequires:  elfutils
@@ -166,18 +165,24 @@ GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1 -Denable_ozone_wayland_vkb=1 -
 
 GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Ddisable_nacl=%{_disable_nacl}"
 
-# Linking fails in Tizen when fatal ld warnings are enabled. XWALK-1379.
+# Linking fails in Tizen Common when fatal ld warnings are enabled. XWALK-1379.
+%if "%{profile}" == "common" || "%{profile}" == "generic"
 GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Ddisable_fatal_linker_warnings=1"
+%endif
 
 # For building for arm in OBS, we need :
 # -> to unset sysroot value.
 # sysroot variable is automatically set for cross compilation to use arm-sysroot provided by Chromium project
+# -> to force system ld binary.
+# Indeed the build is made on Emulated / Virtualized environment that correspond
+# to the target.
+# gold ld used is avaible only for 32/64 bits Intel Arch.
 # sysroot usage is not needed, we need to use arm libraries from the virtualized environment.
 #
 # Crosswalk build fails if the fpu selected in the gcc option is different from neon in case of arm7 compilation
 # So force it.
 %ifarch %{arm}
-GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Dsysroot="
+GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Dsysroot= -Dlinux_use_gold_binary=0"
 export CFLAGS=`echo $CFLAGS | sed s,-mfpu=vfpv3,-mfpu=neon,g`
 export CXXFLAGS=`echo $CXXFLAGS | sed s,-mfpu=vfpv3,-mfpu=neon,g`
 export FFLAGS=`echo $FFLAGS | sed s,-mfpu=vfpv3,-mfpu=neon,g`
@@ -185,8 +190,6 @@ export FFLAGS=`echo $FFLAGS | sed s,-mfpu=vfpv3,-mfpu=neon,g`
 
 # --no-parallel is added because chroot does not mount a /dev/shm, this will
 # cause python multiprocessing.SemLock error.
-# Force gold binary from chroot ld.gold provided by binutils-gold
-#  -Dlinux_use_bundled_binutils=0 -Dlinux_use_bundled_gold=0
 export GYP_GENERATORS='ninja'
 ./src/xwalk/gyp_xwalk src/xwalk/xwalk.gyp \
 --no-parallel \
@@ -203,9 +206,7 @@ ${GYP_EXTRA_FLAGS} \
 -Duse_system_libexif=1 \
 -Duse_system_libxml=1 \
 -Duse_system_nspr=1 \
--Denable_hidpi=1 \
--Dlinux_use_bundled_binutils=0 \
--Dlinux_use_bundled_gold=0
+-Denable_hidpi=1
 
 ninja %{?_smp_mflags} -C src/out/Release xwalk xwalkctl xwalk_launcher xwalk-pkg-helper
 


### PR DESCRIPTION
This has caused a regression in Tizen builds from scratch when NaCl
support is enabled (ie. 32-bit Tizen, like IVI and Mobile).

One stage of the NaCl build process involves calling the ld_bfd.py
script, that invokes `gcc -print-prog-name=ld' and later tries finding a
binary with ".bfd" appended to it because certain NaCl binaries must be
built with ld.bfd instead of gold.

binutils's packaging in Tizen is such that it creates symlinks in
/usr/i586-tizen-linux/bin to ar, as, ld, nm, ranlib, strip, but not
ld.bfd or ld.gold. The build-dependency on binutils-gold introduced in
the commit we are reverting makes /usr/bin/ld point to ld.gold instead
of ld.bfd. Finally, when `gcc -print-prog-name=ld' is called it finds
/usr/i586-tizen-linux/bin/ld but not /usr/i586-tizen-linux/bin/ld.bfd,
and since the former points to gold the script ends up linking the NaCl
binaries with gold instead of ld.bfd.

There are different ways to fix this, but for now we have to revert back
to a state where all Tizen profiles build, since this has blocked canary
builds for two days at least.

Related to XWALK-1904.

This reverts commit 55c37c02e29ba6ac21f1bb4031e7b9099ee11a38.
