### PR TITLE
[Android] Prompt dialog when CPU architecture mismatch

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -235,8 +235,19 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         // Intialize library, paks and others.
         try {
             XWalkViewDelegate.init(this);
-        } catch (UnsatisfiedLinkError e) {
-            final UnsatisfiedLinkError err = e;
+        } catch (Throwable e) {
+            // Try to find if there is UnsatisfiedLinkError in the cause chain of the met Throwable.
+            Throwable linkError = e;
+            while (true) {
+                if (linkError == null) throw new RuntimeException(e);
+                if (linkError instanceof UnsatisfiedLinkError) break;
+                if (linkError.getCause() == null ||
+                        linkError.getCause().equals(linkError)) {
+                    throw new RuntimeException(e);
+                }
+                linkError = linkError.getCause();
+            }
+            final UnsatisfiedLinkError err = (UnsatisfiedLinkError) linkError;
             final Activity activity = getActivity();
             final String packageName = context.getPackageName();
             String missingArch = XWalkViewDelegate.isRunningOnIA() ? "Intel" : "ARM";

--- a/runtime/browser/android/xwalk_view_delegate.cc
+++ b/runtime/browser/android/xwalk_view_delegate.cc
@@ -5,6 +5,7 @@
 #include "xwalk/runtime/browser/android/xwalk_view_delegate.h"
 
 #include "base/android/jni_android.h"
+#include "build/build_config.h"
 #include "jni/XWalkViewDelegate_jni.h"
 
 namespace xwalk {


### PR DESCRIPTION
Previous commit c86dcf7e fixed running ARM on x86.
It was broken, due to the MACRO used to detect CPU
architecture now needs including a header file.

For the opposite, if installing x86 crosswalk on ARM,
the native library will not be available at all.
(ARM native library could still be run on x86 devices, but slow).
A ProcessInit exception will be thrown instead of an
UnsatisfiedLinkError which is expected in previous commit.
To fix this, try to find the UnsatisfiedLinkError in the cause
chain of the exception met while initiating crosswalk.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2011
