### PR TITLE
[Android] Increase Embedding API version to 2.1

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -648,7 +648,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      */
     // TODO(yongsheng): make it static?
     public String getAPIVersion() {
-        return "2.0";
+        return "2.1";
     }
 
     /**


### PR DESCRIPTION
2.0 => 2.1 contains the following API changes:

XWalkResourceClient:
- public boolean shouldOverrideUrlLoading(XWalkView view, String url);

XWalkUIClient:
- public void onReceivedTitle(XWalkView view, String title);
- public boolean shouldOverrideKeyEvent(XWalkView view, KeyEvent event);
- public void onUnhandledKeyEvent(XWalkView view, KeyEvent event);
- public void onPageLoadStarted(XWalkView view, String url);
- enum LoadStatus;
- public void onPageLoadStopped(XWalkView view, String url, LoadStatus status);
- XWalkExtension:
  - public XWalkExtension(String extensionName, String sourceContent);
  - public XWalkExtension(String extensionName, String sourceContent, String[] entryPoints);
  - public final void postMessage(int instanceID, String message);
  - public final void broadcastMessage(String message);
  - public abstract void onMessage(int instanceID, String message);
  - public abstract String onSyncMessage(int instanceID, String message);

BUG=https://crosswalk-project.org/jira/browse/XWALK-2068
