### PR TITLE
[Tizen] Application resource protection implementation

### DIFF
--- a/application/browser/application_encrypted_file_job_tizen.cc
+++ b/application/browser/application_encrypted_file_job_tizen.cc
@@ -1,0 +1,200 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/application_encrypted_file_job_tizen.h"
+
+#include "base/strings/string_util.h"
+#include "base/task_runner.h"
+#include "base/threading/worker_pool.h"
+#include "base/threading/sequenced_worker_pool.h"
+#include "net/base/file_stream.h"
+#include "net/base/mime_util.h"
+#include "net/base/io_buffer.h"
+#include "net/base/net_errors.h"
+#include "net/http/http_response_headers.h"
+#include "net/http/http_response_info.h"
+#include "net/url_request/url_request_status.h"
+#include "xwalk/application/common/encryption_tizen.h"
+
+namespace xwalk {
+namespace application {
+
+URLRequestAppEncryptedFileJob::URLRequestAppEncryptedFileJob(
+    net::URLRequest* request,
+    net::NetworkDelegate* network_delegate,
+    const scoped_refptr<base::TaskRunner>& file_task_runner,
+    const std::string& application_id,
+    const base::FilePath& directory_path,
+    const base::FilePath& relative_path,
+    const std::string& content_security_policy,
+    const std::list<std::string>& locales)
+    : net::URLRequestJob(request, network_delegate),
+      file_task_runner_(file_task_runner),
+      stream_(new net::FileStream(file_task_runner)),
+      relative_path_(relative_path),
+      resource_(application_id, directory_path, relative_path),
+      content_security_policy_(content_security_policy),
+      locales_(locales),
+      weak_ptr_factory_(this) {
+}
+
+URLRequestAppEncryptedFileJob::~URLRequestAppEncryptedFileJob() {}
+
+void URLRequestAppEncryptedFileJob::GetResponseInfo(
+    net::HttpResponseInfo* info) {
+  std::string headers("HTTP/1.1 200 OK");
+  if (!content_security_policy_.empty()) {
+    headers.append(1, '\0');
+    headers.append("Content-Security-Policy: ");
+    headers.append(content_security_policy_);
+  }
+  headers.append(1, '\0');
+  headers.append("Access-Control-Allow-Origin: *");
+  std::string mime_type;
+  GetMimeType(&mime_type);
+  if (!mime_type.empty()) {
+    headers.append(1, '\0');
+    headers.append("Content-Type: ");
+    headers.append(mime_type);
+  }
+  headers.append(2, '\0');
+  info->headers = new net::HttpResponseHeaders(headers);
+}
+
+void URLRequestAppEncryptedFileJob::Start() {
+  base::FilePath* read_file_path = new base::FilePath;
+  resource_.SetLocales(locales_);
+  bool posted = base::WorkerPool::PostTaskAndReply(
+      FROM_HERE,
+      base::Bind(&URLRequestAppEncryptedFileJob::ReadFilePath,
+                 weak_ptr_factory_.GetWeakPtr(),
+                 resource_,
+                 base::Unretained(read_file_path)),
+      base::Bind(&URLRequestAppEncryptedFileJob::DidReadFilePath,
+                 weak_ptr_factory_.GetWeakPtr(),
+                 base::Owned(read_file_path)),
+      true /* task is slow */);
+  DCHECK(posted);
+}
+
+void URLRequestAppEncryptedFileJob::Kill() {
+  weak_ptr_factory_.InvalidateWeakPtrs();
+  URLRequestJob::Kill();
+}
+
+bool URLRequestAppEncryptedFileJob::ReadRawData(net::IOBuffer* buf,
+                                                int buf_size,
+                                                int* bytes_read) {
+  int remaining = plain_buffer_->size() - plain_buffer_offset_;
+  if (buf_size > remaining)
+    buf_size = remaining;
+  if (!buf_size) {
+    *bytes_read = 0;
+    return true;
+  }
+  memcpy(buf->data(), plain_buffer_->data() + plain_buffer_offset_, buf_size);
+  plain_buffer_offset_ += buf_size;
+  *bytes_read = buf_size;
+  return true;
+}
+
+bool URLRequestAppEncryptedFileJob::IsRedirectResponse(GURL* location,
+                                                       int* http_status_code) {
+  return false;
+}
+
+bool URLRequestAppEncryptedFileJob::GetMimeType(std::string* mime_type) const {
+  DCHECK(mime_type);
+  if (!mime_type_.empty()) {
+    *mime_type = mime_type_;
+    return true;
+  }
+  return false;
+}
+
+void URLRequestAppEncryptedFileJob::ReadFilePath(
+    const ApplicationResource& resource,
+    base::FilePath* file_path) {
+  *file_path = resource.GetFilePath();
+}
+
+void URLRequestAppEncryptedFileJob::DidReadFilePath(
+    base::FilePath* read_file_path) {
+  file_path_ = *read_file_path;
+  if (file_path_.empty()) {
+    NotifyHeadersComplete();
+    return;
+  }
+  base::File::Info* file_info = new base::File::Info();
+  file_task_runner_->PostTaskAndReply(
+      FROM_HERE,
+      base::Bind(&URLRequestAppEncryptedFileJob::FetchFileInfo,
+                 weak_ptr_factory_.GetWeakPtr(),
+                 file_path_,
+                 base::Unretained(file_info)),
+      base::Bind(&URLRequestAppEncryptedFileJob::DidFetchFileInfo,
+                 weak_ptr_factory_.GetWeakPtr(),
+                 base::Owned(file_info)));
+}
+
+void URLRequestAppEncryptedFileJob::FetchFileInfo(
+    const base::FilePath& file_path,
+    base::File::Info* file_info) {
+  base::GetFileInfo(file_path, file_info);
+}
+
+void URLRequestAppEncryptedFileJob::DidFetchFileInfo(
+    const base::File::Info* file_info) {
+  if (!file_info->size) {
+    NotifyDone(net::URLRequestStatus(net::URLRequestStatus::FAILED,
+        net::ERR_FILE_NOT_FOUND));
+    return;
+  }
+
+  net::GetMimeTypeFromFile(file_path_, &mime_type_);
+  cipher_buffer_ = new net::IOBufferWithSize(file_info->size);
+  int flags = base::File::FLAG_OPEN |
+              base::File::FLAG_READ |
+              base::File::FLAG_ASYNC;
+  int rv = stream_->Open(file_path_,
+                         flags,
+                         base::Bind(&URLRequestAppEncryptedFileJob::DidOpen,
+                                    weak_ptr_factory_.GetWeakPtr()));
+  if (rv != net::ERR_IO_PENDING)
+    DidOpen(rv);
+}
+
+void URLRequestAppEncryptedFileJob::DidOpen(int result) {
+  if (result) {
+    NotifyDone(net::URLRequestStatus(net::URLRequestStatus::FAILED, result));
+    return;
+  }
+  int rv = stream_->Read(
+      cipher_buffer_.get(),
+      cipher_buffer_->size(),
+      base::Bind(&URLRequestAppEncryptedFileJob::DidReadEncryptedData,
+                 weak_ptr_factory_.GetWeakPtr(),
+                 cipher_buffer_));
+  if (rv != net::ERR_IO_PENDING)
+    NotifyDone(net::URLRequestStatus(net::URLRequestStatus::FAILED, rv));
+}
+
+void URLRequestAppEncryptedFileJob::DidReadEncryptedData(
+    scoped_refptr<net::IOBufferWithSize> buf,
+    int result) {
+  stream_.reset();
+  std::string plain_text;
+  if (!DecryptData(buf->data(), buf->size(), &plain_text)) {
+    NotifyDone(net::URLRequestStatus(net::URLRequestStatus::FAILED,
+        net::ERR_REQUEST_RANGE_NOT_SATISFIABLE));
+    return;
+  }
+  plain_buffer_ = new net::StringIOBuffer(plain_text);
+  set_expected_content_size(plain_buffer_->size());
+  plain_buffer_offset_ = 0;
+  NotifyHeadersComplete();
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/application_encrypted_file_job_tizen.h
+++ b/application/browser/application_encrypted_file_job_tizen.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_APPLICATION_ENCRYPTED_FILE_JOB_TIZEN_H_
+#define XWALK_APPLICATION_BROWSER_APPLICATION_ENCRYPTED_FILE_JOB_TIZEN_H_
+
+#include <list>
+#include <string>
+
+#include "base/file_util.h"
+#include "base/files/file_path.h"
+#include "base/memory/weak_ptr.h"
+#include "net/url_request/url_request.h"
+#include "net/url_request/url_request_job.h"
+
+#include "xwalk/application/common/application_resource.h"
+
+namespace base {
+class TaskRunner;
+}
+
+namespace net {
+class FileStream;
+class StringIOBuffer;
+}
+
+namespace xwalk {
+namespace application {
+
+class URLRequestAppEncryptedFileJob : public net::URLRequestJob {
+ public:
+  URLRequestAppEncryptedFileJob(
+    net::URLRequest* request,
+    net::NetworkDelegate* network_delegate,
+    const scoped_refptr<base::TaskRunner>& file_task_runner,
+    const std::string& application_id,
+    const base::FilePath& directory_path,
+    const base::FilePath& relative_path,
+    const std::string& content_security_policy,
+    const std::list<std::string>& locales);
+
+  virtual void GetResponseInfo(net::HttpResponseInfo* info) OVERRIDE;
+  virtual void Start() OVERRIDE;
+  virtual void Kill() OVERRIDE;
+  virtual bool ReadRawData(net::IOBuffer* buf,
+                           int buf_size,
+                           int* bytes_read) OVERRIDE;
+  virtual bool IsRedirectResponse(GURL* location,
+                                  int* http_status_code) OVERRIDE;
+  virtual bool GetMimeType(std::string* mime_type) const OVERRIDE;
+
+ protected:
+  virtual ~URLRequestAppEncryptedFileJob();
+
+ private:
+  void ReadFilePath(const ApplicationResource& resource,
+                    base::FilePath* file_path);
+  void DidReadFilePath(base::FilePath* read_file_path);
+  void FetchFileInfo(const base::FilePath& file_path,
+                     base::File::Info* file_info);
+  void DidFetchFileInfo(const base::File::Info* file_info);
+  void DidOpen(int result);
+  void DidReadEncryptedData(scoped_refptr<net::IOBufferWithSize> buf,
+                            int result);
+
+  base::FilePath file_path_;
+  const scoped_refptr<base::TaskRunner> file_task_runner_;
+  scoped_ptr<net::FileStream> stream_;
+  base::FilePath relative_path_;
+  std::string content_security_policy_;
+  ApplicationResource resource_;
+  std::list<std::string> locales_;
+  scoped_refptr<net::IOBufferWithSize> cipher_buffer_;
+  scoped_refptr<net::StringIOBuffer> plain_buffer_;
+  int plain_buffer_offset_;
+  std::string mime_type_;
+  base::WeakPtrFactory<URLRequestAppEncryptedFileJob> weak_ptr_factory_;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_APPLICATION_ENCRYPTED_FILE_JOB_TIZEN_H_

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -98,6 +98,7 @@ const char kCSPReportOnlyKey[] =
     "widget.content-security-policy-report-only.#text";
 const char kTizenSettingKey[] = "widget.setting";
 const char kTizenHardwareKey[] = "widget.setting.@hwkey-event";
+const char kTizenEncryptionKey[] = "widget.setting.@encryption";
 const char kTizenMetaDataKey[] = "widget.metadata";
 // Child keys inside 'kTizenMetaDataKey'
 const char kTizenMetaDataNameKey[] = "@key";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -84,6 +84,7 @@ namespace application_widget_keys {
   extern const char kCSPReportOnlyKey[];
   extern const char kTizenSettingKey[];
   extern const char kTizenHardwareKey[];
+  extern const char kTizenEncryptionKey[];
   extern const char kTizenMetaDataKey[];
   extern const char kTizenMetaDataNameKey[];
   extern const char kTizenMetaDataValueKey[];

--- a/application/common/encryption_tizen.cc
+++ b/application/common/encryption_tizen.cc
@@ -1,0 +1,66 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/encryption_tizen.h"
+
+#include "base/files/file_path.h"
+#include "base/strings/string_util.h"
+
+namespace xwalk {
+namespace application {
+
+namespace {
+// The following file types should be encrypted when the application is
+// installed on the client device.
+// The application launching, the file should be decrypted by run time.
+const base::FilePath::StringType kHTMLFormat(FILE_PATH_LITERAL(".html"));
+const base::FilePath::StringType kHTMFormat(FILE_PATH_LITERAL(".htm"));
+const base::FilePath::StringType kJSFormat(FILE_PATH_LITERAL(".js"));
+const base::FilePath::StringType kCSSFormat(FILE_PATH_LITERAL(".css"));
+}
+
+bool RequiresEncryption(const base::FilePath& file_path) {
+  return EndsWith(file_path.value(), kHTMLFormat, false) ||
+    EndsWith(file_path.value(), kHTMFormat, false) ||
+    EndsWith(file_path.value(), kJSFormat, false) ||
+    EndsWith(file_path.value(), kCSSFormat, false);
+}
+
+bool EncryptData(const char* plain_data, int len, std::string* encrypted_data) {
+  // TODO(yejingfu):
+  // The encryption & decryption should be performed at system-level, such as
+  // the trust-zone on ARM or chaabi on IA. But at this moment Tizen does
+  // not include such security module.
+  //
+  // Other solution may be storing the security key within system-level storage
+  // like gnome-keyring or some other external / internal storage. See
+  // "src/components/os_crypt" for reference.
+  // However this is still not supported in Tizen.
+  //
+  // So leave the EncryptData() and DecryptData() not implemented at present
+  // until we get supports from system (low-level) in the future.
+  //
+
+  // Assume the input is valid (not empty).
+  DCHECK(plain_data);
+  DCHECK_GT(len, 0);
+  DCHECK(encrypted_data);
+  *encrypted_data = std::string(plain_data, len);
+  return true;
+}
+
+bool DecryptData(const char* encrypted_data, int len, std::string* plain_data) {
+  // TODO(yejingfu): See the comments in EncryptData().
+
+  // Assume the input is valid (not empty).
+  DCHECK(encrypted_data);
+  DCHECK_GT(len, 0);
+  DCHECK(plain_data);
+
+  *plain_data = std::string(encrypted_data, len);
+  return true;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/encryption_tizen.h
+++ b/application/common/encryption_tizen.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_ENCRYPTION_TIZEN_H_
+#define XWALK_APPLICATION_COMMON_ENCRYPTION_TIZEN_H_
+
+#include <string>
+
+namespace base {
+class FilePath;
+}
+
+namespace xwalk {
+namespace application {
+
+bool RequiresEncryption(const base::FilePath& file_path);
+
+bool EncryptData(const char* plain_data, int len, std::string* encrypted_data);
+
+bool DecryptData(const char* encrypted_data, int len, std::string* plain_data);
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_ENCRYPTION_TIZEN_H_

--- a/application/common/installer/package_installer.cc
+++ b/application/common/installer/package_installer.cc
@@ -27,7 +27,9 @@
 #include "xwalk/runtime/common/xwalk_paths.h"
 
 #if defined(OS_TIZEN)
+#include "xwalk/application/common/encryption_tizen.h"
 #include "xwalk/application/common/installer/package_installer_tizen.h"
+#include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
 #endif
 
 namespace xwalk {
@@ -150,6 +152,28 @@ bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
     if (!base::Move(unpacked_dir, app_dir))
       return false;
   }
+
+#if defined(OS_TIZEN)
+  TizenSettingInfo* info = static_cast<TizenSettingInfo*>(
+      app_data->GetManifestData(application_widget_keys::kTizenSettingKey));
+  if (info && info->encryption_enabled()) {
+    // Encrypt the resources if needed.
+    base::FileEnumerator iter(app_dir, true, base::FileEnumerator::FILES);
+    for (base::FilePath file_path = iter.Next();
+         !file_path.empty();
+         file_path = iter.Next()) {
+      if (RequiresEncryption(file_path) && base::PathIsWritable(file_path)) {
+        std::string content;
+        std::string encrypted;
+        if (!base::ReadFileToString(file_path, &content))
+          LOG(ERROR) << "Failed to read " << file_path.MaybeAsASCII();
+        if (!EncryptData(content.data(), content.size(), &encrypted) ||
+            !base::WriteFile(file_path, encrypted.data(), encrypted.size()))
+          LOG(ERROR) << "Failed to encrypt " << file_path.MaybeAsASCII();
+      }
+    }
+  }
+#endif
 
   app_data->SetPath(app_dir);
 

--- a/application/common/manifest_handlers/tizen_setting_handler.cc
+++ b/application/common/manifest_handlers/tizen_setting_handler.cc
@@ -35,6 +35,10 @@ bool TizenSettingHandler::Parse(scoped_refptr<ApplicationData> application,
   manifest->GetString(keys::kTizenHardwareKey, &hwkey);
   app_info->set_hwkey_enabled(hwkey != "disable");
 
+  std::string encryption;
+  manifest->GetString(keys::kTizenEncryptionKey, &encryption);
+  app_info->set_encryption_enabled(encryption == "enable");
+
   application->SetManifestData(keys::kTizenSettingKey,
                                app_info.release());
   return true;
@@ -51,6 +55,14 @@ bool TizenSettingHandler::Validate(
   if (!hwkey.empty() && hwkey != "enable" && hwkey != "disable") {
     *error = std::string("The hwkey value must be 'enable'/'disable',"
                          " or not specified in configuration file.");
+    return false;
+  }
+  std::string encryption;
+  manifest->GetString(keys::kTizenEncryptionKey, &encryption);
+  if (!encryption.empty() && encryption != "enable" &&
+      encryption != "disable") {
+    *error = std::string("The encryption value must be 'enable'/'disable', "
+                         "or not specified in configuration file.");
     return false;
   }
   return true;

--- a/application/common/manifest_handlers/tizen_setting_handler.h
+++ b/application/common/manifest_handlers/tizen_setting_handler.h
@@ -23,8 +23,12 @@ class TizenSettingInfo : public ApplicationData::ManifestData {
   void set_hwkey_enabled(bool enabled) { hwkey_enabled_ = enabled; }
   bool hwkey_enabled() const { return hwkey_enabled_; }
 
+  void set_encryption_enabled(bool enabled) { encryption_enabled_ = enabled; }
+  bool encryption_enabled() const { return encryption_enabled_; }
+
  private:
   bool hwkey_enabled_;
+  bool encryption_enabled_;
 };
 
 class TizenSettingHandler : public ManifestHandler {

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -31,6 +31,8 @@
         'application_storage_constants.h',
         'constants.cc',
         'constants.h',
+        'encryption_tizen.cc',
+        'encryption_tizen.h',
         'id_util.cc',
         'id_util.h',
         'install_warning.h',

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -19,6 +19,8 @@
       'sources': [
         'browser/application.cc',
         'browser/application.h',
+        'browser/application_encrypted_file_job_tizen.cc',
+        'browser/application_encrypted_file_job_tizen.h',
         'browser/application_protocols.cc',
         'browser/application_protocols.h',
         'browser/application_service.cc',


### PR DESCRIPTION
This is the first commit which includes:
- Add the attribute "encryption" in the tizen:setting in config.xml.
- If the value is "enable", the WRT must encrypt the HTML, CSS, JS file resources when the application is installed. And the WRT should be able to decrypt the encrypted data when the application is loaded for running. According to the spec, the encryption is performed at the installation moment (not at packaging time).

For security consideration, I do not implement the encyption & decryption algorithm. They need supports from the system level, such as the trust-zone on ARM or chaabi on IA. But at this moment the Tizen does not include such the security module. Another solution may be storing the security key within system-level storage like gnome-keyring or some external / internal storage. However this is still not supported by Tizen. So at present I leave the encryption & decryption not implemented until we get support from system in the future. I will be back to finish the feature when the security module is available at system-level.

BUG=XWALK-1172
