### PR TITLE
[Android] Display no scaled image when no border specified in LaunchScre...

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLaunchScreenManager.java
@@ -394,13 +394,26 @@ public class XWalkLaunchScreenManager
         Bitmap img = BitmapFactory.decodeResource(mActivity.getResources(), imgResId);
         if (img == null) return null;
 
-        // Create the 9-piece layout as spec defined.
         RelativeLayout root = new RelativeLayout(mActivity);
         root.setLayoutParams(new RelativeLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT));
         RelativeLayout.LayoutParams params;
         ImageView subImageView;
+
+        // If no border specified, display the foreground image centered horizontally and vertically.
+        if (borders.size() == 0) {
+            subImageView = new ImageView(mActivity);
+            subImageView.setImageBitmap(img);
+            params = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.WRAP_CONTENT,
+                    RelativeLayout.LayoutParams.WRAP_CONTENT);
+            params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+            root.addView(subImageView, params);
+            return root;
+        }
+
+        // Create the 9-piece layout as spec defined.
 
         // Get Screen width and height.
         Display display = mActivity.getWindowManager().getDefaultDisplay();


### PR DESCRIPTION
...en

When no border specified in the manifest, the image should not be scaled, just display
the image centered in the screen.

BUG=XWALK-1998
(cherry picked from commit b51e1af3fca89d4ba7f8b909bce2ea5013c5dd57)
