### PR TITLE
DEPS.xwalk: Roll ozone-wayland (7c9ae33 -> 0a8caf9)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -20,7 +20,7 @@
 chromium_crosswalk_rev = 'b93afe0192aa9888d1246e8933d31272afecb7f0'
 blink_crosswalk_rev = 'b656b39cc2eb71a9f4b70f8439c2d0a1ca54d619'
 v8_crosswalk_rev = '8baa2b8fb1a66d5842294840aed969164c52d978'
-ozone_wayland_rev = '7c9ae3304bb4766c065ef06cd47eef2ba4b0df21'
+ozone_wayland_rev = '0a8caf9bc740d767464b2d1d16fec08ff2f91d1f'
 
 crosswalk_git = 'https://github.com/crosswalk-project'
 ozone_wayland_git = 'https://github.com/01org'


### PR DESCRIPTION
ozone-wayland:
0a8caf9 Merge pull request #257 from CooderIan/fix_pointer_crash
c55ebd1 Fix crash when unplug the mouse with pointer in the window.

BUG=https://bugs.tizen.org/jira/browse/TC-341
