### PR TITLE
[Linux] Fixed the regression issue that failed to start xwalk from comma...

### DIFF
--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -74,7 +74,7 @@ bool ApplicationSystem::LaunchWithCommandLineParam<GURL>(
 
   Application::LaunchParams launch_params;
   launch_params.force_fullscreen = cmd_line.HasSwitch(switches::kFullscreen);
-  launch_params.entry_points = Application::URLKey;
+  launch_params.entry_points = Application::StartURLKey;
 
   return !!application_service_->Launch(application_data, launch_params);
 }


### PR DESCRIPTION
...nd line.

In the patch 053869eb we set the url_spec into manifest using
keys::kStartURLKey instead of keys::kURLKey in
ApplicationData::Create, and we forget to replace the
Application::URLKey by Application::StartURLKey when launching
application from url in ApplicationSystem::LaunchWithCommandLineParam,
in this case we would fail to lunch xwalk on Linux from command line
with a startup url as its argument.
