### PR TITLE
[Android] Copy Contacts and Messaging API to make runnable on xwalk_core_library

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -75,7 +75,11 @@ def CopyJSBindingFiles(project_source, out_dir):
       'xwalk/experimental/launch_screen/launch_screen_api.js',
       'xwalk/experimental/presentation/presentation_api.js',
       'xwalk/runtime/android/core_internal/src/org/xwalk/core/'
-      + 'internal/extension/api/device_capabilities/device_capabilities_api.js'
+      + 'internal/extension/api/contacts/contacts_api.js',
+      'xwalk/runtime/android/core_internal/src/org/xwalk/core/'
+      + 'internal/extension/api/device_capabilities/device_capabilities_api.js',
+      'xwalk/runtime/android/core_internal/src/org/xwalk/core/'
+      + 'internal/extension/api/messaging/messaging_api.js'
   ]
 
   # Copy JS binding file to assets/jsapi folder.


### PR DESCRIPTION
Copy right contacts_api.js and messaging_api.js while generating xwalk_core_library.

BUG=XWALK-2156
