### PR TITLE
[Tizen] This commit implements the splash screen for Tizen.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -96,6 +96,9 @@ bool Application::Launch(const LaunchParams& launch_params) {
     params.state = GetWindowShowStateWGT(launch_params);
   else
     params.state = GetWindowShowStateXPK(launch_params);
+
+  params.splash_screen_path = GetSplashScreenPath();
+
   runtime->AttachWindow(params);
 
   return true;
@@ -364,6 +367,10 @@ bool Application::CanRequestURL(const GURL& url) const {
   if (security_policy_)
     return security_policy_->IsAccessAllowed(url);
   return true;
+}
+
+base::FilePath Application::GetSplashScreenPath() {
+  return base::FilePath();
 }
 
 }  // namespace application

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -12,6 +12,7 @@
 
 #include "base/callback.h"
 #include "base/compiler_specific.h"
+#include "base/files/file_path.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_vector.h"
 #include "base/observer_list.h"
@@ -131,6 +132,10 @@ class Application : public Runtime::Observer,
               Observer* observer);
   virtual bool Launch(const LaunchParams& launch_params);
   virtual void InitSecurityPolicy();
+
+  // Get the path of splash screen image. Return empty path by default.
+  // Sub class can override it to return a specific path.
+  virtual base::FilePath GetSplashScreenPath();
 
   std::set<Runtime*> runtimes_;
   scoped_refptr<ApplicationData> const data_;

--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -27,6 +27,7 @@
 #endif
 
 #include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/manifest_handlers/tizen_splash_screen_handler.h"
 
 namespace xwalk {
 
@@ -100,6 +101,14 @@ bool ApplicationTizen::Launch(const LaunchParams& launch_params) {
     return true;
   }
   return false;
+}
+
+base::FilePath ApplicationTizen::GetSplashScreenPath() {
+  if (TizenSplashScreenInfo* ss_info = static_cast<TizenSplashScreenInfo*>(
+      data()->GetManifestData(widget_keys::kTizenSplashScreenKey))) {
+    return data()->Path().Append(FILE_PATH_LITERAL(ss_info->src()));
+  }
+  return base::FilePath();
 }
 
 #if defined(USE_OZONE)

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -32,6 +32,8 @@ class ApplicationTizen :  // NOLINT
                    Application::Observer* observer);
   virtual bool Launch(const LaunchParams& launch_params) OVERRIDE;
 
+  virtual base::FilePath GetSplashScreenPath() OVERRIDE;
+
 #if defined(USE_OZONE)
   virtual void WillProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
   virtual void DidProcessEvent(const ui::PlatformEvent& event) OVERRIDE;

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -102,6 +102,8 @@ const char kTizenMetaDataKey[] = "widget.metadata";
 // Child keys inside 'kTizenMetaDataKey'
 const char kTizenMetaDataNameKey[] = "@key";
 const char kTizenMetaDataValueKey[] = "@value";
