### PR TITLE
[Tizen] gbs-build crosswalk8 rpm fail.

### DIFF
--- a/packaging/gbp-flat-tree.sh
+++ b/packaging/gbp-flat-tree.sh
@@ -54,6 +54,7 @@ echo "Creating a new ${TAR_FILE} from ${BASE_SRC_DIR}/src"
 # version bump.
 tar --update --file "${TAR_FILE}" \
     --exclude-vcs --exclude=LayoutTests \
-    --exclude=src/out --directory="${BASE_SRC_DIR}" \
+    --exclude=src/out --exclude=src/third_party/android_tools \
+    --directory="${BASE_SRC_DIR}" \
     --transform="s:^:crosswalk/:S" \
     src


### PR DESCRIPTION
Exclude unnecessary directory android_tools when build for tizen.
The size of src/third_party/android_tools directory in Crosswalk8 is almost  5.6G.
After add  --exclude=src/third_party/android_tools to src/xwalk/packaging/gbp-flat-tree.sh.
The rpm can build success.

BUG=XWALK-2224
