### PR TITLE
DEPS.xwalk: Roll ozone-wayland (a5ca2e9 -> 5047b6e)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -10,7 +10,7 @@ chromium_version = '36.0.1985.18'
 chromium_crosswalk_point = '6488cb72d9cc33832af16d65d75f16e06f0bdd88'
 blink_crosswalk_point = '07920aa9d1a9ae404ba8fb574ae1a9b109b22083'
 v8_crosswalk_point = '535cd006e5174ff00fd7b745a581980b1d371a9f'
-ozone_wayland_point = 'a5ca2e9203e6a0567751cc0400995982b703dde4'
+ozone_wayland_point = '5047b6ea8843bfd439a9f5adf2e270cd6fa6db7c'
 
 deps_xwalk = {
   'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,


### PR DESCRIPTION
5047b6e wayland: Fix segfault when trying to set cursor without input
6f22c54 Update RELEASE-NOTES.txt
93c95a0 Update RELEASE-NOTES.txt

The important part is the topmost commit: it fixes a crash that happens
when a mouse is not connected to an IVI device.

BUG=XWALK-1939
