### PR TITLE
Really fix org.xwalk.core.internal.xwview.test.loadTest#testContentUrl.

### DIFF
--- a/runtime/android/core_internal_shell/AndroidManifest.xml
+++ b/runtime/android/core_internal_shell/AndroidManifest.xml
@@ -26,9 +26,9 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST" />
           </intent-filter>
-          <provider android:name="org.xwalk.core.internal.xwview.test.TestContentProvider"
-            android:authorities="org.xwalk.core.internal.xwview.test.TestContentProvider" />
         </activity>
+        <provider android:name="org.xwalk.core.internal.xwview.test.TestContentProvider"
+            android:authorities="org.xwalk.core.internal.xwview.test.TestContentProvider" />
     </application>
 
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19" />


### PR DESCRIPTION
The <provider> tag in AndroidManifest.xml should be outside <activity>,
not inside it.

Pointy hat: darktears, rakuco.

BUG=XWALK-2172
