### PR TITLE
Embedding api v2

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkResourceClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkResourceClient.java
@@ -4,8 +4,6 @@
 
 package org.xwalk.core;
 
-import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.webkit.WebResourceResponse;
 
 import org.xwalk.core.internal.XWalkResourceClientInternal;
@@ -228,5 +226,36 @@ public class XWalkResourceClient extends XWalkResourceClientInternal {
         } else {
             super.onReceivedLoadError(view, errorCode, description, failingUrl);
         }
+    }
+
+    /**
+     * Give the host application a chance to take over the control when a new
+     * url is about to be loaded in the current XWalkView. If XWalkClient is not
+     * provided, by default XWalkView will ask Activity Manager to choose the
+     * proper handler for the url. If XWalkClient is provided, return true
+     * means the host application handles the url, while return false means the
+     * current XWalkView handles the url.
+     *
+     * @param view The XWalkView that is initiating the callback.
+     * @param url The url to be loaded.
+     * @return True if the host application wants to leave the current XWalkView
+     *         and handle the url itself, otherwise return false.
+     *
+     * @since 2.1
+     */
+    public boolean shouldOverrideUrlLoading(XWalkView view, String url) {
+        return super.shouldOverrideUrlLoading(view, url);
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public boolean shouldOverrideUrlLoading(XWalkViewInternal view, String url) {
+        if (view instanceof XWalkView) {
+            return shouldOverrideUrlLoading((XWalkView) view, url);
+        }
+
+        return super.shouldOverrideUrlLoading(view, url);
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
@@ -5,6 +5,8 @@
 package org.xwalk.core;
 
 import android.net.Uri;
+import android.os.Message;
+import android.view.KeyEvent;
 import android.webkit.ValueCallback;
 
 import org.xwalk.core.internal.XWalkJavascriptResultInternal;
@@ -193,6 +195,155 @@ public class XWalkUIClient extends XWalkUIClientInternal {
             onScaleChanged((XWalkView) view, oldScale, newScale);
         } else {
             super.onScaleChanged(view, oldScale, newScale);
+        }
+    }
+
+    /**
+     * Give the host application a chance to handle the key event synchronously.
+     * e.g. menu shortcut key events need to be filtered this way. If return
+     * true, XWalkView will not handle the key event. If return false, XWalkView
+     * will always handle the key event, so none of the super in the view chain
+     * will see the key event. The default behavior returns false.
+     *
+     * @param view The XWalkView that is initiating the callback.
+     * @param event The key event.
+     * @return True if the host application wants to handle the key event
+     *         itself, otherwise return false
+     *
+     * @since 2.1
+     */
+    public boolean shouldOverrideKeyEvent(XWalkView view, KeyEvent event) {
+        return super.shouldOverrideKeyEvent(view, event);
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public boolean shouldOverrideKeyEvent(XWalkViewInternal view, KeyEvent event) {
+        if (view instanceof XWalkView) {
+            return shouldOverrideKeyEvent((XWalkView) view, event);
+        }
+
+        return super.shouldOverrideKeyEvent(view, event);
+    }
+
+    /**
+     * Notify the host application that a key was not handled by the XWalkView.
+     * Except system keys, XWalkView always consumes the keys in the normal flow
+     * or if shouldOverrideKeyEvent returns true. This is called asynchronously
+     * from where the key is dispatched. It gives the host application a chance
+     * to handle the unhandled key events.
+     *
+     * @param view The XWalkView that is initiating the callback.
+     * @param event The key event.
+     *
+     * @since 2.1
+     */
+    public void onUnhandledKeyEvent(XWalkView view, KeyEvent event) {
+        super.onUnhandledKeyEvent(view, event);
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public void onUnhandledKeyEvent(XWalkViewInternal view, KeyEvent event) {
+        if (view instanceof XWalkView) {
+            onUnhandledKeyEvent((XWalkView) view, event);
+        } else {
+            super.onUnhandledKeyEvent(view, event);
+        }
+    }
+
+    /**
+     * Notify the host application of a change in the document title.
+     * @param view The XWalkView that initiated the callback.
+     * @param title A String containing the new title of the document.
+     * @since 2.1
+     */
+    public void onReceivedTitle(XWalkView view, String title) {
+        super.onReceivedTitle(view, title);
+    }
+
+    @Override
+    public void onReceivedTitle(XWalkViewInternal view, String title) {
+        if (view instanceof XWalkView) {
+            onReceivedTitle((XWalkView) view, title);
+        } else {
+            super.onReceivedTitle(view, title);
+        }
+    }
+
+    /**
+     * The status when a page stopped loading
+     * @since 2.1
+     */
+    public enum LoadStatus {
+        /** Loading finished. */
+        FINISHED,
+        /** Loading failed. */
+        FAILED,
+        /** Loading cancelled by user. */
+        CANCELLED
+    }
+
+    /**
+     * Notify the host application that a page has started loading. This method
+     * is called once for each main frame load so a page with iframes or
+     * framesets will call onPageLoadStarted one time for the main frame. This also
+     * means that onPageLoadStarted will not be called when the contents of an
+     * embedded frame changes, i.e. clicking a link whose target is an iframe.
+     *
+     * @param view The XWalkView that is initiating the callback.
+     * @param url The url to be loaded.
+     *
+     * @since 2.1
+     */
+    public void onPageLoadStarted(XWalkView view, String url) {
+        super.onPageLoadStarted(view, url);
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public void onPageLoadStarted(XWalkViewInternal view, String url) {
+        if (view instanceof XWalkView) {
+            onPageLoadStarted((XWalkView) view, url);
+        } else {
+            super.onPageLoadStarted(view, url);
+        }
+    }
+
+    /**
+     * Notify the host application that a page has stopped loading. This method
+     * is called only for main frame. When onPageLoadStopped() is called, the
+     * rendering picture may not be updated yet. To get the notification for the
+     * new Picture, use {@link XWalkView.PictureListener#onNewPicture}.
+     *
+     * @param view The XWalkView that is initiating the callback.
+     * @param url The url of the page.
+     * @param status the status when the page stopped loading.
+     *
+     * @since 2.1
+     */
+    public void onPageLoadStopped(XWalkView view, String url, LoadStatus status) {
+        LoadStatusInternal statusInternal = LoadStatusInternal.valueOf(status.toString());
+        super.onPageLoadStopped(view, url, statusInternal);
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public void onPageLoadStopped(
+            XWalkViewInternal view, String url, LoadStatusInternal statusInternal) {
+        LoadStatus status = LoadStatus.valueOf(statusInternal.toString());
+        if (view instanceof XWalkView) {
+            onPageLoadStopped((XWalkView) view, url, status);
+        } else {
+            super.onPageLoadStopped(view, url, statusInternal);
         }
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkClient.java
@@ -49,48 +49,6 @@ public class XWalkClient {
     }
 
     /**
-     * Give the host application a chance to take over the control when a new
-     * url is about to be loaded in the current XWalkViewInternal. If XWalkClient is not
-     * provided, by default XWalkViewInternal will ask Activity Manager to choose the
-     * proper handler for the url. If XWalkClient is provided, return true
-     * means the host application handles the url, while return false means the
-     * current XWalkViewInternal handles the url.
-     *
-     * @param view The XWalkViewInternal that is initiating the callback.
-     * @param url The url to be loaded.
-     * @return True if the host application wants to leave the current XWalkViewInternal
-     *         and handle the url itself, otherwise return false.
-     */
-    public boolean shouldOverrideUrlLoading(XWalkViewInternal view, String url) {
-        return false;
-    }
-
-    /**
-     * Notify the host application that a page has started loading. This method
-     * is called once for each main frame load so a page with iframes or
-     * framesets will call onPageStarted one time for the main frame. This also
-     * means that onPageStarted will not be called when the contents of an
-     * embedded frame changes, i.e. clicking a link whose target is an iframe.
-     *
-     * @param view The XWalkViewInternal that is initiating the callback.
-     * @param url The url to be loaded.
-     */
-    public void onPageStarted(XWalkViewInternal view, String url) {
-    }
-
-    /**
-     * Notify the host application that a page has finished loading. This method
-     * is called only for main frame. When onPageFinished() is called, the
-     * rendering picture may not be updated yet. To get the notification for the
-     * new Picture, use {@link XWalkViewInternal.PictureListener#onNewPicture}.
-     *
-     * @param view The XWalkViewInternal that is initiating the callback.
-     * @param url The url of the page.
-     */
-    public void onPageFinished(XWalkViewInternal view, String url) {
-    }
-
-    /**
      * Notify the host application that the renderer of XWalkViewInternal is hung.
      *
      * @param view The XWalkViewInternal on which the render is hung.
@@ -258,40 +216,6 @@ public class XWalkClient {
                         haHandler.cancel();
                     }
                 }).create().show();
-    }
-
-    /**
-     * Give the host application a chance to handle the key event synchronously.
-     * e.g. menu shortcut key events need to be filtered this way. If return
-     * true, XWalkViewInternal will not handle the key event. If return false, XWalkViewInternal
-     * will always handle the key event, so none of the super in the view chain
-     * will see the key event. The default behavior returns false.
-     *
-     * @param view The XWalkViewInternal that is initiating the callback.
-     * @param event The key event.
-     * @return True if the host application wants to handle the key event
-     *         itself, otherwise return false
-     */
-    public boolean shouldOverrideKeyEvent(XWalkViewInternal view, KeyEvent event) {
-        return false;
-    }
-
-    /**
-     * Notify the host application that a key was not handled by the XWalkViewInternal.
-     * Except system keys, XWalkViewInternal always consumes the keys in the normal flow
-     * or if shouldOverrideKeyEvent returns true. This is called asynchronously
-     * from where the key is dispatched. It gives the host application a chance
-     * to handle the unhandled key events.
-     *
-     * @param view The XWalkViewInternal that is initiating the callback.
-     * @param event The key event.
-     */
-    public void onUnhandledKeyEvent(XWalkViewInternal view, KeyEvent event) {
-        // TODO: Commment the below code for compile
-        // ViewRootImpl root = view.getViewRootImpl();
-        // if (root != null) {
-        //     root.dispatchUnhandledKey(event);
-        // }
     }
 
     /**

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
@@ -52,6 +52,6 @@ class XWalkContentVideoViewClient implements ContentVideoViewClient {
 
     @Override
     public View getVideoLoadingProgressView() {
-        return mContentsClient.getVideoLoadingProgressView();
+        return null;
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -164,13 +164,9 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
     protected abstract void onCloseWindow();
 
-    public abstract void onReceivedTouchIconUrl(String url, boolean precomposed);
-
     public abstract void onReceivedIcon(Bitmap bitmap);
 
     protected abstract void onRequestFocus();
-
-    protected abstract View getVideoLoadingProgressView();
 
     public abstract void onPageStarted(String url);
 
@@ -204,8 +200,6 @@ abstract class XWalkContentsClient extends ContentViewClient {
     }
 
     public abstract void onHideCustomView();
-
-    public abstract Bitmap getDefaultVideoPoster();
 
     public abstract void didFinishLoad(String url);
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -175,4 +175,23 @@ public class XWalkResourceClientInternal {
         AlertDialog dialog = dialogBuilder.create();
         dialog.show();
     }
+
+    /**
+     * Give the host application a chance to take over the control when a new
+     * url is about to be loaded in the current XWalkViewInternal. If XWalkClient is not
+     * provided, by default XWalkViewInternal will ask Activity Manager to choose the
+     * proper handler for the url. If XWalkClient is provided, return true
+     * means the host application handles the url, while return false means the
+     * current XWalkViewInternal handles the url.
+     *
+     * @param view The XWalkViewInternal that is initiating the callback.
+     * @param url The url to be loaded.
+     * @return True if the host application wants to leave the current XWalkViewInternal
+     *         and handle the url itself, otherwise return false.
+     *
+     * @since 2.1
+     */
+    public boolean shouldOverrideUrlLoading(XWalkViewInternal view, String url) {
+        return false;
+    }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -196,6 +196,92 @@ public class XWalkUIClientInternal {
     public void onScaleChanged(XWalkViewInternal view, float oldScale, float newScale) {
     }
 
+    /**
+     * Give the host application a chance to handle the key event synchronously.
+     * e.g. menu shortcut key events need to be filtered this way. If return
+     * true, XWalkViewInternal will not handle the key event. If return false, XWalkViewInternal
+     * will always handle the key event, so none of the super in the view chain
+     * will see the key event. The default behavior returns false.
+     *
+     * @param view The XWalkViewInternal that is initiating the callback.
+     * @param event The key event.
+     * @return True if the host application wants to handle the key event
+     *         itself, otherwise return false
+     *
+     * @since 2.1
+     */
+    public boolean shouldOverrideKeyEvent(XWalkViewInternal view, KeyEvent event) {
+        return false;
+    }
+
+    /**
+     * Notify the host application that a key was not handled by the XWalkViewInternal.
+     * Except system keys, XWalkViewInternal always consumes the keys in the normal flow
+     * or if shouldOverrideKeyEvent returns true. This is called asynchronously
+     * from where the key is dispatched. It gives the host application a chance
+     * to handle the unhandled key events.
+     *
+     * @param view The XWalkViewInternal that is initiating the callback.
+     * @param event The key event.
+     *
+     * @since 2.1
+     */
+    public void onUnhandledKeyEvent(XWalkViewInternal view, KeyEvent event) {
+    }
+
+    /**
+     * Notify the host application of a change in the document title.
+     * @param view The XWalkViewInternal that initiated the callback.
+     * @param title A String containing the new title of the document.
+     * @since 2.1
+     */
+    public void onReceivedTitle(XWalkViewInternal view, String title) {
+    }
+
+
+    /**
+     * The status when a page stopped loading
+     * @since 2.1
+     */
+    public enum LoadStatusInternal {
+        /** Loading finished. */
+        FINISHED,
+        /** Loading failed. */
+        FAILED,
+        /** Loading cancelled by user. */
+        CANCELLED
+    }
+
+    /**
+     * Notify the host application that a page has started loading. This method
+     * is called once for each main frame load so a page with iframes or
+     * framesets will call onPageLoadStarted one time for the main frame. This also
+     * means that onPageLoadStarted will not be called when the contents of an
+     * embedded frame changes, i.e. clicking a link whose target is an iframe.
+     *
+     * @param view The XWalkViewInternal that is initiating the callback.
+     * @param url The url to be loaded.
+     *
+     * @since 2.1
+     */
+    public void onPageLoadStarted(XWalkViewInternal view, String url) {
+    }
+
+    /**
+     * Notify the host application that a page has stopped loading. This method
+     * is called only for main frame. When onPageLoadStopped() is called, the
+     * rendering picture may not be updated yet. To get the notification for the
+     * new Picture, use {@link XWalkViewInternal.PictureListener#onNewPicture}.
+     *
+     * @param view The XWalkViewInternal that is initiating the callback.
+     * @param url The url of the page.
+     * @param status The status when the page stopped loading.
+     *
+     * @since 2.1
+     */
+    public void onPageLoadStopped(XWalkViewInternal view, String url, LoadStatusInternal status) {
+    }
+
     private boolean onJsAlert(XWalkViewInternal view, String url, String message,
             XWalkJavascriptResultInternal result) {
         final XWalkJavascriptResultInternal fResult = result;

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
@@ -55,27 +55,11 @@ public class XWalkWebChromeClient {
     }
 
     /**
-     * Notify the host application of a change in the document title.
-     * @param view The XWalkViewInternal that initiated the callback.
-     * @param title A String containing the new title of the document.
-     */
-    public void onReceivedTitle(XWalkViewInternal view, String title) {}
-
-    /**
      * Notify the host application of a new favicon for the current page.
      * @param view The XWalkViewInternal that initiated the callback.
      * @param icon A Bitmap containing the favicon for the current page.
      */
     public void onReceivedIcon(XWalkViewInternal view, Bitmap icon) {}
-
-    /**
-     * Notify the host application of the url for an apple-touch-icon.
-     * @param view The XWalkViewInternal that initiated the callback.
-     * @param url The icon url.
-     * @param precomposed True if the url is for a precomposed touch icon.
-     */
-    public void onReceivedTouchIconUrl(XWalkViewInternal view, String url,
-            boolean precomposed) {}
 
     /**
      * A callback interface used by the host application to notify
@@ -151,37 +135,6 @@ public class XWalkWebChromeClient {
 
         mCustomXWalkView = null;
         mCustomViewCallback = null;
-    }
-
-    /**
-     * Request the host application to create a new window. If the host
-     * application chooses to honor this request, it should return true from
-     * this method, create a new XWalkViewInternal to host the window, insert it into the
-     * View system and send the supplied resultMsg message to its target with
-     * the new XWalkViewInternal as an argument. If the host application chooses not to
-     * honor the request, it should return false from this method. The default
-     * implementation of this method does nothing and hence returns false.
-     * @param view The XWalkViewInternal from which the request for a new window
-     *             originated.
-     * @param isDialog True if the new window should be a dialog, rather than
-     *                 a full-size window.
-     * @param isUserGesture True if the request was initiated by a user gesture,
-     *                      such as the user clicking a link.
-     * @param resultMsg The message to send when once a new XWalkViewInternal has been
-     *                  created. resultMsg.obj is a
-     *                  {@link XWalkViewInternal.XWalkViewTransport} object. This should be
-     *                  used to transport the new XWalkViewInternal, by calling
-     *                  {@link XWalkViewInternal.XWalkViewTransport#setXWalkView(XWalkViewInternal)
-     *                  XWalkViewInternal.XWalkViewTransport.setXWalkView(XWalkViewInternal)}.
-     * @return This method should return true if the host application will
-     *         create a new window, in which case resultMsg should be sent to
-     *         its target. Otherwise, this method should return false. Returning
-     *         false from this method but also sending resultMsg will result in
-     *         undefined behavior.
-     */
-    public boolean onCreateWindow(XWalkViewInternal view, boolean isDialog,
-            boolean isUserGesture, Message resultMsg) {
-        return false;
     }
 
    /**
@@ -310,31 +263,6 @@ public class XWalkWebChromeClient {
         onConsoleMessage(consoleMessage.message(), consoleMessage.lineNumber(),
                 consoleMessage.sourceId());
         return false;
-    }
-
-    /**
-     * When not playing, video elements are represented by a 'poster' image. The
-     * image to use can be specified by the poster attribute of the video tag in
-     * HTML. If the attribute is absent, then a default poster will be used. This
-     * method allows the ChromeClient to provide that default image.
-     *
-     * @return Bitmap The image to use as a default poster, or null if no such image is
-     * available.
-     */
-    public Bitmap getDefaultVideoPoster() {
-        return null;
-    }
-
-    /**
-     * When the user starts to playback a video element, it may take time for enough
-     * data to be buffered before the first frames can be rendered. While this buffering
-     * is taking place, the ChromeClient can use this function to provide a View to be
-     * displayed. For example, the ChromeClient could show a spinner animation.
-     *
-     * @return View The View to be displayed whilst the video is loading.
-     */
-    public View getVideoLoadingProgressView() {
-        return null;
     }
 
     /** Obtains a list of all visited history items, used for link coloring

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/XWalkPresentationContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/XWalkPresentationContent.java
@@ -35,15 +35,6 @@ public class XWalkPresentationContent {
     public void load(final String url) {
         if (mContentView == null) {
             mContentView = new XWalkViewInternal(mContext, mActivity);
-            final XWalkClient xWalkClient = new XWalkClient(mContentView) {
-                @Override
-                public void onPageFinished(XWalkViewInternal view, String url) {
-                    mPresentationId = mContentView.getContentID();
-                    onContentLoaded();
-                }
-            };
-            mContentView.setXWalkClient(xWalkClient);
-
             final XWalkUIClientInternal xWalkUIClient = new XWalkUIClientInternal(mContentView) {
                 @Override
                 public void onJavascriptCloseWindow(XWalkViewInternal view) {
@@ -51,6 +42,15 @@ public class XWalkPresentationContent {
                     // presentation id now.
                     mPresentationId = INVALID_PRESENTATION_ID;
                     onContentClosed();
+                }
+
+                @Override
+                public void onPageLoadStopped(
+                        XWalkViewInternal view, String url, LoadStatusInternal status) {
+                    if (status == LoadStatusInternal.FINISHED) {
+                        mPresentationId = mContentView.getContentID();
+                        onContentLoaded();
+                    }
                 }
             };
             mContentView.setUIClient(xWalkUIClient);

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -39,12 +39,11 @@ import org.chromium.content.browser.TracingControllerAndroid;
 import org.xwalk.core.XWalkNavigationHistory;
 import org.xwalk.core.XWalkPreferences;
 import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkViewInternal;
-import org.xwalk.core.internal.XWalkWebChromeClient;
 
 public class XWalkViewShellActivity extends FragmentActivity
-        implements ActionBar.TabListener, XWalkViewSectionFragment.OnXWalkViewCreatedListener{
+        implements ActionBar.TabListener, XWalkViewSectionFragment.OnXWalkViewCreatedListener {
     public static final String COMMAND_LINE_FILE = "/data/local/tmp/xwview-shell-command-line";
     private static final String TAG = XWalkViewShellActivity.class.getName();
     public static final String COMMAND_LINE_ARGS_KEY = "commandLineArgs";
@@ -313,11 +312,10 @@ public class XWalkViewShellActivity extends FragmentActivity
             }
         });
 
-        // TODO: core shell shouldn't use internal APIs.
-        xwalkView.setXWalkWebChromeClient(new XWalkWebChromeClient(xwalkView) {
+        xwalkView.setUIClient(new XWalkUIClient(xwalkView) {
             @Override
-            public void onReceivedTitle(XWalkViewInternal view, String title) {
-                mSectionsPagerAdapter.setPageTitle((XWalkView)view, title);
+            public void onReceivedTitle(XWalkView view, String title) {
+                mSectionsPagerAdapter.setPageTitle(view, title);
             }
         });
     }

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -107,8 +107,7 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
     public void setCallbackForTest(Object callback) {
         XWalkRuntimeTestHelper testHelper = new XWalkRuntimeTestHelper(mContext, mXWalkView);
         testHelper.setCallbackForTest(callback);
-        mXWalkView.setXWalkClient(testHelper.getClient());
-        mXWalkView.setXWalkWebChromeClient(testHelper.getWebChromeClient());
+        mXWalkView.setUIClient(testHelper.getUIClient());
         mXWalkView.setResourceClient(testHelper.getResourceClient());
     }
 

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeTestHelper.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeTestHelper.java
@@ -12,10 +12,8 @@ import android.webkit.ValueCallback;
 import java.lang.reflect.Method;
 
 import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkClient;
-import org.xwalk.core.internal.XWalkViewInternal;
-import org.xwalk.core.internal.XWalkWebChromeClient;
 
 class XWalkRuntimeTestHelper {
 
@@ -42,14 +40,14 @@ class XWalkRuntimeTestHelper {
         }
     }
 
-    class TestXWalkClient extends XWalkClient {
-        TestXWalkClient(Context context, XWalkView view) {
+    class TestXWalkUIClient extends XWalkUIClient {
+        TestXWalkUIClient(Context context, XWalkView view) {
             super(view);
         }
 
         @Override
-        public void onPageStarted(XWalkViewInternal view, String url) {
-            super.onPageStarted(view, url);
+        public void onPageLoadStarted(XWalkView view, String url) {
+            super.onPageLoadStarted(view, url);
             if (mCallbackForTest != null) {
                 try {
                     Class<?> objectClass = mCallbackForTest.getClass();
@@ -62,27 +60,21 @@ class XWalkRuntimeTestHelper {
         }
 
         @Override
-        public void onPageFinished(XWalkViewInternal view, String url) {
-            super.onPageFinished(view, url);
+        public void onPageLoadStopped(XWalkView view, String url, LoadStatus status) {
+            super.onPageLoadStopped(view, url, status);
             if (mCallbackForTest != null) {
                 try {
                     Class<?> objectClass = mCallbackForTest.getClass();
-                    Method onPageStarted = objectClass.getMethod("onPageFinished", String.class);
-                    onPageStarted.invoke(mCallbackForTest, url);
+                    Method onPageFinished = objectClass.getMethod("onPageFinished", String.class);
+                    onPageFinished.invoke(mCallbackForTest, url);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
             }
         }
-    }
-
-    class TestXWalkWebChromeClient extends XWalkWebChromeClient {
-        TestXWalkWebChromeClient(Context context, XWalkView view) {
-            super(view);
-        }
 
         @Override
-        public void onReceivedTitle(XWalkViewInternal view, String title) {
+        public void onReceivedTitle(XWalkView view, String title) {
             super.onReceivedTitle(view, title);
             if (mCallbackForTest != null) {
                 try {
@@ -97,13 +89,11 @@ class XWalkRuntimeTestHelper {
     }
 
     private Object mCallbackForTest;
-    private TestXWalkClient mClient;
-    private TestXWalkWebChromeClient mWebChromeClient;
+    private TestXWalkUIClient mUIClient;
     private TestXWalkResourceClient mResourceClient;
 
     XWalkRuntimeTestHelper(Context context, XWalkView view) {
-        mClient = new TestXWalkClient(context, view);
-        mWebChromeClient = new TestXWalkWebChromeClient(context, view);
+        mUIClient = new TestXWalkUIClient(context, view);
         mResourceClient = new TestXWalkResourceClient(context, view);
     }
 
@@ -111,12 +101,8 @@ class XWalkRuntimeTestHelper {
         mCallbackForTest = callback;
     }
 
-    XWalkClient getClient() {
-        return mClient;
-    }
-
-    XWalkWebChromeClient getWebChromeClient() {
-        return mWebChromeClient;
+    XWalkUIClient getUIClient() {
+        return mUIClient;
     }
 
     XWalkResourceClient getResourceClient() {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/AddJavascriptInterfaceTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/AddJavascriptInterfaceTest.java
@@ -20,8 +20,6 @@ public class AddJavascriptInterfaceTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     class TestJavascriptInterface {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/CanGoBackTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/CanGoBackTest.java
@@ -16,8 +16,6 @@ public class CanGoBackTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/CanGoForwardTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/CanGoForwardTest.java
@@ -16,8 +16,6 @@ public class CanGoForwardTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearCacheTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearCacheTest.java
@@ -24,8 +24,6 @@ public class ClearCacheTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
         mWebServer = new TestWebServer(false);
     }
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearHistoryTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearHistoryTest.java
@@ -20,8 +20,6 @@ public class ClearHistoryTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     // TODO(guangzhen): Since the device issue, it can not access the network,

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
@@ -39,7 +39,6 @@ public class CookieManagerTest extends XWalkViewTestBase {
         super.setUp();
 
         mCookieManager = new XWalkCookieManager();
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/EvaluateJavascriptTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/EvaluateJavascriptTest.java
@@ -16,8 +16,6 @@ public class EvaluateJavascriptTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionBroadcastTest.java
@@ -22,9 +22,6 @@ public class ExtensionBroadcastTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
-        setXWalkWebChromeClient(new XWalkViewTestBase.TestXWalkWebChromeClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEchoTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ExtensionEchoTest.java
@@ -22,9 +22,6 @@ public class ExtensionEchoTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
-        setXWalkWebChromeClient(new XWalkViewTestBase.TestXWalkWebChromeClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GeolocationPermissionTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GeolocationPermissionTest.java
@@ -17,6 +17,8 @@ import org.xwalk.core.internal.XWalkGeolocationPermissions;
 import org.xwalk.core.internal.XWalkWebChromeClient;
 
 /**
+ * TODO(wang16): This test should be moved to internal test.
+ *
  * Test suite for onGeolocationPermissionsShowPrompt() and
  *                onGeolocationPermissionsHidePrompt().
  */
@@ -25,7 +27,6 @@ public class GeolocationPermissionTest extends XWalkViewTestBase {
     public void setUp() throws Exception {
         super.setUp();
 
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
@@ -59,7 +60,12 @@ public class GeolocationPermissionTest extends XWalkViewTestBase {
             }
         }
         final TestWebChromeClient testWebChromeClient = new TestWebChromeClient();
-        setXWalkWebChromeClient(testWebChromeClient);
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkWebChromeClient(testWebChromeClient);
+            }
+        });
         loadAssetFile("geolocation.html");
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
@@ -85,7 +91,12 @@ public class GeolocationPermissionTest extends XWalkViewTestBase {
                 // Do something.
             }
         }
-        setXWalkWebChromeClient(new TestWebChromeClient());
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                getXWalkView().setXWalkWebChromeClient(new TestWebChromeClient());
+            }
+        });
         loadUrlSync("http://html5demos.com/geo");
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetAPIVersionTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetAPIVersionTest.java
@@ -20,8 +20,6 @@ public class GetAPIVersionTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetCurrentItemTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetCurrentItemTest.java
@@ -18,8 +18,6 @@ public class GetCurrentItemTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetItemAtTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetItemAtTest.java
@@ -18,8 +18,6 @@ public class GetItemAtTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetTitleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetTitleTest.java
@@ -18,8 +18,6 @@ public class GetTitleTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetUrlTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetUrlTest.java
@@ -17,8 +17,6 @@ public class GetUrlTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetXWalkVersionTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetXWalkVersionTest.java
@@ -20,8 +20,6 @@ public class GetXWalkVersionTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/HandleActionUriTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/HandleActionUriTest.java
@@ -46,8 +46,6 @@ public class HandleActionUriTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/HasItemAtTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/HasItemAtTest.java
@@ -18,8 +18,6 @@ public class HasItemAtTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/HistorySizeTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/HistorySizeTest.java
@@ -18,8 +18,6 @@ public class HistorySizeTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadTest.java
@@ -20,8 +20,6 @@ public class LoadTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     // TODO(hengzhi): Since the device issue, it can not access the network,

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/NavigateTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/NavigateTest.java
@@ -16,8 +16,6 @@ public class NavigateTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
@@ -26,9 +26,6 @@ public class OnPageFinishedTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
-        setResourceClient(new XWalkViewTestBase.TestXWalkResourceClient());
     }
 
     @MediumTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnUpdateTitleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnUpdateTitleTest.java
@@ -20,9 +20,6 @@ public class OnUpdateTitleTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
-        setXWalkWebChromeClient(new XWalkViewTestBase.TestXWalkWebChromeClient());
     }
 
     @SmallTest

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ReloadTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ReloadTest.java
@@ -25,7 +25,6 @@ public class ReloadTest extends XWalkViewTestBase {
     public void setUp() throws Exception {
         super.setUp();
 
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
         mWebServer = new TestWebServer(false);
     }
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/RendererResponsivenessTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/RendererResponsivenessTest.java
@@ -24,6 +24,8 @@ import org.xwalk.core.internal.XWalkClient;
 import org.xwalk.core.internal.XWalkViewInternal;
 
 /**
+ * TODO(wang16): This test should be moved to internal test.
+ *
  * Renderer responsiveness tests:
  *
  * Internally, a hang monitor timer will start for each renderer when there is
@@ -44,11 +46,15 @@ public class RendererResponsivenessTest extends XWalkViewTestBase {
     //@MediumTest
     @DisabledTest
     public void testRendererUnresponsive() throws Throwable {
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
-        getXWalkView().setXWalkClient(new XWalkClient(getXWalkView()) {
+        getInstrumentation().runOnMainSync(new Runnable() {
             @Override
-            public void onRendererUnresponsive(XWalkViewInternal view) {
-                unresponsiveHelper.notifyCalled(view);
+            public void run() {
+                getXWalkView().setXWalkClient(new XWalkClient(getXWalkView()) {
+                    @Override
+                    public void onRendererUnresponsive(XWalkViewInternal view) {
+                        unresponsiveHelper.notifyCalled(view);
+                    }
+                });
             }
         });
 
@@ -77,14 +83,15 @@ public class RendererResponsivenessTest extends XWalkViewTestBase {
     //@MediumTest
     @DisabledTest
     public void testRendererResponsiveAgain() throws Throwable {
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
-        getXWalkView().setXWalkClient(new XWalkClient(getXWalkView()) {
-            /**
-             * Called once the renderer become responsive again.
-             */
+        getInstrumentation().runOnMainSync(new Runnable() {
             @Override
-            public void onRendererResponsive(XWalkViewInternal view) {
-                responsiveHelper.notifyCalled(view);
+            public void run() {
+                getXWalkView().setXWalkClient(new XWalkClient(getXWalkView()) {
+                    @Override
+                    public void onRendererResponsive(XWalkViewInternal view) {
+                        responsiveHelper.notifyCalled(view);
+                    }
+                });
             }
         });
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SaveRestoreStateTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SaveRestoreStateTest.java
@@ -54,7 +54,8 @@ public class SaveRestoreStateTest extends XWalkViewTestBase {
             public void run() {
                 mXWalkView = getXWalkView();
                 mRestoreXWalkView = new XWalkView(activity, activity);
-                mXWalkView.setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
+                mXWalkView.setUIClient(new XWalkViewTestBase.TestXWalkUIClient());
+                mXWalkView.setResourceClient(new XWalkViewTestBase.TestXWalkResourceClient());
             }
         });
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetAppCacheEnabledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetAppCacheEnabledTest.java
@@ -27,6 +27,8 @@ import org.xwalk.core.internal.XWalkWebChromeClient;
 import org.xwalk.core.xwview.test.util.CommonResources;
 
 /**
+ * TODO(wang16): This test should be moved to internal test.
+ *
  * Test suite for setAppCacheEnabled().
  */
 public class SetAppCacheEnabledTest extends XWalkViewTestBase {
@@ -103,15 +105,13 @@ public class SetAppCacheEnabledTest extends XWalkViewTestBase {
         final TestHelperBridge helperBridge =
                 new TestHelperBridge();
         mContentClient = helperBridge;
-        final XWalkViewTestBase.TestXWalkClientBase client =
-                new XWalkViewTestBase.TestXWalkClientBase(helperBridge);
+        final XWalkViewTestBase.TestXWalkUIClientBase uiClient =
+                new XWalkViewTestBase.TestXWalkUIClientBase(helperBridge);
         final XWalkViewTestBase.TestXWalkResourceClientBase resourceClient =
                 new XWalkViewTestBase.TestXWalkResourceClientBase(helperBridge);
-        final XWalkViewTestBase.TestXWalkWebChromeClientBase chromeClient =
-                new XWalkViewTestBase.TestXWalkWebChromeClientBase(helperBridge);
         final XWalkView xWalkView =
-                createXWalkViewContainerOnMainSync(getActivity(), client,
-                        resourceClient, chromeClient);
+                createXWalkViewContainerOnMainSync(getActivity(), uiClient,
+                        resourceClient);
 
         final XWalkSettings settings = getXWalkSettings(xWalkView);
         settings.setJavaScriptEnabled(true);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetDatabaseEnabledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetDatabaseEnabledTest.java
@@ -25,10 +25,6 @@ public class SetDatabaseEnabledTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
-        setXWalkWebChromeClient(new XWalkViewTestBase.TestXWalkWebChromeClient());
-        setResourceClient(new XWalkViewTestBase.TestXWalkResourceClient());
     }
 
     abstract class XWalkViewSettingsTestHelper<T> {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetNetworkAvailableTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetNetworkAvailableTest.java
@@ -25,8 +25,6 @@ public class SetNetworkAvailableTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     @Feature({"SetNetworkAvailableTest"})

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldInterceptLoadRequestTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldInterceptLoadRequestTest.java
@@ -74,7 +74,6 @@ public class ShouldInterceptLoadRequestTest extends XWalkViewTestBase {
     protected void setUp() throws Exception {
         super.setUp();
 
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/UserAgentTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/UserAgentTest.java
@@ -27,8 +27,6 @@ public class UserAgentTest extends XWalkViewTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
     }
 
     protected XWalkSettings getXWalkSettingsOnUiThread(

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/WebNotificationTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/WebNotificationTest.java
@@ -23,6 +23,8 @@ import org.xwalk.core.internal.XWalkWebChromeClient;
 import org.xwalk.core.internal.XWalkNotificationServiceImpl;
 
 /**
+ * TODO(wang16): This test should be moved into internal test.
+ *
  * Test suite for web notification API.
  * This test will only cover notification.show() and notification.close().
  * The event handler will be covered in runtime level test. Because that
@@ -66,7 +68,6 @@ public class WebNotificationTest extends XWalkViewTestBase {
     public void setUp() throws Exception {
         super.setUp();
 
-        setXWalkClient(new XWalkViewTestBase.TestXWalkClient());
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
This commit added following APIs as Embedding API:
XWalkResourceClient.shouldOverrideURLLoading
XWalkUIClient.onUnhandledKeyEvent
XWalkUIClient.shouldOverrideKeyEvent
XWalkUIClient.onReceivedTitle
XWalkUIClient.onPageLoadStarted
XWalkUIClient.onPageLoadStopped
XWalkUIClient.onCreateWindowRequested

Some of those APIs were implemented inside xwalk core
internal previously. Now moving them to public Client
classes of XWalkView to expose in Embedding API.

Beside, remove the internal callbacks which are decided
not to expose in Embedding API and currently are dead code
or have empty implementation in core internal, including:
XWalkWebChromeClient.onReceivedTouchIconUrl
XWalkWebChromeClient.getDefaultVideoPoster
XWalkWebChromeClient.getVideoLoadingProgressView

TODO(wang16): Implement XWalkUIClient.onCreateWindowRequested
and LoadStatus for XWalkUIClient.onPageLoadStopped.

Related BUGs: XWALK-2005, XWALK-2031
BUG=XWALK-2003, XWALK-2004
