### PR TITLE
[Tizen][Runtime] Send tizen_app_id to extensions for tizen.

### DIFF
--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -134,7 +134,7 @@ class XWalkRunner {
 
   // These variables are used to export some values from the browser process
   // side to the extension side, such as application IDs and whatnot.
-  void InitializeRuntimeVariablesForExtensions(
+  virtual void InitializeRuntimeVariablesForExtensions(
       const content::RenderProcessHost* host,
       base::ValueMap* runtime_variables);
 

--- a/runtime/browser/xwalk_runner_tizen.cc
+++ b/runtime/browser/xwalk_runner_tizen.cc
@@ -6,6 +6,9 @@
 
 #include "content/public/browser/browser_thread.h"
 #include "crypto/nss_util.h"
+#include "xwalk/application/browser/application_service.h"
+#include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/common/id_util.h"
 #include "xwalk/runtime/browser/sysapps_component.h"
 #include "xwalk/runtime/browser/xwalk_component.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
@@ -33,6 +36,20 @@ void XWalkRunnerTizen::PreMainMessageLoopRun() {
       FROM_HERE,
       base::Bind(&crypto::EnsureNSSInit));
 #endif
+}
+
+void XWalkRunnerTizen::InitializeRuntimeVariablesForExtensions(
+    const content::RenderProcessHost* host,
+    base::ValueMap* variables) {
+  application::Application* app = app_system()->application_service()->
+      GetApplicationByRenderHostID(host->GetID());
+
+  if (app) {
+    (*variables)["app_id"] = base::Value::CreateStringValue(app->id());
+    (*variables)["tizen_app_id"] = base::Value::CreateStringValue(
+        application::RawAppIdToAppIdForTizenPkgmgrDB(
+            application::GetTizenAppId(app->data())));
+  }
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_runner_tizen.h
+++ b/runtime/browser/xwalk_runner_tizen.h
@@ -29,6 +29,10 @@ class XWalkRunnerTizen : public XWalkRunner {
   friend class XWalkRunner;
   XWalkRunnerTizen();
 
+  virtual void InitializeRuntimeVariablesForExtensions(
+      const content::RenderProcessHost* host,
+      base::ValueMap* runtime_variables) OVERRIDE;
+
   TizenLocaleListener tizen_locale_listener_;
 };
 


### PR DESCRIPTION
After commit c22823fae34f299b8861af6cf3ee7a05d36cc118
we had already storage [tizen_app_id] to tizen pkgmgr db for
wgt packaged app, and some parts of t-e-c will need to get app
info from pkgmgr db according to [tizen_app_id], so we need to
send [tizen_app_id] to extensions.

Besides we still use [app_id] in xwalk internal, and send
[app_id] to extensions.
