### PR TITLE
[Android] make_apk: Use open(), not file().

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -361,7 +361,7 @@ def CustomizeExtensions(app_info, extensions):
       print('Error: %s is not found in %s.' % (file_name, source_path))
       sys.exit(9)
     else:
-      src_file_handle = file(src_file)
+      src_file_handle = open(src_file)
       src_file_content = src_file_handle.read()
       json_output = json.JSONDecoder().decode(src_file_content)
       # Below 3 properties are used by runtime. See extension manager.

--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -142,7 +142,7 @@ def CustomizeBackground(background_color,
     content = content.replace('<!-- Background Image -->', tmp, 1)
     has_background = True
   if has_background:
-    background_file = file(background_path, 'w')
+    background_file = open(background_path, 'w')
     background_file.write(content)
     background_file.close()
   return has_background


### PR DESCRIPTION
The latter does not exist in Python 3, so those functions were broken
when invoked.
