### PR TITLE
[Tools] Groundwork for tracking Chromium's dependencies with git.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -1,22 +1,75 @@
-''' This file indicate the dependencies crosswalk lays on.
-    DO NOT use this DEPS to checkout code, it's for tools/generate_gclient-xwalk.py.
-'''
+# Source code dependencies required for building Crosswalk.
+#
+# This file is used as a template to generate .gclient-xwalk, which is a
+# regular .gclient file pointing to additional source code repositories that
+# need to be checked out in order to build Crosswalk.
+#
+# These dependencies are not specified in DEPS for historical compatibility
+# reasons and also to allow us to perform some additional manipulation on some
+# entries (such as setting a custom value for "deps_file" in certain
+# solutions).
+#
+# If you are doing a DEPS roll, you should only need to worry about the *_rev
+# variables below.
 
-# chromium_version is the version of chromium crosswalk based,
-# Usually it's major.minor.build.patch
-# Use 'Trunk' for trunk.
-# If using trunk, will use '.DEPS.git' for gclient.
+# -----------------------------------
+# Crosswalk dependencies.
+# Edit these when rolling DEPS.xwalk.
+# -----------------------------------
+
 chromium_version = '36.0.1985.18'
-chromium_crosswalk_point = 'f8b103e7c4f60e2cf88f49594dbcdd06e58ffa17'
-blink_crosswalk_point = '99b0aa2fd873af570eb84cbbd342a343ce8bfd7f'
-v8_crosswalk_point = '535cd006e5174ff00fd7b745a581980b1d371a9f'
-ozone_wayland_point = '5047b6ea8843bfd439a9f5adf2e270cd6fa6db7c'
 
