### PR TITLE
[Extensions] Check validation of XWalkExtensionInstance before binding callbacks

### DIFF
--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -68,6 +68,12 @@ void XWalkExtensionServer::OnCreateInstance(int64_t instance_id,
   }
 
   XWalkExtensionInstance* instance = it->second->CreateInstance();
+  if (!instance) {
+    LOG(WARNING) << "Can't create instance of extension: " << name
+        << ". CreateInstance() return invalid pointer.";
+    return;
+  }
+
   instance->SetPostMessageCallback(
       base::Bind(&XWalkExtensionServer::PostMessageToJSCallback,
                  base::Unretained(this), instance_id));

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -55,14 +55,6 @@ class XWalkBrowserMainParts : public content::BrowserMainParts {
       content::RenderProcessHost* host,
       extensions::XWalkExtensionVector* extensions);
 
-#if defined(OS_ANDROID)
-  // XWalkExtensionAndroid needs to register its extensions on
-  // XWalkBrowserMainParts so they get correctly registered on-demand
-  // by XWalkExtensionService each time a in_process Server is created.
-  void RegisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
-  void UnregisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
-#endif
-
  protected:
   void RegisterExternalExtensions();
 


### PR DESCRIPTION
...allbacks.

There is race condition that sometimes CreateInstance() return invalid
XWalkExtensionInstance.

So far, this crash does not happen on any C++ extensions or Android
extension tests. Only happens on CordovaTests apk. And worse and worse
when loadUrl calling times increased.

Meanwhile, the Android speicific function RegisterExtension() and
UnregisterExtension() are removed from xwalk_browser_main_parts.h

BUG=https://crosswalk-project.org/jira/browse/XWALK-1688