+const char kTizenSplashScreenKey[] = "widget.splash-screen";
+const char kTizenSplashScreenSrcKey[] = "@src";
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -87,6 +87,8 @@ namespace application_widget_keys {
   extern const char kTizenMetaDataKey[];
   extern const char kTizenMetaDataNameKey[];
   extern const char kTizenMetaDataValueKey[];
+  extern const char kTizenSplashScreenKey[];
+  extern const char kTizenSplashScreenSrcKey[];
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -13,6 +13,7 @@
 #include "xwalk/application/common/manifest_handlers/tizen_application_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_metadata_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
+#include "xwalk/application/common/manifest_handlers/tizen_splash_screen_handler.h"
 #endif
 #include "xwalk/application/common/manifest_handlers/permissions_handler.h"
 #include "xwalk/application/common/manifest_handlers/warp_handler.h"
@@ -80,6 +81,7 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   handlers.push_back(new TizenApplicationHandler);
   handlers.push_back(new TizenSettingHandler);
   handlers.push_back(new TizenMetaDataHandler);
+  handlers.push_back(new TizenSplashScreenHandler);
 #endif
   widget_registry_ = new ManifestHandlerRegistry(handlers);
   return widget_registry_;

--- a/application/common/manifest_handlers/tizen_splash_screen_handler.cc
+++ b/application/common/manifest_handlers/tizen_splash_screen_handler.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/tizen_splash_screen_handler.h"
+
+#include <map>
+#include <utility>
+
+#include "base/file_util.h"
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+namespace application {
+
+TizenSplashScreenInfo::TizenSplashScreenInfo() {}
+TizenSplashScreenInfo::~TizenSplashScreenInfo() {}
+
+TizenSplashScreenHandler::TizenSplashScreenHandler() {}
+
+TizenSplashScreenHandler::~TizenSplashScreenHandler() {}
+
+bool TizenSplashScreenHandler::Parse(scoped_refptr<ApplicationData> application,
+                                     base::string16* error) {
+  scoped_ptr<TizenSplashScreenInfo> ss_info(new TizenSplashScreenInfo);
+  const Manifest* manifest = application->GetManifest();
+  DCHECK(manifest);
+
+  base::Value* splash_screen = NULL;
+  manifest->Get(keys::kTizenSplashScreenKey, &splash_screen);
+  if (splash_screen && splash_screen->IsType(base::Value::TYPE_DICTIONARY)) {
+    base::DictionaryValue* ss_dict = NULL;
+    splash_screen->GetAsDictionary(&ss_dict);
+    std::string src;
+    ss_dict->GetString(keys::kTizenSplashScreenSrcKey, &src);
+    ss_info->set_src(src);
+  }
+  application->SetManifestData(keys::kTizenSplashScreenKey, ss_info.release());
+  return true;
+}
+
+bool TizenSplashScreenHandler::Validate(
+    scoped_refptr<const ApplicationData> application,
+    std::string* error,
+    std::vector<InstallWarning>* warnings) const {
+  const Manifest* manifest = application->GetManifest();
+  DCHECK(manifest);
+  base::Value* splash_screen = NULL;
+  manifest->Get(keys::kTizenSplashScreenKey, &splash_screen);
+  if (!splash_screen || !splash_screen->IsType(base::Value::TYPE_DICTIONARY)) {
+    *error = std::string("The splash-screen attribute is not set correctly.");
+    return false;
+  }
+  base::DictionaryValue* ss_dict = NULL;
+  splash_screen->GetAsDictionary(&ss_dict);
+  std::string ss_src;
+  ss_dict->GetString(keys::kTizenSplashScreenSrcKey, &ss_src);
+  base::FilePath path = application->Path().Append(FILE_PATH_LITERAL(ss_src));
+  if (!base::PathExists(path)) {
+    *error = std::string("The splash screen image does not exist");
+    return false;
+  }
+  return true;
+}
+
+std::vector<std::string> TizenSplashScreenHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kTizenSplashScreenKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/tizen_splash_screen_handler.h
+++ b/application/common/manifest_handlers/tizen_splash_screen_handler.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_SPLASH_SCREEN_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_SPLASH_SCREEN_HANDLER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "base/values.h"
+#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest_handler.h"
+
+namespace xwalk {
+namespace application {
+
+class TizenSplashScreenInfo : public ApplicationData::ManifestData {
+ public:
+  TizenSplashScreenInfo();
+  virtual ~TizenSplashScreenInfo();
+
+  void set_src(const std::string &src) { src_ = src; }
+  const std::string& src() const { return src_; }
+
+ private:
+  std::string src_;
+};
+
+class TizenSplashScreenHandler : public ManifestHandler {
+ public:
+  TizenSplashScreenHandler();
+  virtual ~TizenSplashScreenHandler();
+
+  virtual bool Parse(scoped_refptr<ApplicationData> application,
+                     base::string16* error) OVERRIDE;
+  virtual bool Validate(scoped_refptr<const ApplicationData> application,
+                        std::string* error,
+                        std::vector<InstallWarning>* warnings) const OVERRIDE;
+  virtual std::vector<std::string> Keys() const OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(TizenSplashScreenHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_SPLASH_SCREEN_HANDLER_H_

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -75,6 +75,8 @@
             'manifest_handlers/tizen_metadata_handler.h',
             'manifest_handlers/tizen_setting_handler.cc',
             'manifest_handlers/tizen_setting_handler.h',
+            'manifest_handlers/tizen_splash_screen_handler.cc',
+            'manifest_handlers/tizen_splash_screen_handler.h',
             'installer/package_installer_tizen.cc',
             'installer/package_installer_tizen.h',
             'installer/tizen/packageinfo_constants.cc',

--- a/runtime/browser/image_util.cc
+++ b/runtime/browser/image_util.cc
@@ -9,6 +9,7 @@
 #include "base/file_util.h"
 #include "base/strings/string_util.h"
 #include "ui/gfx/image/image_skia.h"
+#include "ui/gfx/image/image_util.h"
 #include "ui/gfx/size.h"
 
 #if defined(OS_WIN)
@@ -20,6 +21,8 @@ namespace xwalk_utils {
 gfx::Image LoadImageFromFilePath(const base::FilePath& filename) {
   const base::FilePath::StringType kPNGFormat(FILE_PATH_LITERAL(".png"));
   const base::FilePath::StringType kICOFormat(FILE_PATH_LITERAL(".ico"));
+  const base::FilePath::StringType kJPGFormat(FILE_PATH_LITERAL(".jpg"));
+  const base::FilePath::StringType kJPEGFormat(FILE_PATH_LITERAL(".jpeg"));
 
   if (EndsWith(filename.value(), kPNGFormat, false)) {
     std::string contents;
@@ -27,6 +30,15 @@ gfx::Image LoadImageFromFilePath(const base::FilePath& filename) {
     return gfx::Image::CreateFrom1xPNGBytes(
         reinterpret_cast<const unsigned char*>(contents.data()),
             contents.size());
+  }
+
+  if (EndsWith(filename.value(), kJPGFormat, false) ||
+      EndsWith(filename.value(), kJPEGFormat, false)) {
+    std::string contents;
+    base::ReadFileToString(filename, &contents);
+    return gfx::ImageFrom1xJPEGEncodedData(
+        reinterpret_cast<const unsigned char*>(contents.data()),
+        contents.size());
   }
 
   if (EndsWith(filename.value(), kICOFormat, false)) {

--- a/runtime/browser/ui/native_app_window.h
+++ b/runtime/browser/ui/native_app_window.h
@@ -6,6 +6,7 @@
 #define XWALK_RUNTIME_BROWSER_UI_NATIVE_APP_WINDOW_H_
 
 #include "base/compiler_specific.h"
+#include "base/files/file_path.h"
 #include "base/strings/string16.h"
 #include "ui/base/ui_base_types.h"
 #include "ui/gfx/image/image.h"
@@ -53,6 +54,9 @@ class NativeAppWindow {
     int32 net_wm_pid;
     // The parent view which this window belongs to. NULL if it is root window.
     gfx::NativeView parent;
+    // The absolute path of splash screen.
+    // Empty if splash screen is not to be shown.
+    base::FilePath splash_screen_path;
   };
 
   // Do one time initialization at application startup.

--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -12,6 +12,7 @@
 #include "ui/gfx/screen.h"
 #include "ui/views/view.h"
 #include "ui/views/widget/widget.h"
+#include "xwalk/runtime/browser/ui/splash_screen.h"
 #include "xwalk/runtime/browser/ui/top_view_layout_views.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 
@@ -93,11 +94,17 @@ NativeAppWindowTizen::NativeAppWindowTizen(
       indicator_widget_(new TizenSystemIndicatorWidget()),
       indicator_container_(new WidgetContainerView(indicator_widget_)),
 #endif
-      orientation_lock_(blink::WebScreenOrientationLockAny) {
-}
+      orientation_lock_(blink::WebScreenOrientationLockAny) {}
 
 void NativeAppWindowTizen::Initialize() {
   NativeAppWindowViews::Initialize();
+
+  const base::FilePath& splash_screen_path = create_params().splash_screen_path;
+  if (!splash_screen_path.empty()) {
+    splash_screen_.reset(new SplashScreen(
+        GetWidget(), splash_screen_path, create_params().web_contents));
+    splash_screen_->Start();
+  }
 
   // Get display info such as device_scale_factor, and current
   // rotation (orientation).

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -5,6 +5,7 @@
 #ifndef XWALK_RUNTIME_BROWSER_UI_NATIVE_APP_WINDOW_TIZEN_H_
 #define XWALK_RUNTIME_BROWSER_UI_NATIVE_APP_WINDOW_TIZEN_H_
 
+#include "base/memory/scoped_ptr.h"
 #include "content/browser/screen_orientation/screen_orientation_provider.h"
 #include "xwalk/runtime/browser/ui/screen_orientation.h"
 #include "xwalk/runtime/browser/ui/native_app_window_views.h"
@@ -14,6 +15,8 @@
 #include "ui/aura/window_observer.h"
 
 namespace xwalk {
+
+class SplashScreen;
 
 // Tizen uses the Views native window but adds its own features like orientation
 // handling and integration with system indicator bar.
@@ -67,6 +70,7 @@ class NativeAppWindowTizen
 
   gfx::Display display_;
   blink::WebScreenOrientationLockType orientation_lock_;
+  scoped_ptr<SplashScreen> splash_screen_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeAppWindowTizen);
 };

--- a/runtime/browser/ui/native_app_window_views.h
+++ b/runtime/browser/ui/native_app_window_views.h
@@ -56,6 +56,9 @@ class NativeAppWindowViews : public NativeAppWindow,
 
  protected:
   TopViewLayout* top_view_layout();
+  const NativeAppWindow::CreateParams& create_params() const {
+    return create_params_;
+  }
 
   virtual void ViewHierarchyChanged(
       const ViewHierarchyChangedDetails& details) OVERRIDE;

--- a/runtime/browser/ui/splash_screen.cc
+++ b/runtime/browser/ui/splash_screen.cc
@@ -1,0 +1,121 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ui/splash_screen.h"
+
+#include "base/location.h"
+#include "ui/compositor/layer.h"
+#include "ui/compositor/scoped_layer_animation_settings.h"
+#include "ui/gfx/canvas.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/views/widget/widget.h"
+#include "xwalk/runtime/browser/image_util.h"
+
+namespace xwalk {
+
+namespace {
+const int kHideAnimationDuration = 1;  // second
+}  // namespace
+
+class SplashScreen::SplashScreenLayerDelegate : public ui::LayerDelegate {
+ public:
+  SplashScreenLayerDelegate() {}
+
+  virtual ~SplashScreenLayerDelegate() {}
+
+  void set_image(const gfx::Image& image) { image_ = image; }
+  const gfx::Image& image() const { return image_; }
+
+  virtual void OnPaintLayer(gfx::Canvas* canvas) OVERRIDE {
+    if (!image_.IsEmpty()) {
+      canvas->DrawImageInt(image_.AsImageSkia(), 0, 0);
+    } else {
+      LOG(WARNING) << "The splash screen image is not loaded.";
+    }
+  }
+
+  // Override the pure virtual function.
+  virtual void OnDeviceScaleFactorChanged(float device_scale_factor) OVERRIDE {}
+
+  virtual base::Closure PrepareForLayerBoundsChange() OVERRIDE {
+    return base::Closure();
+  }
+
+ private:
+  gfx::Image image_;
+
+  DISALLOW_COPY_AND_ASSIGN(SplashScreenLayerDelegate);
+};
+
+SplashScreen::SplashScreen(views::Widget* host,
+                           const base::FilePath& file,
+                           content::WebContents* web_contents)
+    : content::WebContentsObserver(web_contents),
+      widget_host_(host),
+      splash_screen_image_(file),
+      layer_(new ui::Layer(ui::LAYER_TEXTURED)),
+      layer_delegate_(new SplashScreenLayerDelegate()),
+      is_started(false) {
+  DCHECK(widget_host_);
+  layer_->set_delegate(layer_delegate_.get());
+}
+
+SplashScreen::~SplashScreen() {}
+
+void SplashScreen::Start() {
+  DCHECK(widget_host_);
+  if (is_started)
+    return;
+
+  is_started = true;
+  gfx::Image image = xwalk_utils::LoadImageFromFilePath(splash_screen_image_);
+  if (!image.IsEmpty()) {
+    layer_delegate_->set_image(image);
+    ui::Layer* top_layer = widget_host_->GetLayer();
+    gfx::Rect rc = gfx::Rect(widget_host_->GetWindowBoundsInScreen());
+    // The bound of current layer locating at the host window.
+    gfx::Rect layer_bound((rc.width() - image.Width()) / 2,
+        (rc.height() - image.Height()) / 2, image.Width(), image.Height());
+    layer_->SetBounds(layer_bound);
+    top_layer->Add(layer_.get());
+    top_layer->StackAtTop(layer_.get());
+  }
+}
+
+void SplashScreen::Stop() {
+  DCHECK(widget_host_);
+  if (!is_started)
+    return;
+
+  is_started = false;
+  ui::ScopedLayerAnimationSettings settings(layer_->GetAnimator());
+  settings.SetTransitionDuration(base::TimeDelta::FromSeconds(
+      kHideAnimationDuration));
+  settings.SetPreemptionStrategy(ui::LayerAnimator::REPLACE_QUEUED_ANIMATIONS);
+  settings.AddObserver(this);
+  layer_->SetOpacity(0.0f);
+}
+
+void SplashScreen::DidFinishLoad(int64 frame_id,
+                                 const GURL& validated_url,
+                                 bool is_main_frame,
+                                 content::RenderViewHost* render_view_host) {
+  Stop();
+}
+
+void SplashScreen::DidFailLoad(int64 frame_id,
+                               const GURL& validated_url,
+                               bool is_main_frame,
+                               int error_code,
+                               const base::string16& error_description,
+                               content::RenderViewHost* render_view_host) {
+  Stop();
+}
+
+void SplashScreen::OnImplicitAnimationsCompleted() {
+  DCHECK(widget_host_);
+  widget_host_->GetLayer()->Remove(layer_.get());
+}
+
+}  // namespace xwalk

--- a/runtime/browser/ui/splash_screen.h
+++ b/runtime/browser/ui/splash_screen.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_SPLASH_SCREEN_H_
+#define XWALK_RUNTIME_BROWSER_UI_SPLASH_SCREEN_H_
+
+#include "base/files/file_path.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "ui/compositor/layer_animation_observer.h"
+
+namespace content {
+class WebContents;
+class RenderViewHost;
+}
+
+namespace ui {
+class Layer;
+}
+
+namespace views {
+class Widget;
+}
+
+namespace xwalk {
+
+class SplashScreen : public content::WebContentsObserver,
+                     public ui::ImplicitAnimationObserver {
+ public:
+  SplashScreen(views::Widget* host,
+               const base::FilePath& file,
+               content::WebContents* web_contents);
+  ~SplashScreen();
+
+  void Start();
+  void Stop();
+
+  // Overridden from content::WebContentsObserver.
+  virtual void DidFinishLoad(int64 frame_id,
+                             const GURL& validated_url,
+                             bool is_main_frame,
+                             content::RenderViewHost* render_view_host)
+                             OVERRIDE;
+
+  virtual void DidFailLoad(int64 frame_id,
+                           const GURL& validated_url,
+                           bool is_main_frame,
+                           int error_code,
+                           const base::string16& error_description,
+                           content::RenderViewHost* render_view_host) OVERRIDE;
+
+  // ui::ImplicitAnimationObserver overrides:
+  virtual void OnImplicitAnimationsCompleted() OVERRIDE;
+
+ private:
+  views::Widget* widget_host_;
+  base::FilePath splash_screen_image_;
+
+  scoped_ptr<ui::Layer> layer_;
+  class SplashScreenLayerDelegate;
+  scoped_ptr<SplashScreenLayerDelegate> layer_delegate_;
+
+  bool is_started;
+
+  DISALLOW_COPY_AND_ASSIGN(SplashScreen);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_SPLASH_SCREEN_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -205,6 +205,8 @@
         'runtime/browser/ui/native_app_window_tizen.h',
         'runtime/browser/ui/native_app_window_views.cc',
         'runtime/browser/ui/native_app_window_views.h',
+        'runtime/browser/ui/splash_screen.cc',
+        'runtime/browser/ui/splash_screen.h',
         'runtime/browser/ui/taskbar_util.h',
         'runtime/browser/ui/taskbar_util_win.cc',
         'runtime/browser/ui/top_view_layout_views.cc',


### PR DESCRIPTION
It read a splash screen image (static) from the wgt config file and show it on the center of the main window when the application is launched.
And after the content is loaded, hide the splash screen image in amincation way.

The wgt config has a setting node to define the basic configuration of the splash screen. And currently it contains the path of the image as below:
&lt;splash-screen src="splash.png"/&gt;

BUG=XWALK-1150
