### PR TITLE
[Android] Disable PauseResumeTest for runtime client

### DIFF
--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/PauseResumeTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/PauseResumeTest.java
@@ -6,6 +6,7 @@
 package org.xwalk.runtime.client.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.shell.XWalkRuntimeClientShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -15,8 +16,9 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class PauseResumeTest extends XWalkRuntimeClientTestBase {
 
-    @SmallTest
-    @Feature({"PauseResume"})
+    // @SmallTest
+    // @Feature({"PauseResume"})
+    @DisabledTest
     public void testPauseAndResume() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PauseResumeTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PauseResumeTest.java
@@ -6,6 +6,7 @@
 package org.xwalk.runtime.client.embedded.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.embedded.shell.XWalkRuntimeClientEmbeddedShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -15,8 +16,9 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class PauseResumeTest extends XWalkRuntimeClientTestBase {
 
-    @SmallTest
-    @Feature({"PauseResume"})
+    // @SmallTest
+    // @Feature({"PauseResume"})
+    @DisabledTest
     public void testPauseAndResume() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(


### PR DESCRIPTION
As the XWalkView now doesn't relies on embedders to
call onHide/Show and pause/ResumeTimer when Activity
state changes.
The onPause/onResume callback in XWalkRuntimeClient is
now empty. We need to find another solution to
actually pause/resume the Activity to test the case.

Disable the test before that.

BUG=
