### PR TITLE
[Android] Clear FLAG_FORCE_NOT_FULLSCREEN when entering fullscreen

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
@@ -36,6 +36,7 @@ public class XWalkUIClient {
     private View mDecorView;
     private XWalkView mXWalkView;
     private boolean mOriginalFullscreen;
+    private boolean mOriginalForceNotFullscreen;
 
     /**
      * Constructor.
@@ -138,22 +139,30 @@ public class XWalkUIClient {
                         View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
                         View.SYSTEM_UI_FLAG_FULLSCREEN |
                         View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+                if ((activity.getWindow().getAttributes().flags &
+                        WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN) != 0) {
+                    mOriginalForceNotFullscreen = true;
+                    activity.getWindow().clearFlags(
+                            WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                } else {
+                    mOriginalForceNotFullscreen = false;
+                }
             } else {
                 if ((activity.getWindow().getAttributes().flags &
                         WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
                     mOriginalFullscreen = true;
                 } else {
                     mOriginalFullscreen = false;
-                }
-                if (!mOriginalFullscreen) {
-                    activity.getWindow().setFlags(
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                    activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
             }
         } else {
             if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
                 mDecorView.setSystemUiVisibility(mSystemUiFlag);
+                if (mOriginalForceNotFullscreen) {
+                    activity.getWindow().addFlags(
+                            WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                }
             } else {
                 // Clear the activity fullscreen flag.
                 if (!mOriginalFullscreen) {


### PR DESCRIPTION
The FLAG_FORCE_NOT_FULLSCREEN flag of Android Window will force the
Android system to show status bar, even with SYSTEM_UI_FLAG_FULLSCREEN
set in SystemUIVisibility.

Record whether the FLAG_FORCE_NOT_FULLSCREEN is set before entering
fullscreen and clear it if so. Add the flag back if necessary when
exiting fullscreen.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2150
(cherry picked from commit a00f56eac4579ea4302757ee98ee1b19d421bc3d)
