### PR TITLE
[Android] Stop doing manual argument separation in javac.py.

### DIFF
--- a/app/tools/android/gyp/javac.py
+++ b/app/tools/android/gyp/javac.py
@@ -17,13 +17,11 @@ from util import md5_check
 def DoJavac(options):
   output_dir = options.output_dir
 
-  src_dirs = options.src_dirs.split()
-  java_files = build_utils.FindInDirectories(src_dirs, '*.java')
+  java_files = build_utils.FindInDirectories(options.src_dirs, '*.java')
   if options.javac_includes:
-    javac_includes = options.javac_includes.split()
     filtered_java_files = []
     for f in java_files:
-      for include in javac_includes:
+      for include in options.javac_includes:
         if fnmatch.fnmatch(f, include):
           filtered_java_files.append(f)
           break
@@ -33,10 +31,9 @@ def DoJavac(options):
   # crash... Sorted order works, so use that.
   # See https://code.google.com/p/guava-libraries/issues/detail?id=950
   java_files.sort()
-  classpath = options.classpath.split()
 
   jar_inputs = []
-  for path in classpath:
+  for path in options.classpath:
     if os.path.exists(path + '.TOC'):
       jar_inputs.append(path + '.TOC')
     else:
@@ -47,7 +44,7 @@ def DoJavac(options):
       '-g',
       '-source', '1.5',
       '-target', '1.5',
-      '-classpath', os.pathsep.join(classpath),
+      '-classpath', os.pathsep.join(options.classpath),
       '-d', output_dir,
       '-Xlint:unchecked',
       '-Xlint:deprecation',
@@ -73,11 +70,13 @@ def DoJavac(options):
 
 def main():
   parser = optparse.OptionParser()
-  parser.add_option('--src-dirs', help='Directories containing java files.')
-  parser.add_option('--javac-includes',
+  parser.add_option('--src-dirs', action='append',
+                    help='Directories containing java files.')
+  parser.add_option('--javac-includes', action='append',
       help='A list of file patterns. If provided, only java files that match' +
         'one of the patterns will be compiled.')
-  parser.add_option('--classpath', help='Classpath for javac.')
+  parser.add_option('--classpath', action='append',
+                    help='Classpaths for javac.')
   parser.add_option('--output-dir', help='Directory for javac output.')
   parser.add_option('--stamp', help='Path to touch on success.')
   parser.add_option('--chromium-code', type='int', help='Whether code being '

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -355,17 +355,16 @@ def Execution(options, sanitized_name):
     sys.exit(5)
 
   # Compile App source code with app runtime code.
-  classpath = '--classpath='
-  classpath += os.path.join(os.getcwd(), 'libs',
-                            'xwalk_app_runtime_java.jar')
-  classpath += ' ' + sdk_jar_path
-  src_dirs = '--src-dirs=' + os.path.join(os.getcwd(), sanitized_name, 'src') +\
-             ' ' + os.path.join(os.getcwd(), 'out', 'gen')
   cmd = ['python', os.path.join('scripts', 'gyp', 'javac.py'),
          '--output-dir=%s' % os.path.join('out', 'classes'),
-         classpath,
-         src_dirs,
-         '--javac-includes=',
+         '--classpath',
+         os.path.join(os.getcwd(), 'libs', 'xwalk_app_runtime_java.jar'),
+         '--classpath',
+         sdk_jar_path,
+         '--src-dirs',
+         os.path.join(os.getcwd(), name, 'src'),
+         '--src-dirs',
+         os.path.join(os.getcwd(), 'out', 'gen'),
          '--chromium-code=0',
          '--stamp=compile.stam']
   RunCommand(cmd)


### PR DESCRIPTION
Stop doing nonsensical things like calling str.split() to manually split
option arguments since it obviously breaks arguments with spaces.

Instead, make "--src-dirs", "--javac-includes" and "--classpath"
accumulate its arguments, and just pass them multiple times in
make_apk.py.

BUG=XWALK-1905

(cherry picked from commit 2fd3337df93ee8300533ba7a9559af427546e403)

Conflicts:
    app/tools/android/make_apk.py
