### PR TITLE
[Android] Enable instrument test for Contacts API.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/contacts/contacts_api.js
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/contacts/contacts_api.js
@@ -60,10 +60,15 @@ extension.setMessageListener(function(json) {
     return;
   }
 
-  if (msg.data && msg.data.error) {
-    g_async_calls[msg.asyncCallId].reject(msg.data.error);
+  if (msg.data) {
+    if (!msg.data.hasOwnProperty("error") || !msg.data.error) {
+      g_async_calls[msg.asyncCallId].resolve(msg.data);
+    } else {
+      g_async_calls[msg.asyncCallId].reject(msg.data);
+    }
   } else {
-    g_async_calls[msg.asyncCallId].resolve(msg.data);
+    console.log("WARNING: Message from backend doesn't have data.")
+    g_async_calls[msg.asyncCallId].resolve();
   }
 
   delete g_async_calls[msg.asyncCallId];

--- a/test/android/data/contacts.html
+++ b/test/android/data/contacts.html
@@ -59,15 +59,6 @@ window.onload = function() {
   var testNewContactFlag = false;
   var expectedNewPhoneNumber = '+4455001';
   function testNewContacts() {
-    // Test Case 2: check if oncontactchanges received all new contacts IDs.
-    if (addedIDs.length != 2) {
-      return;
-    }
-
-    if (ifcontains(addedIDs, contact1.id) && ifcontains(addedIDs, contact2.id)) {
-      testNewContactFlag = true;
-    }
-
     // Test Case 3: update first contact after both contacts are saved.
     var output = 'Will update contact ' + 
                  contact1.id + ' ' +
@@ -78,18 +69,6 @@ window.onload = function() {
 
     contact1.phoneNumbers[0].value = expectedNewPhoneNumber;
     contacts.save(contact1).then(updateCallback, errorCallback);
-  }
-
-  var removedIDs = [];
-  contacts.oncontactschange = function(data) {
-    if (data.added) {
-      addedIDs.push.apply(addedIDs, data.added); // Append added IDs to addedIDs
-      testNewContacts();
-    }
-    if (data.removed) {
-      removedIDs.push.apply(removedIDs, data.removed); // Append removed IDs to removedIDs
-      tryFinalVerify();
-    }
   }
 
   // Create two contacts for testing
@@ -128,8 +107,26 @@ window.onload = function() {
     phoneNumbers: [mobilePhone2]
   });
 
-  contacts.save(contact1).then(function(item) { logContactSaved(item); contact1.id = item.id; }, errorCallback);
-  contacts.save(contact2).then(function(item) { logContactSaved(item); contact2.id = item.id; }, errorCallback);
+  function handleSaveSuccessCallback(_contact, item) {
+    addedIDs.push(item.id);
+    logContactSaved(item);
+    _contact.id = item.id; 
+    // Test Case 2: check if oncontactchanges received all new contacts IDs.
+    if (ifcontains(addedIDs, contact1.id) && ifcontains(addedIDs, contact2.id)) {
+      testNewContactFlag = true;
+      testNewContacts();
+    }
+  }
+
+  contacts.save(contact1).then(function(item) {
+      handleSaveSuccessCallback(contact1, item);
+    }, 
+    errorCallback);
+
+  contacts.save(contact2).then(function(item) { 
+      handleSaveSuccessCallback(contact2, item);
+    }, 
+    errorCallback);
 
   var testUpdateFirstFlag = false;
   function updateCallback(item) {
@@ -179,17 +176,13 @@ window.onload = function() {
   function removeCallback() {
     addHTML('remove', contact2.id + " is removed.<br>Will test clear()");
     // Test Case 6: clear all contacts.
-    contacts.clear().then(tryFinalVerify, errorCallback);
+    contacts.clear().then(clearCallback, errorCallback);
   }
 
   // Check if contacts are all removed, which means all test steps are done. If so we verify all results.
-  function tryFinalVerify() {
-    if (removedIDs.length != 2) {
-      return;
-    }
+  function clearCallback() {
     addHTML('remove', "All contacts are removed.");
-    testRemovedSecondFlag = ifcontains(removedIDs, contact2.id);
-    if (testNewContactFlag && testUpdateFirstFlag && testFindFirstFlag && testRemovedSecondFlag) {
+    if (testNewContactFlag && testUpdateFirstFlag && testFindFirstFlag) {
       document.title = 'Pass';
     } else {
       document.title = 'Fail';

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/ContactsTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/ContactsTest.java
@@ -18,7 +18,6 @@ public class ContactsTest extends XWalkRuntimeClientTestBase {
 
     // @SmallTest
     // @Feature({"Contacts"})
-    @DisabledTest
     public void testContacts() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/ContactsTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/ContactsTest.java
@@ -18,7 +18,6 @@ public class ContactsTest extends XWalkRuntimeClientTestBase {
 
     // @SmallTest
     // @Feature({"Contacts"})
-    @DisabledTest
     public void testContacts() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(


### PR DESCRIPTION
Enable instrument test for Contacts API. And, fixed some issues in
contacts test case. The callback function of Promise is invoked after
oncontactchanges(). So, testNewContactFlag will be false. The test
always fail.
