### PR TITLE
[Android] Support loading manifest following w3c spec

### DIFF
--- a/runtime/android/sample/assets/manifest.json
+++ b/runtime/android/sample/assets/manifest.json
@@ -1,11 +1,6 @@
 {
   "name": "ManifestTest",
   "start_url": "index.html",
-  "app": {
-    "launch": {
-      "local_path": "index.html"
-    }
-  },
   "description": "Manifest test",
   "version": "1.0.0"
 }

--- a/test/android/data/manifest.json
+++ b/test/android/data/manifest.json
@@ -2,10 +2,6 @@
   "name": "loadAppFromManifest Test",
   "version": "1.0.0",
   "description": "Test for loadAppFromManifest",
-  "app": {
-    "launch": {
-      "local_path": "index.html"
-    }
-  }
+  "start_url": "index.html"
 }
 


### PR DESCRIPTION
Spec: http://w3c.github.io/manifest/

This commit is only for the loading API of XWalkView to
work with w3c manifest spec.
For packaging tool's support, it needs additional work.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1920
