### PR TITLE
[Android] Fix the issue of accessing asset resources with unnormalized U...

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/AndroidProtocolHandler.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/AndroidProtocolHandler.java
@@ -188,10 +188,9 @@ class AndroidProtocolHandler {
         assert uri.getScheme().equals(FILE_SCHEME);
         assert uri.getPath() != null;
         assert uri.getPath().startsWith(nativeGetAndroidAssetPath());
-        String path = uri.getPath().replaceFirst(nativeGetAndroidAssetPath(), "");
         try {
             AssetManager assets = context.getAssets();
-            return assets.open(path, AssetManager.ACCESS_STREAMING);
+            return assets.open(getAssetPath(uri), AssetManager.ACCESS_STREAMING);
         } catch (IOException e) {
             Log.e(TAG, "Unable to open asset URL: " + uri);
             return null;

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/LoadTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/LoadTest.java
@@ -55,6 +55,15 @@ public class LoadTest extends XWalkViewInternalTestBase {
     }
 
     @SmallTest
+    @Feature({"LoadUnnormalized"})
+    public void testAndroidAssetUrlUnnormalized() throws Throwable {
+        final String url = "file:///android_asset/www//index.html";
+
+        loadUrlSync(url);
+        assertEquals(expectedLocalTitle, getTitleOnUiThread());
+    }
+
+    @SmallTest
     @Feature({"LoadWithData"})
     public void testWithData() throws Throwable {
         final String name = "index.html";


### PR DESCRIPTION
...RI.

Web applications may have unnormalized URI (additional slashes), which causes
failure of accessing them with AndroidProtocolHandler.
The fix was in Crosswalk, but https://github.com/crosswalk-project/crosswalk/commit/12b98a890de27d1ec96eb7f10558010fc7412e58
reverts it. So moving it back.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2226
