### PR TITLE
[Tizen/Desktop] Re-organize storage partition management

### DIFF
--- a/application/common/application_storage.cc
+++ b/application/common/application_storage.cc
@@ -50,5 +50,10 @@ bool ApplicationStorage::GetInstalledApplications(
   return impl_->GetInstalledApplications(apps);
 }
 
+bool ApplicationStorage::GetInstalledApplicationIDs(
+    std::vector<std::string>& app_ids) const {  // NOLINT
+  return impl_->GetInstalledApplicationIDs(app_ids);
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/application_storage.h
+++ b/application/common/application_storage.h
@@ -30,9 +30,13 @@ class ApplicationStorage {
 
   scoped_refptr<ApplicationData> GetApplicationData(
       const std::string& app_id) const;
-
+  // Note: Do not use this method! It is too heavy and it will be
+  // removed.
   bool GetInstalledApplications(
       ApplicationData::ApplicationDataMap& apps) const;  // NOLINT
+
+  bool GetInstalledApplicationIDs(
+      std::vector<std::string>& app_ids) const;  // NOLINT
 
  private:
   scoped_ptr<class ApplicationStorageImpl> impl_;

--- a/application/common/application_storage_constants.cc
+++ b/application/common/application_storage_constants.cc
@@ -27,16 +27,6 @@ const char kCreatePermissionTableOp[] =
     "FOREIGN KEY (id) REFERENCES applications(id)"
     "ON DELETE CASCADE)";
 
-const char kCreateGarbageCollectionTableOp[] =
-    "CREATE TABLE garbage_collection ("
-    "app_id TEXT NOT NULL PRIMARY KEY)";
-
-const char kCreateGarbageCollectionTriggersOp[] =
-    "CREATE TRIGGER IF NOT EXISTS add_garbage_app AFTER DELETE ON applications"
-    " BEGIN INSERT INTO garbage_collection VALUES (OLD.id); END;"
-    "CREATE TRIGGER IF NOT EXISTS del_garbage_app AFTER INSERT ON applications"
-    " BEGIN DELETE FROM garbage_collection WHERE app_id = NEW.id; END";
-
 const char kGetRowFromAppTableOp[] =
     "SELECT A.id, A.manifest, A.path, A.install_time, "
     "C.permission_names FROM applications as A "
@@ -48,6 +38,9 @@ const char kGetAllRowsFromAppTableOp[] =
     "C.permission_names FROM applications as A "
     "LEFT JOIN stored_permissions as C "
     "ON A.id = C.id";
+
+extern const char kGetAllIDsFromAppTableOp[] =
+    "SELECT id FROM applications";
 
 const char kSetApplicationWithBindOp[] =
     "INSERT INTO applications (manifest, path, install_time, id) "
@@ -69,12 +62,6 @@ const char kUpdatePermissionsWithBindOp[] =
 
 const char kDeletePermissionsWithBindOp[] =
     "DELETE FROM stored_permissions WHERE id = ?";
-
-const char kGetAllRowsFromGarbageCollectionTableOp[] =
-    "SELECT app_id FROM garbage_collection";
-
-const char kDeleteGarbageAppIdWithBindOp[] =
-    "DELETE FROM garbage_collection WHERE app_id = ?";
 
 }  // namespace application_storage_constants
 }  // namespace xwalk

--- a/application/common/application_storage_constants.h
+++ b/application/common/application_storage_constants.h
@@ -16,18 +16,15 @@ namespace application_storage_constants {
 
   extern const char kCreateAppTableOp[];
   extern const char kCreatePermissionTableOp[];
-  extern const char kCreateGarbageCollectionTableOp[];
-  extern const char kCreateGarbageCollectionTriggersOp[];
   extern const char kGetRowFromAppTableOp[];
   extern const char kGetAllRowsFromAppTableOp[];
+  extern const char kGetAllIDsFromAppTableOp[];
   extern const char kSetApplicationWithBindOp[];
   extern const char kUpdateApplicationWithBindOp[];
   extern const char kDeleteApplicationWithBindOp[];
   extern const char kInsertPermissionsWithBindOp[];
   extern const char kUpdatePermissionsWithBindOp[];
   extern const char kDeletePermissionsWithBindOp[];
-  extern const char kGetAllRowsFromGarbageCollectionTableOp[];
-  extern const char kDeleteGarbageAppIdWithBindOp[];
 
 }  // namespace application_storage_constants
 }  // namespace xwalk

--- a/application/common/application_storage_impl.h
+++ b/application/common/application_storage_impl.h
@@ -37,6 +37,9 @@ class ApplicationStorageImpl {
   bool GetInstalledApplications(
       ApplicationData::ApplicationDataMap& applications);  // NOLINT
 
+  bool GetInstalledApplicationIDs(
+      std::vector<std::string>& app_ids);  // NOLINT
+
  private:
   scoped_refptr<ApplicationData> ExtractApplicationData(
       const sql::Statement& smt);
@@ -53,8 +56,6 @@ class ApplicationStorageImpl {
   bool UpdatePermissions(const std::string& id,
                          const StoredPermissionMap& permissions);
   bool RevokePermissions(const std::string& id);
-
-  bool CollectGarbageApplications();
 
   scoped_ptr<sql::Connection> sqlite_db_;
   sql::MetaTable meta_table_;

--- a/application/common/installer/package_installer.cc
+++ b/application/common/installer/package_installer.cc
@@ -24,8 +24,6 @@
 #include "xwalk/application/common/permission_policy_manager.h"
 #include "xwalk/application/common/application_storage.h"
 #include "xwalk/application/common/installer/tizen/packageinfo_constants.h"
-#include "xwalk/runtime/browser/runtime_context.h"
-#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 
 #if defined(OS_TIZEN)
@@ -305,13 +303,6 @@ bool PackageInstaller::Uninstall(const std::string& id) {
                << id << "; Cannot remove all resources.";
     result = false;
   }
-
-  // Clear databases, the directory clean up will happen next time Crosswalk
-  // startup by ApplicationStorageImpl::CollectGarbageApplications.
-  content::BrowserContext::AsyncObliterateStoragePartition(
-      XWalkRunner::GetInstance()->runtime_context(),
-      ApplicationData::GetBaseURLFromApplicationId(id),
-      base::Bind(&base::DoNothing));
 
   if (!PlatformUninstall(app_data))
     result = false;


### PR DESCRIPTION
This patch removes storage partition cleanup logic from Application
Storage and Package Installer making them completely independent
from browser content API layer. Hence now both of them can be used
outside the browser process (e.g. from 'xwalkctl').

The Application Storage implementation is now much simpler which is
very important as we have plans to create an alternative Application
Storage implementation for Tizen, based on the platform 'app_info.db'.
