### PR TITLE
[Extension] Implemented bulk data transmission enhancement test case

### DIFF
--- a/extensions/external_extension_sample.gyp
+++ b/extensions/external_extension_sample.gyp
@@ -93,5 +93,22 @@
         }],
       ],
     },
+    {
+      'target_name': 'bulk_data_transmission',
+      'type': 'loadable_module',
+      'variables': {
+        'mac_strip': 0,
+      },
+      'sources': [
+        'test/bulk_data_transmission.c',
+      ],
+      'conditions': [
+        ['OS=="win"', {
+          'product_dir': '<(PRODUCT_DIR)\\tests\\extension\\bulk_data_transmission\\'
+        }, {
+          'product_dir': '<(PRODUCT_DIR)/tests/extension/bulk_data_transmission/'
+        }],
+      ],
+    },
   ],
 }

--- a/extensions/test/bulk_data_transmission.c
+++ b/extensions/test/bulk_data_transmission.c
@@ -1,0 +1,68 @@
+// Bulk data transmission example for Crosswalk
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "xwalk/extensions/public/XW_Extension.h"
+
+static const char* kSource_bulk_data_api = "var bulkDataListener = null;"
+""
+"extension.setMessageListener(function(msg) {"
+"  if (bulkDataListener instanceof Function) {"
+"    bulkDataListener(msg);"
+"  };"
+"});"
+""
+"exports.requestBulkDataAsync = function(power, callback) {"
+"  bulkDataListener = callback;"
+"  extension.postMessage(power.toString());"
+"};"
+;
+
+static XW_Extension g_extension = 0;
+static const XW_CoreInterface* g_core = NULL;
+static const XW_MessagingInterface* g_messaging = NULL;
+
+static void instance_created(XW_Instance instance) {
+  printf("Instance %d created!\n", instance);
+}
+
+static void instance_destroyed(XW_Instance instance) {
+  printf("Instance %d destroyed!\n", instance);
+}
+
+static void handle_message(XW_Instance instance, const char* message) {
+  int size = atoi(message);
+  char* data = malloc(size + 1);
+  memset(data, 'p', size);
+  data[size] = '\0';
+  printf("Instance %d created %d bytes of data chunk from native.\n", instance, size);
+  g_messaging->PostMessage(instance, data);
+  free(data);
+}
+
+static void shutdown(XW_Extension extension) {
+  printf("Shutdown\n");
+}
+
+// this is the only function which needs to be public
+int32_t XW_Initialize(XW_Extension extension, XW_GetInterface get_interface) {
+  // set up the extension
+  g_extension = extension;
+  g_core = get_interface(XW_CORE_INTERFACE);
+  g_core->SetExtensionName(extension, "bulkData");
+
+  g_core->SetJavaScriptAPI(extension, kSource_bulk_data_api);
+
+  g_core->RegisterInstanceCallbacks(
+    extension, instance_created, instance_destroyed);
+  g_core->RegisterShutdownCallback(extension, shutdown);
+
+  g_messaging = get_interface(XW_MESSAGING_INTERFACE);
+  g_messaging->Register(extension, handle_message);
+
+  return XW_OK;
+}

--- a/extensions/test/data/bulk_data_transmission.html
+++ b/extensions/test/data/bulk_data_transmission.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Bulk Data Transmission demo</title>
+</head>
+<body>
+
+<p>This uses the bulk data transmission extension defined in
+bulk_data_transmission.c (compiled to libbulk_data_transmission.so) to
+extend Crosswalk.</p>
+
+<div id="out">
+  <div id='async' />
+</div>
+
+<script>
+var div = document.getElementById('out');
+var divAsync = document.getElementById('async');
+
+var readableSize = function(size) {
+  var suffixCount = 0;
+  while (size >= 1024) {
+    size = size / 1024;
+    ++suffixCount;
+  }
+
+  var suffix;
+  switch(suffixCount) {
+  case 0:
+    suffix = 'B';
+    break;
+  case 1:
+    suffix = 'KB';
+    break;
+  case 2:
+    suffix = 'MB';
+    break;
+  case 3:
+    suffix = 'GB';
+    break;
+  case 4:
+    suffix = 'TB';
+    break;
+  default:
+    return nil;
+  }
+  return size + suffix;
+}
+
+var requestDataAsync = function(size) {
+  bulkData.requestBulkDataAsync(size, function(msg) {
+      var message = document.createElement('p');
+      message.innerText = 'Requested '
+        + readableSize(msg.length) + ' data chunk asynchronously';
+      divAsync.appendChild(message);
+    });
+}
+
+var startPow = 1;
+var maxPow = 26; // 26 is 64MB, which is the limit of IPC post message
+var repeatTimes = 1;
+
+var index = startPow * repeatTimes;
+
+function runTestCase() {
+  return new Promise(function(resolve) {
+      var size = Math.pow(2, Math.floor(index / repeatTimes));
+      requestDataAsync(size);
+      resolve();
+    }).then(function() {
+      ++index;
+      if (index == (maxPow + 1) * repeatTimes) {
+        document.title = "Pass";
+        return;
+      }
+      runTestCase();
+    }, function(e) {
+      console.error(e);
+      document.title = "Fail";
+    });
+};
+runTestCase();
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Created a test case to test the bulk data transmission enhancement
feature. This extension test case introduced a javascript API to
request data from native side asynchronously, and native side created
the data chunk according to the requested size and post it back to
javascript.

This test case only tests transmission from native to javascript as for
now we've only implemented the enhancement feature in this direction.

BUG: https://crosswalk-project.org/jira/browse/XWALK-1377
