### PR TITLE
[Tizen] Remove Ringtone from virtual root

### DIFF
--- a/experimental/native_file_system/virtual_root_provider_tizen.cc
+++ b/experimental/native_file_system/virtual_root_provider_tizen.cc
@@ -31,8 +31,4 @@ VirtualRootProvider::VirtualRootProvider() {
         base::FilePath::FromUTF8Unsafe(
             std::string(tzplatform_getenv(dirs[i])));
   }
-
-  virtual_root_map_["RINGTONES"] =
-      base::FilePath::FromUTF8Unsafe(
-          std::string(tzplatform_mkpath(TZ_USER_SHARE, "settings/Ringtones")));
 }


### PR DESCRIPTION
IVI doesn't need "Ringtone" path. So, remove it.
