### PR TITLE
Gardening M37 : Fix TestContentProvider not found when running the tests

### DIFF
--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -27,6 +27,8 @@
             <category android:name="android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST" />
           </intent-filter>
         </activity>
+        <provider android:name="org.xwalk.core.xwview.test.TestContentProvider"
+            android:authorities="org.xwalk.core.xwview.test.TestContentProvider" />
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />

--- a/runtime/android/runtime_shell/AndroidManifest.xml
+++ b/runtime/android/runtime_shell/AndroidManifest.xml
@@ -27,6 +27,8 @@
             <category android:name="android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST" />
           </intent-filter>
         </activity>
+        <provider android:name="org.xwalk.core.xwview.test.TestContentProvider"
+            android:authorities="org.xwalk.core.xwview.test.TestContentProvider" />
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />
@@ -37,12 +39,12 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
-  <uses-permission android:name="android.permission.READ_SMS" /> 
+  <uses-permission android:name="android.permission.READ_SMS" />
   <uses-permission android:name="android.permission.RECEIVE_SMS" />
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.SEND_SMS" />
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.WRITE_SMS" /> 
+  <uses-permission android:name="android.permission.WRITE_SMS" />
 </manifest>

--- a/test/android/core/javatests/AndroidManifest.xml
+++ b/test/android/core/javatests/AndroidManifest.xml
@@ -10,8 +10,6 @@
 
     <application>
         <uses-library android:name="android.test.runner" />
-        <provider android:name="TestContentProvider"
-            android:authorities="org.xwalk.core.xwview.test.TestContentProvider" />
     </application>
 
     <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />

--- a/test/android/runtime/javatests/AndroidManifest.xml
+++ b/test/android/runtime/javatests/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <application>
         <uses-library android:name="android.test.runner" />
-        <provider android:name="TestContentProvider"
+        <provider android:name="org.xwalk.runtime.client.test.TestContentProvider"
             android:authorities="org.xwalk.runtime.test.TestContentProvider" />
     </application>
 

--- a/test/android/runtime_client/javatests/AndroidManifest.xml
+++ b/test/android/runtime_client/javatests/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <application>
         <uses-library android:name="android.test.runner" />
-        <provider android:name="TestContentProvider"
+        <provider android:name="org.xwalk.runtime.client.test.TestContentProvider"
             android:authorities="org.xwalk.runtime.client.test.TestContentProvider" />
     </application>
 

--- a/test/android/runtime_client_embedded/javatests/AndroidManifest.xml
+++ b/test/android/runtime_client_embedded/javatests/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <application>
         <uses-library android:name="android.test.runner" />
-        <provider android:name="TestContentProvider"
+        <provider android:name="org.xwalk.runtime.client.test.TestContentProvider"
             android:authorities="org.xwalk.runtime.client.embedded.test.TestContentProvider" />
     </application>
 


### PR DESCRIPTION
on Android.

Following what upstream is doing we need to move the declaration
to various targets.

Relate to https://chromiumcodereview.appspot.com/23346011
