### PR TITLE
Remove OS_ANDROID for --disable-xwalk-extensions flag

### DIFF
--- a/extensions/common/xwalk_extension_switches.cc
+++ b/extensions/common/xwalk_extension_switches.cc
@@ -23,7 +23,7 @@ const char kXWalkExternalExtensionsPath[] = "external-extensions-path";
 // Useful values might be "valgrind" or "xterm -e gdb --args".
 const char kXWalkExtensionCmdPrefix[] = "xwalk-extension-cmd-prefix";
 
-// Disable XWalkExtensionSystem and all extensions only for Android OS
+// Disable XWalkExtensionSystem and all extensions
 const char kXWalkDisableExtensions[] = "disable-xwalk-extensions";
 
 }  // namespace switches

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -70,14 +70,10 @@ void XWalkRunner::PreMainMessageLoopRun() {
   runtime_context_.reset(new RuntimeContext);
   app_extension_bridge_.reset(new XWalkAppExtensionBridge());
 
-#if defined(OS_ANDROID)
   CommandLine* cmd_line = CommandLine::ForCurrentProcess();
   if (!cmd_line->HasSwitch(switches::kXWalkDisableExtensions))
-#endif
-  {
     extension_service_.reset(new extensions::XWalkExtensionService(
         app_extension_bridge_.get()));
-  }
 
   CreateComponents();
   app_extension_bridge_->SetApplicationSystem(app_component_->app_system());

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -95,14 +95,10 @@ XWalkContentRendererClient::~XWalkContentRendererClient() {
 }
 
 void XWalkContentRendererClient::RenderThreadStarted() {
-#if defined(OS_ANDROID)
   CommandLine* cmd_line = CommandLine::ForCurrentProcess();
   if (!cmd_line->HasSwitch(switches::kXWalkDisableExtensions))
-#endif
-  {
     extension_controller_.reset(
         new extensions::XWalkExtensionRendererController(this));
-  }
 
   blink::WebString application_scheme(
       base::ASCIIToUTF16(application::kApplicationScheme));


### PR DESCRIPTION
@wang16
@hmin
@halton

As we discussed in the disable extensions for OS_Android thread, there should be no OS dependency of disable extensions.
I have tested on Android using --disable-xwalk-extensions: It will cause the JS interface of extensions not recognized.
