### PR TITLE
Fix Mac build.

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -4,11 +4,11 @@
 
 #include "xwalk/application/browser/application_service.h"
 
-#include <hash_set>
 #include <set>
 #include <string>
 #include <vector>
 
+#include "base/containers/hash_tables.h"
 #include "base/files/file_enumerator.h"
 #include "base/file_util.h"
 #include "base/memory/scoped_ptr.h"
@@ -52,7 +52,7 @@ void CollectUnusedStoragePartitions(RuntimeContext* context,
     return;
 
   scoped_ptr<base::hash_set<base::FilePath> > active_paths(
-      new base::hash_set<base::FilePath>());
+      new base::hash_set<base::FilePath>()); // NOLINT
 
   for (unsigned i = 0; i < app_ids.size(); ++i) {
     active_paths->insert(

--- a/application/common/installer/package_installer.cc
+++ b/application/common/installer/package_installer.cc
@@ -72,6 +72,18 @@ scoped_ptr<PackageInstaller> PackageInstaller::Create(
 #endif
 }
 
+bool PackageInstaller::PlatformInstall(ApplicationData* data) {
+  return true;
+}
+
+bool PackageInstaller::PlatformUninstall(ApplicationData* data) {
+  return true;
+}
+
+bool PackageInstaller::PlatformUpdate(ApplicationData* updated_data) {
+  return true;
+}
+
 bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
   // FIXME(leandro): Installation is not robust enough -- should any step
   // fail, it can't roll back to a consistent state.

--- a/application/common/installer/package_installer.h
+++ b/application/common/installer/package_installer.h
@@ -28,9 +28,9 @@ class PackageInstaller {
  protected:
   explicit PackageInstaller(ApplicationStorage* storage);
   // Those to be overriden to implement platform specific logic.
-  virtual bool PlatformInstall(ApplicationData* data) { return true; }
-  virtual bool PlatformUninstall(ApplicationData* data) { return true; }
-  virtual bool PlatformUpdate(ApplicationData* updated_data) { return true; }
+  virtual bool PlatformInstall(ApplicationData* data);
+  virtual bool PlatformUninstall(ApplicationData* data);
+  virtual bool PlatformUpdate(ApplicationData* updated_data);
 
   ApplicationStorage* storage_;
 };


### PR DESCRIPTION
- Virtual methods needs to go in the cpp files (Chromium style).
- Replace include of <hash_set> which is not working on clang with "base/containers/hash_tables.h" which is what we use in the code. Silent the bug of cpplint which claims I need to include <hash_set>.
