### PR TITLE
[Tizen][Runtime] Fix unable to launch from a url.

### DIFF
--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -123,7 +123,7 @@ void RunningApplicationsManager::OnLaunch(
   if (GURL(app_id_or_url).spec().empty()) {
     application = application_service_->Launch(app_id_or_url, params);
   } else {
-    params.entry_points = Application::URLKey;
+    params.entry_points = Application::StartURLKey;
     std::string error;
     scoped_refptr<ApplicationData> application_data =
         ApplicationData::Create(GURL(app_id_or_url), &error);


### PR DESCRIPTION
The xwalk-launcher can not launch an application from a url, because of using a
wrong entry point. This patch will solve this, using the entry point
"StartURLKey" instead.

BUG=XWALK-2171
