### PR TITLE
[Tizen] Do not use Crosswalk daemon when uninstalling webapps

### DIFF
--- a/application/browser/linux/running_applications_manager.h
+++ b/application/browser/linux/running_applications_manager.h
@@ -39,6 +39,8 @@ class RunningApplicationsManager : public ApplicationService::Observer {
   // org.crosswalkproject.Running.Manager1 interface.
   void OnLaunch(dbus::MethodCall* method_call,
                 dbus::ExportedObject::ResponseSender response_sender);
+  void OnTerminateIfRunning(dbus::MethodCall* method_call,
+      dbus::ExportedObject::ResponseSender response_sender);
 
   void OnExported(const std::string& interface_name,
                   const std::string& method_name,

--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -27,6 +27,8 @@
       'dependencies': [
         'gio',
         '../../../application/common/xwalk_application_common.gypi:xwalk_application_common_lib',
+        '../../../../build/linux/system.gyp:dbus',
+        '../../../../dbus/dbus.gyp:dbus',
       ],
       'include_dirs': [
         '../../../..',

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -14,6 +14,10 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/path_service.h"
 
+#include "dbus/bus.h"
+#include "dbus/message.h"
+#include "dbus/object_proxy.h"
+
 #include "xwalk/application/common/application_storage.h"
 #include "xwalk/application/common/installer/package_installer.h"
 #include "xwalk/application/tools/linux/dbus_connection.h"
@@ -37,92 +41,33 @@ static GOptionEntry entries[] = {
   { NULL }
 };
 
-static bool uninstall_application(const char* appid) {
-  static const char* xwalk_service_name = "org.crosswalkproject.Runtime1";
-  static const char* xwalk_installed_path = "/installed1";
-  static const char* xwalk_installed_app_iface =
-      "org.crosswalkproject.Installed.Application1";
+namespace {
 
-  GError* error = NULL;
-  GDBusConnection* connection = get_session_bus_connection(&error);
-  if (!connection) {
-    fprintf(stderr, "Couldn't get the session bus connection: %s\n",
-            error->message);
-    exit(1);
-  }
+const char xwalk_service_name[] = "org.crosswalkproject.Runtime1";
+const char xwalk_running_manager_iface[] =
+    "org.crosswalkproject.Running.Manager1";
+const dbus::ObjectPath kRunningManagerDBusPath("/running1");
 
-  GDBusObjectManager* installed_om = g_dbus_object_manager_client_new_sync(
-      connection, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
-      xwalk_service_name, xwalk_installed_path,
-      NULL, NULL, NULL, NULL, &error);
-  if (!installed_om) {
-    g_print("Service '%s' could not be reached: %s\n", xwalk_service_name,
-            error->message);
-    exit(1);
-  }
+}  // namespace
 
-  // GDBus may return a valid ObjectManager even if it fails to auto activate
-  // the proper service name. We should check 'name-owner' property to make sure
-  // the service is working. See GDBusObjectManager documentation.
-  gchar* name_owner = NULL;
-  g_object_get(installed_om, "name-owner", &name_owner, NULL);
-  if (!name_owner) {
-    g_print("Service '%s' could not be activated.\n", xwalk_service_name);
-    exit(1);
-  }
-  g_free(name_owner);
+static void TerminateIfRunning(const std::string& app_id) {
+  dbus::Bus::Options options;
+#if defined(OS_TIZEN_MOBILE)
+  options.bus_type = dbus::Bus::CUSTOM_ADDRESS;
+  options.address.assign("unix:path=/run/user/app/dbus/user_bus_socket");
+#endif
+  scoped_refptr<dbus::Bus> bus(new dbus::Bus(options));
+  dbus::ObjectProxy* app_proxy =
+      bus->GetObjectProxy(xwalk_service_name, kRunningManagerDBusPath);
+  if (!app_proxy)
+    return;
 
-  GList* objects = g_dbus_object_manager_get_objects(installed_om);
-  GList* l;
-  bool ret = false;
+  dbus::MethodCall method_call(
+      xwalk_running_manager_iface, "TerminateIfRunning");
+  dbus::MessageWriter writer(&method_call);
+  writer.AppendString(app_id);
 
-  for (l = objects; l; l = l->next) {
-    GDBusObject* object = reinterpret_cast<GDBusObject*>(l->data);
-    GDBusInterface* iface = g_dbus_object_get_interface(
-        object,
-        xwalk_installed_app_iface);
-    if (!iface)
-      continue;
-
-    GDBusProxy* proxy = G_DBUS_PROXY(iface);
-
-    GVariant* value = g_dbus_proxy_get_cached_property(proxy, "AppID");
-    if (!value) {
-      g_object_unref(iface);
-      continue;
-    }
-
-    const char* id;
-    g_variant_get(value, "s", &id);
-
-    if (g_strcmp0(appid, id)) {
-      g_object_unref(iface);
-      continue;
-    }
-
-    GError* error = NULL;
-    GVariant* result = g_dbus_proxy_call_sync(proxy, "Uninstall", NULL,
-                                              G_DBUS_CALL_FLAGS_NONE,
-                                              -1, NULL, &error);
-    if (!result) {
-      g_print("Uninstalling application failed: %s\n", error->message);
-      g_error_free(error);
-      g_object_unref(iface);
-      ret = false;
-      goto done;
-    }
-
-    g_object_unref(iface);
-    ret = true;
-    goto done;
-  }
-
-  g_print("Application ID '%s' could not be found\n", appid);
-
- done:
-  g_list_free_full(objects, g_object_unref);
-
-  return ret;
+  app_proxy->CallMethodAndBlock(&method_call, 1000);
 }
 
 bool list_applications(ApplicationStorage* storage) {
@@ -175,7 +120,8 @@ int main(int argc, char* argv[]) {
     std::string id;
     success = installer->Install(base::FilePath(install_path), &id);
   } else if (uninstall_appid) {
-    success = uninstall_application(uninstall_appid);
+    TerminateIfRunning(uninstall_appid);
+    success = installer->Uninstall(uninstall_appid);
   } else {
     success = list_applications(storage.get());
   }


### PR DESCRIPTION
This patch allows 'xwalkctl' to uninstall an application even
without Crosswalk daemon involved. The running app however
should be terminated before uninstallation.
