### PR TITLE
[Android] Fix CPU architecture mismatch causes crash in crosswalk runtim...

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
@@ -48,7 +48,14 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
         mInstance = this.createInstance(activity, libCtx, attrs);
         Method getVersion = lookupMethod("getVersion");
         String libVersion = (String) invokeMethod(getVersion, mInstance);
-        if (libVersion == null || !compareVersion(libVersion, getVersion())) {
+        if (libVersion == null) {
+            // If the code executes to here and libVersion got is null, it means
+            // the library package is available but native library is not.
+            // It probably meets CPU arch mismatch, stop execution here to avoid crash.
+            // A dialog should be prompt to user for this information.
+            return;
+        }
+        if (!compareVersion(libVersion, getVersion())) {
             handleException(new XWalkRuntimeLibraryException(
                     XWalkRuntimeLibraryException.XWALK_RUNTIME_LIBRARY_NOT_UP_TO_DATE_CRITICAL));
             mInstance = null;


### PR DESCRIPTION
In runtime, it will try to get the version of runtime library
before using runtime view. Which causes crash if CPU arch mismatches
for crosswalk native library.
Fix this by stop executing to avoid crash after detected CPU arch
mismatch.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2011
