### PR TITLE
[Android] Adjust annotation of Embedding API for documentation

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkJavascriptResult.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkJavascriptResult.java
@@ -16,16 +16,19 @@ public interface XWalkJavascriptResult {
     /**
      * Handle a confirm with a result from caller.
      * @param result the result string from caller.
+     * @since 1.0
      */
     public void confirmWithResult(String result);
 
     /**
      * Handle a confirm without a result.
+     * @since 1.0
      */
     public void confirm();
 
     /**
      * Handle the result if the caller cancelled the dialog.
+     * @since 1.0
      */
     public void cancel();
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkNavigationHistory.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNavigationHistory.java
@@ -14,13 +14,14 @@ import org.xwalk.core.internal.XWalkNavigationItemInternal;
  */
 public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal {
 
-    public XWalkNavigationHistory(XWalkNavigationHistoryInternal internal) {
+    XWalkNavigationHistory(XWalkNavigationHistoryInternal internal) {
         super(internal);
     }
 
     /**
      * Total size of navigation history for the XWalkView.
      * @return the size of total navigation items.
+     * @since 1.0
      */
     public int size() {
         return super.size();
@@ -30,6 +31,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
      * Test whether there is an item at a specific index.
      * @param index the given index.
      * @return true if there is an item at the specific index.
+     * @since 1.0
      */
     public boolean hasItemAt(int index) {
         return super.hasItemAt(index);
@@ -39,6 +41,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
      * Get a specific item given by index.
      * @param index the given index.
      * @return the navigation item for the given index.
+     * @since 1.0
      */
     public XWalkNavigationItem getItemAt(int index) {
         XWalkNavigationItemInternal item = super.getItemAt(index);
@@ -52,6 +55,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
     /**
      * Get the current item which XWalkView displays.
      * @return the current navigation item.
+     * @since 1.0
      */
     public XWalkNavigationItem getCurrentItem() {
         XWalkNavigationItemInternal item = super.getCurrentItem();
@@ -65,6 +69,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
     /**
      * Test whether XWalkView can go back.
      * @return true if it can go back.
+     * @since 1.0
      */
     public boolean canGoBack() {
         return super.canGoBack();
@@ -73,6 +78,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
     /**
      * Test whether XWalkView can go forward.
      * @return true if it can go forward.
+     * @since 1.0
      */
     public boolean canGoForward() {
         return super.canGoForward();
@@ -80,6 +86,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
 
     /**
      * The direction for web page navigation.
+     * @since 1.0
      */
     public enum Direction {
         /** The backward direction for web page navigation. */
@@ -93,6 +100,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
      * Do nothing if the offset is out of bound.
      * @param direction the direction of navigation.
      * @param steps go back or foward with a given steps.
+     * @since 1.0
      */
     public void navigate(Direction direction, int steps) {
         super.navigate(DirectionInternal.valueOf(direction.toString()), steps);
@@ -101,6 +109,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
     /**
      * Get the index for current navigation item.
      * @return current index in the navigation history.
+     * @since 1.0
      */
     public int getCurrentIndex() {
         return super.getCurrentIndex();
@@ -108,6 +117,7 @@ public final class XWalkNavigationHistory extends XWalkNavigationHistoryInternal
 
     /**
      * Clear all history owned by this XWalkView.
+     * @since 1.0
      */
     public void clear() {
         super.clear();

--- a/runtime/android/core/src/org/xwalk/core/XWalkNavigationItem.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkNavigationItem.java
@@ -11,13 +11,14 @@ import org.xwalk.core.internal.XWalkNavigationItemInternal;
  */
 public final class XWalkNavigationItem extends XWalkNavigationItemInternal {
 
-    public XWalkNavigationItem(XWalkNavigationItemInternal internal) {
+    XWalkNavigationItem(XWalkNavigationItemInternal internal) {
         super(internal);
     }
 
     /**
      * Get the url of current navigation item.
      * @return the string of the url.
+     * @since 1.0
      */
     public String getUrl() {
         return super.getUrl();
@@ -26,6 +27,7 @@ public final class XWalkNavigationItem extends XWalkNavigationItemInternal {
     /**
      * Get the original url of current navigation item.
      * @return the string of the original url.
+     * @since 1.0
      */
     public String getOriginalUrl() {
         return super.getOriginalUrl();
@@ -34,6 +36,7 @@ public final class XWalkNavigationItem extends XWalkNavigationItemInternal {
     /**
      * Get the title of current navigation item.
      * @return the string of the title.
+     * @since 1.0
      */
     public String getTitle() {
         return super.getTitle();

--- a/runtime/android/core/src/org/xwalk/core/XWalkPreferences.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkPreferences.java
@@ -15,6 +15,7 @@ import org.xwalk.core.internal.XWalkPreferencesInternal;
 public final class XWalkPreferences extends XWalkPreferencesInternal {
     /**
      * The key string to enable/disable remote debugging.
+     * @since 1.0
      */
     public static final String REMOTE_DEBUGGING = "remote-debugging";
 
@@ -39,6 +40,7 @@ public final class XWalkPreferences extends XWalkPreferencesInternal {
      *
      * Note this key MUST be set before creating the first XWalkView, otherwise
      * a RuntimeException will be thrown.
+     * @since 2.0
      */
     public static final String ANIMATABLE_XWALK_VIEW = "animatable-xwalk-view";
 
@@ -47,6 +49,7 @@ public final class XWalkPreferences extends XWalkPreferencesInternal {
      * the key for the preference is not valid.
      * @param key the string name of the key.
      * @param enabled true if setting it as enabled.
+     * @since 1.0
      */
     public static synchronized void setValue(String key, boolean enabled) throws RuntimeException {
         XWalkPreferencesInternal.setValue(key, enabled);
@@ -57,6 +60,7 @@ public final class XWalkPreferences extends XWalkPreferencesInternal {
      * the key for the preference is not valid.
      * @param key the string name of the key.
      * @return true if it's enabled.
+     * @since 1.0
      */
     public static synchronized boolean getValue(String key) throws RuntimeException {
         return XWalkPreferencesInternal.getValue(key);

--- a/runtime/android/core/src/org/xwalk/core/XWalkResourceClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkResourceClient.java
@@ -15,47 +15,110 @@ import org.xwalk.core.internal.XWalkViewInternal;
  * This class notifies the embedder resource events/callbacks.
  */
 public class XWalkResourceClient extends XWalkResourceClientInternal {
-    /** Success */
+    /**
+     * Success
+     * @since 1.0
+     */
     public static final int ERROR_OK = 0;
-    /** Generic error */
+    /**
+     * Generic error
+     * @since 1.0
+     */
     public static final int ERROR_UNKNOWN = -1;
-    /** Server or proxy hostname lookup failed */
+    /**
+     * Server or proxy hostname lookup failed
+     * @since 1.0
+     */
     public static final int ERROR_HOST_LOOKUP = -2;
-    /** Unsupported authentication scheme (not basic or digest) */
+    /**
+     * Unsupported authentication scheme (not basic or digest)
+     * @since 1.0
+     */
     public static final int ERROR_UNSUPPORTED_AUTH_SCHEME = -3;
-    /** User authentication failed on server */
+    /**
+     * User authentication failed on server
+     * @since 1.0
+     */
     public static final int ERROR_AUTHENTICATION = -4;
-    /** User authentication failed on proxy */
+    /**
+     * User authentication failed on proxy
+     * @since 1.0
+     */
     public static final int ERROR_PROXY_AUTHENTICATION = -5;
-    /** Failed to connect to the server */
+    /**
+     * Failed to connect to the server
+     * @since 1.0
+     */
     public static final int ERROR_CONNECT = -6;
-    /** Failed to read or write to the server */
+    /**
+     * Failed to read or write to the server
+     * @since 1.0
+     */
     public static final int ERROR_IO = -7;
-    /** Connection timed out */
+    /**
+     * Connection timed out
+     * @since 1.0
+     */
     public static final int ERROR_TIMEOUT = -8;
-    /** Too many redirects */
+    /**
+     * Too many redirects
+     * @since 1.0
+     */
     public static final int ERROR_REDIRECT_LOOP = -9;
-    /** Unsupported URI scheme */
+    /**
+     * Unsupported URI scheme
+     * @since 1.0
+     */
     public static final int ERROR_UNSUPPORTED_SCHEME = -10;
-    /** Failed to perform SSL handshake */
+    /**
+     * Failed to perform SSL handshake
+     * @since 1.0
+     */
     public static final int ERROR_FAILED_SSL_HANDSHAKE = -11;
-    /** Malformed URL */
+    /**
+     * Malformed URL
+     * @since 1.0
+     */
     public static final int ERROR_BAD_URL = -12;
-    /** Generic file error */
+    /**
+     * Generic file error
+     * @since 1.0
+     */
     public static final int ERROR_FILE = -13;
-    /** File not found */
+    /**
+     * File not found
+     * @since 1.0
+     */
     public static final int ERROR_FILE_NOT_FOUND = -14;
-    /** Too many requests during this load */
+    /**
+     * Too many requests during this load
+     * @since 1.0
+     */
     public static final int ERROR_TOO_MANY_REQUESTS = -15;
 
     /**
      * Constructor.
      * @param view the owner XWalkView instance.
+     * @since 1.0
      */
     public XWalkResourceClient(XWalkView view) {
         super(view);
     }
 
+    /**
+     * Notify the client that the XWalkView will load the resource specified
+     * by the given url.
+     * @param view the owner XWalkView instance.
+     * @param url the url for the resource to be loaded.
+     * @since 1.0
+     */
+    public void onLoadStarted(XWalkView view, String url) {
+        super.onLoadStarted(view, url);
+    }
+
+    /**
+     * @hide
+     */
     @Override
     public void onLoadStarted(XWalkViewInternal view, String url) {
         if (view instanceof XWalkView) {
@@ -66,15 +129,19 @@ public class XWalkResourceClient extends XWalkResourceClientInternal {
     }
 
     /**
-     * Notify the client that the XWalkView will load the resource specified
-     * by the given url.
+     * Notify the client that the XWalkView completes to load the resource
+     * specified by the given url.
      * @param view the owner XWalkView instance.
-     * @param url the url for the resource to be loaded.
+     * @param url the url for the resource done for loading.
+     * @since 1.0
      */
-    public void onLoadStarted(XWalkView view, String url) {
-        super.onLoadStarted(view, url);
+    public void onLoadFinished(XWalkView view, String url) {
+        super.onLoadFinished(view, url);
     }
 
+    /**
+     * @hide
+     */
     @Override
     public void onLoadFinished(XWalkViewInternal view, String url) {
         if (view instanceof XWalkView) {
@@ -85,15 +152,18 @@ public class XWalkResourceClient extends XWalkResourceClientInternal {
     }
 
     /**
-     * Notify the client that the XWalkView completes to load the resource
-     * specified by the given url.
+     * Notify the client the progress info of loading a specific url.
      * @param view the owner XWalkView instance.
-     * @param url the url for the resource done for loading.
+     * @param progressInPercent the loading process in percent.
+     * @since 1.0
      */
-    public void onLoadFinished(XWalkView view, String url) {
-        super.onLoadFinished(view, url);
+    public void onProgressChanged(XWalkView view, int progressInPercent) {
+        super.onProgressChanged(view, progressInPercent);
     }
 
+    /**
+     * @hide
+     */
     @Override
     public void onProgressChanged(XWalkViewInternal view, int progressInPercent) {
         if (view instanceof XWalkView) {
@@ -101,24 +171,6 @@ public class XWalkResourceClient extends XWalkResourceClientInternal {
         } else {
             super.onProgressChanged(view, progressInPercent);
         }
-    }
-
-    /**
-     * Notify the client the progress info of loading a specific url.
-     * @param view the owner XWalkView instance.
-     * @param progressInPercent the loading process in percent.
-     */
-    public void onProgressChanged(XWalkView view, int progressInPercent) {
-        super.onProgressChanged(view, progressInPercent);
-    }
-
-    @Override
-    public WebResourceResponse shouldInterceptLoadRequest(XWalkViewInternal view, String url) {
-        if (view instanceof XWalkView) {
-            return shouldInterceptLoadRequest((XWalkView) view, url);
-        }
-
-        return super.shouldInterceptLoadRequest(view, url);
     }
 
     /**
@@ -134,19 +186,22 @@ public class XWalkResourceClient extends XWalkResourceClientInternal {
      * @return A {@link android.webkit.WebResourceResponse} containing the
      *         response information or null if the XWalkView should load the
      *         resource itself.
+     * @since 1.0
      */
     public WebResourceResponse shouldInterceptLoadRequest(XWalkView view, String url) {
         return super.shouldInterceptLoadRequest(view, url);
     }
 
+    /**
+     * @hide
+     */
     @Override
-    public void onReceivedLoadError(XWalkViewInternal view, int errorCode, String description,
-            String failingUrl) {
+    public WebResourceResponse shouldInterceptLoadRequest(XWalkViewInternal view, String url) {
         if (view instanceof XWalkView) {
-            onReceivedLoadError((XWalkView) view, errorCode, description, failingUrl);
-        } else {
-            super.onReceivedLoadError(view, errorCode, description, failingUrl);
+            return shouldInterceptLoadRequest((XWalkView) view, url);
         }
+
+        return super.shouldInterceptLoadRequest(view, url);
     }
 
     /**
@@ -155,9 +210,23 @@ public class XWalkResourceClient extends XWalkResourceClientInternal {
      * @param errorCode the error id.
      * @param description A String describing the error.
      * @param failingUrl The url that failed to load.
+     * @since 1.0
      */
     public void onReceivedLoadError(XWalkView view, int errorCode, String description,
             String failingUrl) {
         super.onReceivedLoadError(view, errorCode, description, failingUrl);
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public void onReceivedLoadError(XWalkViewInternal view, int errorCode, String description,
+            String failingUrl) {
+        if (view instanceof XWalkView) {
+            onReceivedLoadError((XWalkView) view, errorCode, description, failingUrl);
+        } else {
+            super.onReceivedLoadError(view, errorCode, description, failingUrl);
+        }
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
@@ -19,6 +19,7 @@ public class XWalkUIClient extends XWalkUIClientInternal {
     /**
      * Constructor.
      * @param view the owner XWalkView instance.
+     * @since 1.0
      */
     public XWalkUIClient(XWalkView view) {
         super(view);
@@ -26,6 +27,7 @@ public class XWalkUIClient extends XWalkUIClientInternal {
 
     /**
      * The type of JavaScript modal dialog.
+     * @since 1.0
      */
     public enum JavascriptMessageType {
         /** JavaScript alert dialog. */
@@ -38,6 +40,29 @@ public class XWalkUIClient extends XWalkUIClientInternal {
         JAVASCRIPT_BEFOREUNLOAD
     }
 
+    /**
+     * Tell the client to display a prompt dialog to the user.
+     * @param view the owner XWalkView instance.
+     * @param type the type of JavaScript modal dialog.
+     * @param url the url of the web page which wants to show this dialog.
+     * @param message the message to be shown.
+     * @param defaultValue the default value string. Only valid for Prompt dialog.
+     * @param result the callback to handle the result from caller.
+     * @since 1.0
+     */
+    public boolean onJavascriptModalDialog(XWalkView view, JavascriptMessageType type,
+            String url, String message, String defaultValue, XWalkJavascriptResult result) {
+        XWalkJavascriptResultInternal resultInternal =
+                ((XWalkJavascriptResultHandler) result).getInternal();
+        JavascriptMessageTypeInternal typeInternal =
+                JavascriptMessageTypeInternal.valueOf(type.toString());
+        return super.onJavascriptModalDialog(
+                view, typeInternal, url, message, defaultValue, resultInternal);
+    }
+
+    /**
+     * @hide
+     */
     @Override
     public boolean onJavascriptModalDialog(XWalkViewInternal view,
             JavascriptMessageTypeInternal typeInternal,
@@ -55,24 +80,17 @@ public class XWalkUIClient extends XWalkUIClientInternal {
     }
 
     /**
-     * Tell the client to display a prompt dialog to the user.
+     * Request display and focus for this XWalkView.
      * @param view the owner XWalkView instance.
-     * @param type the type of JavaScript modal dialog.
-     * @param url the url of the web page which wants to show this dialog.
-     * @param message the message to be shown.
-     * @param defaultValue the default value string. Only valid for Prompt dialog.
-     * @param result the callback to handle the result from caller.
+     * @since 1.0
      */
-    public boolean onJavascriptModalDialog(XWalkView view, JavascriptMessageType type,
-            String url, String message, String defaultValue, XWalkJavascriptResult result) {
-        XWalkJavascriptResultInternal resultInternal =
-                ((XWalkJavascriptResultHandler) result).getInternal();
-        JavascriptMessageTypeInternal typeInternal =
-                JavascriptMessageTypeInternal.valueOf(type.toString());
-        return super.onJavascriptModalDialog(
-                view, typeInternal, url, message, defaultValue, resultInternal);
+    public void onRequestFocus(XWalkView view) {
+        super.onRequestFocus(view);
     }
 
+    /**
+     * @hide
+     */
     @Override
     public void onRequestFocus(XWalkViewInternal view) {
         if (view instanceof XWalkView) {
@@ -83,13 +101,17 @@ public class XWalkUIClient extends XWalkUIClientInternal {
     }
 
     /**
-     * Request display and focus for this XWalkView.
+     * Notify the client to close the given XWalkView.
      * @param view the owner XWalkView instance.
+     * @since 1.0
      */
-    public void onRequestFocus(XWalkView view) {
-        super.onRequestFocus(view);
+    public void onJavascriptCloseWindow(XWalkView view) {
+        super.onJavascriptCloseWindow(view);
     }
 
+    /**
+     * @hide
+     */
     @Override
     public void onJavascriptCloseWindow(XWalkViewInternal view) {
         if (view instanceof XWalkView) {
@@ -100,38 +122,24 @@ public class XWalkUIClient extends XWalkUIClientInternal {
     }
 
     /**
-     * Notify the client to close the given XWalkView.
+     * Tell the client to toggle fullscreen mode.
      * @param view the owner XWalkView instance.
+     * @param enterFullscreen true if it has entered fullscreen mode.
+     * @since 1.0
      */
-    public void onJavascriptCloseWindow(XWalkView view) {
-        super.onJavascriptCloseWindow(view);
+    public void onFullscreenToggled(XWalkView view, boolean enterFullscreen) {
+        super.onFullscreenToggled(view, enterFullscreen);
     }
 
+    /**
+     * @hide
+     */
     @Override
     public void onFullscreenToggled(XWalkViewInternal view, boolean enterFullscreen) {
         if (view instanceof XWalkView) {
             onFullscreenToggled((XWalkView) view, enterFullscreen);
         } else {
             super.onFullscreenToggled(view, enterFullscreen);
-        }
-    }
-
-    /**
-     * Tell the client to toggle fullscreen mode.
-     * @param view the owner XWalkView instance.
-     * @param enterFullscreen true if it has entered fullscreen mode.
-     */
-    public void onFullscreenToggled(XWalkView view, boolean enterFullscreen) {
-        super.onFullscreenToggled(view, enterFullscreen);
-    }
-
-    @Override
-    public void openFileChooser(XWalkViewInternal view, ValueCallback<Uri> uploadFile,
-            String acceptType, String capture) {
-        if (view instanceof XWalkView) {
-            openFileChooser((XWalkView) view, uploadFile, acceptType, capture);
-        } else {
-            super.openFileChooser(view, uploadFile, acceptType, capture);
         }
     }
 
@@ -145,18 +153,23 @@ public class XWalkUIClient extends XWalkUIClientInternal {
      *        with this file picker.
      * @param capture value of the 'capture' attribute of the input tag associated
      *        with this file picker
+     * @since 1.0
      */
     public void openFileChooser(XWalkView view, ValueCallback<Uri> uploadFile,
             String acceptType, String capture) {
         super.openFileChooser(view, uploadFile, acceptType, capture);
     }
 
+    /**
+     * @hide
+     */
     @Override
-    public void onScaleChanged(XWalkViewInternal view, float oldScale, float newScale) {
+    public void openFileChooser(XWalkViewInternal view, ValueCallback<Uri> uploadFile,
+            String acceptType, String capture) {
         if (view instanceof XWalkView) {
-            onScaleChanged((XWalkView) view, oldScale, newScale);
+            openFileChooser((XWalkView) view, uploadFile, acceptType, capture);
         } else {
-            super.onScaleChanged(view, oldScale, newScale);
+            super.openFileChooser(view, uploadFile, acceptType, capture);
         }
     }
 
@@ -165,8 +178,21 @@ public class XWalkUIClient extends XWalkUIClientInternal {
      * @param view the owner XWalkView instance.
      * @param oldScale the old scale before scaling.
      * @param newScale the current scale factor after scaling.
+     * @since 1.0
      */
     public void onScaleChanged(XWalkView view, float oldScale, float newScale) {
         super.onScaleChanged(view, oldScale, newScale);
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public void onScaleChanged(XWalkViewInternal view, float oldScale, float newScale) {
+        if (view instanceof XWalkView) {
+            onScaleChanged((XWalkView) view, oldScale, newScale);
+        } else {
+            super.onScaleChanged(view, oldScale, newScale);
+        }
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkView.java
@@ -137,15 +137,22 @@ import org.xwalk.core.internal.XWalkViewInternal;
  */
 public class XWalkView extends XWalkViewInternal {
 
-    /** Normal reload mode as default. */
+    /**
+     * Normal reload mode as default.
+     * @since 1.0
+     */
     public static final int RELOAD_NORMAL = 0;
-    /** Reload mode with bypassing the cache. */
+    /**
+     * Reload mode with bypassing the cache.
+     * @since 1.0
+     */
     public static final int RELOAD_IGNORE_CACHE = 1;
 
     /**
      * Constructor for inflating via XML.
      * @param context  a Context object used to access application assets.
      * @param attrs    an AttributeSet passed to our parent.
+     * @since 1.0
      */
     public XWalkView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -156,6 +163,7 @@ public class XWalkView extends XWalkViewInternal {
      * different from activity. In embedded mode, they're same.
      * @param context  a Context object used to access application assets
      * @param activity the activity for this XWalkView.
+     * @since 1.0
      */
     public XWalkView(Context context, Activity activity) {
         super(context, activity);
@@ -174,6 +182,7 @@ public class XWalkView extends XWalkViewInternal {
      * It can also load files from Android assets, e.g. 'file:///android_asset/'.
      * @param url the url for web page/app.
      * @param content the content for the web page/app. Could be empty.
+     * @since 1.0
      */
     public void load(String url, String content) {
         super.load(url, content);
@@ -189,6 +198,7 @@ public class XWalkView extends XWalkViewInternal {
      * It can also load files from Android assets, e.g. 'file:///android_asset/'.
      * @param url the url for manifest.json.
      * @param content the content for manifest.json.
+     * @since 1.0
      */
     public void loadAppFromManifest(String url, String content) {
         super.loadAppFromManifest(url, content);
@@ -197,6 +207,7 @@ public class XWalkView extends XWalkViewInternal {
     /**
      * Reload a web app with a given mode.
      * @param mode the reload mode.
+     * @since 1.0
      */
     public void reload(int mode) {
         super.reload(mode);
@@ -204,6 +215,7 @@ public class XWalkView extends XWalkViewInternal {
 
     /**
      * Stop current loading progress.
+     * @since 1.0
      */
     public void stopLoading() {
         super.stopLoading();
@@ -213,6 +225,7 @@ public class XWalkView extends XWalkViewInternal {
      * Get the url of current web page/app. This may be different from what's passed
      * by caller.
      * @return the url for current web page/app.
+     * @since 1.0
      */
     public String getUrl() {
         return super.getUrl();
@@ -222,6 +235,7 @@ public class XWalkView extends XWalkViewInternal {
      * Get the title of current web page/app. This may be different from what's passed
      * by caller.
      * @return the title for current web page/app.
+     * @since 1.0
      */
     public String getTitle() {
         return super.getTitle();
@@ -230,6 +244,7 @@ public class XWalkView extends XWalkViewInternal {
     /**
      * Get the original url specified by caller.
      * @return the original url.
+     * @since 1.0
      */
     public String getOriginalUrl() {
         return super.getOriginalUrl();
@@ -239,6 +254,7 @@ public class XWalkView extends XWalkViewInternal {
      * Get the navigation history for current XWalkView. It's synchronized with
      * this XWalkView if any backward/forward and navigation operations.
      * @return the navigation history.
+     * @since 1.0
      */
     public XWalkNavigationHistory getNavigationHistory() {
         XWalkNavigationHistoryInternal history = super.getNavigationHistory();
@@ -255,6 +271,7 @@ public class XWalkView extends XWalkViewInternal {
      * marked with {@link JavascriptInterface} if it's called by JavaScript.
      * @param object the supplied Java object, called by JavaScript.
      * @param name the name injected in JavaScript.
+     * @since 1.0
      */
     public void addJavascriptInterface(Object object, String name) {
         super.addJavascriptInterface(object, name);
@@ -264,6 +281,7 @@ public class XWalkView extends XWalkViewInternal {
      * Evaluate a fragment of JavaScript code and get the result via callback.
      * @param script the JavaScript string.
      * @param callback the callback to handle the evaluated result.
+     * @since 1.0
      */
     public void evaluateJavascript(String script, ValueCallback<String> callback) {
         super.evaluateJavascript(script, callback);
@@ -273,6 +291,7 @@ public class XWalkView extends XWalkViewInternal {
      * Clear the resource cache. Note that the cache is per-application, so this
      * will clear the cache for all XWalkViews used.
      * @param includeDiskFiles indicate whether to clear disk files for cache.
+     * @since 1.0
      */
     public void clearCache(boolean includeDiskFiles) {
         super.clearCache(includeDiskFiles);
@@ -281,6 +300,7 @@ public class XWalkView extends XWalkViewInternal {
     /**
      * Indicate that a HTML element is occupying the whole screen.
      * @return true if any HTML element is occupying the whole screen.
+     * @since 1.0
      */
     public boolean hasEnteredFullscreen() {
         return super.hasEnteredFullscreen();
@@ -289,6 +309,7 @@ public class XWalkView extends XWalkViewInternal {
     /**
      * Leave fullscreen mode if it's. Do nothing if it's not
      * in fullscreen.
+     * @since 1.0
      */
     public void leaveFullscreen() {
         super.leaveFullscreen();
@@ -302,6 +323,8 @@ public class XWalkView extends XWalkViewInternal {
      *
      * Note that it will globally impact all XWalkView instances, not limited to
      * just this XWalkView.
+     *
+     * @since 1.0
      */
     public void pauseTimers() {
         super.pauseTimers();
@@ -313,6 +336,8 @@ public class XWalkView extends XWalkViewInternal {
      *
      * Note that it will globally impact all XWalkView instances, not limited to
      * just this XWalkView.
+     *
+     * @since 1.0
      */
     public void resumeTimers() {
         super.resumeTimers();
@@ -323,6 +348,7 @@ public class XWalkView extends XWalkViewInternal {
      * like video player, modal dialogs, etc. See {@link #pauseTimers} about pausing
      * JavaScript timers.
      * Typically it should be called when the activity for this view is paused.
+     * @since 1.0
      */
     public void onHide() {
         super.onHide();
@@ -332,6 +358,7 @@ public class XWalkView extends XWalkViewInternal {
      * Resume video player, modal dialogs. Embedders are in charge of calling
      * this during resuming this activity if they call onHide.
      * Typically it should be called when the activity for this view is resumed.
+     * @since 1.0
      */
     public void onShow() {
         super.onShow();
@@ -339,6 +366,7 @@ public class XWalkView extends XWalkViewInternal {
 
     /**
      * Release internal resources occupied by this XWalkView.
+     * @since 1.0
      */
     public void onDestroy() {
         super.onDestroy();
@@ -352,6 +380,7 @@ public class XWalkView extends XWalkViewInternal {
      * @param requestCode passed from android.app.Activity.onActivityResult().
      * @param resultCode passed from android.app.Activity.onActivityResult().
      * @param data passed from android.app.Activity.onActivityResult().
+     * @since 1.0
      */
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
@@ -363,6 +392,7 @@ public class XWalkView extends XWalkViewInternal {
      * <a href="http://developer.android.com/reference/android/app/Activity.html">
      * android.app.Activity.onNewIntent()</a>.
      * @param intent passed from android.app.Activity.onNewIntent().
+     * @since 1.0
      */
     public boolean onNewIntent(Intent intent) {
         return super.onNewIntent(intent);
@@ -372,6 +402,7 @@ public class XWalkView extends XWalkViewInternal {
      * Save current internal state of this XWalkView. This can help restore this state
      * afterwards restoring.
      * @param outState the saved state for restoring.
+     * @since 1.0
      */
     public boolean saveState(Bundle outState) {
         return super.saveState(outState);
@@ -381,6 +412,7 @@ public class XWalkView extends XWalkViewInternal {
      * Restore the state from the saved bundle data.
      * @param inState the state saved from saveState().
      * @return true if it can restore the state.
+     * @since 1.0
      */
     public boolean restoreState(Bundle inState) {
         return super.restoreState(inState);
@@ -389,6 +421,7 @@ public class XWalkView extends XWalkViewInternal {
     /**
      * Get the API version of Crosswalk embedding API.
      * @return the string of API level.
+     * @since 1.0
      */
     // TODO(yongsheng): make it static?
     public String getAPIVersion() {
@@ -398,6 +431,7 @@ public class XWalkView extends XWalkViewInternal {
     /**
      * Get the Crosswalk version.
      * @return the string of Crosswalk.
+     * @since 1.0
      */
     // TODO(yongsheng): make it static?
     public String getXWalkVersion() {
@@ -408,6 +442,7 @@ public class XWalkView extends XWalkViewInternal {
      * Embedders use this to customize their handlers to events/callbacks related
      * to UI.
      * @param client the XWalkUIClient defined by callers.
+     * @since 1.0
      */
     public void setUIClient(XWalkUIClient client) {
         super.setUIClient(client);
@@ -417,6 +452,7 @@ public class XWalkView extends XWalkViewInternal {
      * Embedders use this to customize their handlers to events/callbacks related
      * to resource loading.
      * @param client the XWalkResourceClient defined by callers.
+     * @since 1.0
      */
     public void setResourceClient(XWalkResourceClient client) {
         super.setResourceClient(client);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkJavascriptResultInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkJavascriptResultInternal.java
@@ -16,16 +16,19 @@ public interface XWalkJavascriptResultInternal {
     /**
      * Handle a confirm with a result from caller.
      * @param result the result string from caller.
+     * @since 1.0
      */
     public void confirmWithResult(String result);
 
     /**
      * Handle a confirm without a result.
+     * @since 1.0
      */
     public void confirm();
 
     /**
      * Handle the result if the caller cancelled the dialog.
+     * @since 1.0
      */
     public void cancel();
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationHistoryInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationHistoryInternal.java
@@ -29,6 +29,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
     /**
      * Total size of navigation history for the XWalkViewInternal.
      * @return the size of total navigation items.
+     * @since 1.0
      */
     public int size() {
         return mHistory.getEntryCount();
@@ -38,6 +39,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
      * Test whether there is an item at a specific index.
      * @param index the given index.
      * @return true if there is an item at the specific index.
+     * @since 1.0
      */
     public boolean hasItemAt(int index) {
         return index >=0 && index <= size() - 1;
@@ -47,6 +49,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
      * Get a specific item given by index.
      * @param index the given index.
      * @return the navigation item for the given index.
+     * @since 1.0
      */
     public XWalkNavigationItemInternal getItemAt(int index) {
         if (index < 0 || index >= size()) return null;
@@ -56,6 +59,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
     /**
      * Get the current item which XWalkViewInternal displays.
      * @return the current navigation item.
+     * @since 1.0
      */
     public XWalkNavigationItemInternal getCurrentItem() {
         return getItemAt(getCurrentIndex());
@@ -64,6 +68,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
     /**
      * Test whether XWalkViewInternal can go back.
      * @return true if it can go back.
+     * @since 1.0
      */
     public boolean canGoBack() {
         return mXWalkView.canGoBack();
@@ -72,6 +77,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
     /**
      * Test whether XWalkViewInternal can go forward.
      * @return true if it can go forward.
+     * @since 1.0
      */
     public boolean canGoForward() {
         return mXWalkView.canGoForward();
@@ -79,6 +85,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
 
     /**
      * The direction for web page navigation.
+     * @since 1.0
      */
     public enum DirectionInternal {
         /** The backward direction for web page navigation. */
@@ -92,6 +99,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
      * Do nothing if the offset is out of bound.
      * @param direction the direction of navigation.
      * @param steps go back or foward with a given steps.
+     * @since 1.0
      */
     public void navigate(DirectionInternal direction, int steps) {
         switch(direction) {
@@ -109,6 +117,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
     /**
      * Get the index for current navigation item.
      * @return current index in the navigation history.
+     * @since 1.0
      */
     public int getCurrentIndex() {
         return mHistory.getCurrentEntryIndex();
@@ -116,6 +125,7 @@ public class XWalkNavigationHistoryInternal implements Cloneable, Serializable {
 
     /**
      * Clear all history owned by this XWalkViewInternal.
+     * @since 1.0
      */
     public void clear() {
         mXWalkView.clearHistory();

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationItemInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationItemInternal.java
@@ -23,6 +23,7 @@ public class XWalkNavigationItemInternal implements Cloneable {
     /**
      * Get the url of current navigation item.
      * @return the string of the url.
+     * @since 1.0
      */
     public String getUrl() {
         return mEntry.getUrl();
@@ -31,6 +32,7 @@ public class XWalkNavigationItemInternal implements Cloneable {
     /**
      * Get the original url of current navigation item.
      * @return the string of the original url.
+     * @since 1.0
      */
     public String getOriginalUrl() {
         return mEntry.getOriginalUrl();
@@ -39,6 +41,7 @@ public class XWalkNavigationItemInternal implements Cloneable {
     /**
      * Get the title of current navigation item.
      * @return the string of the title.
+     * @since 1.0
      */
     public String getTitle() {
         return mEntry.getTitle();

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
@@ -27,6 +27,7 @@ public class XWalkPreferencesInternal {
 
     /**
      * The key string to enable/disable remote debugging.
+     * @since 1.0
      */
     public static final String REMOTE_DEBUGGING = "remote-debugging";
 
@@ -51,6 +52,8 @@ public class XWalkPreferencesInternal {
      *
      * Note this key MUST be set before creating the first XWalkViewInternal, otherwise
      * a RuntimeException will be thrown.
+     *
+     * @since 2.0
      */
     public static final String ANIMATABLE_XWALK_VIEW = "animatable-xwalk-view";
 
@@ -64,6 +67,7 @@ public class XWalkPreferencesInternal {
      * the key for the preference is not valid.
      * @param key the string name of the key.
      * @param enabled true if setting it as enabled.
+     * @since 1.0
      */
     public static synchronized void setValue(String key, boolean enabled) throws RuntimeException {
         checkKey(key);
@@ -84,6 +88,7 @@ public class XWalkPreferencesInternal {
      * the key for the preference is not valid.
      * @param key the string name of the key.
      * @return true if it's enabled.
+     * @since 1.0
      */
     public static synchronized boolean getValue(String key) throws RuntimeException {
         checkKey(key);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -14,42 +14,91 @@ import android.webkit.WebResourceResponse;
  * This class notifies the embedder resource events/callbacks.
  */
 public class XWalkResourceClientInternal {
-    /** Success */
+    /**
+     * Success
+     * @since 1.0
+     */
     public static final int ERROR_OK = 0;
-    /** Generic error */
+    /**
+     * Generic error
+     * @since 1.0
+     */
     public static final int ERROR_UNKNOWN = -1;
-    /** Server or proxy hostname lookup failed */
+    /**
+     * Server or proxy hostname lookup failed
+     * @since 1.0
+     */
     public static final int ERROR_HOST_LOOKUP = -2;
-    /** Unsupported authentication scheme (not basic or digest) */
+    /**
+     * Unsupported authentication scheme (not basic or digest)
+     * @since 1.0
+     */
     public static final int ERROR_UNSUPPORTED_AUTH_SCHEME = -3;
-    /** User authentication failed on server */
+    /**
+     * User authentication failed on server
+     * @since 1.0
+     */
     public static final int ERROR_AUTHENTICATION = -4;
-    /** User authentication failed on proxy */
+    /**
+     * User authentication failed on proxy
+     * @since 1.0
+     */
     public static final int ERROR_PROXY_AUTHENTICATION = -5;
-    /** Failed to connect to the server */
+    /**
+     * Failed to connect to the server
+     * @since 1.0
+     */
     public static final int ERROR_CONNECT = -6;
-    /** Failed to read or write to the server */
+    /**
+     * Failed to read or write to the server
+     * @since 1.0
+     */
     public static final int ERROR_IO = -7;
-    /** Connection timed out */
+    /**
+     * Connection timed out
+     * @since 1.0
+     */
     public static final int ERROR_TIMEOUT = -8;
-    /** Too many redirects */
+    /**
+     * Too many redirects
+     * @since 1.0
+     */
     public static final int ERROR_REDIRECT_LOOP = -9;
-    /** Unsupported URI scheme */
+    /**
+     * Unsupported URI scheme
+     * @since 1.0
+     */
     public static final int ERROR_UNSUPPORTED_SCHEME = -10;
-    /** Failed to perform SSL handshake */
+    /**
+     * Failed to perform SSL handshake
+     * @since 1.0
+     */
     public static final int ERROR_FAILED_SSL_HANDSHAKE = -11;
-    /** Malformed URL */
+    /**
+     * Malformed URL
+     * @since 1.0
+     */
     public static final int ERROR_BAD_URL = -12;
-    /** Generic file error */
+    /**
+     * Generic file error
+     * @since 1.0
+     */
     public static final int ERROR_FILE = -13;
-    /** File not found */
+    /**
+     * File not found
+     * @since 1.0
+     */
     public static final int ERROR_FILE_NOT_FOUND = -14;
-    /** Too many requests during this load */
+    /**
+     * Too many requests during this load
+     * @since 1.0
+     */
     public static final int ERROR_TOO_MANY_REQUESTS = -15;
 
     /**
      * Constructor.
      * @param view the owner XWalkViewInternal instance.
+     * @since 1.0
      */
     public XWalkResourceClientInternal(XWalkViewInternal view) {
         // Keep the above parameter for future use.
@@ -60,6 +109,7 @@ public class XWalkResourceClientInternal {
      * by the given url.
      * @param view the owner XWalkViewInternal instance.
      * @param url the url for the resource to be loaded.
+     * @since 1.0
      */
     public void onLoadStarted(XWalkViewInternal view, String url) {
     }
@@ -69,6 +119,7 @@ public class XWalkResourceClientInternal {
      * specified by the given url.
      * @param view the owner XWalkViewInternal instance.
      * @param url the url for the resource done for loading.
+     * @since 1.0
      */
     public void onLoadFinished(XWalkViewInternal view, String url) {
     }
@@ -77,6 +128,7 @@ public class XWalkResourceClientInternal {
      * Notify the client the progress info of loading a specific url.
      * @param view the owner XWalkViewInternal instance.
      * @param progressInPercent the loading process in percent.
+     * @since 1.0
      */
     public void onProgressChanged(XWalkViewInternal view, int progressInPercent) {
     }
@@ -94,6 +146,7 @@ public class XWalkResourceClientInternal {
      * @return A {@link android.webkit.WebResourceResponse} containing the
      *         response information or null if the XWalkViewInternal should load the
      *         resource itself.
+     * @since 1.0
      */
     public WebResourceResponse shouldInterceptLoadRequest(XWalkViewInternal view, String url) {
         return null;
@@ -105,6 +158,7 @@ public class XWalkResourceClientInternal {
      * @param errorCode the error id.
      * @param description A String describing the error.
      * @param failingUrl The url that failed to load.
+     * @since 1.0
      */
     public void onReceivedLoadError(XWalkViewInternal view, int errorCode, String description,
             String failingUrl) {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -40,6 +40,7 @@ public class XWalkUIClientInternal {
     /**
      * Constructor.
      * @param view the owner XWalkViewInternal instance.
+     * @since 1.0
      */
     public XWalkUIClientInternal(XWalkViewInternal view) {
         mContext = view.getContext();
@@ -65,6 +66,7 @@ public class XWalkUIClientInternal {
     /**
      * Request display and focus for this XWalkViewInternal.
      * @param view the owner XWalkViewInternal instance.
+     * @since 1.0
      */
     public void onRequestFocus(XWalkViewInternal view) {
     }
@@ -72,6 +74,7 @@ public class XWalkUIClientInternal {
     /**
      * Notify the client to close the given XWalkViewInternal.
      * @param view the owner XWalkViewInternal instance.
+     * @since 1.0
      */
     public void onJavascriptCloseWindow(XWalkViewInternal view) {
         if (view != null && view.getActivity() != null) {
@@ -81,6 +84,7 @@ public class XWalkUIClientInternal {
 
     /**
      * The type of JavaScript modal dialog.
+     * @since 1.0
      */
     public enum JavascriptMessageTypeInternal {
         /** JavaScript alert dialog. */
@@ -101,6 +105,7 @@ public class XWalkUIClientInternal {
      * @param message the message to be shown.
      * @param defaultValue the default value string. Only valid for Prompt dialog.
      * @param result the callback to handle the result from caller.
+     * @since 1.0
      */
     public boolean onJavascriptModalDialog(XWalkViewInternal view, JavascriptMessageTypeInternal type,
             String url, String message, String defaultValue, XWalkJavascriptResultInternal result) {
@@ -125,6 +130,7 @@ public class XWalkUIClientInternal {
      * Tell the client to toggle fullscreen mode.
      * @param view the owner XWalkViewInternal instance.
      * @param enterFullscreen true if it has entered fullscreen mode.
+     * @since 1.0
      */
     public void onFullscreenToggled(XWalkViewInternal view, boolean enterFullscreen) {
         Activity activity = view.getActivity();
@@ -173,6 +179,7 @@ public class XWalkUIClientInternal {
      *        with this file picker.
      * @param capture value of the 'capture' attribute of the input tag associated
      *        with this file picker
+     * @since 1.0
      */
     public void openFileChooser(XWalkViewInternal view, ValueCallback<Uri> uploadFile,
             String acceptType, String capture) {
@@ -184,6 +191,7 @@ public class XWalkUIClientInternal {
      * @param view the owner XWalkViewInternal instance.
      * @param oldScale the old scale before scaling.
      * @param newScale the current scale factor after scaling.
+     * @since 1.0
      */
     public void onScaleChanged(XWalkViewInternal view, float oldScale, float newScale) {
     }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -159,15 +159,22 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     private XWalkExtensionManager mExtensionManager;
     private boolean mIsHidden;
 
-    /** Normal reload mode as default. */
+    /**
+     * Normal reload mode as default.
+     * @since 1.0
+     */
     public static final int RELOAD_NORMAL = 0;
-    /** Reload mode with bypassing the cache. */
+    /**
+     * Reload mode with bypassing the cache.
+     * @since 1.0
+     */
     public static final int RELOAD_IGNORE_CACHE = 1;
 
     /**
      * Constructor for inflating via XML.
      * @param context  a Context object used to access application assets.
      * @param attrs    an AttributeSet passed to our parent.
+     * @since 1.0
      */
     public XWalkViewInternal(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -182,6 +189,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * different from activity. In embedded mode, they're same.
      * @param context  a Context object used to access application assets
      * @param activity the activity for this XWalkViewInternal.
+     * @since 1.0
      */
     public XWalkViewInternal(Context context, Activity activity) {
         super(context, null);
@@ -346,6 +354,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * It can also load files from Android assets, e.g. 'file:///android_asset/'.
      * @param url the url for web page/app.
      * @param content the content for the web page/app. Could be empty.
+     * @since 1.0
      */
     public void load(String url, String content) {
         if (mContent == null) return;
@@ -363,6 +372,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * It can also load files from Android assets, e.g. 'file:///android_asset/'.
      * @param url the url for manifest.json.
      * @param content the content for manifest.json.
+     * @since 1.0
      */
     public void loadAppFromManifest(String url, String content) {
         if (mContent == null) return;
@@ -373,6 +383,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * Reload a web app with a given mode.
      * @param mode the reload mode.
+     * @since 1.0
      */
     public void reload(int mode) {
         if (mContent == null) return;
@@ -382,6 +393,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
 
     /**
      * Stop current loading progress.
+     * @since 1.0
      */
     public void stopLoading() {
         if (mContent == null) return;
@@ -393,6 +405,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Get the url of current web page/app. This may be different from what's passed
      * by caller.
      * @return the url for current web page/app.
+     * @since 1.0
      */
     public String getUrl() {
         if (mContent == null) return null;
@@ -404,6 +417,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Get the title of current web page/app. This may be different from what's passed
      * by caller.
      * @return the title for current web page/app.
+     * @since 1.0
      */
     public String getTitle() {
         if (mContent == null) return null;
@@ -414,6 +428,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * Get the original url specified by caller.
      * @return the original url.
+     * @since 1.0
      */
     public String getOriginalUrl() {
         if (mContent == null) return null;
@@ -425,6 +440,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Get the navigation history for current XWalkViewInternal. It's synchronized with
      * this XWalkViewInternal if any backward/forward and navigation operations.
      * @return the navigation history.
+     * @since 1.0
      */
     public XWalkNavigationHistoryInternal getNavigationHistory() {
         if (mContent == null) return null;
@@ -438,6 +454,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * marked with {@link JavascriptInterface} if it's called by JavaScript.
      * @param object the supplied Java object, called by JavaScript.
      * @param name the name injected in JavaScript.
+     * @since 1.0
      */
     public void addJavascriptInterface(Object object, String name) {
         if (mContent == null) return;
@@ -449,6 +466,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Evaluate a fragment of JavaScript code and get the result via callback.
      * @param script the JavaScript string.
      * @param callback the callback to handle the evaluated result.
+     * @since 1.0
      */
     public void evaluateJavascript(String script, ValueCallback<String> callback) {
         if (mContent == null) return;
@@ -460,6 +478,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Clear the resource cache. Note that the cache is per-application, so this
      * will clear the cache for all XWalkViews used.
      * @param includeDiskFiles indicate whether to clear disk files for cache.
+     * @since 1.0
      */
     public void clearCache(boolean includeDiskFiles) {
         if (mContent == null) return;
@@ -470,6 +489,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * Indicate that a HTML element is occupying the whole screen.
      * @return true if any HTML element is occupying the whole screen.
+     * @since 1.0
      */
     public boolean hasEnteredFullscreen() {
         if (mContent == null) return false;
@@ -480,6 +500,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * Leave fullscreen mode if it's. Do nothing if it's not
      * in fullscreen.
+     * @since 1.0
      */
     public void leaveFullscreen() {
         if (mContent == null) return;
@@ -495,6 +516,8 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      *
      * Note that it will globally impact all XWalkViewInternal instances, not limited to
      * just this XWalkViewInternal.
+     *
+     * @since 1.0
      */
     public void pauseTimers() {
         if (mContent == null) return;
@@ -508,6 +531,8 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      *
      * Note that it will globally impact all XWalkViewInternal instances, not limited to
      * just this XWalkViewInternal.
+     *
+     * @since 1.0
      */
     public void resumeTimers() {
         if (mContent == null) return;
@@ -520,6 +545,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * like video player, modal dialogs, etc. See {@link #pauseTimers} about pausing
      * JavaScript timers.
      * Typically it should be called when the activity for this view is paused.
+     * @since 1.0
      */
     public void onHide() {
         if (mContent == null || mIsHidden) return;
@@ -532,6 +558,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Resume video player, modal dialogs. Embedders are in charge of calling
      * this during resuming this activity if they call onHide.
      * Typically it should be called when the activity for this view is resumed.
+     * @since 1.0
      */
     public void onShow() {
         if (mContent == null || !mIsHidden ) return;
@@ -542,6 +569,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
 
     /**
      * Release internal resources occupied by this XWalkViewInternal.
+     * @since 1.0
      */
     public void onDestroy() {
         destroy();
@@ -555,6 +583,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * @param requestCode passed from android.app.Activity.onActivityResult().
      * @param resultCode passed from android.app.Activity.onActivityResult().
      * @param data passed from android.app.Activity.onActivityResult().
+     * @since 1.0
      */
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (mContent == null) return;
@@ -568,6 +597,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * <a href="http://developer.android.com/reference/android/app/Activity.html">
      * android.app.Activity.onNewIntent()</a>.
      * @param intent passed from android.app.Activity.onNewIntent().
+     * @since 1.0
      */
     public boolean onNewIntent(Intent intent) {
         if (mContent == null) return false;
@@ -578,6 +608,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Save current internal state of this XWalkViewInternal. This can help restore this state
      * afterwards restoring.
      * @param outState the saved state for restoring.
+     * @since 1.0
      */
     public boolean saveState(Bundle outState) {
         if (mContent == null) return false;
@@ -589,6 +620,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Restore the state from the saved bundle data.
      * @param inState the state saved from saveState().
      * @return true if it can restore the state.
+     * @since 1.0
      */
     public boolean restoreState(Bundle inState) {
         if (mContent == null) return false;
@@ -599,6 +631,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * Get the API version of Crosswalk embedding API.
      * @return the string of API level.
+     * @since 1.0
      */
     // TODO(yongsheng): make it static?
     public String getAPIVersion() {
@@ -608,6 +641,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * Get the Crosswalk version.
      * @return the string of Crosswalk.
+     * @since 1.0
      */
     // TODO(yongsheng): make it static?
     public String getXWalkVersion() {
@@ -619,6 +653,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Embedders use this to customize their handlers to events/callbacks related
      * to UI.
      * @param client the XWalkUIClientInternal defined by callers.
+     * @since 1.0
      */
     public void setUIClient(XWalkUIClientInternal client) {
         if (mContent == null) return;
@@ -630,6 +665,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Embedders use this to customize their handlers to events/callbacks related
      * to resource loading.
      * @param client the XWalkResourceClientInternal defined by callers.
+     * @since 1.0
      */
     public void setResourceClient(XWalkResourceClientInternal client) {
         if (mContent == null) return;


### PR DESCRIPTION
Before reflection layer for shared mode lands, there are still
public methods in org.xwalk.core which are not supposed to be
Embedding API. So we still need to support doclava for now.

This commit includes following changes:
1, Reorder the declare sequence to make Exposed APIs prior to the
internal one with the same function name (which takes internal
class as paramter).
2. Add @since tag for all APIs, although since tag is not supported
in doclava, it's still worth to do it for API maintenance. This
also applies to the internal classes, before in future, the annotation
in org.xwalk.core will be generated from org.xwalk.core.internal by
script. So for now, we need to keep them synced.
3. Add @hide to the non-Embedding API public methods.

Related Bugs: XWALK-1856, XWALK-2017
