### PR TITLE
[Android] "version" field in manifest should not be mandatory and should...

### DIFF
--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -594,6 +594,13 @@ class TestMakeApk(unittest.TestCase):
     self.assertIn('WARNING: description is deprecated for Crosswalk', out)
     Clean('Example', '1.0.0')
 
+    manifest_path = os.path.join('test_data', 'manifest', 'deprecated',
+                                 'manifest_deprecated_version.json')
+    cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
+           '--manifest=%s' % manifest_path, self._mode]
+    out = RunCommand(cmd)
+    self.assertIn('WARNING: version is deprecated for Crosswalk', out)
+
   def testManifestWithError(self):
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_no_app_launch_path.json')
@@ -607,12 +614,6 @@ class TestMakeApk(unittest.TestCase):
            '--manifest=%s' % manifest_path, '--verbose', self._mode]
     out = RunCommand(cmd)
     self.assertTrue(out.find('no \'name\' field') != -1)
-    manifest_path = os.path.join('test_data', 'manifest',
-                                 'manifest_no_version.json')
-    cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
-           '--manifest=%s' % manifest_path, '--verbose', self._mode]
-    out = RunCommand(cmd)
-    self.assertTrue(out.find('no \'version\' field') != -1)
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_permissions_format_error.json')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -113,10 +113,16 @@ class ManifestJsonParser(object):
       print('Error: no \'name\' field in manifest.json file.')
       sys.exit(1)
     ret_dict['app_name'] = self.data_src['name']
-    if 'version' not in self.data_src:
-      print('Error: no \'version\' field in manifest.json file.')
-      sys.exit(1)
-    ret_dict['version'] = self.data_src['version']
+    ret_dict['version'] = ''
+    if 'version' in self.data_src and 'xwalk_version' in self.data_src:
+      print('WARNING: the value in "version" will be ignored and support '
+            'for it will be removed in the future.')
+      ret_dict['version'] = self.data_src['xwalk_version']
+    elif 'xwalk_version' in self.data_src:
+      ret_dict['version'] = self.data_src['xwalk_version']
+    elif 'version' in self.data_src:
+      PrintDeprecationWarning('version')
+      ret_dict['version'] = self.data_src['version']
     if 'start_url' in self.data_src:
       app_url = self.data_src['start_url']
     elif 'launch_path' in self.data_src:

--- a/app/tools/android/test_data/manifest/deprecated/manifest_app_local_path.json
+++ b/app/tools/android/test_data/manifest/deprecated/manifest_app_local_path.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "app": {
       "launch": {
           "local_path": "http://www.intel.com"

--- a/app/tools/android/test_data/manifest/deprecated/manifest_deprecated_version.json
+++ b/app/tools/android/test_data/manifest/deprecated/manifest_deprecated_version.json
@@ -1,8 +1,10 @@
 {
   "name": "Example",
+  "version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "icons": [],
   "xwalk_permissions": ["geolocation"],
+  "default_locale": "en",
   "fullscreen":"true"
 }

--- a/app/tools/android/test_data/manifest/deprecated/manifest_launch_path.json
+++ b/app/tools/android/test_data/manifest/deprecated/manifest_launch_path.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "launch_path": "http://www.intel.com",
   "xwalk_description": "a sample description"
 }

--- a/app/tools/android/test_data/manifest/deprecated/manifest_permissions.json
+++ b/app/tools/android/test_data/manifest/deprecated/manifest_permissions.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "permissions": [

--- a/app/tools/android/test_data/manifest/invalidchars/manifest_contain_space_name.json
+++ b/app/tools/android/test_data/manifest/invalidchars/manifest_contain_space_name.json
@@ -1,6 +1,6 @@
 {
   "name": "app name ",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "fullscreen":"true"

--- a/app/tools/android/test_data/manifest/invalidchars/manifest_parse_error.json
+++ b/app/tools/android/test_data/manifest/invalidchars/manifest_parse_error.json
@@ -1,6 +1,6 @@
 {
   "name": "\Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "fullscreen":"true"

--- a/app/tools/android/test_data/manifest/invalidchars/manifest_with_chinese_name.json
+++ b/app/tools/android/test_data/manifest/invalidchars/manifest_with_chinese_name.json
@@ -1,6 +1,6 @@
 {
   "name": "你好",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "fullscreen":"true"

--- a/app/tools/android/test_data/manifest/invalidchars/manifest_with_invalid_name.json
+++ b/app/tools/android/test_data/manifest/invalidchars/manifest_with_invalid_name.json
@@ -1,6 +1,6 @@
 {
   "name": "@*&^Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "fullscreen":"true"

--- a/app/tools/android/test_data/manifest/invalidchars/manifest_with_space_name.json
+++ b/app/tools/android/test_data/manifest/invalidchars/manifest_with_space_name.json
@@ -1,6 +1,6 @@
 {
   "name": " ",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "fullscreen":"true"

--- a/app/tools/android/test_data/manifest/manifest.json
+++ b/app/tools/android/test_data/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "icons": [],

--- a/app/tools/android/test_data/manifest/manifest_app_launch_local_path.json
+++ b/app/tools/android/test_data/manifest/manifest_app_launch_local_path.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http.html",
   "xwalk_description": "a sample description",
   "icons": [],

--- a/app/tools/android/test_data/manifest/manifest_deprecated_icon.json
+++ b/app/tools/android/test_data/manifest/manifest_deprecated_icon.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "icons": {

--- a/app/tools/android/test_data/manifest/manifest_icon.json
+++ b/app/tools/android/test_data/manifest/manifest_icon.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "icons": [

--- a/app/tools/android/test_data/manifest/manifest_no_app_launch_path.json
+++ b/app/tools/android/test_data/manifest/manifest_no_app_launch_path.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "xwalk_description": "a sample description",
   "icons": [],
   "xwalk_permissions": ["geolocation"],

--- a/app/tools/android/test_data/manifest/manifest_no_name.json
+++ b/app/tools/android/test_data/manifest/manifest_no_name.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "icons": [],

--- a/app/tools/android/test_data/manifest/manifest_not_supported_permission.json
+++ b/app/tools/android/test_data/manifest/manifest_not_supported_permission.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "icons": [],

--- a/app/tools/android/test_data/manifest/manifest_permissions_field_error.json
+++ b/app/tools/android/test_data/manifest/manifest_permissions_field_error.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "icons": [],

--- a/app/tools/android/test_data/manifest/manifest_permissions_format_error.json
+++ b/app/tools/android/test_data/manifest/manifest_permissions_format_error.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "version": "1.0.0",
+  "xwalk_version": "1.0.0",
   "start_url": "http://www.intel.com",
   "xwalk_description": "a sample description",
   "icons": [],


### PR DESCRIPTION
... be renamed to "xwalk_version"

According W3C manifest spec, 'version' field of manifest should be:
1) renamed to "xwalk_version"
2) optional
3) the "version" field should be handled if present, but issue a deprecation warning

BUG=https://crosswalk-project.org/jira/browse/XWALK-2053
