### PR TITLE
[Android] Simplify check for --app-{local-path,root,url} in make_apk.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -729,16 +729,26 @@ def main(argv):
       options.name = ReplaceSpaceWithUnderscore(options.name)
     else:
       parser.error('The APK name is required! Please use "--name" option.')
-    if not ((options.app_url and
-             not options.app_root and
-             not options.app_local_path) or
-            (not options.app_url and
-             options.app_root and
-             options.app_local_path)):
-      parser.error('The entry is required. If the entry is a remote url, '
-                   'please use "--app-url" option; If the entry is local, '
-                   'please use "--app-root" and '
-                   '"--app-local-path" options together!')
+
+    # The checks here are really convoluted, but at the moment make_apk
+    # misbehaves any of the following conditions is true.
+    if options.app_url:
+      # 1) --app-url must be passed without either --app-local-path or
+      #    --app-root.
+      if options.app_root or options.app_local_path:
+        parser.error('You must pass either "--app-url" or "--app-local-path" '
+                     'with "--app-root", but not all.')
+    else:
+      # 2) --app-url is not passed but only one of --app-local-path and
+      #    --app-root is set.
+      if bool(options.app_root) != bool(options.app_local_path):
+        parser.error('You must specify both "--app-local-path" and '
+                     '"--app-root".')
+      # 3) None of --app-url, --app-local-path and --app-root are passed.
+      elif not options.app_root and not options.app_local_path:
+        parser.error('You must pass either "--app-url" or "--app-local-path" '
+                     'with "--app-root".')
+
     if options.permissions:
       permission_list = options.permissions.split(':')
     else:

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -347,8 +347,11 @@ class TestMakeApk(unittest.TestCase):
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
            self._mode]
     out = RunCommand(cmd)
+    self.assertNotIn('You must pass either "--app-url" or',
+                     out)
+    self.assertNotIn('You must specify both "--app-local-path" and',
+                     out)
     self.addCleanup(Clean, 'Example', '1.0.0')
-    self.assertTrue(out.find('The entry is required.') == -1)
     self.checkApks('Example', '1.0.0')
     Clean('Example', '1.0.0')
 
@@ -357,7 +360,10 @@ class TestMakeApk(unittest.TestCase):
            '--package=org.xwalk.example', '--app-root=%s' % test_entry_root,
            '--app-local-path=index.html', self._mode]
     out = RunCommand(cmd)
-    self.assertTrue(out.find('The entry is required.') == -1)
+    self.assertNotIn('You must pass either "--app-url" or',
+                     out)
+    self.assertNotIn('You must specify both "--app-local-path" and',
+                     out)
     self.checkApks('Example', '1.0.0')
 
   def testEntryWithErrors(self):
@@ -365,7 +371,9 @@ class TestMakeApk(unittest.TestCase):
            '--package=org.xwalk.example', self._mode]
     out = RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
-    self.assertTrue(out.find('The entry is required.') != -1)
+    self.assertIn('You must pass either "--app-url" or',
+                  out)
+
     self.assertFalse(os.path.exists('Example.apk'))
     Clean('Example', '1.0.0')
 
@@ -373,14 +381,16 @@ class TestMakeApk(unittest.TestCase):
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
            '--app-root=.', self._mode]
     out = RunCommand(cmd)
-    self.assertTrue(out.find('The entry is required.') != -1)
+    self.assertIn('You must pass either "--app-url" or',
+                  out)
     self.assertFalse(os.path.exists('Example.apk'))
     Clean('Example', '1.0.0')
 
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-root=./', self._mode]
     out = RunCommand(cmd)
-    self.assertTrue(out.find('The entry is required.') != -1)
+    self.assertIn('You must specify both "--app-local-path" and',
+                  out)
     self.assertFalse(os.path.exists('Example.apk'))
     Clean('Example', '1.0.0')
 
@@ -388,7 +398,8 @@ class TestMakeApk(unittest.TestCase):
            '--package=org.xwalk.example', '--app-local-path=index.html',
            self._mode]
     out = RunCommand(cmd)
-    self.assertTrue(out.find('The entry is required.') != -1)
+    self.assertIn('You must specify both "--app-local-path" and',
+                  out)
     self.assertFalse(os.path.exists('Example.apk'))
     Clean('Example', '1.0.0')
 


### PR DESCRIPTION
The existing check for those parameters is very convoluted and hard to
follow.

Split it into several smaller checks with different error messages for
each of them.
