### PR TITLE
[Tools] Use .gclient's value of |cache_dir| in .gclient-xwalk.

### DIFF
--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -7,8 +7,11 @@
 """
 This script is responsible for generating .gclient-xwalk in the top-level
 source directory from DEPS.xwalk.
+
+User-configurable values such as |cache_dir| are fetched from .gclient instead.
 """
 
+import logging
 import optparse
 import os
 import pprint
@@ -18,14 +21,33 @@ CROSSWALK_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GCLIENT_ROOT = os.path.dirname(os.path.dirname(CROSSWALK_ROOT))
 
 
+def ParseGClientConfig():
+  """
+  Parses the top-level .gclient file (NOT .gclient-xwalk) and returns the
+  values set there as a dictionary.
+  """
+  with open(os.path.join(GCLIENT_ROOT, '.gclient')) as dot_gclient:
+    config = {}
+    exec(dot_gclient, config)
+  return config
+
+
 def GenerateGClientXWalk(options):
   with open(os.path.join(CROSSWALK_ROOT, 'DEPS.xwalk')) as deps_file:
     deps_contents = deps_file.read()
 
   if 'XWALK_OS_ANDROID' in os.environ:
     deps_contents += 'target_os = [\'android\']\n'
+
+  gclient_config = ParseGClientConfig()
   if options.cache_dir:
-    deps_contents += 'cache_dir = %s\n' % pprint.pformat(options.cache_dir)
+    logging.warning('--cache_dir is deprecated and will be removed in '
+                    'Crosswalk 8. You should set cache_dir in .gclient '
+                    'instead.')
+    cache_dir = options.cache_dir
+  else:
+    cache_dir = gclient_config.get('cache_dir')
+  deps_contents += 'cache_dir = %s\n' % pprint.pformat(cache_dir)
 
   with open(os.path.join(GCLIENT_ROOT, '.gclient-xwalk'), 'w') as gclient_file:
     gclient_file.write(deps_contents)
@@ -33,11 +55,11 @@ def GenerateGClientXWalk(options):
 
 def main():
   option_parser = optparse.OptionParser()
+  # TODO(rakuco): Remove in Crosswalk 8.
   option_parser.add_option('--cache-dir',
-                           help='Set "cache_dir" in the .gclient file to this '
-                                'directory, so that all git repositories are '
-                                'cached there and shared across multiple '
-                                'clones.')
+                           help='DEPRECATED Set "cache_dir" in .gclient-xwalk '
+                                'to this directory, so that all git '
+                                'repositories are cached there.')
   options, _ = option_parser.parse_args()
   GenerateGClientXWalk(options)
 


### PR DESCRIPTION
This change does not have a big visible effect to most, as it was
introduced mainly for the canary/beta builders and was never documented.

The previous approach was not easy to use at all, as one had to manually
call `gclient sync` with `--nohooks`, call `generate_gclient-xwalk.py`
manually with `--cache-dir` and then run the other hooks.

Instead, just use the same value as `.gclient` so that all repositories
are cached in the same location, thus also reducing the differences
between `.gclient` and `.gclient-xwalk`.

`--cache-dir` is still accepted and used if passed for compatibility
reasons; support for it can be removed altogether in the next major
version (Crosswalk 8).

Related to XWALK-1184 and XWALK-1894.
