### PR TITLE
Fix the invalid product string of Crosswalk.

### DIFF
--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -39,8 +39,12 @@ const char kPnaclPluginDescription[] = "Portable Native Client Executable";
 
 namespace xwalk {
 
+std::string GetProduct() {
+  return "Chrome/" CHROME_VERSION;
+}
+
 std::string GetUserAgent() {
-  std::string product = "Chrome/" CHROME_VERSION;
+  std::string product = GetProduct();
 #if (defined(OS_TIZEN) || defined(OS_ANDROID))
   product += " Mobile Crosswalk/" XWALK_VERSION;
 #else
@@ -94,7 +98,7 @@ void XWalkContentClient::AddPepperPlugins(
 }
 
 std::string XWalkContentClient::GetProduct() const {
-  return std::string("Version/4.0");
+  return xwalk::GetProduct();
 }
 
 std::string XWalkContentClient::GetUserAgent() const {


### PR DESCRIPTION
The product string value should align with the value in user agent, which
will also be used by the DevTools ('Browser' section of version command).

The product string is meanful for remote debugging, eg: if the version in
product string is higer than the version of desktop Chrome. Then the
'chrome://inspect' UI should report the following warning string:
"You may need a newer version of desktop Chrome. Please try Chrome 36.0.1985.18 or later."

This is useful information for remote debugging, to make it work with non-Chrome
browsers (include Crosswalk) in device, the upstream patch under review should also
be required:
   https://codereview.chromium.org/367083002/

BUG=
