### PR TITLE
[Tizen][Runtime] Enable pause/resume web application JS engine.

### DIFF
--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -23,6 +23,8 @@ class ApplicationTizen :  // NOLINT
  public:
   virtual ~ApplicationTizen();
   void Hide();
+  void Suspend();
+  void Resume();
 
  private:
   // We enforce ApplicationService ownership.
@@ -38,6 +40,8 @@ class ApplicationTizen :  // NOLINT
   virtual void WillProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
   virtual void DidProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
 #endif
+
+  bool is_suspended_;
 };
 
 inline ApplicationTizen* ToApplicationTizen(Application* app) {

--- a/application/browser/linux/running_application_object.cc
+++ b/application/browser/linux/running_application_object.cc
@@ -76,6 +76,20 @@ RunningApplicationObject::RunningApplicationObject(
                  base::Unretained(this)),
       base::Bind(&RunningApplicationObject::OnExported,
                  base::Unretained(this)));
+
+  dbus_object()->ExportMethod(
+      kRunningApplicationDBusInterface, "Suspend",
+      base::Bind(&RunningApplicationObject::OnSuspend,
+                 base::Unretained(this)),
+      base::Bind(&RunningApplicationObject::OnExported,
+                 base::Unretained(this)));
+
+  dbus_object()->ExportMethod(
+      kRunningApplicationDBusInterface, "Resume",
+      base::Bind(&RunningApplicationObject::OnResume,
+                 base::Unretained(this)),
+      base::Bind(&RunningApplicationObject::OnExported,
+                 base::Unretained(this)));
 #endif
 }
 
@@ -143,6 +157,44 @@ void RunningApplicationObject::OnHide(
   }
 
   ToApplicationTizen(application_)->Hide();
+
+  scoped_ptr<dbus::Response> response =
+      dbus::Response::FromMethodCall(method_call);
+  response_sender.Run(response.Pass());
+}
+
+void RunningApplicationObject::OnSuspend(
+    dbus::MethodCall* method_call,
+    dbus::ExportedObject::ResponseSender response_sender) {
+  if (method_call->GetSender() != launcher_name_) {
+    scoped_ptr<dbus::ErrorResponse> error_response =
+        dbus::ErrorResponse::FromMethodCall(method_call,
+                                            kRunningApplicationDBusError,
+                                            "Not permitted");
+    response_sender.Run(error_response.PassAs<dbus::Response>());
+    return;
+  }
+
+  ToApplicationTizen(application_)->Suspend();
+
+  scoped_ptr<dbus::Response> response =
+      dbus::Response::FromMethodCall(method_call);
+  response_sender.Run(response.Pass());
+}
+
+void RunningApplicationObject::OnResume(
+    dbus::MethodCall* method_call,
+    dbus::ExportedObject::ResponseSender response_sender) {
+  if (method_call->GetSender() != launcher_name_) {
+    scoped_ptr<dbus::ErrorResponse> error_response =
+        dbus::ErrorResponse::FromMethodCall(method_call,
+                                            kRunningApplicationDBusError,
+                                            "Not permitted");
+    response_sender.Run(error_response.PassAs<dbus::Response>());
+    return;
+  }
+
+  ToApplicationTizen(application_)->Resume();
 
   scoped_ptr<dbus::Response> response =
       dbus::Response::FromMethodCall(method_call);

--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -53,6 +53,12 @@ class RunningApplicationObject : public dbus::ManagedObject {
 #if defined(OS_TIZEN)
   void OnHide(dbus::MethodCall* method_call,
               dbus::ExportedObject::ResponseSender response_sender);
+
+  void OnSuspend(dbus::MethodCall* method_call,
+                 dbus::ExportedObject::ResponseSender response_sender);
+
+  void OnResume(dbus::MethodCall* method_call,
+                dbus::ExportedObject::ResponseSender response_sender);
 #endif
 
   void ListenForOwnerChange();
@@ -76,4 +82,3 @@ class RunningApplicationObject : public dbus::ManagedObject {
 }  // namespace xwalk
 
 #endif  // XWALK_APPLICATION_BROWSER_LINUX_RUNNING_APPLICATION_OBJECT_H_
-

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -224,7 +224,7 @@ static void launch_application(const char* appid_or_url,
   char name[128];
   snprintf(name, sizeof(name), "xwalk-%s", appid_or_url);
 
-  if (xwalk_appcore_init(g_argc, g_argv, name)) {
+  if (xwalk_appcore_init(g_argc, g_argv, name, app_proxy)) {
     fprintf(stderr, "Failed to initialize appcore");
     exit(1);
   }

--- a/application/tools/linux/xwalk_launcher_tizen.h
+++ b/application/tools/linux/xwalk_launcher_tizen.h
@@ -5,7 +5,8 @@
 #ifndef XWALK_APPLICATION_TOOLS_LINUX_XWALK_LAUNCHER_TIZEN_H_
 #define XWALK_APPLICATION_TOOLS_LINUX_XWALK_LAUNCHER_TIZEN_H_
 
-int xwalk_appcore_init(int argc, char** argv, const char* name);
+int xwalk_appcore_init(int argc, char** argv,
+                       const char* name, GDBusProxy* app_proxy);
 
 int xwalk_change_cmdline(int argc, char** argv, const char* app_id);
 

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -39,6 +39,9 @@ IPC_MESSAGE_CONTROL2(ViewMsg_EnableSecurityMode,    // NOLINT
                      xwalk::application::SecurityPolicy::SecurityMode
                      /* security mode */)
 
+IPC_MESSAGE_CONTROL1(ViewMsg_SuspendJSEngine,  // NOLINT
+                     bool /* is suspend */)
+
 IPC_MESSAGE_ROUTED1(ViewMsg_HWKeyPressed, int /*keycode*/)  // NOLINT
 
 // These are messages sent from the renderer to the browser process.

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -51,8 +51,10 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
       const GURL& source, const GURL& dest, bool allow_subdomains);
   void OnEnableSecurityMode(
       const GURL& url, application::SecurityPolicy::SecurityMode mode);
+  void OnSuspendJSEngine(bool is_pause);
 
   bool is_webkit_initialized_;
+  bool is_suspended_;
   application::SecurityPolicy::SecurityMode security_mode_;
   GURL app_url_;
 };


### PR DESCRIPTION
The Tizen core spec requires that the web runtime should have the ability to
pause and resume the renderer process and javascript engine when receiving 
the corresponding system events.

BUG=XWALK-1497,XWALK-1498
