### PR TITLE
[Android][Manifest] Support 'orientation' member

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -128,6 +128,8 @@ def ParseManifest(options, app_info):
   if parser.GetAppRoot():
     options.app_root = parser.GetAppRoot()
     options.icon_dict = parser.GetIcons()
+  if parser.GetOrientation():
+    options.orientation = parser.GetOrientation()
   if parser.GetFullScreenFlag().lower() == 'true':
     options.fullscreen = True
   elif parser.GetFullScreenFlag().lower() == 'false':

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -503,6 +503,7 @@ class TestMakeApk(unittest.TestCase):
     self.assertTrue(content.find('android.permission.RECEIVE_SMS') != -1)
     self.assertTrue(content.find('android.permission.SEND_SMS') != -1)
     self.assertTrue(content.find('android.permission.WRITE_SMS') != -1)
+    self.assertTrue(content.find('landscape') != -1)
     theme = 'Example/res/values/theme.xml'
     with open(theme, 'r') as content_file:
       content = content_file.read()

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -84,6 +84,7 @@ class ManifestJsonParser(object):
     permissions:      The permission list.
     required_version: The required crosswalk runtime version.
     plugin:           The plug-in information.
+    orientation       The default allowed orientations.
     fullscreen:       The fullscreen flag of the application.
     launch_screen:    The launch screen configuration.
     """
@@ -135,6 +136,21 @@ class ManifestJsonParser(object):
     ret_dict['plugin'] = ''
     if 'plugin' in self.data_src:
       ret_dict['plugin'] = self.data_src['plugin']
+    orientation = {'landscape':'landscape',
+                   'landscape-primary':'landscape',
+                   'landscape-secondary':'reverseLandscape',
+                   'portrait':'portrait',
+                   'portrait-primary':'portrait',
+                   'portrait-secondary':'reversePortrait',
+                   'any':'unspecified',
+                   'natural':'unspecified'}
+    if 'orientation' in self.data_src:
+      if self.data_src['orientation'] in orientation:
+        ret_dict['orientation'] = orientation[self.data_src['orientation']]
+      else:
+        ret_dict['orientation'] = 'unspecified'
+    else:
+      ret_dict['orientation'] = 'unspecified'
     if 'display' in self.data_src and 'fullscreen' in self.data_src['display']:
       ret_dict['fullscreen'] = 'true'
     else:
@@ -174,6 +190,7 @@ class ManifestJsonParser(object):
     print("permissions: %s" % self.GetPermissions())
     print("required_version: %s" % self.GetRequiredVersion())
     print("plugins: %s" % self.GetPlugins())
+    print("orientation: %s" % self.GetOrientation())
     print("fullscreen: %s" % self.GetFullScreenFlag())
     print('launch_screen.default.background_color: %s' %
         self.GetLaunchScreenBackgroundColor('default'))
@@ -239,6 +256,10 @@ class ManifestJsonParser(object):
   def GetPlugins(self):
     """Return the plug-in path and file name."""
     return self.ret_dict['plugin']
+
+  def GetOrientation(self):
+    """Return the default allowed orientations"""
+    return self.ret_dict['orientation']
 
   def GetFullScreenFlag(self):
     """Return the set fullscreen flag of the application."""

--- a/app/tools/android/test_data/manifest/manifest.json
+++ b/app/tools/android/test_data/manifest/manifest.json
@@ -18,5 +18,6 @@
     "Messaging"],
   "required_version": "1.28.1.0",
   "plugin": [],
+  "orientation": "landscape",
   "display": ["fullscreen"]
 }


### PR DESCRIPTION
Packaging tool support the 'orientation' member of the manifest:
http://w3c.github.io/manifest/#orientation-member

BUG=https://crosswalk-project.org/jira/browse/XWALK-2022
