### PR TITLE
[Android] Fix white screen issue after press home button

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -877,16 +877,20 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     private void onActivityStateChange(Activity activity, int newState) {
         assert(getActivity() == activity);
         switch (newState) {
+	    case ActivityState.STARTED:
+                onShow();
+                break;
             case ActivityState.PAUSED:
                 pauseTimers();
-                onHide();
                 break;
             case ActivityState.RESUMED:
-                onShow();
                 resumeTimers();
                 break;
             case ActivityState.DESTROYED:
                 onDestroy();
+                break;
+	    case ActivityState.STOPPED:
+                onHide();
                 break;
             default:
                 break;


### PR DESCRIPTION
Call onHide() when activity stopped, and onShow() when activity started,
instead of activity resumed and paused.
activity::onStop() means activity is hidden, and activity::onPause() means
activity partially visible.

BUG=XWALK-2188
