### PR TITLE
[Android Extension] Fix Activity leaking caused by DeviceCapabilities ex...

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/device_capabilities/DeviceCapabilitiesCodecs.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/device_capabilities/DeviceCapabilitiesCodecs.java
@@ -8,14 +8,14 @@ import org.json.JSONObject;
 import org.xwalk.core.internal.extension.XWalkExtensionContext;
 
 class DeviceCapabilitiesCodecs {
-    private static XWalkMediaCodec sMediaCodec;
+    private XWalkMediaCodec mediaCodec;
 
     public DeviceCapabilitiesCodecs(DeviceCapabilities instance,
                                     XWalkExtensionContext context) {
-        sMediaCodec = XWalkMediaCodec.getInstance(instance);
+        mediaCodec = XWalkMediaCodec.Create(instance);
     }
 
     public JSONObject getInfo() {
-        return sMediaCodec.getCodecsInfo();
+        return mediaCodec.getCodecsInfo();
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/device_capabilities/XWalkMediaCodec.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/device_capabilities/XWalkMediaCodec.java
@@ -31,7 +31,6 @@ abstract class XWalkMediaCodec {
     protected Set<VideoCodecElement> mVideoCodecsSet;
 
     protected DeviceCapabilities mDeviceCapabilities;
-    private static XWalkMediaCodec sInstance;
 
     protected class AudioCodecElement {
         public String codecName;
@@ -75,15 +74,14 @@ abstract class XWalkMediaCodec {
         }
     }
 
-    public static XWalkMediaCodec getInstance(DeviceCapabilities instance) {
-        if (sInstance == null) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                sInstance = new MediaCodec(instance);
-            } else {
-                sInstance = new MediaCodecNull(instance);
-            }
+    public static XWalkMediaCodec Create(DeviceCapabilities instance) {
+        XWalkMediaCodec codec;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            codec = new MediaCodec(instance);
+        } else {
+            codec = new MediaCodecNull(instance);
         }
-        return sInstance;
+        return codec;
     }
 
     public abstract JSONObject getCodecsInfo();


### PR DESCRIPTION
...tension

The static XWalkMediaCodec singleton instance indirectly holds a
reference to Activity via XWalkExtensionManager, it would prevent the
Activity object from GCed and then leak it and all its resources.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2000
