### PR TITLE
[Runtime] Fix cannot get right application's permissions information from database.

### DIFF
--- a/application/common/application_storage_impl.cc
+++ b/application/common/application_storage_impl.cc
@@ -260,7 +260,7 @@ scoped_refptr<ApplicationData> ApplicationStorageImpl::ExtractApplicationData(
 
   app_data->install_time_ = base::Time::FromDoubleT(install_time);
 
-  app_data->permission_map_ = ToPermissionMap(smt.ColumnString(5));
+  app_data->permission_map_ = ToPermissionMap(smt.ColumnString(4));
 
   return app_data;
 }

--- a/application/common/application_storage_impl_unittest.cc
+++ b/application/common/application_storage_impl_unittest.cc
@@ -158,5 +158,32 @@ TEST_F(ApplicationStorageImplTest, DBUpdate) {
       new_application->GetManifest()->value()));
 }
 
+TEST_F(ApplicationStorageImplTest, SetPermission) {
+  TestInit();
+  base::DictionaryValue manifest;
+  manifest.SetString(keys::kNameKey, "no name");
+  manifest.SetString(keys::kVersionKey, "0");
+  manifest.SetString("a", "b");
+  std::string error;
+  scoped_refptr<ApplicationData> application =
+      ApplicationData::Create(base::FilePath(),
+                              Manifest::INTERNAL,
+                              manifest,
+                              "",
+                              &error);
+  ASSERT_TRUE(error.empty());
+  ASSERT_TRUE(application);
+  EXPECT_TRUE(application->SetPermission("permission", ALLOW));
+  EXPECT_TRUE(app_storage_impl_->AddApplication(application.get(),
+                                                base::Time::FromDoubleT(0)));
+
+  ApplicationData::ApplicationDataMap applications;
+  ASSERT_TRUE(app_storage_impl_->GetInstalledApplications(applications));
+  EXPECT_EQ(applications.size(), 1);
+  EXPECT_TRUE(applications[application->ID()]);
+  EXPECT_TRUE(
+      applications[application->ID()]->GetPermission("permission") == ALLOW);
+}
+
 }  // namespace application
 }  // namespace xwalk


### PR DESCRIPTION
Crosswalk runtime can not get the permissions information from database
since there's a mistake in source code after some reconstructions. This
patch try to solve this.
