### PR TITLE
[Tizen][Runtime] Add list apps with status.

### DIFF
--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -10,6 +10,9 @@
 #include <gio/gio.h>
 #include <locale.h>
 
+#include <string>
+#include <set>
+
 #include "xwalk/application/tools/linux/dbus_connection.h"
 #if defined(OS_TIZEN)
 #include "xwalk/application/tools/linux/xwalk_tizen_user.h"
@@ -21,9 +24,15 @@ static const char* xwalk_installed_iface =
     "org.crosswalkproject.Installed.Manager1";
 static const char* xwalk_installed_app_iface =
     "org.crosswalkproject.Installed.Application1";
+static const char* xwalk_running_path = "/running1";
+static const char* xwalk_running_manager_iface =
+    "org.crosswalkproject.Running.Manager1";
+static const char* xwalk_running_app_iface =
+    "org.crosswalkproject.Running.Application1";
 
 static char* install_path;
 static char* uninstall_appid;
+static gboolean list_with_status = FALSE;
 static GDBusConnection* g_connection;
 
 static GOptionEntry entries[] = {
@@ -31,8 +40,36 @@ static GOptionEntry entries[] = {
     "Path of the application to be installed/updated", "PATH" },
   { "uninstall", 'u', 0, G_OPTION_ARG_STRING, &uninstall_appid,
     "Uninstall the application with this appid", "APPID" },
+  { "status", 's', 0, G_OPTION_ARG_NONE, &list_with_status,
+    "List running applications", NULL },
   { NULL }
 };
+
+GDBusObjectManager* get_xwalk_object_manager(const char* object_path) {
+  GError* error = NULL;
+  GDBusObjectManager* object_manager = g_dbus_object_manager_client_new_sync(
+      g_connection, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
+      xwalk_service_name, object_path,
+      NULL, NULL, NULL, NULL, &error);
+  if (!object_manager) {
+    g_print("Service '%s' could not be reached: %s\n", xwalk_service_name,
+            error->message);
+    return NULL;
+  }
+
+  // GDBus may return a valid ObjectManager even if it fails to auto activate
+  // the proper service name. We should check 'name-owner' property to make sure
+  // the service is working. See GDBusObjectManager documentation.
+  gchar* name_owner = NULL;
+  g_object_get(object_manager, "name-owner", &name_owner, NULL);
+  if (!name_owner) {
+    g_print("Service '%s' could not be activated.\n", xwalk_service_name);
+    return NULL;
+  }
+  g_free(name_owner);
+
+  return object_manager;
+}
 
 static bool install_application(const char* path) {
   GError* error = NULL;
@@ -133,9 +170,36 @@ static bool uninstall_application(GDBusObjectManager* installed,
   return ret;
 }
 
-static void list_applications(GDBusObjectManager* installed) {
+static void list_applications(GDBusObjectManager* installed,
+                              GDBusObjectManager* running) {
   GList* objects = g_dbus_object_manager_get_objects(installed);
   GList* l;
+
+  std::set<std::string> running_app_ids;
+  if (running) {
+    GList* running_objects = g_dbus_object_manager_get_objects(running);
+    for (l = running_objects; l; l = l->next) {
+      GDBusObject* object = reinterpret_cast<GDBusObject*>(l->data);
+      GDBusInterface* iface =
+          g_dbus_object_get_interface(object, xwalk_running_app_iface);
+      if (!iface)
+        continue;
+
+      GDBusProxy* proxy = G_DBUS_PROXY(iface);
+      GVariant* id_variant;
+      id_variant = g_dbus_proxy_get_cached_property(proxy, "AppID");
+      if (!id_variant) {
+        g_object_unref(iface);
+        continue;
+      }
+
+      const char* id;
+      g_variant_get(id_variant, "s", &id);
+      running_app_ids.insert(std::string(id));
+      g_object_unref(iface);
+    }
+    g_list_free_full(running_objects, g_object_unref);
+  }
 
   for (l = objects; l; l = l->next) {
     GDBusObject* object = reinterpret_cast<GDBusObject*>(l->data);
@@ -166,7 +230,15 @@ static void list_applications(GDBusObjectManager* installed) {
     const char* name;
     g_variant_get(name_variant, "s", &name);
 
-    g_print("%s\t%s\n", id, name);
+    if (running) {
+      if (running_app_ids.find(std::string(id)) != running_app_ids.end()) {
+        g_print("%s   \033[01;49;32mRunning\033[0m   %s\n", id, name);
+      } else {
+        g_print("%s   \033[02;49;37mNot run\033[0m   %s\n", id, name);
+      }
+    } else {
+      g_print("%s\t%s\n", id, name);
+    }
 
     g_object_unref(iface);
   }
@@ -204,35 +276,30 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
-  GDBusObjectManager* installed_om = g_dbus_object_manager_client_new_sync(
-      g_connection, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
-      xwalk_service_name, xwalk_installed_path,
-      NULL, NULL, NULL, NULL, &error);
-  if (!installed_om) {
-    g_print("Service '%s' could not be reached: %s\n", xwalk_service_name,
-            error->message);
+  GDBusObjectManager* installed_om =
+      get_xwalk_object_manager(xwalk_installed_path);
+  if (!installed_om)
     exit(1);
-  }
 
-  // GDBus may return a valid ObjectManager even if it fails to auto activate
-  // the proper service name. We should check 'name-owner' property to make sure
-  // the service is working. See GDBusObjectManager documentation.
-  gchar* name_owner = NULL;
-  g_object_get(installed_om, "name-owner", &name_owner, NULL);
-  if (!name_owner) {
-    g_print("Service '%s' could not be activated.\n", xwalk_service_name);
+  GDBusObjectManager* running_om =
+      get_xwalk_object_manager(xwalk_running_path);
+  if (!running_om)
     exit(1);
-  }
-  g_free(name_owner);
 
   if (install_path) {
     success = install_application(install_path);
   } else if (uninstall_appid) {
     success = uninstall_application(installed_om, uninstall_appid);
+  } else if (list_with_status) {
+    g_print("Application ID                     Status    Application Name\n");
+    g_print("-------------------------------------------------------------\n");
+    list_applications(installed_om, running_om);
+    g_print("-------------------------------------------------------------\n");
+    success = true;
   } else {
     g_print("Application ID                       Application Name\n");
     g_print("-----------------------------------------------------\n");
-    list_applications(installed_om);
+    list_applications(installed_om, NULL);
     g_print("-----------------------------------------------------\n");
     success = true;
   }


### PR DESCRIPTION
Add option -s(--status) to xwalkctl for list apps with status.

Since tizen common have mutliuser, the user may want to know
the status of all his(her) applications.

And the old command xwalkctl(without any option) still work(some
test cases might use the result string of xwalkctl and I do not
want to break they).
