### PR TITLE
[Tizen] Use Tizen application database to store application data

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -75,30 +75,6 @@ ApplicationService::ApplicationService(RuntimeContext* runtime_context,
 ApplicationService::~ApplicationService() {
 }
 
-void ApplicationService::ChangeLocale(const std::string& locale) {
-  ApplicationData::ApplicationDataMap apps;
-  if (!application_storage_->GetInstalledApplications(apps))
-    return;
-
-  ApplicationData::ApplicationDataMap::const_iterator it;
-  for (it = apps.begin(); it != apps.end(); ++it) {
-    base::string16 error;
-    std::string old_name = it->second->Name();
-    if (!it->second->SetApplicationLocale(locale, &error)) {
-      LOG(ERROR) << "Error when set locale " << locale
-                 << " to application " << it->second->ID()
-                 << "error : " << error;
-    }
-    if (old_name != it->second->Name()) {
-      // After we has changed the application locale, we might get a new name in
-      // the new locale, so call all observer for this event.
-      FOR_EACH_OBSERVER(
-          Observer, observers_,
-          OnApplicationNameChanged(it->second->ID(), it->second->Name()));
-    }
-  }
-}
-
 Application* ApplicationService::Launch(
     scoped_refptr<ApplicationData> application_data,
     const Application::LaunchParams& launch_params) {

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -32,11 +32,6 @@ class ApplicationService : public Application::Observer {
   // keep track of [un]installation of applications.
   class Observer {
    public:
-    // When we change the application locale, we might get a new name in
-    // the new locale.
-    virtual void OnApplicationNameChanged(const std::string& app_id,
-                                          const std::string& app_name) {}
-
     virtual void DidLaunchApplication(Application* app) {}
     virtual void WillDestroyApplication(Application* app) {}
    protected:
@@ -46,8 +41,6 @@ class ApplicationService : public Application::Observer {
   ApplicationService(RuntimeContext* runtime_context,
                      ApplicationStorage* app_storage);
   virtual ~ApplicationService();
-
-  void ChangeLocale(const std::string& locale);
 
   Application* Launch(scoped_refptr<ApplicationData> application_data,
                       const Application::LaunchParams& launch_params);

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -131,9 +131,7 @@ void RunningApplicationsManager::OnLaunch(
     response_sender.Run(response.Pass());
     return;
   }
-  if (GURL(app_id_or_url).spec().empty()) {
-    CHECK(app_id_or_url == application->id());
-  }
+
   // FIXME(cmarcelo): ApplicationService will tell us when new applications
   // appear (with DidLaunchApplication()) and we create new managed objects
   // in D-Bus based on that.

--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -322,6 +322,19 @@ scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_path,
     const std::string& application_id,
     Manifest::SourceType source_type,
+    std::string* error) {
+  Package::Type package_type;
+  if (!GetPackageType(application_path, &package_type, error))
+    return NULL;
+
+  return LoadApplication(application_path, application_id,
+                         source_type, package_type, error);
+}
+
+scoped_refptr<ApplicationData> LoadApplication(
+    const base::FilePath& application_path,
+    const std::string& application_id,
+    Manifest::SourceType source_type,
     Package::Type package_type,
     std::string* error) {
   scoped_ptr<base::DictionaryValue> manifest(

--- a/application/common/application_file_util.h
+++ b/application/common/application_file_util.h
@@ -38,6 +38,12 @@ scoped_refptr<ApplicationData> LoadApplication(
     const base::FilePath& application_root,
     const std::string& application_id,
     Manifest::SourceType source_type,
+    std::string* error);
+
+scoped_refptr<ApplicationData> LoadApplication(
+    const base::FilePath& application_root,
+    const std::string& application_id,
+    Manifest::SourceType source_type,
     Package::Type package_type,
     std::string* error);
 

--- a/application/common/application_storage.cc
+++ b/application/common/application_storage.cc
@@ -3,7 +3,12 @@
 // found in the LICENSE file.
 
 #include "xwalk/application/common/application_storage.h"
+
+#if defined(OS_TIZEN)
+#include "xwalk/application/common/application_storage_impl_tizen.h"
+#else
 #include "xwalk/application/common/application_storage_impl.h"
+#endif
 
 namespace xwalk {
 namespace application {
@@ -43,11 +48,6 @@ bool ApplicationStorage::Contains(const std::string& app_id) const {
 scoped_refptr<ApplicationData> ApplicationStorage::GetApplicationData(
     const std::string& app_id) const {
   return impl_->GetApplicationData(app_id);
-}
-
-bool ApplicationStorage::GetInstalledApplications(
-    ApplicationData::ApplicationDataMap& apps) const { // NOLINT
-  return impl_->GetInstalledApplications(apps);
 }
 
 bool ApplicationStorage::GetInstalledApplicationIDs(

--- a/application/common/application_storage.h
+++ b/application/common/application_storage.h
@@ -30,10 +30,6 @@ class ApplicationStorage {
 
   scoped_refptr<ApplicationData> GetApplicationData(
       const std::string& app_id) const;
-  // Note: Do not use this method! It is too heavy and it will be
-  // removed.
-  bool GetInstalledApplications(
-      ApplicationData::ApplicationDataMap& apps) const;  // NOLINT
 
   bool GetInstalledApplicationIDs(
       std::vector<std::string>& app_ids) const;  // NOLINT

--- a/application/common/application_storage_impl_tizen.cc
+++ b/application/common/application_storage_impl_tizen.cc
@@ -1,0 +1,169 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/application_storage_impl_tizen.h"
+
+#include <ail.h>
+#include <pkgmgr-info.h>
+
+#include <string>
+#include <vector>
+
+#include "base/file_util.h"
+#include "third_party/re2/re2/re2.h"
+#include "xwalk/application/common/application_file_util.h"
+#include "xwalk/application/common/application_storage.h"
+#include "xwalk/application/common/id_util.h"
+
+namespace xwalk {
+namespace application {
+
+ApplicationStorageImpl::ApplicationStorageImpl(const base::FilePath& path) {
+}
+
+ApplicationStorageImpl::~ApplicationStorageImpl() {
+}
+
+bool ApplicationStorageImpl::Init() {
+  return true;
+}
+
+namespace {
+
+ail_cb_ret_e appinfo_get_exec_cb(const ail_appinfo_h appinfo, void *user_data) {
+  char* package_exec;
+  ail_appinfo_get_str(appinfo, AIL_PROP_X_SLP_EXE_PATH, &package_exec);
+  if (!package_exec)
+    return AIL_CB_RET_CONTINUE;
+
+  std::string* x_slp_exe_path = static_cast<std::string*>(user_data);
+  *x_slp_exe_path = package_exec;
+  return AIL_CB_RET_CANCEL;
+}
+
+base::FilePath GetApplicationPath(const std::string& app_id) {
+  std::string ail_id = RawAppIdToAppIdForTizenPkgmgrDB(app_id);
+  ail_filter_h filter;
+  ail_error_e ret = ail_filter_new(&filter);
+  if (ret != AIL_ERROR_OK) {
+    LOG(ERROR) << "Failed to create AIL filter.";
+    return base::FilePath();
+  }
+
+  ret = ail_filter_add_str(filter, AIL_PROP_X_SLP_APPID_STR, ail_id.c_str());
+  if (ret != AIL_ERROR_OK) {
+    LOG(ERROR) << "Failed to init AIL filter.";
+    ail_filter_destroy(filter);
+    return base::FilePath();
+  }
+
+  int count;
+  ret = ail_filter_count_appinfo(filter, &count);
+  if (ret != AIL_ERROR_OK) {
+    LOG(ERROR) << "Failed to count AIL app info.";
+    ail_filter_destroy(filter);
+    return base::FilePath();
+  }
+
+  if (count != 1) {
+      LOG(ERROR) << "Invalid count (" << count
+                 << ") of the AIL DB records for the app id " << app_id;
+    ail_filter_destroy(filter);
+    return base::FilePath();
+  }
+
+  std::string x_slp_exe_path;
+  ail_filter_list_appinfo_foreach(filter, appinfo_get_exec_cb, &x_slp_exe_path);
+  ail_filter_destroy(filter);
+
+  // x_slp_exe_path is <app_path>/bin/<app_id>, we need to
+  // return just <app_path>.
+  std::string toBeExcluded = "/bin/" + app_id;
+  unsigned found = x_slp_exe_path.rfind(toBeExcluded);
+  if (found == std::string::npos) {
+    LOG(ERROR) << "Invalid 'x_slp_exe_path' value (" << x_slp_exe_path
+               << ") for the app id " << app_id;
+    return base::FilePath();
+  }
+
+  CHECK(found < x_slp_exe_path.length());
+  x_slp_exe_path.resize(found);
+  return base::FilePath(x_slp_exe_path);
+}
+
+}  // namespace
+
+scoped_refptr<ApplicationData> ApplicationStorageImpl::GetApplicationData(
+    const std::string& app_id) {
+  base::FilePath app_path = GetApplicationPath(app_id);
+
+  std::string error_str;
+  return LoadApplication(app_path, RawAppIdToCrosswalkAppId(app_id),
+                         Manifest::INTERNAL, &error_str);
+}
+
+namespace {
+
+int pkgmgrinfo_app_list_cb(pkgmgrinfo_appinfo_h handle, void *user_data) {
+  std::vector<std::string>* app_ids =
+    static_cast<std::vector<std::string>*>(user_data);
+  char* appid = NULL;
+  pkgmgrinfo_appinfo_get_appid(handle, &appid);
+  CHECK(appid);
+
+  app_ids->push_back(TizenPkgmgrDBAppIdToRawAppId(appid));
+  return 0;
+}
+
+}  // namespace
+
+bool ApplicationStorageImpl::GetInstalledApplicationIDs(
+    std::vector<std::string>& app_ids) {  // NOLINT
+  pkgmgrinfo_appinfo_filter_h handle;
+  int ret = pkgmgrinfo_appinfo_filter_create(&handle);
+  if (ret != PMINFO_R_OK) {
+    LOG(ERROR) << "Failed to create pkgmgrinfo filter.";
+    return false;
+  }
+
+  ret = pkgmgrinfo_appinfo_filter_add_string(
+      handle, PMINFO_APPINFO_PROP_APP_TYPE, "webapp");
+  if (ret != PMINFO_R_OK) {
+    LOG(ERROR) << "Failed to init pkgmgrinfo filter.";
+    pkgmgrinfo_appinfo_filter_destroy(handle);
+    return false;
+  }
+
+  ret = pkgmgrinfo_appinfo_filter_foreach_appinfo(
+      handle, pkgmgrinfo_app_list_cb, &app_ids);
+  if (ret != PMINFO_R_OK) {
+    LOG(ERROR) << "Failed to apply pkgmgrinfo filter.";
+    pkgmgrinfo_appinfo_filter_destroy(handle);
+    return false;
+  }
+  pkgmgrinfo_appinfo_filter_destroy(handle);
+
+  return true;
+}
+
+bool ApplicationStorageImpl::AddApplication(const ApplicationData* application,
+                                            const base::Time& install_time) {
+  return true;
+}
+
+bool ApplicationStorageImpl::UpdateApplication(
+    ApplicationData* application, const base::Time& install_time) {
+  return true;
+}
+
+bool ApplicationStorageImpl::RemoveApplication(const std::string& id) {
+  return true;
+}
+
+bool ApplicationStorageImpl::ContainsApplication(const std::string& app_id) {
+  return !GetApplicationPath(app_id).empty();
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/application_storage_impl_tizen.h
+++ b/application/common/application_storage_impl_tizen.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_APPLICATION_STORAGE_IMPL_TIZEN_H_
+#define XWALK_APPLICATION_COMMON_APPLICATION_STORAGE_IMPL_TIZEN_H_
+
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "sql/connection.h"
+#include "sql/meta_table.h"
+#include "xwalk/application/common/application_data.h"
+
+namespace xwalk {
+namespace application {
+
+// The Sqlite backend implementation of ApplicationStorage.
+class ApplicationStorageImpl {
+ public:
+  explicit ApplicationStorageImpl(const base::FilePath& path);
+  ~ApplicationStorageImpl();
+
+  bool AddApplication(const ApplicationData* application,
+                      const base::Time& install_time);
+  bool RemoveApplication(const std::string& key);
+  bool ContainsApplication(const std::string& key);
+  bool UpdateApplication(ApplicationData* application,
+                         const base::Time& install_time);
+  bool Init();
+
+  scoped_refptr<ApplicationData> GetApplicationData(const std::string& id);
+
+  bool GetInstalledApplicationIDs(
+      std::vector<std::string>& app_ids);  // NOLINT
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_APPLICATION_STORAGE_IMPL_TIZEN_H_

--- a/application/common/id_util.cc
+++ b/application/common/id_util.cc
@@ -76,6 +76,13 @@ std::string RawAppIdToAppIdForTizenPkgmgrDB(const std::string& id) {
   return kAppIdPrefix + id;
 }
 
+std::string TizenPkgmgrDBAppIdToRawAppId(const std::string& id) {
+  std::string raw_id;
+  if (RE2::FullMatch(id, "xwalk.(\\w+)", &raw_id))
+    return raw_id;
+  return id;
+}
+
 std::string GetTizenAppId(ApplicationData* application) {
   if (application->GetPackageType() == xwalk::application::Package::XPK)
     return application->ID();

--- a/application/common/id_util.h
+++ b/application/common/id_util.h
@@ -45,6 +45,8 @@ std::string RawAppIdToCrosswalkAppId(const std::string& id);
 // for xpk, but it must be an "." on appid or it cannot insert to tizen pkgmgr
 // db, so we have to have a "xwalk." as it's prefix.
 std::string RawAppIdToAppIdForTizenPkgmgrDB(const std::string& id);
+// Does the opposite to the above function.
+std::string TizenPkgmgrDBAppIdToRawAppId(const std::string& id);
 
 // For xpk, app_id == crosswalk_32bytes_app_id == this->ID(),
 // For wgt, app_id == tizen_wrt_10bytes_package_id.app_name,

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -16,8 +16,6 @@
       'sources': [
         'application_storage.cc',
         'application_storage.h',
-        'application_storage_impl.cc',
-        'application_storage_impl.h',
 
         'application_data.cc',
         'application_data.h',
@@ -67,6 +65,8 @@
             '../../../third_party/re2/re2.gyp:re2',
           ],
           'sources': [
+            'application_storage_impl_tizen.cc',
+            'application_storage_impl_tizen.h',
             'manifest_handlers/navigation_handler.cc',
             'manifest_handlers/navigation_handler.h',
             'manifest_handlers/tizen_application_handler.cc',
@@ -82,6 +82,11 @@
             'installer/tizen/packageinfo_constants.cc',
             'installer/tizen/packageinfo_constants.h',
           ],
+        }, {
+        'sources': [
+            'application_storage_impl.cc',
+            'application_storage_impl.h',
+          ]
         }],
       ],
       'include_dirs': [

--- a/application/tools/linux/xwalk_launcher_main.cc
+++ b/application/tools/linux/xwalk_launcher_main.cc
@@ -18,7 +18,7 @@
 #include "xwalk/application/tools/linux/dbus_connection.h"
 #include "xwalk/application/tools/linux/xwalk_extension_process_launcher.h"
 #if defined(OS_TIZEN)
-#include "xwalk/application/common/id_util.h"
+#include "url/gurl.h"
 #include "xwalk/application/tools/linux/xwalk_launcher_tizen.h"
 #include "xwalk/application/tools/linux/xwalk_tizen_user.h"
 #endif
@@ -298,11 +298,6 @@ int main(int argc, char** argv) {
     appid_or_url = strdup(basename(argv[0]));
   }
 
-#if defined(OS_TIZEN)
-    std::string crosswalk_app_id =
-        xwalk::application::RawAppIdToCrosswalkAppId(appid_or_url);
-    appid_or_url = strdup(crosswalk_app_id.c_str());
-#endif
 
   // Query app.
   if (query_running) {

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -74,20 +74,21 @@ static void TerminateIfRunning(const std::string& app_id) {
 #endif
 
 bool list_applications(ApplicationStorage* storage) {
-  ApplicationData::ApplicationDataMap apps;
-  if (!storage->GetInstalledApplications(apps))
+  std::vector<std::string> app_ids;
+  if (!storage->GetInstalledApplicationIDs(app_ids))
     return false;
 
   g_print("Application ID                       Application Name\n");
   g_print("-----------------------------------------------------\n");
-  ApplicationData::ApplicationDataMap::const_iterator it;
-  for (it = apps.begin(); it != apps.end(); ++it) {
+  for (unsigned i = 0; i < app_ids.size(); ++i) {
+    scoped_refptr<ApplicationData> app_data =
+        storage->GetApplicationData(app_ids.at(i));
 #if defined(OS_TIZEN)
     g_print("%s  %s\n",
-            GetTizenAppId(it->second).c_str(),
-            it->second->Name().c_str());
+            GetTizenAppId(app_data).c_str(),
+            app_data->Name().c_str());
 #else
-    g_print("%s  %s\n", it->first.c_str(), it->second->Name().c_str());
+    g_print("%s  %s\n", app_data->ID().c_str(), app_data->Name().c_str());
 #endif
   }
   g_print("-----------------------------------------------------\n");

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -34,6 +34,7 @@
           'type': 'none',
           'variables': {
             'packages': [
+              'ail',
               'dlog',
               'pkgmgr-parser',
               'pkgmgr-info',

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -45,6 +45,7 @@ BuildRequires:  python
 BuildRequires:  python-xml
 BuildRequires:  perl
 BuildRequires:  which
+BuildRequires:  pkgconfig(ail)
 BuildRequires:  pkgconfig(alsa)
 BuildRequires:  pkgconfig(appcore-common)
 BuildRequires:  pkgconfig(cairo)

--- a/runtime/browser/tizen/tizen_locale_listener.cc
+++ b/runtime/browser/tizen/tizen_locale_listener.cc
@@ -9,9 +9,6 @@
 
 #include "base/logging.h"
 #include "content/public/browser/browser_thread.h"
-#include "xwalk/runtime/browser/xwalk_runner_tizen.h"
-#include "xwalk/application/browser/application_system.h"
-#include "xwalk/application/browser/application_service.h"
 
 namespace xwalk {
 namespace {
@@ -98,11 +95,6 @@ void TizenLocaleListener::SetLocale(const std::string& locale) {
 
   LOG(INFO) << "Locale change from " << locale_ << " to " << locale;
   locale_ = locale;
-
-  application::ApplicationSystem* application_system_ =
-      XWalkRunnerTizen::GetInstance()->app_system();
-  if (application_system_)
-    application_system_->application_service()->ChangeLocale(locale);
 }
 
 }  // namespace xwalk


### PR DESCRIPTION
Crosswalk should use the Tizen platform's application database
to store application data, instead of its own. This reduces
duplication of information and allows webapps to be behave
more like native apps in the eyes of the system.

BUG=XWALK-2029
