### PR TITLE
[Android] Refine the key event dispatch for xwalkview

### DIFF
--- a/app/android/app_hello_world/src/org/xwalk/app/hello/world/HelloWorldActivity.java
+++ b/app/android/app_hello_world/src/org/xwalk/app/hello/world/HelloWorldActivity.java
@@ -6,7 +6,6 @@ package org.xwalk.app.hello.world;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.view.KeyEvent;
 import android.view.View;
 import android.widget.TextView;
 
@@ -16,17 +15,6 @@ public class HelloWorldActivity extends XWalkRuntimeActivityBase {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-    }
-
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        // Passdown the key-up event to runtime view.
-        if (getRuntimeView() != null &&
-                getRuntimeView().onKeyUp(keyCode, event)) {
-            return true;
-        }
-
-        return super.onKeyUp(keyCode, event);
     }
 
     @Override

--- a/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
+++ b/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
@@ -9,7 +9,6 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.view.WindowManager;
-import android.view.KeyEvent;
 import android.view.View;
 import android.widget.TextView;
 
@@ -19,17 +18,6 @@ public class AppTemplateActivity extends XWalkRuntimeActivityBase {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-    }
-
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        // Passdown the key-up event to runtime view.
-        if (getRuntimeView() != null &&
-                getRuntimeView().onKeyUp(keyCode, event)) {
-            return true;
-        }
-
-        return super.onKeyUp(keyCode, event);
     }
 
     @Override

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
@@ -8,7 +8,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.util.AttributeSet;
-import android.view.KeyEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 
@@ -37,7 +36,6 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
     private Method mOnNewIntent;
     private Method mEnableRemoteDebugging;
     private Method mDisableRemoteDebugging;
-    private Method mOnKeyUp;
 
     // For instrumentation test.
     private Method mGetTitleForTest;
@@ -67,7 +65,6 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
         mOnNewIntent = lookupMethod("onNewIntent", Intent.class);
         mEnableRemoteDebugging = lookupMethod("enableRemoteDebugging", String.class, String.class);
         mDisableRemoteDebugging = lookupMethod("disableRemoteDebugging");
-        mOnKeyUp = lookupMethod("onKeyUp", int.class, KeyEvent.class);
     }
 
     /**
@@ -243,19 +240,6 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
      */
     public void disableRemoteDebugging() {
         invokeMethod(mDisableRemoteDebugging, mInstance);
-    }
-
-    /**
-     * Passdown key-up event to the runtime view.
-     * Usually meet the case of clicking on the back key.
-     */
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        // Normally, java can handle the convertion of boolean and Boolean well,
-        // But here invokeMethod is possible to return null if runtime lib not found,
-        // Convert null to boolean will cause NullPointerException.
-        Boolean handled = (Boolean) invokeMethod(mOnKeyUp, mInstance, keyCode, event);
-        if (handled != null) return handled;
-        return false;
     }
 
     // The following functions just for instrumentation test.

--- a/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/shell/XWalkRuntimeClientEmbeddedShellActivity.java
+++ b/app/android/runtime_client_embedded_shell/src/org/xwalk/runtime/client/embedded/shell/XWalkRuntimeClientEmbeddedShellActivity.java
@@ -45,17 +45,6 @@ public class XWalkRuntimeClientEmbeddedShellActivity extends XWalkRuntimeActivit
     }
 
     @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        // Passdown the key-up event to runtime view.
