### PR TITLE
[Android] Add "xwalk" prefix to manifest extensions

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -33,6 +33,17 @@ const char kURLKey[] = "url";
 const char kVersionKey[] = "version";
 const char kWebURLsKey[] = "app.urls";
 const char kXWalkHostsKey[] = "xwalk_hosts";
+const char kXWalkLaunchScreen[] = "xwalk_launch_screen";
+const char kXWalkLaunchScreenDefault[] = "xwalk_launch_screen.default";
+const char kXWalkLaunchScreenImageBorderDefault[] =
+    "xwalk_launch_screen.default.image_border";
+const char kXWalkLaunchScreenImageBorderLandscape[] =
+    "xwalk_launch_screen.landscape.image_border";
+const char kXWalkLaunchScreenImageBorderPortrait[] =
+    "xwalk_launch_screen.portrait.image_border";
+const char kXWalkLaunchScreenLandscape[] = "xwalk_launch_screen.landscape";
+const char kXWalkLaunchScreenPortrait[] = "xwalk_launch_screen.portrait";
+const char kXWalkLaunchScreenReadyWhen[] = "xwalk_launch_screen.ready_when";
 
 #if defined(OS_TIZEN)
 const char kTizenAppIdKey[] = "tizen_app_id";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -32,6 +32,14 @@ namespace application_manifest_keys {
   extern const char kVersionKey[];
   extern const char kWebURLsKey[];
   extern const char kXWalkHostsKey[];
+  extern const char kXWalkLaunchScreen[];
+  extern const char kXWalkLaunchScreenDefault[];
+  extern const char kXWalkLaunchScreenImageBorderDefault[];
+  extern const char kXWalkLaunchScreenImageBorderLandscape[];
+  extern const char kXWalkLaunchScreenImageBorderPortrait[];
+  extern const char kXWalkLaunchScreenLandscape[];
+  extern const char kXWalkLaunchScreenPortrait[];
+  extern const char kXWalkLaunchScreenReadyWhen[];
 
 #if defined(OS_TIZEN)
   extern const char kTizenAppIdKey[];


### PR DESCRIPTION
According to http://w3c.github.io/manifest/, vendor
extensions should have vendor prefix.
For Crosswalk on Android, launch screen is an extension
of manifest.
This commit add "xwalk" prefix to all related paths.
The legacy paths are still supported, but will print a
warning message to logcat.

Related to XWALK-1918
