### PR TITLE
[Android] Add preference keys for cordova usage

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -611,9 +611,16 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
 
     @Override
     public void onKeyValueChanged(String key, boolean value) {
-        if (key == XWalkPreferencesInternal.REMOTE_DEBUGGING) {
+        if (key == null) return;
+        if (key.equals(XWalkPreferencesInternal.REMOTE_DEBUGGING)) {
             if (value) enableRemoteDebugging();
             else disableRemoteDebugging();
+        } else if (key.equals(XWalkPreferencesInternal.ENABLE_JAVASCRIPT)) {
+            if (mSettings != null) mSettings.setJavaScriptEnabled(value);
+        } else if (key.equals(XWalkPreferencesInternal.JAVASCRIPT_CAN_OPEN_WINDOW)) {
+            if (mSettings != null) mSettings.setJavaScriptCanOpenWindowsAutomatically(value);
+        } else if (key.equals(XWalkPreferencesInternal.ALLOW_UNIVERSAL_ACCESS_FROM_FILE)) {
+            if (mSettings != null) mSettings.setAllowUniversalAccessFromFileURLs(value);
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
@@ -57,9 +57,32 @@ public class XWalkPreferencesInternal {
      */
     public static final String ANIMATABLE_XWALK_VIEW = "animatable-xwalk-view";
 
+    /**
+     * The key string to enable/disable javascript.
+     */
+    static final String ENABLE_JAVASCRIPT = "enable-javascript";
+
+    /**
+     * The key string to allow/disallow javascript to open
+     * window automatically.
+     */
+    static final String JAVASCRIPT_CAN_OPEN_WINDOW =
+            "javascript-can-open-window";
+
+    /**
+     * The key string to allow/disallow having universal access
+     * from file origin.
+     */
+    static final String ALLOW_UNIVERSAL_ACCESS_FROM_FILE =
+            "allow-universal-access-from-file";
+
     static {
         sPrefMap.put(REMOTE_DEBUGGING, Boolean.FALSE);
         sPrefMap.put(ANIMATABLE_XWALK_VIEW, Boolean.FALSE);
+        sPrefMap.put(ENABLE_JAVASCRIPT, Boolean.TRUE);
+        sPrefMap.put(JAVASCRIPT_CAN_OPEN_WINDOW, Boolean.TRUE);
+        sPrefMap.put(
+                ALLOW_UNIVERSAL_ACCESS_FROM_FILE, Boolean.FALSE);
     }
 
     /**


### PR DESCRIPTION
The new preference keys are for
1. enabling javascript;
2. allow javascript to open window automatically;
3. allow universal access from file origin.

Related to Bug: XWALK-1857
