### PR TITLE
[Tizen][Runtime] Fix bug: crash on installation of a wgt without application element in config.xml

### DIFF
--- a/application/common/manifest_handlers/tizen_application_handler.cc
+++ b/application/common/manifest_handlers/tizen_application_handler.cc
@@ -115,5 +115,9 @@ std::vector<std::string> TizenApplicationHandler::Keys() const {
   return std::vector<std::string>(1, keys::kTizenApplicationKey);
 }
 
+bool TizenApplicationHandler::AlwaysParseForType(Manifest::Type type) const {
+  return true;
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/manifest_handlers/tizen_application_handler.h
+++ b/application/common/manifest_handlers/tizen_application_handler.h
@@ -56,6 +56,7 @@ class TizenApplicationHandler : public ManifestHandler {
   virtual bool Validate(scoped_refptr<const ApplicationData> application,
                         std::string* error,
                         std::vector<InstallWarning>* warnings) const OVERRIDE;
+  virtual bool AlwaysParseForType(Manifest::Type type) const OVERRIDE;
   virtual std::vector<std::string> Keys() const OVERRIDE;
 
  private:


### PR DESCRIPTION
According to
https://source.tizen.org/sites/default/files/page/tizen-2.2-wrt-core-spec.pdf
<tizen:application / > MUST occurrence one time.

If application element is not found in manifest, the parser 
should stop and the installation will fail.
