### PR TITLE
Fix org.xwalk.core.internal.xwview.test.loadTest#testContentUrl

### DIFF
--- a/runtime/android/core_internal_shell/AndroidManifest.xml
+++ b/runtime/android/core_internal_shell/AndroidManifest.xml
@@ -26,6 +26,8 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST" />
           </intent-filter>
+          <provider android:name="org.xwalk.core.internal.xwview.test.TestContentProvider"
+            android:authorities="org.xwalk.core.internal.xwview.test.TestContentProvider" />
         </activity>
     </application>
 

--- a/test/android/core_internal/javatests/AndroidManifest.xml
+++ b/test/android/core_internal/javatests/AndroidManifest.xml
@@ -10,8 +10,6 @@
 
     <application>
         <uses-library android:name="android.test.runner" />
-        <provider android:name="TestContentProvider"
-            android:authorities="org.xwalk.core.internal.xwview.test.TestContentProvider" />
     </application>
 
     <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />


### PR DESCRIPTION
Since M37 the test was failing. It was missing to change the declaration
of TestContentProvider the same way we did for the non internal xwalkview.

BUG=XWALK-2172
