### PR TITLE
[Android] make_apk: Make the code handling icons easier to read.

### DIFF
--- a/app/tools/android/app_info.py
+++ b/app/tools/android/app_info.py
@@ -10,7 +10,7 @@ class AppInfo:
     self.app_version = '1.0.0'
     self.app_versionCode = ''
     self.fullscreen_flag = ''
-    self.icon = ''
+    self.icon = None
     self.name = 'AppTemplate'
     self.orientation = 'unspecified'
     self.original_name = ''

--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -452,18 +452,14 @@ def CustomizeIconByDict(name, app_root, icon_dict):
 
 
 def CustomizeIconByOption(name, icon):
-  if os.path.isfile(icon):
-    drawable_path = os.path.join(name, 'res', 'drawable')
-    if not os.path.exists(drawable_path):
-      os.makedirs(drawable_path)
-    icon_file = os.path.basename(icon)
-    icon_file = ReplaceInvalidChars(icon_file)
-    shutil.copyfile(icon, os.path.join(drawable_path, icon_file))
-    icon_name = os.path.splitext(icon_file)[0]
-    return icon_name
-  else:
-    print('Error: "%s" does not exist.')
-    sys.exit(6)
+  drawable_path = os.path.join(name, 'res', 'drawable')
+  if not os.path.exists(drawable_path):
+    os.makedirs(drawable_path)
+  icon_file = os.path.basename(icon)
+  icon_file = ReplaceInvalidChars(icon_file)
+  shutil.copyfile(icon, os.path.join(drawable_path, icon_file))
+  icon_name = os.path.splitext(icon_file)[0]
+  return icon_name
 
 
 def CustomizeIcon(name, app_root, icon, icon_dict):

--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -175,7 +175,7 @@ def CustomizeThemeXML(name, fullscreen, app_manifest):
   theme_file.close()
 
 
-def CustomizeXML(app_info, description, icon_dict, app_manifest, permissions):
+def CustomizeXML(app_info, description, app_manifest, permissions):
   app_version = app_info.app_version
   app_versionCode = app_info.app_versionCode
   name = app_info.name
@@ -209,7 +209,7 @@ def CustomizeXML(app_info, description, icon_dict, app_manifest, permissions):
   if orientation:
     EditElementAttribute(xmldoc, 'activity', 'android:screenOrientation',
                          orientation)
-  icon_name = CustomizeIcon(name, app_info.app_root, app_info.icon, icon_dict)
+  icon_name = CustomizeIcon(name, app_info.app_root, app_info.icon)
   if icon_name:
     EditElementAttribute(xmldoc, 'application', 'android:icon',
                          '@drawable/%s' % icon_name)
@@ -462,21 +462,22 @@ def CustomizeIconByOption(name, icon):
   return icon_name
 
 
-def CustomizeIcon(name, app_root, icon, icon_dict):
-  icon_name = None
-  if icon:
-    icon_name = CustomizeIconByOption(name, icon)
-  else:
-    icon_name = CustomizeIconByDict(name, app_root, icon_dict)
-  return icon_name
+def CustomizeIcon(name, app_root, icon):
+  if isinstance(icon, str):
+    # Single icon specified on the command line.
+    return CustomizeIconByOption(name, icon)
+  elif isinstance(icon, dict):
+    # Dictionary parsed from the manifest.
+    return CustomizeIconByDict(name, app_root, icon)
+  return None
 
 
-def CustomizeAll(app_info, description, icon_dict, permissions, app_url,
+def CustomizeAll(app_info, description, permissions, app_url,
                  app_local_path, keep_screen_on, extensions, app_manifest,
                  xwalk_command_line='', compressor=None):
   try:
     Prepare(app_info, compressor)
-    CustomizeXML(app_info, description, icon_dict, app_manifest, permissions)
+    CustomizeXML(app_info, description, app_manifest, permissions)
     CustomizeJava(app_info, app_url, app_local_path, keep_screen_on)
     CustomizeExtensions(app_info, extensions)
     GenerateCommandLineFile(app_info, xwalk_command_line)
@@ -548,10 +549,6 @@ def main():
                     type='string', nargs=0, help=info)
   options, _ = parser.parse_args()
   try:
-    icon_dict = {144: 'icons/icon_144.png',
-                 72: 'icons/icon_72.png',
-                 96: 'icons/icon_96.png',
-                 48: 'icons/icon_48.png'}
     app_info = AppInfo()
     if options.name is not None:
       app_info.name = options.name
@@ -571,7 +568,7 @@ def main():
       app_info.fullscreen_flag = options.fullscreen
     app_info.icon = os.path.join('test_data', 'manifest', 'icons',
                                  'icon_96.png')
-    CustomizeAll(app_info, options.description, icon_dict,
+    CustomizeAll(app_info, options.description,
                  options.permissions, options.app_url, options.app_local_path,
                  options.keep_screen_on, options.extensions, options.manifest,
                  options.xwalk_command_line, options.compressor)

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -123,7 +123,7 @@ def ParseManifest(options, app_info):
     sys.exit(9)
   if parser.GetAppRoot():
     options.app_root = parser.GetAppRoot()
-    options.icon_dict = parser.GetIcons()
+    app_info.icon = parser.GetIcons()
   if parser.GetOrientation():
     options.orientation = parser.GetOrientation()
   if parser.GetFullScreenFlag().lower() == 'true':
@@ -209,7 +209,7 @@ def Customize(options, app_info):
     app_info.orientation = options.orientation
   if options.icon:
     app_info.icon = '%s' % os.path.expanduser(options.icon)
-  CustomizeAll(app_info, options.description, options.icon_dict,
+  CustomizeAll(app_info, options.description,
                options.permissions, options.app_url, options.app_local_path,
                options.keep_screen_on, options.extensions, options.manifest,
                options.xwalk_command_line, options.compressor)
@@ -774,7 +774,6 @@ def main(argv):
             'crosswalk-website/wiki/Crosswalk-manifest')
       permission_list = permission_mapping_table.keys()
     options.permissions = HandlePermissionList(permission_list)
-    options.icon_dict = {}
   else:
     try:
       ParseManifest(options, app_info)

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -718,6 +718,9 @@ def main(argv):
       parser.error('VERSION was not found, so Crosswalk\'s version could not '
                    'be determined.')
 
+  if options.icon and not os.path.isfile(options.icon):
+    parser.error('"%s" does not exist.' % options.icon)
+
   xpk_temp_dir = ''
   if options.xpk:
     xpk_name = os.path.splitext(os.path.basename(options.xpk))[0]


### PR DESCRIPTION
`customize.py` is horrible to read, and `CustomizeIconByDict()` is one
of the biggest offenders.

The first two commits does some clean-up that allows us to get rid of
some checks or moves them to an earlier stage in make_apk.

The last commit rewrites `CustomizeIconByDict()` to make it easier to
follow, mostly by getting rid of `drawable_dict` and all the attempts to
be smart by over-manipulating it.