### PR TITLE
[Runtime] Support launch an url from launcher.

### DIFF
--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -63,24 +63,9 @@ bool ApplicationSystem::LaunchWithCommandLineParam(
 template <>
 bool ApplicationSystem::LaunchWithCommandLineParam<GURL>(
     const GURL& url, const base::CommandLine& cmd_line) {
-  namespace keys = xwalk::application_manifest_keys;
-
-  const std::string& url_spec = url.spec();
-  DCHECK(!url_spec.empty());
-  const std::string& app_id = GenerateId(url_spec);
-  // FIXME: we need to handle hash collisions.
-  DCHECK(!application_storage_->GetApplicationData(app_id));
-
-  base::DictionaryValue manifest;
-  // FIXME: define permissions!
-  manifest.SetString(keys::kURLKey, url_spec);
-  manifest.SetString(keys::kNameKey,
-      "Crosswalk Hosted App [Restricted Permissions]");
-  manifest.SetString(keys::kVersionKey, "0");
-  manifest.SetInteger(keys::kManifestVersionKey, 1);
   std::string error;
-  scoped_refptr<ApplicationData> application_data = ApplicationData::Create(
-            base::FilePath(), Manifest::COMMAND_LINE, manifest, app_id, &error);
+  scoped_refptr<ApplicationData> application_data =
+      ApplicationData::Create(url, &error);
   if (!application_data) {
     LOG(ERROR) << "Error occurred while trying to launch application: "
                << error;

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -76,6 +76,26 @@ scoped_refptr<ApplicationData> ApplicationData::Create(
 }
 
 // static
+scoped_refptr<ApplicationData> ApplicationData::Create(
+    const GURL& url,
+    std::string* error_message) {
+  const std::string& url_spec = url.spec();
+  DCHECK(!url_spec.empty());
+  const std::string& app_id = GenerateId(url_spec);
+
+  base::DictionaryValue manifest;
+  // FIXME: define permissions!
+  manifest.SetString(application_manifest_keys::kURLKey, url_spec);
+  manifest.SetString(application_manifest_keys::kNameKey, url_spec);
+  manifest.SetString(application_manifest_keys::kVersionKey, "0");
+  scoped_refptr<ApplicationData> application_data =
+      ApplicationData::Create(base::FilePath(), Manifest::COMMAND_LINE,
+                              manifest, app_id, error_message);
+
+  return application_data;
+}
+
+// static
 bool ApplicationData::IsIDValid(const std::string& id) {
   std::string temp = StringToLowerASCII(id);
 

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -65,6 +65,9 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
       const std::string& explicit_id,
       std::string* error_message);
 
+  static scoped_refptr<ApplicationData> Create(const GURL& url,
+                                               std::string* error_message);
+
   // Checks to see if the application has a valid ID.
   static bool IsIDValid(const std::string& id);
 

--- a/runtime/browser/runtime_platform_util_tizen.cc
+++ b/runtime/browser/runtime_platform_util_tizen.cc
@@ -25,7 +25,7 @@ void OpenExternal(const GURL& url) {
     if (base::PathExists(base::FilePath(kWebBrowserPath)))
       argv.push_back(kWebBrowserPath);
     else
-      argv.push_back("xwalk");
+      argv.push_back("xwalk-launcher");
     argv.push_back(url.spec());
     base::ProcessHandle handle;
 


### PR DESCRIPTION
After commit 4f4eca4773e7e4a98dc0198fdca1bae1886c749e

We always compile a Shared Process Model binary for
tizen, and it always run as shared process model, so we cannot
launch a page with url like 'xwalk http://www.google.com'.

There is an easy way that we can support launch an url from
launcher, and create an temp app for url.

BUG=XWALK-2060
