### PR TITLE
[Android] Remove unused chromium import in runtime

### DIFF
--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -10,7 +10,6 @@ import android.content.Intent;
 import android.view.View;
 import android.widget.FrameLayout;
 
-import org.chromium.content.browser.LoadUrlParams;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkPreferences;
 


### PR DESCRIPTION
Runtime should not depends on chromium, thus
the import is not used anywhere.
