### PR TITLE
Fix Application Type in app_info.db

### DIFF
--- a/application/common/installer/package_installer_tizen.cc
+++ b/application/common/installer/package_installer_tizen.cc
@@ -117,6 +117,7 @@ bool GeneratePkgInfoXml(xwalk::application::ApplicationData* application,
   xml_writer.StartElement("manifest");
   xml_writer.AddAttribute("xmlns", "http://tizen.org/ns/packages");
   xml_writer.AddAttribute("package", package_id);
+  xml_writer.AddAttribute("type", "wgt");
   xml_writer.AddAttribute("version", application->VersionString());
   xml_writer.WriteElement("label", application->Name());
   xml_writer.WriteElement("description", application->Description());

--- a/application/tools/tizen/xwalk_package_installer_helper.cc
+++ b/application/tools/tizen/xwalk_package_installer_helper.cc
@@ -26,7 +26,7 @@ const std::string kXmlFileExt(".xml");
 const std::string kPngFileExt(".png");
 
 // Package type sent in every signal.
-const char PKGMGR_PKG_TYPE[] = "rpm";
+const char PKGMGR_PKG_TYPE[] = "wgt";
 
 // Notification about operation start.
 const char PKGMGR_START_KEY[] = "start";


### PR DESCRIPTION
Currently in app_info.db the widget are typed as rpm not widget.

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
