### PR TITLE
[Android] Add test cases about canGoBack() and canGoForward().

### DIFF
--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/CanGoBackTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/CanGoBackTest.java
@@ -1,0 +1,32 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for CanGoBack().
+ */
+public class CanGoBackTest extends XWalkViewInternalTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @SmallTest
+    @Feature({"CanGoBack"})
+    public void testCanGoBack() throws Throwable {
+        final String url1 = "about:blank";
+        final String url2 = "file:///android_asset/www/index.html";
+        assertFalse(canGoBackOnUiThread());
+        loadUrlSync(url1);
+        assertFalse(canGoBackOnUiThread());
+        loadUrlSync(url2);
+        assertTrue(canGoBackOnUiThread());
+    }
+}

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/CanGoForwardTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/CanGoForwardTest.java
@@ -1,0 +1,33 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for CanGoForward().
+ */
+public class CanGoForwardTest extends XWalkViewInternalTestBase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @SmallTest
+    @Feature({"CanGoForward"})
+    public void testCanGoForward() throws Throwable {
+        final String url1 = "about:blank";
+        final String url2 = "file:///android_asset/www/index.html";
+        assertFalse(canGoForwardOnUiThread());
+        loadUrlSync(url1);
+        loadUrlSync(url2);
+        assertFalse(canGoForwardOnUiThread());
+        goBackSync();
+        assertTrue(canGoForwardOnUiThread());
+    }
+}


### PR DESCRIPTION
This patch is to add test cases about canGoBack() and canGoForward()
for XWalkViewInternal.
