### PR TITLE
[Android] Fix native filesystem API initialize crash for cordova

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkPathHelper.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkPathHelper.java
@@ -6,6 +6,7 @@ package org.xwalk.core.extension;
 
 import android.os.Environment;
 
+import java.io.File;
 import java.util.ArrayList;
 
 import org.chromium.base.CalledByNative;
@@ -43,8 +44,10 @@ public class XWalkPathHelper {
             Environment.DIRECTORY_RINGTONES
         };
         for (int i = 0; i < names.length; ++i) {
-            nativeSetDirectory(names[i],
-                  Environment.getExternalStoragePublicDirectory(dirs[i]).getPath());
+            File dir = Environment.getExternalStoragePublicDirectory(dirs[i]);
+            if (null != dir) {
+                nativeSetDirectory(names[i], dir.getPath());
+            }
         }
     }
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkView.java
@@ -21,6 +21,7 @@ import android.view.ViewGroup;
 import android.webkit.ValueCallback;
 import android.widget.FrameLayout;
 
+import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
@@ -325,8 +326,10 @@ public class XWalkView extends android.widget.FrameLayout {
         String state = Environment.getExternalStorageState();
         if (Environment.MEDIA_MOUNTED.equals(state) ||
                 Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
-            XWalkPathHelper.setExternalCacheDirectory(
-                    mContext.getApplicationContext().getExternalCacheDir().getPath());
+            File extCacheDir =  mContext.getApplicationContext().getExternalCacheDir();
+            if (null != extCacheDir) {
+                XWalkPathHelper.setExternalCacheDirectory(extCacheDir.getPath());
+            }
         }
     }
 


### PR DESCRIPTION
When application doesn't declare "WRITE/READ_EXTERNAL_STORAGE" permission in
its Android.manifest, getExternalCacheDirectory() will still return null even
though sd card is mounted.For cordova usage, the permission is not added by default.

BUG=XWALK-1952
