### PR TITLE
[Android] Fix that xwalk core library is missing resources

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -181,7 +181,7 @@ def CopyResources(project_source, out_dir):
       # (package, prefix) turple.
       ('ui/android/java/res', 'ui'),
       ('content/public/android/java/res', 'content'),
-      ('xwalk/runtime/android/java/res', 'xwalk_core'),
+      ('xwalk/runtime/android/core_internal/res', 'xwalk_core_internal'),
   ]
 
   # For each res, there are two generated res folder in out directory,


### PR DESCRIPTION
The script to generate xwalk core library is still trying
to fetch resources from xwalk core.
It should be xwalk core internal.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1978
