### PR TITLE
Revert "[Android] Enable hardware acceleration video decoding for WebRTC...

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -90,10 +90,11 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
 #endif
 
-  // Disable HW encoding acceleration for WebRTC on Android.
-  // FIXME: Remove this switch for Android when Android OS is removed from
+  // Disable HW encoding/decoding acceleration for WebRTC on Android.
+  // FIXME: Remove these switches for Android when Android OS is removed from
   // GPU accelerated_video_decode blacklist or we stop ignoring the GPU
   // blacklist.
+  command_line->AppendSwitch(switches::kDisableWebRtcHWDecoding);
   command_line->AppendSwitch(switches::kDisableWebRtcHWEncoding);
 
   // For fullscreen video playback, the ContentVideoView is still buggy, so


### PR DESCRIPTION
..."

This reverts commit 1b114b10fef10879a90045c7aceb0fff61d6b709.

It's a walk around of the current P1 crash issue of WebRTC, will reopen
the HW decoding after the fix.

BUG=XWALK-1888
