### PR TITLE
Revert "[Runtime] Disable extensions api for external web page."

### DIFF
--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -16,7 +16,6 @@
 #include "third_party/WebKit/public/web/WebFrame.h"
 #include "third_party/WebKit/public/web/WebScopedMicrotaskSuppression.h"
 #include "v8/include/v8.h"
-#include "xwalk/application/common/constants.h"
 #include "xwalk/extensions/common/xwalk_extension_messages.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/extensions/renderer/xwalk_extension_client.h"
@@ -79,24 +78,20 @@ void XWalkExtensionRendererController::DidCreateScriptContext(
   XWalkModuleSystem::SetModuleSystemInContext(
       scoped_ptr<XWalkModuleSystem>(module_system), context);
 
-  GURL url = static_cast<GURL>(frame->document().url());
-  if (url.SchemeIs(xwalk::application::kApplicationScheme) ||
-      url.SchemeIsFile()) {
-    module_system->RegisterNativeModule(
-        "v8tools", scoped_ptr<XWalkNativeModule>(new XWalkV8ToolsModule));
-    module_system->RegisterNativeModule(
-        "internal", CreateJSModuleFromResource(
-            IDR_XWALK_EXTENSIONS_INTERNAL_API));
+  module_system->RegisterNativeModule(
+      "v8tools", scoped_ptr<XWalkNativeModule>(new XWalkV8ToolsModule));
+  module_system->RegisterNativeModule(
+      "internal", CreateJSModuleFromResource(
+          IDR_XWALK_EXTENSIONS_INTERNAL_API));
 
-    delegate_->DidCreateModuleSystem(module_system);
+  delegate_->DidCreateModuleSystem(module_system);
 
-    CreateExtensionModules(in_browser_process_extensions_client_.get(),
+  CreateExtensionModules(in_browser_process_extensions_client_.get(),
+                         module_system);
+
+  if (external_extensions_client_) {
+    CreateExtensionModules(external_extensions_client_.get(),
                            module_system);
-
-    if (external_extensions_client_) {
-      CreateExtensionModules(external_extensions_client_.get(),
-                             module_system);
-    }
   }
 
   module_system->Initialize();


### PR DESCRIPTION
It broke several Android device tests:
- org.xwalk.runtime.client.test.DeviceCapabilitiesTest#testDeviceCapabilities
- org.xwalk.runtime.client.test.ExternalExtensionTest#testExternalExtensionAsync
- org.xwalk.runtime.client.test.PresentationTest#testPresentationDisplayAvailable
- org.xwalk.runtime.client.test.ExternalExtensionTest#testExternalExtensionSync
- org.xwalk.runtime.client.embedded.test.PresentationTest#testPresentationDisplayAvailable
- org.xwalk.runtime.client.embedded.test.ExternalExtensionTest#testExternalExtensionAsync
- org.xwalk.runtime.client.embedded.test.DeviceCapabilitiesTest#testDeviceCapabilities
- org.xwalk.runtime.client.embedded.test.ExternalExtensionTest#testExternalExtensionSync
- org.xwalk.core.xwview.test.ExtensionEchoTest#testSync
- org.xwalk.core.xwview.test.LoadTest#testContentUrl
- org.xwalk.core.xwview.test.ExtensionEchoTest#testMultiFrames
- org.xwalk.core.xwview.test.ShouldInterceptLoadRequestTest#testNotCalledForExistingContentUrl
- org.xwalk.core.xwview.test.ExtensionEchoTest#testAsync
- org.xwalk.core.internal.xwview.test.ExtensionEchoInternalTest#testAsync
- org.xwalk.core.internal.xwview.test.ExtensionEchoInternalTest#testSync
- org.xwalk.core.internal.xwview.test.ExtensionBroadcastInternalTest#test
- org.xwalk.core.internal.xwview.test.ExtensionEchoInternalTest#testMultiFrames
- org.xwalk.core.internal.xwview.test.LoadTest#testContentUrl

This reverts commit 08afec43d74cfa2b586b7297bb7fe60543552bf6.
