### PR TITLE
[Android] Re-enable DeviceCapabilities instrumentation test

### DIFF
--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/DeviceCapabilitiesTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/DeviceCapabilitiesTest.java
@@ -6,7 +6,6 @@
 package org.xwalk.runtime.client.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.shell.XWalkRuntimeClientShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -18,7 +17,6 @@ public class DeviceCapabilitiesTest extends XWalkRuntimeClientTestBase {
 
     // @SmallTest
     // @Feature({"DeviceCapabilities"})
-    @DisabledTest
     public void testDeviceCapabilities() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/DeviceCapabilitiesTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/DeviceCapabilitiesTest.java
@@ -6,7 +6,6 @@
 package org.xwalk.runtime.client.embedded.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.runtime.client.embedded.shell.XWalkRuntimeClientEmbeddedShellActivity;
 import org.xwalk.test.util.RuntimeClientApiTestBase;
@@ -18,7 +17,6 @@ public class DeviceCapabilitiesTest extends XWalkRuntimeClientTestBase {
 
     // @SmallTest
     // @Feature({"DeviceCapabilities"})
-    @DisabledTest
     public void testDeviceCapabilities() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(

--- a/test/android/util/src/org/xwalk/test/util/XWalkTestUtilBase.java
+++ b/test/android/util/src/org/xwalk/test/util/XWalkTestUtilBase.java
@@ -7,6 +7,7 @@ package org.xwalk.test.util;
 
 import android.app.Instrumentation;
 import android.content.Context;
+import android.net.Uri;
 
 import java.io.InputStream;
 import java.io.IOException;
@@ -74,7 +75,8 @@ public class XWalkTestUtilBase<T> {
     }
 
     public void loadAssetFile(String fileName) throws Exception {
-        String fileContent = getFileContent(fileName);
+        //The content of "Data URI scheme" should be escaped when data type is "text/html".
+        String fileContent = Uri.encode(getFileContent(fileName));
         loadDataSync(fileContent, "text/html", false);
     }
 


### PR DESCRIPTION
The root cause is instrument test loads test page as "Data URI scheme". The body of "Data URI scheme" should be escaped when data type is "text/html".

Related to XWALK-99
