### PR TITLE
xwalk_launcher build fix.

### DIFF
--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -52,6 +52,7 @@
         '../../../..',
       ],
       'dependencies': [
+        '../../../../base/third_party/dynamic_annotations/dynamic_annotations.gyp:dynamic_annotations',
         '../../../extensions/extensions.gyp:xwalk_extensions',
       ],
       'sources': [


### PR DESCRIPTION
Fix linking errors when building xwalk_launcher with component=shared_library.

error: undefined reference to 'AnnotateHappensAfter'
error: undefined reference to 'AnnotateHappensBefore'
error: undefined reference to 'AnnotateHappensAfter'
