### PR TITLE
[Android] Fix issue of make_apk does not work with Andorid SDK tools 23.

### DIFF
--- a/app/tools/android/gyp/finalize_apk.py
+++ b/app/tools/android/gyp/finalize_apk.py
@@ -8,7 +8,6 @@
 """
 
 import optparse
-import os
 import shutil
 import sys
 
@@ -29,9 +28,9 @@ def SignApk(keystore_path, unsigned_path, signed_path, alias, code):
   shutil.move(intermediate_path, signed_path)
 
 
-def AlignApk(android_sdk_root, unaligned_path, final_path):
+def AlignApk(zipalign_path, unaligned_path, final_path):
   align_cmd = [
-      os.path.join(android_sdk_root, 'tools', 'zipalign'),
+      zipalign_path,
       '-f', '4',  # 4 bytes
       unaligned_path,
       final_path
@@ -42,7 +41,7 @@ def AlignApk(android_sdk_root, unaligned_path, final_path):
 def main():
   parser = optparse.OptionParser()
 
-  parser.add_option('--android-sdk-root', help='Android sdk root directory.')
+  parser.add_option('--zipalign-path', help='Path to the zipalign tool.')
   parser.add_option('--unsigned-apk-path', help='Path to input unsigned APK.')
   parser.add_option('--final-apk-path',
       help='Path to output signed and aligned APK.')
@@ -55,7 +54,7 @@ def main():
   signed_apk_path = options.unsigned_apk_path + '.signed.apk'
   SignApk(options.keystore_path, options.unsigned_apk_path,
           signed_apk_path, options.keystore_alias, options.keystore_passcode)
-  AlignApk(options.android_sdk_root, signed_apk_path, options.final_apk_path)
+  AlignApk(options.zipalign_path, signed_apk_path, options.final_apk_path)
 
   if options.stamp:
     build_utils.Touch(options.stamp)


### PR DESCRIPTION
Android SDK tools 23 moves the 'zipalign' to $SDK_ROOT/build-tools, this
does not compatible with older SDK versions wich put 'zipalign' under
$SDK_ROOT/tools

Update the patch to make make_apk compatible with Android SDK tools 23.
Also refer to: https://codereview.chromium.org/238253015

BUG=https://crosswalk-project.org/jira/browse/XWALK-2033
