### PR TITLE
[Tizen] 'xwalkctl' should not crash

### DIFF
--- a/application/common/application_storage_impl_tizen.cc
+++ b/application/common/application_storage_impl_tizen.cc
@@ -80,14 +80,13 @@ base::FilePath GetApplicationPath(const std::string& app_id) {
   // x_slp_exe_path is <app_path>/bin/<app_id>, we need to
   // return just <app_path>.
   std::string toBeExcluded = "/bin/" + app_id;
-  unsigned found = x_slp_exe_path.rfind(toBeExcluded);
+  size_t found = x_slp_exe_path.find(toBeExcluded);
   if (found == std::string::npos) {
     LOG(ERROR) << "Invalid 'x_slp_exe_path' value (" << x_slp_exe_path
                << ") for the app id " << app_id;
     return base::FilePath();
   }
 
-  CHECK(found < x_slp_exe_path.length());
   x_slp_exe_path.resize(found);
   return base::FilePath(x_slp_exe_path);
 }

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -83,6 +83,11 @@ bool list_applications(ApplicationStorage* storage) {
   for (unsigned i = 0; i < app_ids.size(); ++i) {
     scoped_refptr<ApplicationData> app_data =
         storage->GetApplicationData(app_ids.at(i));
+    if (!app_data) {
+      g_print("Failed to obtain app data for xwalk id: %s\n",
+              app_ids.at(i).c_str());
+      continue;
+    }
 #if defined(OS_TIZEN)
     g_print("%s  %s\n",
             GetTizenAppId(app_data).c_str(),


### PR DESCRIPTION
'xwalkctl' should not crash when obtains inconsistent data
from Tizen middleware.

BUG=XWALK-2189
