### PR TITLE
[Android] Mark content as a local scheme in blink

### DIFF
--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -25,6 +25,7 @@
 #include "xwalk/runtime/renderer/pepper/pepper_helper.h"
 
 #if defined(OS_ANDROID)
+#include "xwalk/runtime/browser/android/net/url_constants.h"
 #include "xwalk/runtime/renderer/android/xwalk_permission_client.h"
 #include "xwalk/runtime/renderer/android/xwalk_render_process_observer.h"
 #include "xwalk/runtime/renderer/android/xwalk_render_view_ext.h"
@@ -103,6 +104,10 @@ void XWalkContentRendererClient::RenderThreadStarted() {
   xwalk_render_process_observer_.reset(new XWalkRenderProcessObserver);
   thread->AddObserver(xwalk_render_process_observer_.get());
 #if defined(OS_ANDROID)
+  blink::WebString content_scheme(
+      base::ASCIIToUTF16(xwalk::kContentScheme));
+  blink::WebSecurityPolicy::registerURLSchemeAsLocal(content_scheme);
+
   visited_link_slave_.reset(new visitedlink::VisitedLinkSlave);
   thread->AddObserver(visited_link_slave_.get());
 #endif


### PR DESCRIPTION
Now there is no option to enable the cross-origin-access in the
context of content url in embedded mode. Regarding file scheme we
use setAllowUniversalAccessFromFileURLs option to support the
cross-orign-access. This way works for all the schemes which are
recognized as the "local" ones in blink. That's straightforward
to let content scheme follow this way to support the
cross-orgin-access setting.

BUG=XWALK-1959
