### PR TITLE
Update codebase to use scoped_refptr<T>::get() rather

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -60,7 +60,7 @@ Application::Application(
       entry_point_used_(Default),
       weak_factory_(this) {
   DCHECK(runtime_context_);
-  DCHECK(data_);
+  DCHECK(data_.get());
   DCHECK(observer_);
 }
 

--- a/dbus/dbus_manager.cc
+++ b/dbus/dbus_manager.cc
@@ -14,12 +14,12 @@ namespace xwalk {
 DBusManager::DBusManager() {}
 
 DBusManager::~DBusManager() {
-  if (session_bus_)
+  if (session_bus_.get())
     session_bus_->ShutdownOnDBusThreadAndBlock();
 }
 
 scoped_refptr<dbus::Bus> DBusManager::session_bus() {
-  if (!session_bus_) {
+  if (!session_bus_.get()) {
     base::Thread::Options thread_options;
     thread_options.message_loop_type = base::MessageLoop::TYPE_IO;
     std::string thread_name = "Crosswalk D-Bus thread";

--- a/runtime/browser/android/net/android_stream_reader_url_request_job.cc
+++ b/runtime/browser/android/net/android_stream_reader_url_request_job.cc
@@ -222,7 +222,7 @@ void AndroidStreamReaderURLRequestJob::OnInputStreamOpened(
       CreateStreamReader(input_stream.get()));
   DCHECK(input_stream_reader);
 
-  DCHECK(!input_stream_reader_wrapper_);
+  DCHECK(!input_stream_reader_wrapper_.get());
   input_stream_reader_wrapper_ = new InputStreamReaderWrapper(
       input_stream.Pass(), input_stream_reader.Pass());
 
@@ -277,7 +277,7 @@ bool AndroidStreamReaderURLRequestJob::ReadRawData(net::IOBuffer* dest,
                                                    int dest_size,
                                                    int* bytes_read) {
   DCHECK(thread_checker_.CalledOnValidThread());
-  if (!input_stream_reader_wrapper_) {
+  if (!input_stream_reader_wrapper_.get()) {
     // This will happen if opening the InputStream fails in which case the
     // error is communicated by setting the HTTP response status header rather
     // than failing the request during the header fetch phase.
@@ -306,7 +306,7 @@ bool AndroidStreamReaderURLRequestJob::GetMimeType(
   JNIEnv* env = AttachCurrentThread();
   DCHECK(env);
 
-  if (!input_stream_reader_wrapper_)
+  if (!input_stream_reader_wrapper_.get())
     return false;
 
   // Since it's possible for this call to alter the InputStream a
@@ -322,7 +322,7 @@ bool AndroidStreamReaderURLRequestJob::GetCharset(std::string* charset) {
   JNIEnv* env = AttachCurrentThread();
   DCHECK(env);
 
-  if (!input_stream_reader_wrapper_)
+  if (!input_stream_reader_wrapper_.get())
     return false;
 
   // Since it's possible for this call to alter the InputStream a

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -77,7 +77,7 @@ RuntimeContext::RuntimeContext()
 }
 
 RuntimeContext::~RuntimeContext() {
-  if (resource_context_) {
+  if (resource_context_.get()) {
     BrowserThread::DeleteSoon(
         BrowserThread::IO, FROM_HERE, resource_context_.release());
   }
@@ -118,7 +118,7 @@ bool RuntimeContext::IsOffTheRecord() const {
 content::DownloadManagerDelegate* RuntimeContext::GetDownloadManagerDelegate() {
   content::DownloadManager* manager = BrowserContext::GetDownloadManager(this);
 
-  if (!download_manager_delegate_) {
+  if (!download_manager_delegate_.get()) {
     download_manager_delegate_ = new RuntimeDownloadManagerDelegate();
     download_manager_delegate_->SetDownloadManager(manager);
   }
@@ -192,7 +192,7 @@ content::PushMessagingService* RuntimeContext::GetPushMessagingService() {
 net::URLRequestContextGetter* RuntimeContext::CreateRequestContext(
     content::ProtocolHandlerMap* protocol_handlers,
     content::URLRequestInterceptorScopedVector request_interceptors) {
-  DCHECK(!url_request_getter_);
+  DCHECK(!url_request_getter_.get());
 
   application::ApplicationService* service =
       XWalkRunner::GetInstance()->app_system()->application_service();
@@ -272,7 +272,7 @@ void RuntimeContext::InitVisitedLinkMaster() {
 }
 
 void RuntimeContext::AddVisitedURLs(const std::vector<GURL>& urls) {
-  DCHECK(visitedlink_master_);
+  DCHECK(visitedlink_master_.get());
   visitedlink_master_->AddURLs(urls);
 }
 

--- a/sysapps/raw_socket/tcp_socket_object.cc
+++ b/sysapps/raw_socket/tcp_socket_object.cc
@@ -74,7 +74,7 @@ void TCPSocketObject::DoRead() {
 }
 
 void TCPSocketObject::OnInit(scoped_ptr<XWalkExtensionFunctionInfo> info) {
-  if (socket_) {
+  if (socket_.get()) {
     DoRead();
     return;
   }
@@ -101,7 +101,7 @@ void TCPSocketObject::OnInit(scoped_ptr<XWalkExtensionFunctionInfo> info) {
 }
 
 void TCPSocketObject::OnClose(scoped_ptr<XWalkExtensionFunctionInfo> info) {
-  if (socket_)
+  if (socket_.get())
     socket_->Disconnect();
 
   setReadyState(READY_STATE_CLOSED);
@@ -109,7 +109,7 @@ void TCPSocketObject::OnClose(scoped_ptr<XWalkExtensionFunctionInfo> info) {
 }
 
 void TCPSocketObject::OnHalfClose(scoped_ptr<XWalkExtensionFunctionInfo> info) {
-  if (!socket_ || !socket_->IsConnected())
+  if (!socket_.get() || !socket_->IsConnected())
     return;
 
   is_half_closed_ = true;
@@ -129,7 +129,7 @@ void TCPSocketObject::OnSendString(
   if (is_half_closed_ || has_write_pending_)
     return;
 
-  if (!socket_ || !socket_->IsConnected())
+  if (!socket_.get() || !socket_->IsConnected())
     return;
 
   scoped_ptr<SendDOMString::Params>


### PR DESCRIPTION
than implicit "operator T*"

It's going to be removed upstream at some point.