-        if (getRuntimeView() != null &&
-                getRuntimeView().onKeyUp(keyCode, event)) {
-            return true;
-        }
-
-        return super.onKeyUp(keyCode, event);
-    }
-
-    @Override
     public void onDestroy() {
         super.onDestroy();
         unregisterTracingReceiver();

--- a/app/android/runtime_client_shell/src/org/xwalk/runtime/client/shell/XWalkRuntimeClientShellActivity.java
+++ b/app/android/runtime_client_shell/src/org/xwalk/runtime/client/shell/XWalkRuntimeClientShellActivity.java
@@ -30,17 +30,6 @@ public class XWalkRuntimeClientShellActivity extends XWalkRuntimeActivityBase {
         super.onCreate(savedInstanceState);
     }
 
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        // Passdown the key-up event to runtime view.
-        if (getRuntimeView() != null &&
-                getRuntimeView().onKeyUp(keyCode, event)) {
-            return true;
-        }
-
-        return super.onKeyUp(keyCode, event);
-    }
-
     private static String sanitizeUrl(String url) {
         if (url == null) return url;
         if (url.startsWith("www.") || url.indexOf(":") == -1) url = "http://" + url;

--- a/runtime/android/core/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkView.java
@@ -9,7 +9,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.AttributeSet;
-import android.view.KeyEvent;
 import android.webkit.ValueCallback;
 
 import org.xwalk.core.internal.XWalkNavigationHistoryInternal;
@@ -421,17 +420,5 @@ public class XWalkView extends XWalkViewInternal {
      */
     public void setResourceClient(XWalkResourceClient client) {
         super.setResourceClient(client);
-    }
-
-    /**
-     * Inherit from <a href="http://developer.android.com/reference/android/view/View.html">
-     * android.view.View</a>. This class needs to handle some keys like
-     * 'BACK'.
-     * @param keyCode passed from android.view.View.onKeyUp().
-     * @param event passed from android.view.View.onKeyUp().
-     */
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        return super.onKeyUp(keyCode, event);
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -93,6 +93,11 @@ abstract class XWalkContentsClient extends ContentViewClient {
         onTitleChanged(title);
     }
 
+    @Override
+    public boolean shouldOverrideKeyEvent(KeyEvent event) {
+        return super.shouldOverrideKeyEvent(event);
+    }
+
     void installWebContentsObserver(ContentViewCore contentViewCore) {
         if (mWebContentsObserver != null) {
             mWebContentsObserver.detachFromWebContents();

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -153,7 +153,21 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
+    public boolean shouldOverrideKeyEvent(KeyEvent event) {
+        boolean overridden = false;
+        if (mXWalkClient != null && mXWalkView != null)
+            overridden = mXWalkClient.shouldOverrideKeyEvent(mXWalkView, event);
+        if (!overridden) {
+            return super.shouldOverrideKeyEvent(event);
+        }
+        return overridden;
+    }
+
+    @Override
     public void onUnhandledKeyEvent(KeyEvent event) {
+        if (mXWalkClient != null && mXWalkView != null) {
+            mXWalkClient.onUnhandledKeyEvent(mXWalkView, event);
+        }
     }
 
     @Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -637,30 +637,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         mContent.setResourceClient(client);
     }
 
-    /**
-     * Inherit from <a href="http://developer.android.com/reference/android/view/View.html">
-     * android.view.View</a>. This class needs to handle some keys like
-     * 'BACK'.
-     * @param keyCode passed from android.view.View.onKeyUp().
-     * @param event passed from android.view.View.onKeyUp().
-     */
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK) {
-            // If there's navigation happens when app is fullscreen,
-            // the content will still be fullscreen after navigation.
-            // In such case, the back key will exit fullscreen first.
-            if (hasEnteredFullscreen()) {
-                leaveFullscreen();
-                return true;
-            } else if (canGoBack()) {
-                goBack();
-                return true;
-            }
-        }
-        return false;
-    }
-
     // TODO(yongsheng): this is not public.
     /**
      * @hide
@@ -824,5 +800,26 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         if (mContent == null) return;
         checkThreadSafety();
         mContent.setNotificationService(service);
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        if (event.getAction() == KeyEvent.ACTION_UP &&
+                event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+            // If there's navigation happens when app is fullscreen,
+            // the content will still be fullscreen after navigation.
+            // In such case, the back key will exit fullscreen first.
+            if (hasEnteredFullscreen()) {
+                leaveFullscreen();
+                return true;
+            } else if (canGoBack()) {
+                goBack();
+                return true;
+            }
+        }
+        return super.dispatchKeyEvent(event);
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegate.java
@@ -4,6 +4,8 @@
 
 package org.xwalk.core.internal;
 
+import android.view.KeyEvent;
+
 import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
 import org.chromium.components.web_contents_delegate_android.WebContentsDelegateAndroid;
@@ -24,6 +26,9 @@ abstract class XWalkWebContentsDelegate extends WebContentsDelegateAndroid {
 
     @CalledByNative
     public abstract void rendererResponsive();
+
+    @CalledByNative
+    public abstract void handleKeyboardEvent(KeyEvent event);
 
     @CalledByNative
     public abstract boolean shouldOverrideRunFileChooser(

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegateAdapter.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegateAdapter.java
@@ -5,6 +5,7 @@
 package org.xwalk.core.internal;
 
 import android.util.Log;
+import android.view.KeyEvent;
 
 class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
 
@@ -43,6 +44,12 @@ class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
     @Override
     public void rendererResponsive() {
         if (mXWalkContentsClient != null) mXWalkContentsClient.onRendererResponsive();
+    }
+
+    @Override
+    public void handleKeyboardEvent(KeyEvent event) {
+        // Handle the event here when necessary and return if so.
+        if (mXWalkContentsClient != null) mXWalkContentsClient.onUnhandledKeyEvent(event);
     }
 
     @Override

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -196,14 +196,6 @@ public class XWalkViewShellActivity extends FragmentActivity
     }
 
     @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        if (mActiveView != null) {
-            return mActiveView.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event);
-        }
-        return super.onKeyUp(keyCode, event);
-    }
-
-    @Override
     public void onNewIntent(Intent intent) {
         if (mActiveView != null) {
             if (!mActiveView.onNewIntent(intent)) super.onNewIntent(intent);

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -7,7 +7,6 @@ package org.xwalk.runtime;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.view.KeyEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 
@@ -116,10 +115,5 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
     @Override
     public void loadDataForTest(String data, String mimeType, boolean isBase64Encoded) {
         mXWalkView.load("", data);
-    }
-
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        return mXWalkView.onKeyUp(keyCode, event);
     }
 }

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeView.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeView.java
@@ -8,7 +8,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.util.AttributeSet;
-import android.view.KeyEvent;
 import android.widget.FrameLayout;
 
 /**
@@ -170,14 +169,6 @@ public class XWalkRuntimeView extends FrameLayout {
      */
     public void disableRemoteDebugging() {
         mProvider.disableRemoteDebugging();
-    }
-
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        // Passdown the key-up event to runtime core.
-        if (mProvider.onKeyUp(keyCode, event)) return true;
-
-        return super.onKeyUp(keyCode, event);
     }
 
     // For instrumentation test.

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -7,7 +7,6 @@ package org.xwalk.runtime;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.view.KeyEvent;
 import android.view.View;
 
 /**
@@ -31,7 +30,6 @@ interface XWalkRuntimeViewProvider {
     public void loadAppFromManifest(String manifestUrl);
     public void enableRemoteDebugging(String frontEndUrl, String socketName);
     public void disableRemoteDebugging();
-    public boolean onKeyUp(int KeyCode, KeyEvent event);
 
     // For instrumentation test.
     public String getTitleForTest();

--- a/runtime/android/runtime_shell/src/org/xwalk/runtime/shell/XWalkRuntimeShellActivity.java
+++ b/runtime/android/runtime_shell/src/org/xwalk/runtime/shell/XWalkRuntimeShellActivity.java
@@ -76,13 +76,6 @@ public class XWalkRuntimeShellActivity extends Activity {
         mRuntimeView.onActivityResult(requestCode, resultCode, data);
     }
 
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        if (mRuntimeView.onKeyUp(keyCode, event)) return true;
-
-        return super.onKeyUp(keyCode, event);
-    }
-
     private void waitForDebuggerIfNeeded() {
         if (CommandLine.getInstance().hasSwitch(BaseSwitches.WAIT_FOR_JAVA_DEBUGGER)) {
             Log.e(TAG, "Waiting for Java debugger to connect...");

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -146,6 +146,20 @@ void XWalkWebContentsDelegate::RendererResponsive(WebContents* source) {
   Java_XWalkWebContentsDelegate_rendererResponsive(env, obj.obj());
 }
 
+void XWalkWebContentsDelegate::HandleKeyboardEvent(
+    content::WebContents* source,
+    const content::NativeWebKeyboardEvent& event) {
+  jobject key_event = event.os_event;
+  if (!key_event)
+    return;
+  JNIEnv* env = AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> obj = GetJavaDelegate(env);
+  if (obj.is_null())
+    return;
+  Java_XWalkWebContentsDelegate_handleKeyboardEvent(env, obj.obj(), key_event);
+}
+
+
 void XWalkWebContentsDelegate::ToggleFullscreenModeForTab(
     content::WebContents* web_contents,
     bool enter_fullscreen) {

--- a/runtime/browser/android/xwalk_web_contents_delegate.h
+++ b/runtime/browser/android/xwalk_web_contents_delegate.h
@@ -41,6 +41,10 @@ class XWalkWebContentsDelegate
   virtual void RendererUnresponsive(content::WebContents* source) OVERRIDE;
   virtual void RendererResponsive(content::WebContents* source) OVERRIDE;
 
+  virtual void HandleKeyboardEvent(
+      content::WebContents* source,
+      const content::NativeWebKeyboardEvent& event) OVERRIDE;
+
   virtual void ToggleFullscreenModeForTab(content::WebContents* web_contents,
                                           bool enter_fullscreen) OVERRIDE;
   virtual bool IsFullscreenForTabOrPending(


### PR DESCRIPTION
Including following changes:
1. Hook shouldOverrideKeyEvent and onUnhandledKeyEvent into
   content layer correctly.
2. Move the key event handling in xwalkview into dispatchKeyEvent.

After change the process of key dispatch in xwalkview will be:
  Activity.dispatchKeyEvent
  -> XWalkClient.shouldOverrideKeyevent
        <if shouldOverrideKeyevent returns true>
     -> XWalkView.dispatchKeyEvent (handles backkey here)
        <if shouldOverrideKeyevent returns false>
     -> dispatch keyevent to renderer
        <if renderer doesn't consume the keyevent>
        -> web_contents_delegate::HandleKeyboardEvent
           -> XWalkWebContentDelegate.handleKeyboardEvent
              -> XWalkClient.onUnhandledKeyevent

It's pre-adjust for Embedding API v2.

Related to bug: XWALK-2003
