### PR TITLE
[Android] Add a real Activity to simulate Pause/Resume for test

### DIFF
--- a/app/android/runtime_client_embedded_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_embedded_shell/AndroidManifest.xml
@@ -24,6 +24,8 @@
             <category android:name="android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST" />
           </intent-filter>
         </activity>
+        <activity android:name="org.xwalk.test.util.ActivityToCausePause">
+        </activity>
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />

--- a/app/android/runtime_client_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_shell/AndroidManifest.xml
@@ -24,6 +24,8 @@
             <category android:name="android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST" />
           </intent-filter>
         </activity>
+        <activity android:name="org.xwalk.test.util.ActivityToCausePause">
+        </activity>
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/PauseResumeTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/PauseResumeTest.java
@@ -16,13 +16,12 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class PauseResumeTest extends XWalkRuntimeClientTestBase {
 
-    // @SmallTest
-    // @Feature({"PauseResume"})
-    @DisabledTest
+    @SmallTest
+    @Feature({"PauseResume"})
     public void testPauseAndResume() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(
                         getTestUtil(), this);
-        helper.testPauseAndResume();
+        helper.testPauseAndResume(getActivity());
     }
 }

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PauseResumeTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PauseResumeTest.java
@@ -16,13 +16,12 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class PauseResumeTest extends XWalkRuntimeClientTestBase {
 
-    // @SmallTest
-    // @Feature({"PauseResume"})
-    @DisabledTest
+    @SmallTest
+    @Feature({"PauseResume"})
     public void testPauseAndResume() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(
                         getTestUtil(), this);
-        helper.testPauseAndResume();
+        helper.testPauseAndResume(getActivity());
     }
 }

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/ActivityToCausePause.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/ActivityToCausePause.java
@@ -1,0 +1,37 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.test.util;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class ActivityToCausePause extends Activity {
+    private static ActivityToCausePause instance = null;
+
+    public static void pauseActivity(Context activity) {
+        Intent intent = new Intent(activity, ActivityToCausePause.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT);
+        activity.startActivity(intent);
+    }
+
+    public static void resumeActivity() {
+        if (instance != null) instance.finish();
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        assert(instance == null);
+        instance = this;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        instance = null;
+    }
+}

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
@@ -336,7 +336,7 @@ public class RuntimeClientApiTestBase<T extends Activity> {
     }
 
     // For onPause, onResume.
-    public void testPauseAndResume() throws Throwable {
+    public void testPauseAndResume(Context context) throws Throwable {
         String title = "";
         String prevTitle = "";
         String nextTitle = "";
@@ -345,7 +345,7 @@ public class RuntimeClientApiTestBase<T extends Activity> {
         title = mTestUtil.loadAssetFileAndWaitForTitle("timer.html");
         mTestCase.assertNotNull(title);
 
-        mTestUtil.onPause();
+        mTestUtil.pauseActivity(context);
         msg = "The second title should be equal to the first title.";
         // wait for the pause is finished.
         waitForTimerFinish(5000);
@@ -354,7 +354,7 @@ public class RuntimeClientApiTestBase<T extends Activity> {
         nextTitle = getTitleOnUiThread();
         compareTitle(prevTitle, nextTitle, msg, Relation.EQUAL);
 
-        mTestUtil.onResume();
+        mTestUtil.resumeActivity();
         msg = "The second title should be greater than the first title.";
         // wait for the resume is finished.
         waitForTimerFinish(5000);

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientTestUtilBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientTestUtilBase.java
@@ -79,20 +79,20 @@ public class XWalkRuntimeClientTestUtilBase extends XWalkTestUtilBase<XWalkRunti
         });
     }
 
-    public void onPause() throws Exception {
-        mInstrumentation.runOnMainSync(new Runnable() {
+    public void pauseActivity(final Context activity) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                getTestedView().onPause();
+                ActivityToCausePause.pauseActivity(activity);
             }
         });
     }
 
-    public void onResume() throws Exception {
-        mInstrumentation.runOnMainSync(new Runnable() {
+    public void resumeActivity() throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                getTestedView().onResume();
+                ActivityToCausePause.resumeActivity();
             }
         });
     }


### PR DESCRIPTION
Previously, the case is calling onPause()/onResume of
XWalkRuntimeClient to trigger XWalkView's pause/resume.
After 75b09f33, XWalkView handles the activity status
change within itself. So XWalkRuntimeClient's onPause/onResume
is now empty method.

To test this case, a real Activity "ActivityToCausePause" is
created to trigger the pause/resume event of test target
Activity.
