### PR TITLE
[Tizen][Runtime] Always use [tizen_app_id] on tizen.

### DIFF
--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -87,7 +87,7 @@ bool ApplicationSystem::LaunchFromCommandLine(
   const base::CommandLine::StringVector& args = cmd_line.GetArgs();
   if (!args.empty()) {
     std::string app_id = std::string(args[0].begin(), args[0].end());
-    if (ApplicationData::IsIDValid(app_id)) {
+    if (IsValidApplicationID(app_id)) {
       run_default_message_loop = LaunchWithCommandLineParam(app_id, cmd_line);
       return true;
     }

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -68,9 +68,6 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   static scoped_refptr<ApplicationData> Create(const GURL& url,
                                                std::string* error_message);
 
-  // Checks to see if the application has a valid ID.
-  static bool IsIDValid(const std::string& id);
-
   Manifest::Type GetType() const;
 
   // Returns an absolute url to a resource inside of an application. The
@@ -137,20 +134,16 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   friend class base::RefCountedThreadSafe<ApplicationData>;
   friend class ApplicationStorageImpl;
 
-  // Chooses the application ID for an application based on a variety of
-  // criteria. The chosen ID will be set in |manifest|.
-  static bool InitApplicationID(Manifest* manifest,
-                              const base::FilePath& path,
-                              const std::string& explicit_id,
-                              base::string16* error);
-
   ApplicationData(const base::FilePath& path,
             scoped_ptr<Manifest> manifest);
   virtual ~ApplicationData();
 
   // Initialize the application from a parsed manifest.
-  bool Init(base::string16* error);
+  bool Init(const std::string& explicit_id, base::string16* error);
 
+  // Chooses the application ID for an application based on a variety of
+  // criteria. The chosen ID will be set in |manifest|.
+  bool LoadID(const std::string& explicit_id, base::string16* error);
   // The following are helpers for InitFromValue to load various features of the
   // application from the manifest.
   bool LoadName(base::string16* error);

--- a/application/common/application_storage_impl.cc
+++ b/application/common/application_storage_impl.cc
@@ -17,6 +17,7 @@
 #include "sql/transaction.h"
 #include "xwalk/application/common/application_storage.h"
 #include "xwalk/application/common/application_storage_constants.h"
+#include "xwalk/application/common/id_util.h"
 
 namespace db_fields = xwalk::application_storage_constants;
 namespace xwalk {
@@ -324,7 +325,7 @@ bool ApplicationStorageImpl::GetInstalledApplicationIDs(
 
   while (smt.Step()) {
     const std::string& id = smt.ColumnString(0);
-    if (!ApplicationData::IsIDValid(id)) {
+    if (!IsValidApplicationID(id)) {
       LOG(ERROR) << "Failed to obtain Application ID from SQL query";
       return false;
     }

--- a/application/common/application_storage_impl_tizen.cc
+++ b/application/common/application_storage_impl_tizen.cc
@@ -43,7 +43,6 @@ ail_cb_ret_e appinfo_get_exec_cb(const ail_appinfo_h appinfo, void *user_data) {
 }
 
 base::FilePath GetApplicationPath(const std::string& app_id) {
-  std::string ail_id = RawAppIdToAppIdForTizenPkgmgrDB(app_id);
   ail_filter_h filter;
   ail_error_e ret = ail_filter_new(&filter);
   if (ret != AIL_ERROR_OK) {
@@ -51,7 +50,7 @@ base::FilePath GetApplicationPath(const std::string& app_id) {
     return base::FilePath();
   }
 
-  ret = ail_filter_add_str(filter, AIL_PROP_X_SLP_APPID_STR, ail_id.c_str());
+  ret = ail_filter_add_str(filter, AIL_PROP_X_SLP_APPID_STR, app_id.c_str());
   if (ret != AIL_ERROR_OK) {
     LOG(ERROR) << "Failed to init AIL filter.";
     ail_filter_destroy(filter);
@@ -98,8 +97,7 @@ scoped_refptr<ApplicationData> ApplicationStorageImpl::GetApplicationData(
   base::FilePath app_path = GetApplicationPath(app_id);
 
   std::string error_str;
-  return LoadApplication(app_path, RawAppIdToCrosswalkAppId(app_id),
-                         Manifest::INTERNAL, &error_str);
+  return LoadApplication(app_path, app_id, Manifest::INTERNAL, &error_str);
 }
 
 namespace {
@@ -111,7 +109,7 @@ ail_cb_ret_e appinfo_get_app_id_cb(
   char* app_id;
   ail_appinfo_get_str(appinfo, AIL_PROP_X_SLP_APPID_STR, &app_id);
   if (app_id)
-    app_ids->push_back(TizenPkgmgrDBAppIdToRawAppId(app_id));
+    app_ids->push_back(app_id);
 
   return AIL_CB_RET_CONTINUE;
 }

--- a/application/common/application_unittest.cc
+++ b/application/common/application_unittest.cc
@@ -22,17 +22,5 @@ TEST(ApplicationTest, LocationValuesTest) {
   ASSERT_EQ(2, Manifest::COMMAND_LINE);
 }
 
-TEST(ApplicationTest, IsIDValid) {
-  EXPECT_TRUE(ApplicationData::IsIDValid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-  EXPECT_TRUE(ApplicationData::IsIDValid("pppppppppppppppppppppppppppppppp"));
-  EXPECT_TRUE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmnop"));
-  EXPECT_TRUE(ApplicationData::IsIDValid("ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP"));
-  EXPECT_FALSE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmno"));
-  EXPECT_FALSE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmnopa"));
-  EXPECT_FALSE(ApplicationData::IsIDValid("0123456789abcdef0123456789abcdef"));
-  EXPECT_FALSE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmnoq"));
-  EXPECT_FALSE(ApplicationData::IsIDValid("abcdefghijklmnopabcdefghijklmno0"));
-}
-
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/id_util.h
+++ b/application/common/id_util.h
@@ -15,15 +15,6 @@ class FilePath;
 
 namespace xwalk {
 namespace application {
-
-// The number of bytes in a legal id.
-extern const size_t kIdSize;
-
-#if defined(OS_TIZEN)
-// The number of bytes in a legal legacy Tizen id.
-extern const size_t kLegacyTizenIdSize;
-#endif
-
 // Generates an application ID from arbitrary input. The same input string will
 // always generate the same output ID.
 std::string GenerateId(const std::string& input);
@@ -32,25 +23,11 @@ std::string GenerateId(const std::string& input);
 // Used while developing applications, before they have a key.
 std::string GenerateIdForPath(const base::FilePath& path);
 
+// Checks to see if the application has a valid ID.
+bool IsValidApplicationID(const std::string& id);
+
 #if defined(OS_TIZEN)
-// If this appid is a xpk app id(crosswalk_32bytes_app_id), return itself.
-// If this appid is a wgt app id(tizen_app_id), convert it to
-// crosswalk_32bytes_app_id and return it.
-std::string RawAppIdToCrosswalkAppId(const std::string& id);
-
-// If this appid is a xpk app id(crosswalk_32bytes_app_id), return
-// xwalk.crosswalk_32bytes_app_id.
-// If this appid is a wgt app id(tizen_app_id), return itself.
-// It is better to storage crosswalk_32bytes_app_id on tizen pkgmgr db
-// for xpk, but it must be an "." on appid or it cannot insert to tizen pkgmgr
-// db, so we have to have a "xwalk." as it's prefix.
-std::string RawAppIdToAppIdForTizenPkgmgrDB(const std::string& id);
-// Does the opposite to the above function.
-std::string TizenPkgmgrDBAppIdToRawAppId(const std::string& id);
-
-// For xpk, app_id == crosswalk_32bytes_app_id == this->ID(),
-// For wgt, app_id == tizen_wrt_10bytes_package_id.app_name,
-std::string GetTizenAppId(ApplicationData* application);
+std::string GetPackageIdFromAppId(const std::string& app_id);
 #endif
 
 }  // namespace application

--- a/application/common/id_util_unittest.cc
+++ b/application/common/id_util_unittest.cc
@@ -40,5 +40,17 @@ TEST(IDUtilTest, GenerateID) {
                 "this_string_is_longer_than_a_single_sha256_hash_digest"));
 }
 
+TEST(IDUtilTest, IsValidApplicationID) {
+  EXPECT_TRUE(IsValidApplicationID("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+  EXPECT_TRUE(IsValidApplicationID("pppppppppppppppppppppppppppppppp"));
+  EXPECT_TRUE(IsValidApplicationID("abcdefghijklmnopabcdefghijklmnop"));
+  EXPECT_TRUE(IsValidApplicationID("ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP"));
+  EXPECT_FALSE(IsValidApplicationID("abcdefghijklmnopabcdefghijklmno"));
+  EXPECT_FALSE(IsValidApplicationID("abcdefghijklmnopabcdefghijklmnopa"));
+  EXPECT_FALSE(IsValidApplicationID("0123456789abcdef0123456789abcdef"));
+  EXPECT_FALSE(IsValidApplicationID("abcdefghijklmnopabcdefghijklmnoq"));
+  EXPECT_FALSE(IsValidApplicationID("abcdefghijklmnopabcdefghijklmno0"));
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/installer/wgt_package.cc
+++ b/application/common/installer/wgt_package.cc
@@ -55,7 +55,11 @@ WGTPackage::WGTPackage(const base::FilePath& path)
   }
 
   if (!value.empty())
+#if defined(OS_TIZEN)
+    id_ = value;
+#else
     id_ = GenerateId(value);
+#endif
 
   is_valid_ = true;
 

--- a/application/tools/linux/xwalk_launcher_tizen.cc
+++ b/application/tools/linux/xwalk_launcher_tizen.cc
@@ -75,22 +75,18 @@ int xwalk_appcore_init(int argc, char** argv, const char* name) {
 
 int xwalk_change_cmdline(int argc, char** argv, const char* app_id) {
   // Change /proc/<pid>/cmdline to app exec path. See XWALK-1722 for details.
-  char* app_id_for_db = strdup(
-      xwalk::application::RawAppIdToAppIdForTizenPkgmgrDB(app_id).c_str());
   pkgmgrinfo_appinfo_h handle;
   char* exec_path = NULL;
-  if (pkgmgrinfo_appinfo_get_appinfo(app_id_for_db, &handle) != PMINFO_R_OK ||
+  if (pkgmgrinfo_appinfo_get_appinfo(app_id, &handle) != PMINFO_R_OK ||
       pkgmgrinfo_appinfo_get_exec(handle, &exec_path) != PMINFO_R_OK ||
       !exec_path) {
-    fprintf(stderr, "Couldn't find exec path for application: %s\n",
-            app_id_for_db);
+    fprintf(stderr, "Couldn't find exec path for application: %s\n", app_id);
     return -1;
   }
 
   for (int i = 0; i < argc; ++i)
     memset(argv[i], 0, strlen(argv[i]));
   strncpy(argv[0], exec_path, strlen(exec_path)+1);
-  g_free(app_id_for_db);
   pkgmgrinfo_appinfo_destroy_appinfo(handle);
   return 0;
 }

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -88,13 +88,7 @@ bool list_applications(ApplicationStorage* storage) {
               app_ids.at(i).c_str());
       continue;
     }
-#if defined(OS_TIZEN)
-    g_print("%s  %s\n",
-            GetTizenAppId(app_data).c_str(),
-            app_data->Name().c_str());
-#else
-    g_print("%s  %s\n", app_data->ID().c_str(), app_data->Name().c_str());
-#endif
+    g_print("%s  %s\n", app_ids.at(i).c_str(), app_data->Name().c_str());
   }
   g_print("-----------------------------------------------------\n");
 
@@ -143,11 +137,6 @@ int main(int argc, char* argv[]) {
   } else if (uninstall_appid) {
 #if defined(SHARED_PROCESS_MODE)
     TerminateIfRunning(uninstall_appid);
-#endif
-#if defined(OS_TIZEN)
-    std::string crosswalk_app_id =
-        xwalk::application::RawAppIdToCrosswalkAppId(uninstall_appid);
-    uninstall_appid = strdup(crosswalk_app_id.c_str());
 #endif
     success = installer->Uninstall(uninstall_appid);
   } else {

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -134,7 +134,7 @@ class XWalkRunner {
 
   // These variables are used to export some values from the browser process
   // side to the extension side, such as application IDs and whatnot.
-  virtual void InitializeRuntimeVariablesForExtensions(
+  void InitializeRuntimeVariablesForExtensions(
       const content::RenderProcessHost* host,
       base::ValueMap* runtime_variables);
 

--- a/runtime/browser/xwalk_runner_tizen.cc
+++ b/runtime/browser/xwalk_runner_tizen.cc
@@ -38,18 +38,4 @@ void XWalkRunnerTizen::PreMainMessageLoopRun() {
 #endif
 }
 
-void XWalkRunnerTizen::InitializeRuntimeVariablesForExtensions(
-    const content::RenderProcessHost* host,
-    base::ValueMap* variables) {
-  application::Application* app = app_system()->application_service()->
-      GetApplicationByRenderHostID(host->GetID());
-
-  if (app) {
-    (*variables)["app_id"] = base::Value::CreateStringValue(app->id());
-    (*variables)["tizen_app_id"] = base::Value::CreateStringValue(
-        application::RawAppIdToAppIdForTizenPkgmgrDB(
-            application::GetTizenAppId(app->data())));
-  }
-}
-
 }  // namespace xwalk

--- a/runtime/browser/xwalk_runner_tizen.h
+++ b/runtime/browser/xwalk_runner_tizen.h
@@ -29,10 +29,6 @@ class XWalkRunnerTizen : public XWalkRunner {
   friend class XWalkRunner;
   XWalkRunnerTizen();
 
-  virtual void InitializeRuntimeVariablesForExtensions(
-      const content::RenderProcessHost* host,
-      base::ValueMap* runtime_variables) OVERRIDE;
-
   TizenLocaleListener tizen_locale_listener_;
 };
 


### PR DESCRIPTION
For xpk, [tizen_app_id] = xwalk.[GenerateId or GenerateIdForPath]
For wgt, [tizen_app_id] = Get from config.xml

And dbus cannot take [tizen_app_id] as object path, we have
to use [package_id] as app's object path on tizen.
