### PR TITLE
[Tizen][Runtime] Do not require to set the application version in config.xml

### DIFF
--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -263,7 +263,7 @@ bool ApplicationData::LoadVersion(base::string16* error) {
     bool ok = manifest_->GetString(widget_keys::kVersionKey, &version_str);
     if (!ok) {
       *error = base::ASCIIToUTF16(errors::kInvalidVersion);
-      return false;
+      return true;
     }
 
     version_.reset(new base::Version(version_str));


### PR DESCRIPTION
On Tizen platform, a Tizen wgt web application is not required to have a
'version' field in config.xml, the Crosswalk runtime should follow this behavior.

BUG=XWALK-2220
