### PR TITLE
[Tizen][Runtime] Check the package type using application id instead.

### DIFF
--- a/application/common/id_util.cc
+++ b/application/common/id_util.cc
@@ -62,10 +62,20 @@ std::string GenerateIdForPath(const base::FilePath& path) {
   return GenerateId(path_bytes);
 }
 
+#if defined(OS_TIZEN)
+bool IsValidWGTID(const std::string& id) {
+  return RE2::FullMatch(id, kWGTAppIdPattern);
+}
+
+bool IsValidXPKID(const std::string& id) {
+  return RE2::FullMatch(id, kXPKAppIdPattern);
+}
+#endif
+
 bool IsValidApplicationID(const std::string& id) {
 #if defined(OS_TIZEN)
-  if (RE2::FullMatch(id, kWGTAppIdPattern) ||
-      RE2::FullMatch(id, kXPKAppIdPattern))
+  if (IsValidWGTID(id) ||
+      IsValidXPKID(id))
     return true;
   return false;
 #endif

--- a/application/common/id_util.h
+++ b/application/common/id_util.h
@@ -28,6 +28,8 @@ bool IsValidApplicationID(const std::string& id);
 
 #if defined(OS_TIZEN)
 std::string GetPackageIdFromAppId(const std::string& app_id);
+bool IsValidWGTID(const std::string& id);
+bool IsValidXPKID(const std::string& id);
 #endif
 
 }  // namespace application


### PR DESCRIPTION
Crosswalk runtime will check an installed web application type according to the
configure file name, if there's config.xml, it represents a WGT package, and
manifest.json represents an XPK package. But if a package have both of them,
it's always identified as XPK package, no matter it's actually a WGT or XPK
package. The patch will change to check the package type using the application
id, the tizen style app id represents a WGT package, xpk style id will be
identified as XPK package.

BUG=XWALK-2220