-deps_xwalk = {
-  'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,
-  'src/third_party/WebKit': 'https://github.com/crosswalk-project/blink-crosswalk.git@%s' % blink_crosswalk_point,
-  'src/v8': 'https://github.com/crosswalk-project/v8-crosswalk.git@%s' % v8_crosswalk_point,
+chromium_crosswalk_rev = 'f8b103e7c4f60e2cf88f49594dbcdd06e58ffa17'
+blink_crosswalk_rev = '99b0aa2fd873af570eb84cbbd342a343ce8bfd7f'
+v8_crosswalk_rev = '535cd006e5174ff00fd7b745a581980b1d371a9f'
+ozone_wayland_rev = '5047b6ea8843bfd439a9f5adf2e270cd6fa6db7c'
 
-  # Ozone-Wayland is required for Wayland support in Chromium.
-  'src/ozone': 'https://github.com/01org/ozone-wayland.git@%s' % ozone_wayland_point,
+crosswalk_git = 'https://github.com/crosswalk-project'
+ozone_wayland_git = 'https://github.com/01org'
+
+# ------------------------------------------------------
+# gclient solutions.
+# You do not need to worry about these most of the time.
+# ------------------------------------------------------
+
+chromium_solution = {
+  'name': chromium_version,
+  'url': 'http://src.chromium.org/svn/releases/' + chromium_version,
+  'custom_deps': {
+    'src':
+      crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
+    'src/third_party/WebKit':
+      crosswalk_git + '/blink-crosswalk.git@' + blink_crosswalk_rev,
+    'src/v8':
+      crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
+    'src/ozone':
+      ozone_wayland_git + '/ozone-wayland.git@' + ozone_wayland_rev,
+  }
 }
+
+# These directories are not relevant to Crosswalk and can be safely ignored
+# in a checkout. It avoids creating additional directories outside src/ that
+# are not used and also saves some bandwidth.
+ignored_directories = [
+  'build',
+  'build/scripts/command_wrapper/bin',
+  'build/scripts/gsd_generate_index',
+  'build/scripts/private/data/reliability',
+  'build/scripts/tools/deps2git',
+  'build/third_party/cbuildbot_chromite',
+  'build/third_party/gsutil',
+  'build/third_party/lighttpd',
+  'build/third_party/swarm_client',
+  'build/third_party/xvfb',
+  'build/xvfb',
+  'commit-queue',
+  'depot_tools',
+]
+for ignored_directory in ignored_directories:
+  chromium_solution['custom_deps'][ignored_directory] = None
+
+solutions = [chromium_solution]
+
+# -------------------------------------------------
+# This area is edited by generate_gclient-xwalk.py.
+# -------------------------------------------------

--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -6,99 +6,40 @@
 
 """
 This script is responsible for generating .gclient-xwalk in the top-level
-source directory by parsing .DEPS.xwalk.
+source directory from DEPS.xwalk.
 """
 
 import optparse
 import os
 import pprint
-import sys
 
 
-class GClientFileGenerator(object):
-  def __init__(self, options):
-    self._options = options
-    self._xwalk_dir = os.path.dirname(
-        os.path.dirname(os.path.abspath(__file__)))
-    self._deps_file = os.path.join(self._xwalk_dir, 'DEPS.xwalk')
-    self._deps = None
-    self._chromium_version = None
-    self._ParseDepsFile()
-    if not 'src' in self._deps:
-      raise RuntimeError("'src' not specified in deps file(%s)" % options.deps)
-    self._src_dep = self._deps['src']
-    # self should be at src/xwalk/tools/fetch_deps.py
-    # so src is at self/../../../
-    self._src_dir = os.path.dirname(self._xwalk_dir)
-    self._root_dir = os.path.dirname(self._src_dir)
-    self._new_gclient_file = os.path.join(self._root_dir,
-                                          '.gclient-xwalk')
+CROSSWALK_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GCLIENT_ROOT = os.path.dirname(os.path.dirname(CROSSWALK_ROOT))
 
-  def _ParseDepsFile(self):
-    if not os.path.exists(self._deps_file):
-      raise IOError('Deps file does not exist (%s).' % self._deps_file)
-    exec_globals = {}
 
-    execfile(self._deps_file, exec_globals)
-    self._deps = exec_globals['deps_xwalk']
-    self._chromium_version = exec_globals['chromium_version']
+def GenerateGClientXWalk(options):
+  with open(os.path.join(CROSSWALK_ROOT, 'DEPS.xwalk')) as deps_file:
+    deps_contents = deps_file.read()
 
-  def _AddIgnoredPaths(self):
-    """
-    Excludes certain directories from a checkout that are not relevant to
-    Crosswalk (basically, directories outside src/).
-    """
-    ignores = [
-      'build',
-      'build/scripts/command_wrapper/bin',
-      'build/scripts/gsd_generate_index',
-      'build/scripts/private/data/reliability',
-      'build/scripts/tools/deps2git',
-      'build/third_party/cbuildbot_chromite',
-      'build/third_party/gsutil',
-      'build/third_party/lighttpd',
-      'build/third_party/swarm_client',
-      'build/third_party/xvfb',
-      'build/xvfb',
-      'commit-queue',
-      'depot_tools',
-    ]
-    for ignore in ignores:
-      self._deps[ignore] = None
+  if 'XWALK_OS_ANDROID' in os.environ:
+    deps_contents += 'target_os = [\'android\']\n'
+  if options.cache_dir:
+    deps_contents += 'cache_dir = %s\n' % pprint.pformat(options.cache_dir)
 
-  def Generate(self):
-    self._AddIgnoredPaths()
-    solution = {
-      'name': self._chromium_version,
-      'url': 'http://src.chromium.org/svn/releases/%s' %
-              self._chromium_version,
-      'custom_deps': self._deps,
-    }
-    solutions = [solution]
-    gclient_file = open(self._new_gclient_file, 'w')
-    print "Place %s with solutions:\n%s" % (self._new_gclient_file, solutions)
-    gclient_file.write('solutions = %s\n' % pprint.pformat(solutions))
-    # Check whether the target OS is Android.
-    if os.environ.get('XWALK_OS_ANDROID'):
-      target_os = ['android']
-      gclient_file.write('target_os = %s\n' % target_os)
-    if self._options.cache_dir:
-      gclient_file.write('cache_dir = %s\n' %
-                         pprint.pformat(self._options.cache_dir))
+  with open(os.path.join(GCLIENT_ROOT, '.gclient-xwalk'), 'w') as gclient_file:
+    gclient_file.write(deps_contents)
 
 
 def main():
   option_parser = optparse.OptionParser()
-
   option_parser.add_option('--cache-dir',
                            help='Set "cache_dir" in the .gclient file to this '
                                 'directory, so that all git repositories are '
                                 'cached there and shared across multiple '
                                 'clones.')
-
   options, _ = option_parser.parse_args()
-
-  sys.exit(GClientFileGenerator(options).Generate())
+  GenerateGClientXWalk(options)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch series does the majority of the work necessary for actually
making the full switch to git in a way that does not break anyone's
workflow and allows the bots to switch back and forth between git and
SVN while this is being reviewed. It takes a much less radical approach
than #2109 for that matter.

The main idea here is to move most of the logic in
`generate_gclient-xwalk.py` into `DEPS.xwalk` itself. Quoting the last
and most important commit in this series:

> Most of the code in `generate_gclient-xwalk.py` should not exist: it
> functioned mostly as a translator that read values from `DEPS.xwalk`
> and changed them into a format suitable for gclient.
> 
> We can get rid of this intermediate step by writing `DEPS.xwalk` in a
> gclient-compatible format. In practice, this means that `DEPS.xwalk`
> is now responsible for:
> - Setting git revision values for repositories we track, such as
>   chromium-crosswalk and ozone-wayland (as before).
> - Automatically ignoring some directories in the checkout.
> - Setting variables parsed by gclient, such as `solutions`.
> 
> All this also allows us to remove a lot of validation code that was
> scattered around `generate_gclient-xwalk.py`.
> 
> `generate_gclient-xwalk.py` now exists merely for compatibility, as it
> still needs to parse the `XWALK_OS_ANDROID` environment variable and
> the `--cache-dir` option and append a few more lines to
> `.gclient-xwalk` accordingly. I can see these features being moved
> somewhere else and the script getting removed altogether in the
> future.

The other commits are just small simplifications to the code to get rid
of features that were never used. The most significant of them is
_Ignore a smaller subset of directories in a checkout_, which does end
up checking out a few additional smaller repositories.

With this pull request, most of the work in XWALK-1894 is done, even
though there is no visible difference to any users yet and all
repositories still come from SVN just like before.
