### PR TITLE
[Android] [IAP] Add IAP to permission mapping table

### DIFF
--- a/app/tools/android/handle_permissions.py
+++ b/app/tools/android/handle_permissions.py
@@ -37,6 +37,7 @@ permission_mapping_table = {
                   'android.permission.WRITE_SMS'],
     'devicecapabilities': [],
     'fullscreen': [],
+    'iap': ['com.android.vending.BILLING'],
     'presentation': [],
     'rawsockets': [],
     'screenorientation': [],


### PR DESCRIPTION
By this, user can use make_apk.py to package their application
with IAP extension with correct permission, for example:

`$ python make_apk.py --name=apkname --package=org.xwalk.extensions.iap
--permissions=iap --extensions=...`
