### PR TITLE
Create a compile time flag for Shared Process Model

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -261,11 +261,12 @@ void ApplicationService::OnApplicationTerminated(
   FOR_EACH_OBSERVER(Observer, observers_,
                     WillDestroyApplication(application));
   applications_.erase(found);
-  if (!XWalkRunner::GetInstance()->is_running_as_service() &&
-      applications_.empty()) {
+#if !defined(SHARED_PROCESS_MODE)
+  if (applications_.empty()) {
     base::MessageLoop::current()->PostTask(
             FROM_HERE, base::MessageLoop::QuitClosure());
   }
+#endif
 }
 
 void ApplicationService::CheckAPIAccessControl(const std::string& app_id,

--- a/application/browser/application_system_linux.cc
+++ b/application/browser/application_system_linux.cc
@@ -14,12 +14,12 @@ namespace application {
 
 ApplicationSystemLinux::ApplicationSystemLinux(RuntimeContext* runtime_context)
     : ApplicationSystem(runtime_context) {
-  if (XWalkRunner::GetInstance()->is_running_as_service()) {
+#if defined(SHARED_PROCESS_MODE)
     service_provider_.reset(
         new ApplicationServiceProviderLinux(application_service(),
                                             application_storage(),
                                             dbus_manager().session_bus()));
-  }
+#endif
 }
 
 ApplicationSystemLinux::~ApplicationSystemLinux() {}

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -41,6 +41,7 @@ static GOptionEntry entries[] = {
   { NULL }
 };
 
+#if defined(SHARED_PROCESS_MODE)
 namespace {
 
 const char xwalk_service_name[] = "org.crosswalkproject.Runtime1";
@@ -69,6 +70,7 @@ static void TerminateIfRunning(const std::string& app_id) {
 
   app_proxy->CallMethodAndBlock(&method_call, 1000);
 }
+#endif
 
 bool list_applications(ApplicationStorage* storage) {
   ApplicationData::ApplicationDataMap apps;
@@ -120,7 +122,9 @@ int main(int argc, char* argv[]) {
     std::string id;
     success = installer->Install(base::FilePath(install_path), &id);
   } else if (uninstall_appid) {
+#if defined(SHARED_PROCESS_MODE)
     TerminateIfRunning(uninstall_appid);
+#endif
     success = installer->Uninstall(uninstall_appid);
   } else {
     success = list_applications(storage.get());

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -2,6 +2,7 @@
   'variables': {
     'tizen%': 0,
     'tizen_mobile%': 0,
+    'shared_process_mode%': 0,
   },
   'target_defaults': {
     'variables': {
@@ -14,6 +15,9 @@
       }],
       ['tizen_mobile==1', {
         'defines': ['OS_TIZEN_MOBILE=1', 'OS_TIZEN=1'],
+      }],
+      ['shared_process_mode==1', {
+        'defines': ['SHARED_PROCESS_MODE=1'],
       }],
     ],
     'includes': [

--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -152,8 +152,7 @@ void XWalkExtensionProcessHost::StartProcess() {
   CHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
   CHECK(!process_ || !channel_);
 
-  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
-  if (cmd_line->HasSwitch(switches::kXWalkRunAsService)) {
+#if defined(SHARED_PROCESS_MODE)
 #if defined(OS_LINUX)
     std::string channel_id =
         IPC::Channel::GenerateVerifiedChannelID(std::string());
@@ -171,8 +170,8 @@ void XWalkExtensionProcessHost::StartProcess() {
             channel_handle));
 #else
     NOTIMPLEMENTED();
-#endif
-  } else {
+#endif  // #if defined(OS_LINUX)
+#else
     process_.reset(content::BrowserChildProcessHost::Create(
         content::PROCESS_TYPE_CONTENT_END, this));
 
@@ -208,7 +207,7 @@ void XWalkExtensionProcessHost::StartProcess() {
     process_->Launch(
         new ExtensionSandboxedProcessLauncherDelegate(process_->GetHost()),
         cmd_line.release());
-  }
+#endif  // #if defined(SHARED_PROCESS_MODE)
 
   base::ListValue runtime_variables_lv;
   ToListValue(&const_cast<base::ValueMap&>(runtime_variables_),

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -211,6 +211,7 @@ ${GYP_EXTRA_FLAGS} \
 -Duse_system_libexif=1 \
 -Duse_system_libxml=1 \
 -Duse_system_nspr=1 \
+-Dshared_process_mode=1 \
 -Denable_hidpi=1
 
 ninja %{?_smp_mflags} -C src/out/Release xwalk xwalkctl xwalk_launcher xwalk-pkg-helper

--- a/packaging/xwalk.service.in
+++ b/packaging/xwalk.service.in
@@ -4,4 +4,4 @@ Description=Crosswalk
 [Service]
 Type=dbus
 BusName=org.crosswalkproject.Runtime1
-ExecStart=@LIB_INSTALL_DIR@/xwalk/xwalk --run-as-service --external-extensions-path=@LIB_INSTALL_DIR@/tizen-extensions-crosswalk
+ExecStart=@LIB_INSTALL_DIR@/xwalk/xwalk --external-extensions-path=@LIB_INSTALL_DIR@/tizen-extensions-crosswalk

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -220,13 +220,7 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     return;
   }
 
-  if (xwalk_runner_->is_running_as_service()) {
-    // In service mode, Crosswalk doesn't launch anything, just waits
-    // for external requests to launch apps.
-    VLOG(1) << "Crosswalk running as Service.";
-    return;
-  }
-
+#if !defined(SHARED_PROCESS_MODE)
   application::ApplicationSystem* app_system = xwalk_runner_->app_system();
   if (!app_system->HandleApplicationManagementCommands(*command_line,
       startup_url_, run_default_message_loop_)) {
@@ -243,6 +237,7 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     delete parameters_.ui_task;
     run_default_message_loop_ = false;
   }
+#endif
 }
 
 bool XWalkBrowserMainParts::MainMessageLoopRun(int* result_code) {

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -37,16 +37,13 @@ XWalkRunner* g_xwalk_runner = NULL;
 
 }  // namespace
 
-XWalkRunner::XWalkRunner()
-    : is_running_as_service_(false) {
+XWalkRunner::XWalkRunner() {
   VLOG(1) << "Creating XWalkRunner object.";
   DCHECK(!g_xwalk_runner);
   g_xwalk_runner = this;
 
   XWalkRuntimeFeatures::GetInstance()->Initialize(
       CommandLine::ForCurrentProcess());
-  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
-  is_running_as_service_ = cmd_line->HasSwitch(switches::kXWalkRunAsService);
 
   // Initializing after the g_xwalk_runner is set to ensure
   // XWalkRunner::GetInstance() can be used in all sub objects if needed.

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -73,10 +73,6 @@ class XWalkRunner {
     return extension_service_.get();
   }
 
-  // Return true if Crosswalk is running in service mode, i.e. taking
-  // requests from native IPC mechanism to launch applications.
-  bool is_running_as_service() const { return is_running_as_service_; }
-
   // Stages of main parts. See content/browser_main_parts.h for description.
   virtual void PreMainMessageLoopRun();
   virtual void PostMainMessageLoopRun();
@@ -135,8 +131,6 @@ class XWalkRunner {
   ScopedVector<XWalkComponent> components_;
 
   ApplicationComponent* app_component_;
-
-  bool is_running_as_service_;
 
   // These variables are used to export some values from the browser process
   // side to the extension side, such as application IDs and whatnot.

--- a/runtime/browser/xwalk_runner_tizen.cc
+++ b/runtime/browser/xwalk_runner_tizen.cc
@@ -27,12 +27,12 @@ void XWalkRunnerTizen::PreMainMessageLoopRun() {
   // NSSInitSingleton is a costly operation (up to 100ms on VTC-1010),
   // resulting in postponing the parsing and composition steps of the render
   // process at cold start. Therefore, move the initialization logic here.
-  if (XWalkRunner::is_running_as_service()) {
-    content::BrowserThread::PostTask(
-        content::BrowserThread::IO,
-        FROM_HERE,
-        base::Bind(&crypto::EnsureNSSInit));
-  }
+#if defined(SHARED_PROCESS_MODE)
+  content::BrowserThread::PostTask(
+      content::BrowserThread::IO,
+      FROM_HERE,
+      base::Bind(&crypto::EnsureNSSInit));
+#endif
 }
 
 }  // namespace xwalk

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -82,11 +82,7 @@ base::FilePath GetConfigPath() {
 
 bool GetXWalkDataPath(base::FilePath* path) {
   base::FilePath::StringType xwalk_suffix;
-
-// Only Tizen uses the Shared Process Mode now.
-// FIXME: Create common settings to detect process mode in runtime.
-// XWalkRunner::is_running_as_service() cannot be used here.
-#if defined(OS_TIZEN)
+#if defined(SHARED_PROCESS_MODE)
   xwalk_suffix = FILE_PATH_LITERAL("xwalk-service");
 #else
   xwalk_suffix = FILE_PATH_LITERAL("xwalk");

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -33,11 +33,6 @@ const char kUninstall[] = "uninstall";
 const char kXWalkAllowExternalExtensionsForRemoteSources[] =
     "allow-external-extensions-for-remote-sources";
 
-// Runs Crosswalk in service mode: it loads no application by default but stays
-// alive, and listens for external requests to launch applications. The way to
-// issue these requests is platform-specific.
-const char kXWalkRunAsService[] = "run-as-service";
-
 // Specifies the data path directory, which XWalk runtime will look for its
 // state, e.g. cache, localStorage etc.
 const char kXWalkDataPath[] = "data-path";

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -18,7 +18,6 @@ extern const char kListFeaturesFlags[];
 extern const char kUninstall[];
 extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
 extern const char kXWalkDataPath[];
-extern const char kXWalkRunAsService[];
 
 }  // namespace switches
 


### PR DESCRIPTION
Before this change Shared Process Model could be enabled
using 'xwalk' command line argument, this however does not
fit now as 'xwalkctl' also needs to be aware whether
Shared Process Model is enabled or not.
The 'shared_process_mode' gyp flag was introduced to solve the
issue described above.
