### PR TITLE
[Tizen][Runtime] Use tizen application id on tizen for wgt

### DIFF
--- a/application/common/id_util.cc
+++ b/application/common/id_util.cc
@@ -8,9 +8,21 @@
 #include "base/strings/string_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "crypto/sha2.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/manifest_handlers/tizen_application_handler.h"
+
+#if defined(OS_TIZEN)
+#include "third_party/re2/re2/re2.h"
+#endif
 
 namespace xwalk {
 namespace application {
+namespace {
+#if defined(OS_TIZEN)
+const char kTizenAppIdPattern[] = "\\A[0-9a-zA-Z]{10}[.][0-9a-zA-Z]{1,52}\\z";
+const std::string kAppIdPrefix("xwalk.");
+#endif
+}  // namespace
 
 // Converts a normal hexadecimal string into the alphabet used by applications.
 // We use the characters 'a'-'p' instead of '0'-'f' to avoid ever having a
@@ -50,6 +62,30 @@ std::string GenerateIdForPath(const base::FilePath& path) {
                   path.value().size() * sizeof(base::FilePath::CharType));
   return GenerateId(path_bytes);
 }
+
+#if defined(OS_TIZEN)
+std::string RawAppIdToCrosswalkAppId(const std::string& id) {
+  if (RE2::PartialMatch(id, kTizenAppIdPattern))
+    return GenerateId(id);
+  return id;
+}
+
+std::string RawAppIdToAppIdForTizenPkgmgrDB(const std::string& id) {
+  if (RE2::PartialMatch(id, kTizenAppIdPattern))
+    return id;
+  return kAppIdPrefix + id;
+}
+
+std::string GetTizenAppId(ApplicationData* application) {
+  if (application->GetPackageType() == xwalk::application::Package::XPK)
+    return application->ID();
+
+  const TizenApplicationInfo* tizen_app_info =
+      static_cast<TizenApplicationInfo*>(application->GetManifestData(
+          application_widget_keys::kTizenApplicationKey));
+  return tizen_app_info->id();
+}
+#endif
 
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/id_util.h
+++ b/application/common/id_util.h
@@ -7,6 +7,8 @@
 
 #include <string>
 
+#include "xwalk/application/common/application_data.h"
+
 namespace base {
 class FilePath;
 }
@@ -29,6 +31,25 @@ std::string GenerateId(const std::string& input);
 // Generate an ID for an application in the given path.
 // Used while developing applications, before they have a key.
 std::string GenerateIdForPath(const base::FilePath& path);
+
+#if defined(OS_TIZEN)
+// If this appid is a xpk app id(crosswalk_32bytes_app_id), return itself.
+// If this appid is a wgt app id(tizen_app_id), convert it to
+// crosswalk_32bytes_app_id and return it.
+std::string RawAppIdToCrosswalkAppId(const std::string& id);
+
+// If this appid is a xpk app id(crosswalk_32bytes_app_id), return
+// xwalk.crosswalk_32bytes_app_id.
+// If this appid is a wgt app id(tizen_app_id), return itself.
+// It is better to storage crosswalk_32bytes_app_id on tizen pkgmgr db
+// for xpk, but it must be an "." on appid or it cannot insert to tizen pkgmgr
+// db, so we have to have a "xwalk." as it's prefix.
+std::string RawAppIdToAppIdForTizenPkgmgrDB(const std::string& id);
+
+// For xpk, app_id == crosswalk_32bytes_app_id == this->ID(),
+// For wgt, app_id == tizen_wrt_10bytes_package_id.app_name,
+std::string GetTizenAppId(ApplicationData* application);
+#endif
 
 }  // namespace application
 }  // namespace xwalk

--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -64,6 +64,7 @@
       'dependencies': [
         '../../../../base/third_party/dynamic_annotations/dynamic_annotations.gyp:dynamic_annotations',
         '../../../extensions/extensions.gyp:xwalk_extensions',
+        '../../../application/common/xwalk_application_common.gypi:xwalk_application_common_lib',
       ],
       'sources': [
         'dbus_connection.cc',

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -18,6 +18,7 @@
 #include "xwalk/application/tools/linux/dbus_connection.h"
 #include "xwalk/application/tools/linux/xwalk_extension_process_launcher.h"
 #if defined(OS_TIZEN)
+#include "xwalk/application/common/id_util.h"
 #include "xwalk/application/tools/linux/xwalk_launcher_tizen.h"
 #include "xwalk/application/tools/linux/xwalk_tizen_user.h"
 #endif
@@ -299,13 +300,13 @@ int main(int argc, char** argv) {
 #endif
   } else {
     appid = strdup(basename(argv[0]));
-#if defined(OS_TIZEN)
-    if (char* xwalk_appid = xwalk_extract_app_id(appid)) {
-      free(appid);
-      appid = xwalk_appid;
-    }
-#endif
   }
+
+#if defined(OS_TIZEN)
+    std::string crosswalk_app_id =
+        xwalk::application::RawAppIdToCrosswalkAppId(appid);
+    appid = strdup(crosswalk_app_id.c_str());
+#endif
 
   launch_application(appid, fullscreen);
   free(appid);

--- a/application/tools/linux/xwalk_launcher_tizen.h
+++ b/application/tools/linux/xwalk_launcher_tizen.h
@@ -9,6 +9,4 @@ int xwalk_appcore_init(int argc, char** argv, const char* name);
 
 int xwalk_change_cmdline(int argc, char** argv, const char* app_id);
 
-char* xwalk_extract_app_id(const char* tizen_app_id);
-
 #endif  // XWALK_APPLICATION_TOOLS_LINUX_XWALK_LAUNCHER_TIZEN_H_

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -23,6 +23,7 @@
 #include "xwalk/application/tools/linux/dbus_connection.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 #if defined(OS_TIZEN)
+#include "xwalk/application/common/id_util.h"
 #include "xwalk/application/tools/linux/xwalk_tizen_user.h"
 #endif
 
@@ -80,8 +81,15 @@ bool list_applications(ApplicationStorage* storage) {
   g_print("Application ID                       Application Name\n");
   g_print("-----------------------------------------------------\n");
   ApplicationData::ApplicationDataMap::const_iterator it;
-  for (it = apps.begin(); it != apps.end(); ++it)
+  for (it = apps.begin(); it != apps.end(); ++it) {
+#if defined(OS_TIZEN)
+    g_print("%s  %s\n",
+            GetTizenAppId(it->second).c_str(),
+            it->second->Name().c_str());
+#else
     g_print("%s  %s\n", it->first.c_str(), it->second->Name().c_str());
+#endif
+  }
   g_print("-----------------------------------------------------\n");
 
   return true;
@@ -124,6 +132,11 @@ int main(int argc, char* argv[]) {
   } else if (uninstall_appid) {
 #if defined(SHARED_PROCESS_MODE)
     TerminateIfRunning(uninstall_appid);
+#endif
+#if defined(OS_TIZEN)
+    std::string crosswalk_app_id =
+        xwalk::application::RawAppIdToCrosswalkAppId(uninstall_appid);
+    uninstall_appid = strdup(crosswalk_app_id.c_str());
 #endif
     success = installer->Uninstall(uninstall_appid);
   } else {


### PR DESCRIPTION
To consistent with old wrt on tizen, we need to insert
[tizen_application_id] to tizen pkgmgr db when we install an
wgt packaged app, and we also need to launch an app by
[tizen_application_id].

For xpk, we still insert [xwalk.crosswalk_32bytes_app_id] to
pkgmgr db, and launch by it too.

BUG=XWALK-1925
