### PR TITLE
Remove methods in XWalkWebChromeClient which are dead code/empty impl

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
@@ -52,6 +52,6 @@ class XWalkContentVideoViewClient implements ContentVideoViewClient {
 
     @Override
     public View getVideoLoadingProgressView() {
-        return mContentsClient.getVideoLoadingProgressView();
+        return null;
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -163,8 +163,6 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
     protected abstract void onRequestFocus();
 
-    protected abstract View getVideoLoadingProgressView();
-
     public abstract void onPageStarted(String url);
 
     public abstract void onPageFinished(String url);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -351,13 +351,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
-    protected View getVideoLoadingProgressView() {
-        if (mXWalkWebChromeClient != null)
-            return mXWalkWebChromeClient.getVideoLoadingProgressView();
-        return null;
-    }
-
-    @Override
     public void didFinishLoad(String url) {
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
@@ -303,18 +303,6 @@ public class XWalkWebChromeClient {
         return false;
     }
 
-    /**
-     * When the user starts to playback a video element, it may take time for enough
-     * data to be buffered before the first frames can be rendered. While this buffering
-     * is taking place, the ChromeClient can use this function to provide a View to be
-     * displayed. For example, the ChromeClient could show a spinner animation.
-     *
-     * @return View The View to be displayed whilst the video is loading.
-     */
-    public View getVideoLoadingProgressView() {
-        return null;
-    }
-
     /** Obtains a list of all visited history items, used for link coloring
      */
     public void getVisitedHistory(ValueCallback<String[]> callback) {


### PR DESCRIPTION
XWalkWebChromeClient is an internal class and not exposed in Embedding API, if the methods here is designed to be empty inside xwalk core, we should just remove the related code.
