### PR TITLE
[Tizen][Runtime] Enable to load local resources using file protocol.

### DIFF
--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -69,6 +69,17 @@ class XWalkFrameHelper
         render_frame()->GetWebFrame(), context);
   }
 
+#if defined(OS_TIZEN)
+  virtual void DidCommitProvisionalLoad(bool is_new_navigation) OVERRIDE {
+    blink::WebFrame* frame = render_frame()->GetWebFrame();
+    GURL url(frame->document().url());
+    if (url.SchemeIs(application::kApplicationScheme)) {
+      blink::WebSecurityOrigin origin = frame->document().securityOrigin();
+      origin.grantLoadLocalResources();
+    }
+  }
+#endif
+
  private:
   extensions::XWalkExtensionRendererController* extension_controller_;
 


### PR DESCRIPTION
For WGT package, load local resources using file protocol will be
blocked by xwalk runtime, even the permission is granted by CSP or WARP
policy rules. The patch will grant the access permission for file
protocol if it's enabled by CSP or WARP security policy.

BUG=XWALK-1990
