### PR TITLE
[Android] Implement onPageLoadStopped with LoadStatus parameter

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -300,6 +300,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
 
     public void stopLoading() {
         mContentViewCore.stopLoading();
+        mContentsClientBridge.onStopLoading();
     }
 
     // TODO(Guangzhen): ContentViewStatics will be removed in upstream,

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -172,6 +172,8 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
     public abstract void onPageFinished(String url);
 
+    protected abstract void onStopLoading();
+
     public abstract void onReceivedError(int errorCode, String description, String failingUrl);
 
     public abstract void onRendererUnresponsive();


### PR DESCRIPTION
Previously, the LoadStatus of onPageLoadStopped is always FINISHED.
Implement it by record the load status when stopLoading() and
onErrorReceived() get called.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2031
