### PR TITLE
[Android] Accept alias password for specified keystore when making apk

### DIFF
--- a/app/tools/android/gyp/finalize_apk.py
+++ b/app/tools/android/gyp/finalize_apk.py
@@ -13,7 +13,7 @@ import sys
 
 from util import build_utils
 
-def SignApk(keystore_path, unsigned_path, signed_path, alias, code):
+def SignApk(keystore_path, unsigned_path, signed_path, alias, code, alias_code):
   intermediate_path = unsigned_path + '.copy'
   shutil.copy(unsigned_path, intermediate_path)
   sign_cmd = [
@@ -22,6 +22,7 @@ def SignApk(keystore_path, unsigned_path, signed_path, alias, code):
       '-digestalg', 'SHA1',
       '-keystore', keystore_path,
       '-storepass', code,
+      '-keypass', alias_code,
       intermediate_path, alias
       ]
   build_utils.CheckCallDie(sign_cmd)
@@ -48,12 +49,15 @@ def main():
   parser.add_option('--keystore-path', help='Path to keystore for signing.')
   parser.add_option('--keystore-alias', help='Alias name of keystore.')
   parser.add_option('--keystore-passcode', help='Passcode of keystore.')
+  parser.add_option('--keystore-alias-passcode',
+                    help='Passcode for alias\'s private key in the keystore.')
   parser.add_option('--stamp', help='Path to touch on success.')
   options, _ = parser.parse_args()
 
   signed_apk_path = options.unsigned_apk_path + '.signed.apk'
   SignApk(options.keystore_path, options.unsigned_apk_path,
-          signed_apk_path, options.keystore_alias, options.keystore_passcode)
+          signed_apk_path, options.keystore_alias, options.keystore_passcode,
+          options.keystore_alias_passcode)
   AlignApk(options.zipalign_path, signed_apk_path, options.final_apk_path)
 
   if options.stamp:

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -249,12 +249,19 @@ def Execution(options, name):
     else:
       print('Please provide the passcode of the developer key.')
       sys.exit(6)
+    if options.keystore_alias_passcode:
+      key_alias_code = options.keystore_alias_passcode
+    else:
+      print('--keystore-alias-passcode was not specified, '
+            'using the keystore\'s passcode as the alias keystore passcode.')
+      key_alias_code = key_code
   else:
     print ('Use xwalk\'s keystore by default for debugging. '
            'Please switch to your keystore when distributing it to app market.')
     key_store = 'scripts/ant/xwalk-debug.keystore'
     key_alias = 'xwalkdebugkey'
     key_code = 'xwalkdebug'
+    key_alias_code = 'xwalkdebug'
 
   if not os.path.exists('out'):
     os.mkdir('out')
@@ -485,7 +492,8 @@ def Execution(options, name):
          final_apk_path,
          '--keystore-path=%s' % key_store,
          '--keystore-alias=%s' % key_alias,
-         '--keystore-passcode=%s' % key_code]
+         '--keystore-passcode=%s' % key_code,
+         '--keystore-alias-passcode=%s' % key_alias_code]
   RunCommand(cmd)
 
   src_file = os.path.join('out', name + '.apk')
@@ -686,6 +694,9 @@ def main(argv):
   group.add_option('--keystore-alias', help=info)
   info = ('The passcode of keystore. For example, --keystore-passcode=code')
   group.add_option('--keystore-passcode', help=info)
+  info = ('Passcode for alias\'s private key in the keystore, '
+          'For example, --keystore-alias-passcode=alias-code')
+  group.add_option('--keystore-alias-passcode', help=info)
   info = ('Minify and obfuscate javascript and css.'
           '--compressor: compress javascript and css.'
           '--compressor=js: compress javascript.'


### PR DESCRIPTION
Password of alias and keystore can be different.
Previous make_apk.py only accepts keystore password.
Add additional option to accept alias password.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2135
