### PR TITLE
Application storage should not cache all installed applications data

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -84,8 +84,10 @@ bool ApplicationService::Uninstall(const std::string& id) {
 }
 
 void ApplicationService::ChangeLocale(const std::string& locale) {
-  const ApplicationData::ApplicationDataMap& apps =
-      application_storage_->GetInstalledApplications();
+  ApplicationData::ApplicationDataMap apps;
+  if (!application_storage_->GetInstalledApplications(apps))
+    return;
+
   ApplicationData::ApplicationDataMap::const_iterator it;
   for (it = apps.begin(); it != apps.end(); ++it) {
     base::string16 error;

--- a/application/browser/application_storage.h
+++ b/application/browser/application_storage.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/memory/ref_counted.h"
-#include "base/observer_list.h"
 #include "xwalk/application/common/application_data.h"
 
 namespace xwalk {
@@ -23,22 +22,20 @@ class ApplicationStorage {
 
   bool AddApplication(scoped_refptr<ApplicationData> app_data);
 
-  bool RemoveApplication(const std::string& id);
+  bool RemoveApplication(const std::string& app_id);
 
   bool UpdateApplication(scoped_refptr<ApplicationData> app_data);
 
   bool Contains(const std::string& app_id) const;
 
   scoped_refptr<ApplicationData> GetApplicationData(
-      const std::string& application_id) const;
+      const std::string& app_id) const;
 
-  const ApplicationData::ApplicationDataMap& GetInstalledApplications() const;
+  bool GetInstalledApplications(
+      ApplicationData::ApplicationDataMap& apps) const;  // NOLINT
 
  private:
-  bool Insert(scoped_refptr<ApplicationData> app_data);
-  base::FilePath data_path_;
   scoped_ptr<class ApplicationStorageImpl> impl_;
-  ApplicationData::ApplicationDataMap applications_;
   DISALLOW_COPY_AND_ASSIGN(ApplicationStorage);
 };
 

--- a/application/browser/application_storage_impl.h
+++ b/application/browser/application_storage_impl.h
@@ -28,14 +28,18 @@ class ApplicationStorageImpl {
   bool AddApplication(const ApplicationData* application,
                       const base::Time& install_time);
   bool RemoveApplication(const std::string& key);
+  bool ContainsApplication(const std::string& key);
   bool UpdateApplication(ApplicationData* application,
                          const base::Time& install_time);
-  bool Init(
-      ApplicationData::ApplicationDataMap& applications);
+  bool Init();
+
+  scoped_refptr<ApplicationData> GetApplicationData(const std::string& id);
   bool GetInstalledApplications(
-      ApplicationData::ApplicationDataMap& applications);
+      ApplicationData::ApplicationDataMap& applications);  // NOLINT
 
  private:
+  scoped_refptr<ApplicationData> ExtractApplicationData(
+      const sql::Statement& smt);
   bool UpgradeToVersion1(const base::FilePath& v0_file);
   bool SetApplicationValue(const ApplicationData* application,
                            const base::Time& install_time,

--- a/application/browser/application_storage_impl_unittest.cc
+++ b/application/browser/application_storage_impl_unittest.cc
@@ -26,13 +26,12 @@ class ApplicationStorageImplTest : public testing::Test {
     ASSERT_TRUE(PathService::Get(base::DIR_TEMP, &tmp));
     ASSERT_TRUE(temp_dir_.CreateUniqueTempDirUnderPath(tmp));
     app_storage_impl_.reset(new ApplicationStorageImpl(temp_dir_.path()));
-    ASSERT_TRUE(app_storage_impl_->Init(applications));
+    ASSERT_TRUE(app_storage_impl_->Init());
   }
 
  protected:
   base::ScopedTempDir temp_dir_;
   scoped_ptr<ApplicationStorageImpl> app_storage_impl_;
-  ApplicationData::ApplicationDataMap applications;
 };
 
 TEST_F(ApplicationStorageImplTest, CreateDBFile) {
@@ -111,8 +110,9 @@ TEST_F(ApplicationStorageImplTest, DBUpgradeToV1) {
   ASSERT_TRUE(base::PathExists(v0_db_file));
 
   app_storage_impl_.reset(new ApplicationStorageImpl(temp_dir_.path()));
+  ASSERT_TRUE(app_storage_impl_->Init());
   ApplicationData::ApplicationDataMap applications;
-  ASSERT_TRUE(app_storage_impl_->Init(applications));
+  ASSERT_TRUE(app_storage_impl_->GetInstalledApplications(applications));
   ASSERT_FALSE(base::PathExists(v0_db_file));
   EXPECT_EQ(applications.size(), 1);
   EXPECT_TRUE(applications["test_id"]);

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -53,8 +53,8 @@ bool ApplicationSystem::HandleApplicationManagementCommands(
     bool& run_default_message_loop) { // NOLINT
   run_default_message_loop = false;
   if (cmd_line.HasSwitch(switches::kListApplications)) {
-    const ApplicationData::ApplicationDataMap& apps =
-        application_storage_->GetInstalledApplications();
+    ApplicationData::ApplicationDataMap apps;
+    application_storage_->GetInstalledApplications(apps);
     LOG(INFO) << "Application ID                       Application Name";
     LOG(INFO) << "-----------------------------------------------------";
     ApplicationData::ApplicationDataMap::const_iterator it;

--- a/application/browser/linux/installed_applications_manager.cc
+++ b/application/browser/linux/installed_applications_manager.cc
@@ -88,8 +88,8 @@ void InstalledApplicationsManager::OnApplicationNameChanged(
 }
 
 void InstalledApplicationsManager::AddInitialObjects() {
-  const ApplicationData::ApplicationDataMap& apps =
-      app_storage_->GetInstalledApplications();
+  ApplicationData::ApplicationDataMap apps;
+  app_storage_->GetInstalledApplications(apps);
   ApplicationData::ApplicationDataMap::const_iterator it;
   for (it = apps.begin(); it != apps.end(); ++it)
     AddObject(it->second);

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -188,7 +188,6 @@ bool ApplicationData::InitApplicationID(xwalk::application::Manifest* manifest,
 ApplicationData::ApplicationData(const base::FilePath& path,
                      scoped_ptr<xwalk::application::Manifest> manifest)
     : manifest_version_(0),
-      is_dirty_(false),
       manifest_(manifest.release()),
       finished_parsing_manifest_(false) {
   DCHECK(path.empty() || path.IsAbsolute());
@@ -327,7 +326,6 @@ bool ApplicationData::SetPermission(const std::string& permission_name,
                                     StoredPermission perm) {
   if (perm != UNDEFINED_STORED_PERM) {
     permission_map_[permission_name] = perm;
-    is_dirty_ = true;
     return true;
   }
   return false;

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -111,8 +111,6 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
     return manifest_.get();
   }
 
-  bool IsDirty() const { return is_dirty_; }
-
   const base::Time& install_time() const { return install_time_; }
 
   // App-related.

--- a/application/common/application_storage_constants.cc
+++ b/application/common/application_storage_constants.cc
@@ -37,6 +37,12 @@ const char kCreateGarbageCollectionTriggersOp[] =
     "CREATE TRIGGER IF NOT EXISTS del_garbage_app AFTER INSERT ON applications"
     " BEGIN DELETE FROM garbage_collection WHERE app_id = NEW.id; END";
 
+const char kGetRowFromAppTableOp[] =
+    "SELECT A.id, A.manifest, A.path, A.install_time, "
+    "C.permission_names FROM applications as A "
+    "LEFT JOIN stored_permissions as C "
+    "ON A.id = C.id WHERE A.id = ?";
+
 const char kGetAllRowsFromAppTableOp[] =
     "SELECT A.id, A.manifest, A.path, A.install_time, "
     "C.permission_names FROM applications as A "

--- a/application/common/application_storage_constants.h
+++ b/application/common/application_storage_constants.h
@@ -18,6 +18,7 @@ namespace application_storage_constants {
   extern const char kCreatePermissionTableOp[];
   extern const char kCreateGarbageCollectionTableOp[];
   extern const char kCreateGarbageCollectionTriggersOp[];
+  extern const char kGetRowFromAppTableOp[];
   extern const char kGetAllRowsFromAppTableOp[];
   extern const char kSetApplicationWithBindOp[];
   extern const char kUpdateApplicationWithBindOp[];


### PR DESCRIPTION
Since we dropped "Main document" functionality there is no need for
Application storage to cache all installed applications data, besides
doing so uselessly wastes memory.
Another goal of this patch is preparation Application storage for accessing
it from other processes than browser process (e.g. from xwalkctl process)
and for using different Application storage implementations.
