### PR TITLE
[Tizen] Do not use Crosswalk daemon when installing webapps

### DIFF
--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -27,7 +27,6 @@
 #include "net/url_request/url_request_error_job.h"
 #include "net/url_request/url_request_file_job.h"
 #include "net/url_request/url_request_simple_job.h"
-#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/application_file_util.h"
@@ -35,6 +34,7 @@
 #include "xwalk/application/common/application_resource.h"
 #include "xwalk/application/common/constants.h"
 #include "xwalk/application/common/manifest_handlers/csp_handler.h"
+#include "xwalk/runtime/common/xwalk_system_locale.h"
 
 using content::BrowserThread;
 using content::ResourceRequestInfo;
@@ -216,7 +216,7 @@ class ApplicationProtocolHandler
 // The |locale| should be expanded to user agent locale.
 // Such as, "en-us" will be expaned as "en-us, en".
 void GetUserAgentLocales(const std::string& sys_locale,
-                         std::list<std::string>& ua_locales) {
+                         std::list<std::string>& ua_locales) {  // NOLINT
   if (sys_locale.empty())
     return;
 
@@ -266,8 +266,7 @@ ApplicationProtocolHandler::MaybeCreateJob(
 
   std::list<std::string> locales;
   if (application && application->GetPackageType() == Package::WGT) {
-    GetUserAgentLocales(
-        xwalk::XWalkRunner::GetInstance()->GetLocale(), locales);
+    GetUserAgentLocales(GetSystemLocale(), locales);
     GetUserAgentLocales(application->GetManifest()->default_locale(), locales);
   }
 

--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -14,7 +14,7 @@
 #include "base/strings/string_split.h"
 #include "base/strings/utf_string_conversions.h"
 #include "xwalk/application/common/application_manifest_constants.h"
-#include "xwalk/runtime/browser/xwalk_runner.h"
+#include "xwalk/runtime/common/xwalk_system_locale.h"
 
 namespace errors = xwalk::application_manifest_errors;
 namespace keys   = xwalk::application_manifest_keys;
@@ -84,11 +84,7 @@ Manifest::Manifest(SourceType source_type,
       data_->Get(widget_keys::kWidgetKey, NULL))
     ParseWGTI18n();
 
-  // Unittest may not have an xwalkrunner, so we should check here.
-  if (XWalkRunner* xwalk_runner = XWalkRunner::GetInstance())
-    SetSystemLocale(xwalk_runner->GetLocale());
-  else
-    SetSystemLocale(kLocaleUnlocalized);
+  SetSystemLocale(GetSystemLocale());
 }
 
 Manifest::~Manifest() {

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -5,9 +5,13 @@
       'type': 'static_library',
       'dependencies': [
         '../../../base/base.gyp:base',
+        '../../../base/base.gyp:base_i18n',
+        '../../../content/content.gyp:content_common',
+        '../../../crypto/crypto.gyp:crypto',
         '../../../sql/sql.gyp:sql',
         '../../../url/url.gyp:url_lib',
         '../../../third_party/libxml/libxml.gyp:libxml',
+        '../../../third_party/zlib/google/zip.gyp:zip',
       ],
       'sources': [
         'application_storage.cc',

--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -26,6 +26,7 @@
       'product_name': 'xwalkctl',
       'dependencies': [
         'gio',
+        '../../../application/common/xwalk_application_common.gypi:xwalk_application_common_lib',
       ],
       'include_dirs': [
         '../../../..',
@@ -34,9 +35,16 @@
         'dbus_connection.cc',
         'dbus_connection.h',
         'xwalkctl_main.cc',
+        '../../../runtime/common/xwalk_paths.cc',
+        '../../../runtime/common/xwalk_paths.h',
+        '../../../runtime/common/xwalk_system_locale.cc',
+        '../../../runtime/common/xwalk_system_locale.h',
       ],
       'conditions' : [
         ['tizen==1', {
+          'dependencies': [
+            '../../../build/system.gyp:tizen',
+          ],
           'sources': [
             'xwalk_tizen_user.cc',
             'xwalk_tizen_user.h',

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -38,6 +38,7 @@
               'pkgmgr-parser',
               'pkgmgr-info',
               'pkgmgr-installer',
+              'vconf',
             ],
           },
           'direct_dependent_settings': {

--- a/runtime/browser/tizen/tizen_locale_listener.h
+++ b/runtime/browser/tizen/tizen_locale_listener.h
@@ -12,25 +12,29 @@
 
 namespace xwalk {
 
+// FIXME: Do we need to watch system locale change
+// now (we do not keep the cache of the installed
+// apps anymore)? This class should probably be
+// removed.
 class TizenLocaleListener : public base::SimpleThread {
-  public:
-    TizenLocaleListener();
-    virtual ~TizenLocaleListener();
+ public:
+  TizenLocaleListener();
+  virtual ~TizenLocaleListener();
 
-    virtual void Run() OVERRIDE;
+  virtual void Run() OVERRIDE;
 
-    // Get the latest application locale from system.
-    // locale is a langtag defined in [BCP47]
-    std::string GetLocale() const;
-    // Set the locale and apply this locale to all applications.
-    // Locale is a langtag defined in [BCP47].
-    // This function will called by TizenLocaleListener when locale is changed.
-    void SetLocale(const std::string& locale);
+  // Get the latest application locale from system.
+  // locale is a langtag defined in [BCP47]
+  std::string GetLocale() const;
+  // Set the locale and apply this locale to all applications.
+  // Locale is a langtag defined in [BCP47].
+  // This function will called by TizenLocaleListener when locale is changed.
+  void SetLocale(const std::string& locale);
 
-  private:
-    GMainLoop*  main_loop_;
-    // The locale is a langtag defined in [BCP47]
-    std::string locale_;
+ private:
+  GMainLoop*  main_loop_;
+  // The locale is a langtag defined in [BCP47]
+  std::string locale_;
 };
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -33,7 +33,6 @@ namespace xwalk {
 
 namespace {
 
-const char kDefaultLocale[] = "en-US";
 XWalkRunner* g_xwalk_runner = NULL;
 
 }  // namespace
@@ -86,10 +85,6 @@ void XWalkRunner::PostMainMessageLoopRun() {
   DestroyComponents();
   extension_service_.reset();
   runtime_context_.reset();
-}
-
-std::string XWalkRunner::GetLocale() const {
-  return kDefaultLocale;
 }
 
 void XWalkRunner::CreateComponents() {

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -81,10 +81,6 @@ class XWalkRunner {
   virtual void PreMainMessageLoopRun();
   virtual void PostMainMessageLoopRun();
 
-  // Get the latest application locale from system.
-  // locale is a langtag defined in [BCP47]
-  virtual std::string GetLocale() const;
-
  protected:
   XWalkRunner();
 
@@ -146,7 +142,7 @@ class XWalkRunner {
   // side to the extension side, such as application IDs and whatnot.
   void InitializeRuntimeVariablesForExtensions(
       const content::RenderProcessHost* host,
-      base::ValueMap& runtime_variables);
+      base::ValueMap& runtime_variables);  // NOLINT
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRunner);
 };

--- a/runtime/browser/xwalk_runner_tizen.cc
+++ b/runtime/browser/xwalk_runner_tizen.cc
@@ -35,8 +35,4 @@ void XWalkRunnerTizen::PreMainMessageLoopRun() {
   }
 }
 
-std::string XWalkRunnerTizen::GetLocale() const {
-  return tizen_locale_listener_.GetLocale();
-}
-
 }  // namespace xwalk

--- a/runtime/browser/xwalk_runner_tizen.h
+++ b/runtime/browser/xwalk_runner_tizen.h
@@ -25,10 +25,6 @@ class XWalkRunnerTizen : public XWalkRunner {
 
   virtual void PreMainMessageLoopRun() OVERRIDE;
 
-  // Get the latest application locale from system.
-  // locale is a langtag defined in [BCP47]
-  virtual std::string GetLocale() const OVERRIDE;
-
  private:
   friend class XWalkRunner;
   XWalkRunnerTizen();

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -9,7 +9,6 @@
 #include "base/logging.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/path_service.h"
-#include "xwalk/runtime/browser/xwalk_runner.h"
 
 #if defined(OS_WIN)
 #include "base/base_paths_win.h"
@@ -83,10 +82,15 @@ base::FilePath GetConfigPath() {
 
 bool GetXWalkDataPath(base::FilePath* path) {
   base::FilePath::StringType xwalk_suffix;
-  if (XWalkRunner::GetInstance()->is_running_as_service())
-    xwalk_suffix = FILE_PATH_LITERAL("xwalk-service");
-  else
-    xwalk_suffix = FILE_PATH_LITERAL("xwalk");
+
+// Only Tizen uses the Shared Process Mode now.
+// FIXME: Create common settings to detect process mode in runtime.
+// XWalkRunner::is_running_as_service() cannot be used here.
+#if defined(OS_TIZEN)
+  xwalk_suffix = FILE_PATH_LITERAL("xwalk-service");
+#else
+  xwalk_suffix = FILE_PATH_LITERAL("xwalk");
+#endif
   base::FilePath cur;
 
 #if defined(OS_WIN)

--- a/runtime/common/xwalk_paths.h
+++ b/runtime/common/xwalk_paths.h
@@ -6,7 +6,6 @@
 #define XWALK_RUNTIME_COMMON_XWALK_PATHS_H_
 
 #include "build/build_config.h"
-#include "content/public/browser/notification_types.h"
 
 namespace xwalk {
 

--- a/runtime/common/xwalk_system_locale.cc
+++ b/runtime/common/xwalk_system_locale.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/common/xwalk_system_locale.h"
+
+#if defined(OS_TIZEN)
+#include <vconf.h>
+#include <algorithm>
+
+#include "base/logging.h"
+#endif
+
+namespace xwalk {
+#if defined(OS_TIZEN)
+
+namespace {
+const char kTizenDefaultLocale[] = "en-GB";
+
+bool TizenLocaleToBCP47Locale(const std::string& tizen_locale,
+                              std::string* out_BCP47_locale) {
+  if (tizen_locale.empty())
+    return false;
+
+  // Tizen locale format [language[_territory][.codeset][@modifier]] .
+  // Conver to BCP47 format language[-territory] .
+  *out_BCP47_locale = tizen_locale.substr(0, tizen_locale.find_first_of("."));
+  std::replace(out_BCP47_locale->begin(), out_BCP47_locale->end(), '_', '-');
+  return true;
+}
+
+}  // namespace
+
+std::string GetSystemLocale() {
+  std::string tizen_locale;
+  char* langset = vconf_get_str(VCONFKEY_LANGSET);
+  if (langset) {
+    tizen_locale = langset;
+  } else {
+    LOG(ERROR) << "Can not get VCONFKEY_LANGSET from vconf or "
+               << "VCONFKEY_LANGSET vlaue is not a string value";
+  }
+  free(langset);
+
+  // Tizen take en-GB as default.
+  std::string BCP47_locale(kTizenDefaultLocale);
+  TizenLocaleToBCP47Locale(tizen_locale, &BCP47_locale);
+  return BCP47_locale;
+}
+#else
+namespace {
+  const char kDefaultLocale[] = "en-US";
+}  // namespace
+
+std::string GetSystemLocale() {
+  return kDefaultLocale;
+}
+
+#endif
+
+}  // namespace xwalk

--- a/runtime/common/xwalk_system_locale.h
+++ b/runtime/common/xwalk_system_locale.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_COMMON_XWALK_SYSTEM_LOCALE_H_
+#define XWALK_RUNTIME_COMMON_XWALK_SYSTEM_LOCALE_H_
+
+#include <string>
+
+namespace xwalk {
+
+std::string GetSystemLocale();
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_COMMON_XWALK_SYSTEM_LOCALE_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -258,6 +258,8 @@
         'runtime/common/xwalk_runtime_features.h',
         'runtime/common/xwalk_switches.cc',
         'runtime/common/xwalk_switches.h',
+        'runtime/common/xwalk_system_locale.cc',
+        'runtime/common/xwalk_system_locale.h',
         'runtime/renderer/android/xwalk_render_process_observer.cc',
         'runtime/renderer/android/xwalk_render_process_observer.h',
         'runtime/renderer/android/xwalk_permission_client.cc',


### PR DESCRIPTION
The Crosswalk installer shouldn't depend on the Crosswalk service
to be running in order to install applications. This is needed for
example to be able to install applications before the system has
booted.

BUG=XWALK-2028
