### PR TITLE
[Tizen] Adding some xsd file into crosswalk

### DIFF
--- a/application/common/installer/tizen/configuration/access.xsd
+++ b/application/common/installer/tizen/configuration/access.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/ns/widgets" xmlns:widgets="http://www.w3.org/ns/widgets">
+  <xs:include schemaLocation="common.xsd"/>
+  <!--
+    Widget Access Request Policy <http://www.w3.org/TR/widgets-access/>
+    requires common.rnc
+  -->
+  <xs:element name="access">
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:foreignAttribute"/>
+      <xs:attribute name="origin" type="xs:string"/>
+      <!-- w3c policy testcases
+      <xs:attribute name="origin" use="required">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:anyURI">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="*"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      -->
+      <xs:attribute name="subdomains" type="widgets:data.boolean"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/application/common/installer/tizen/configuration/common.xsd
+++ b/application/common/installer/tizen/configuration/common.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" xmlns:widgets="http://www.w3.org/ns/widgets">
+  <xs:include schemaLocation="local.xsd"/>
+
+  <xs:group name="extension">
+    <xs:sequence>
+      <xs:group ref="anyElement"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:attributeGroup name="extension">
+    <xs:attributeGroup ref="anyAttribute"/>
+  </xs:attributeGroup>
+
+  <xs:group name="foreignElement">
+    <xs:sequence>
+      <xs:choice minOccurs="0">
+        <xs:group ref="local"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:attributeGroup name="foreignAttribute">
+    <xs:anyAttribute namespace="##other" processContents="skip"/>
+  </xs:attributeGroup>
+
+  <xs:group name="anyElement">
+    <xs:sequence>
+      <xs:any processContents="skip"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:attributeGroup name="anyAttribute">
+    <xs:anyAttribute processContents="skip"/>
+  </xs:attributeGroup>
+
+  <xs:simpleType name="data.positiveNumber">
+    <xs:restriction base="xs:string">
+      <!-- W3C testcase <xs:pattern value="[1-9]\d*"/> -->
+      <xs:pattern value="\s*([1-9]\d*)?.*"/> <!-- accept everything anyway -->
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="data.boolean">
+    <xs:restriction base="xs:string">
+      <!-- w3c testcases - ignore invalid
+      <xs:enumeration value="true"/>
+      <xs:enumeration value="false"/>
+      -->
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="global.attrs">
+    <xs:attribute name="dir">
+      <xs:simpleType>
+        <xs:list>
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="ltr"/>
+              <xs:enumeration value="rtl"/>
+              <xs:enumeration value="lro"/>
+              <xs:enumeration value="rlo"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:list>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="global.xml">
+    <xs:anyAttribute namespace="##other" processContents="skip"/>
+  </xs:attributeGroup>
+
+  <xs:simpleType name="data.versionNumber">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9]{1,2}.[0-9]{1,2}(.[0-9]{1,4})?"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/application/common/installer/tizen/configuration/local.xsd
+++ b/application/common/installer/tizen/configuration/local.xsd
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" xmlns:widgets="http://www.w3.org/ns/widgets">
+    <xs:group name="local">
+        <xs:sequence>
+            <xs:any namespace="##other" processContents="skip"/>
+        </xs:sequence>
+    </xs:group>
+</xs:schema>

--- a/application/common/installer/tizen/configuration/packaging-configuration.xsd
+++ b/application/common/installer/tizen/configuration/packaging-configuration.xsd
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/ns/widgets" xmlns:widgets="http://www.w3.org/ns/widgets">
+  <xs:include schemaLocation="common.xsd"/>
+  <xs:include schemaLocation="access.xsd"/>
+  <xs:include schemaLocation="updates.xsd"/>
+  <xs:import namespace="http://tizen.org/ns/widgets" schemaLocation="widgets.tizen.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <!--
+    Widget Packaging and Configuration <http://www.w3.org/TR/widgets/>
+    requires common.rnc
+  -->
+  <xs:element name="widget">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="widgets:group.widgetContent">
+          <xs:attributeGroup ref="widgets:global.attrs"/>
+          <xs:attributeGroup ref="widgets:global.xml"/>
+          <xs:attributeGroup ref="widgets:extension"/>
+          <xs:attribute name="id" type="xs:anyURI"/>
+          <xs:attribute name="defaultlocale"/>
+          <xs:attribute name="version" type="widgets:data.versionNumber"/>
+          <xs:attribute name="min-version" type="widgets:data.versionNumber"/>
+          <xs:attribute name="height" type="widgets:data.positiveNumber"/>
+          <xs:attribute name="width" type="widgets:data.positiveNumber"/>
+          <xs:attribute name="viewmodes">
+            <xs:simpleType>
+              <xs:list>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="windowed"/>
+                    <xs:enumeration value="floating"/>
+                    <xs:enumeration value="fullscreen"/>
+                    <xs:enumeration value="maximized"/>
+                    <xs:enumeration value="minimized"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:list>
+            </xs:simpleType>
+          </xs:attribute>
+          <!-- Requirment from IDE UX -->
+          <xs:attribute ref="xml:lang"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="group.widgetContent" mixed="true">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:choice>
+        <xs:element ref="widgets:name"/>
+        <xs:element ref="widgets:description"/>
+        <xs:element ref="widgets:icon"/>
+        <xs:element ref="widgets:author"/>
+        <xs:element ref="widgets:license"/>
+        <xs:element ref="widgets:content"/>
+        <xs:element ref="widgets:feature"/>
+        <xs:element ref="widgets:preference"/>
+
+        <xs:element ref="tizen:app-control"  maxOccurs="unbounded" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:setting"  maxOccurs="unbounded" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:application" minOccurs="1" maxOccurs="1" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:content"  minOccurs="1" maxOccurs="1" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:privilege"  minOccurs="0" maxOccurs="unbounded" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:content-security-policy" minOccurs="0" maxOccurs="1" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:content-security-policy-report-only" minOccurs="0" maxOccurs="1" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:allow-navigation" minOccurs="0" maxOccurs="1" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:app-widget"  minOccurs="0" maxOccurs="unbounded" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:account"  minOccurs="0" maxOccurs="unbounded" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:metadata"  minOccurs="0" maxOccurs="unbounded" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <xs:element ref="tizen:splash"  minOccurs="0" maxOccurs="1" xmlns:tizen="http://tizen.org/ns/widgets"/>
+        <!-- W3C testcases fail - should accept any element -->
+        <!--  <xs:group minOccurs="0" maxOccurs="unbounded" ref="widgets:foreignElement"/> -->
+      </xs:choice>
+      <xs:element ref="widgets:access"/>
+      <!--   <xs:element ref="widgets:update-description"/> -->
+    </xs:choice>
+  </xs:complexType>
+  <xs:element name="name">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="widgets:span"/>
+        <xs:group ref="widgets:foreignElement"/>
+      </xs:choice>
+      <!-- Requirment from IDE UX -->
+      <xs:attribute ref="xml:lang"/>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:global.xml"/>
+      <xs:attributeGroup ref="widgets:extension"/>
+      <xs:attribute name="short"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="description">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="widgets:span"/>
+        <xs:group ref="widgets:foreignElement"/>
+      </xs:choice>
+      <!-- Requirment from IDE UX -->
+      <xs:attribute ref="xml:lang"/>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:global.xml"/>
+      <xs:attributeGroup ref="widgets:extension"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="icon">
+    <xs:complexType>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:foreignAttribute"/>
+      <!-- w3c testcase - must ignore
+      <xs:attribute name="src" use="required" type="xs:anyURI"/>
+      -->
+      <xs:attribute name="src" type="xs:anyURI"/>
+      <xs:attribute name="height" type="widgets:data.positiveNumber"/>
+      <xs:attribute name="width" type="widgets:data.positiveNumber"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="author">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="widgets:span"/>
+        <xs:group ref="widgets:foreignElement"/>
+        <!-- W3C testcases fail - should accept any element -->
+      </xs:choice>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:global.xml"/>
+      <xs:attributeGroup ref="widgets:extension"/>
+      <xs:attribute name="href" type="xs:anyURI"/>
+      <xs:attribute name="email" type="xs:string"/>
+      <!-- fails W3C testcases
+      <xs:attribute name="email">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value=".+@.+"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+       -->
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="license">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="widgets:span"/>
+        <xs:group ref="widgets:foreignElement"/>
+      </xs:choice>
+      <!-- Requirment from IDE UX -->
+      <xs:attribute ref="xml:lang"/>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:global.xml"/>
+      <xs:attributeGroup ref="widgets:extension"/>
+      <xs:attribute name="href" type="xs:anyURI"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="content">
+    <xs:complexType>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:foreignAttribute"/>
+      <!-- w3c testcase - ignore not valid
+      <xs:attribute name="src" use="required" type="xs:anyURI"/>
+      -->
+      <xs:attribute name="src" type="xs:string"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="feature">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="widgets:param"/>
+        <xs:group ref="widgets:foreignElement"/>
+      </xs:choice>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:global.xml"/>
+      <xs:attributeGroup ref="widgets:extension"/>
+      <!-- w3c tescase - must ignore
+      <xs:attribute name="name" use="required" type="xs:anyURI"/>
+      -->
+      <xs:attribute name="name" type="xs:anyURI"/>
+      <xs:attribute name="required" type="widgets:data.boolean"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="param">
+    <xs:complexType mixed="true">
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="widgets:foreignElement"/>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:global.xml"/>
+      <xs:attributeGroup ref="widgets:extension"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="value"/>
+      <!-- w3c testcase - must ignore
+      <xs:attribute name="name" use="required"/>
+      <xs:attribute name="value" use="required"/>
+      -->
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="span">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="widgets:span"/>
+        <xs:group ref="widgets:foreignElement"/>
+      </xs:choice>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:global.xml"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="preference">
+    <xs:complexType mixed="true">
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="widgets:foreignElement"/>
+      <xs:attributeGroup ref="widgets:global.attrs"/>
+      <xs:attributeGroup ref="widgets:global.xml"/>
+      <xs:attributeGroup ref="widgets:extension"/>
+      <!-- w3c testcase -required but missing
+      <xs:attribute name="name" use="required"/>
+      -->
+      <xs:attribute name="name"/>
+      <xs:attribute name="value"/>
+      <xs:attribute name="readonly" type="widgets:data.boolean"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/application/common/installer/tizen/configuration/signature_schema.xsd
+++ b/application/common/installer/tizen/configuration/signature_schema.xsd
@@ -1,0 +1,415 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE schema
+  PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd"
+ [
+   <!ATTLIST schema
+     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
+   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
+   <!ENTITY % p ''>
+   <!ENTITY % s ''>
+  ]>
+
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        targetNamespace="http://www.w3.org/2000/09/xmldsig#"
+        version="0.1" elementFormDefault="qualified">
+
+<!-- Basic Types Defined for Signatures -->
+
+<simpleType name="CryptoBinary">
+  <restriction base="base64Binary">
+  </restriction>
+</simpleType>
+
+<!-- Start Signature -->
+
+<element name="Signature" type="ds:SignatureType"/>
+<complexType name="SignatureType">
+  <sequence>
+    <element ref="ds:SignedInfo"/>
+    <element ref="ds:SignatureValue"/>
+    <element ref="ds:KeyInfo" minOccurs="0"/>
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="SignatureValue" type="ds:SignatureValueType"/>
+  <complexType name="SignatureValueType">
+    <simpleContent>
+      <extension base="base64Binary">
+        <attribute name="Id" type="ID" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+<!-- Start SignedInfo -->
+
+<element name="SignedInfo" type="ds:SignedInfoType"/>
+<complexType name="SignedInfoType">
+  <sequence>
+    <element ref="ds:CanonicalizationMethod"/>
+    <element ref="ds:SignatureMethod"/>
+    <element ref="ds:Reference" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/>
+  <complexType name="CanonicalizationMethodType" mixed="true">
+    <sequence>
+      <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+  <element name="SignatureMethod" type="ds:SignatureMethodType"/>
+  <complexType name="SignatureMethodType" mixed="true">
+    <sequence>
+      <element name="HMACOutputLength" minOccurs="0" type="ds:HMACOutputLengthType"/>
+      <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) external namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+<!-- Start Reference -->
+
+<element name="Reference" type="ds:ReferenceType"/>
+<complexType name="ReferenceType">
+  <sequence>
+    <element ref="ds:Transforms" minOccurs="0"/>
+    <element ref="ds:DigestMethod"/>
+    <element ref="ds:DigestValue"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+  <attribute name="URI" type="anyURI" use="optional"/>
+  <attribute name="Type" type="anyURI" use="optional"/>
+</complexType>
+
+  <element name="Transforms" type="ds:TransformsType"/>
+  <complexType name="TransformsType">
+    <sequence>
+      <element ref="ds:Transform" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <element name="Transform" type="ds:TransformType"/>
+  <complexType name="TransformType" mixed="true">
+    <choice minOccurs="0" maxOccurs="unbounded">
+      <any namespace="##other" processContents="lax"/>
+      <!-- (1,1) elements from (0,unbounded) namespaces -->
+      <element name="XPath" type="string"/>
+    </choice>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+<!-- End Reference -->
+
+<element name="DigestMethod" type="ds:DigestMethodType"/>
+<complexType name="DigestMethodType" mixed="true">
+  <sequence>
+    <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Algorithm" type="anyURI" use="required"/>
+</complexType>
+
+<element name="DigestValue" type="ds:DigestValueType"/>
+<simpleType name="DigestValueType">
+  <restriction base="base64Binary"/>
+</simpleType>
+
+<!-- End SignedInfo -->
+
+<!-- Start KeyInfo -->
+
+<element name="KeyInfo" type="ds:KeyInfoType"/>
+<complexType name="KeyInfoType" mixed="true">
+  <choice maxOccurs="unbounded">
+    <element ref="ds:KeyName"/>
+    <element ref="ds:KeyValue"/>
+    <element ref="ds:RetrievalMethod"/>
+    <element ref="ds:X509Data"/>
+    <element ref="ds:PGPData"/>
+    <element ref="ds:SPKIData"/>
+    <element ref="ds:MgmtData"/>
+    <any processContents="lax" namespace="##other"/>
+    <!-- (1,1) elements from (0,unbounded) namespaces -->
+  </choice>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="KeyName" type="string"/>
+  <element name="MgmtData" type="string"/>
+
+  <element name="KeyValue" type="ds:KeyValueType"/>
+  <complexType name="KeyValueType" mixed="true">
+   <choice>
+     <element ref="ds:DSAKeyValue"/>
+     <element ref="ds:RSAKeyValue"/>
+     <element ref="ds:ECKeyValue"/>
+     <any namespace="##other" processContents="lax"/>
+   </choice>
+  </complexType>
+
+<!-- ECDSA KEY DEFINITIONS -->
+
+  <element name="ECKeyValue" type="ds:ECKeyValueType"/>
+  <complexType name="ECKeyValueType">
+    <sequence>
+      <choice>
+        <element name="ECParameters" type="ds:ECParametersType"/>
+        <element name="NamedCurve" type="ds:NamedCurveType"/>
+      </choice>
+      <element name="PublicKey" type="ds:ECPointType"/>
+    </sequence>
+    <attribute name="Id" type="ID" use="optional"/>
+  </complexType>
+
+  <complexType name="NamedCurveType">
+    <attribute name="URI" type="anyURI" use="required"/>
+  </complexType>
+
+  <simpleType name="ECPointType">
+    <restriction base="ds:CryptoBinary"/>
+  </simpleType>
+
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/>
+  <complexType name="RetrievalMethodType">
+    <sequence>
+      <element ref="ds:Transforms" minOccurs="0"/>
+    </sequence>
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="Type" type="anyURI" use="optional"/>
+  </complexType>
+
+    <complexType name="ECParametersType">
+      <sequence>
+        <element name="FieldID" type="ds:FieldIDType"/>
+        <element name="Curve" type="ds:CurveType"/>
+        <element name="Base" type="ds:ECPointType"/>
+        <element name="Order" type="ds:CryptoBinary"/>
+        <element name="CoFactor" type="integer" minOccurs="0"/>
+        <element name="ValidationData" type="ds:ECValidationDataType" minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="FieldIDType">
+      <choice>
+        <element ref="ds:Prime"/>
+        <element ref="ds:TnB"/>
+        <element ref="ds:PnB"/>
+        <element ref="ds:GnB"/>
+        <any namespace="##other" processContents="lax"/>
+      </choice>
+    </complexType>
+
+    <element name="Prime" type="ds:PrimeFieldParamsType"/>
+    <complexType name="PrimeFieldParamsType">
+      <sequence>
+        <element name="P" type="ds:CryptoBinary"/>
+      </sequence>
+    </complexType>
+
+    <element name="GnB" type="ds:CharTwoFieldParamsType"/>
+    <complexType name="CharTwoFieldParamsType">
+      <sequence>
+        <element name="M" type="positiveInteger"/>
+      </sequence>
+    </complexType>
+
+    <element name="TnB" type="ds:TnBFieldParamsType"/>
+    <complexType name="TnBFieldParamsType">
+      <complexContent>
+        <extension base="ds:CharTwoFieldParamsType">
+          <sequence>
+            <element name="K" type="positiveInteger"/>
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+
+    <element name="PnB" type="ds:PnBFieldParamsType"/>
+    <complexType name="PnBFieldParamsType">
+      <complexContent>
+        <extension base="ds:CharTwoFieldParamsType">
+          <sequence>
+            <element name="K1" type="positiveInteger"/>
+            <element name="K2" type="positiveInteger"/>
+            <element name="K3" type="positiveInteger"/>
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+
+    <complexType name="CurveType">
+      <sequence>
+        <element name="A" type="ds:CryptoBinary"/>
+        <element name="B" type="ds:CryptoBinary"/>
+      </sequence>
+    </complexType>
+
+  <complexType name="ECValidationDataType">
+    <sequence>
+      <element name="seed" type="ds:CryptoBinary"/>
+    </sequence>
+    <attribute name="hashAlgorithm" type="anyURI" use="required"/>
+  </complexType>
+
+
+<!-- Start X509Data -->
+
+<element name="X509Data" type="ds:X509DataType"/>
+<complexType name="X509DataType">
+  <sequence maxOccurs="unbounded">
+    <choice>
+      <element name="X509IssuerSerial" type="ds:X509IssuerSerialType"/>
+      <element name="X509SKI" type="base64Binary"/>
+      <element name="X509SubjectName" type="string"/>
+      <element name="X509Certificate" type="base64Binary"/>
+      <element name="X509CRL" type="base64Binary"/>
+      <any namespace="##other" processContents="lax"/>
+    </choice>
+  </sequence>
+</complexType>
+
+<complexType name="X509IssuerSerialType">
+  <sequence>
+    <element name="X509IssuerName" type="string"/>
+    <element name="X509SerialNumber" type="integer"/>
+  </sequence>
+</complexType>
+
+<!-- End X509Data -->
+
+<!-- Begin PGPData -->
+
+<element name="PGPData" type="ds:PGPDataType"/>
+<complexType name="PGPDataType">
+  <choice>
+    <sequence>
+      <element name="PGPKeyID" type="base64Binary"/>
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/>
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+    <sequence>
+      <element name="PGPKeyPacket" type="base64Binary"/>
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+  </choice>
+</complexType>
+
+<!-- End PGPData -->
+
+<!-- Begin SPKIData -->
+
+<element name="SPKIData" type="ds:SPKIDataType"/>
+<complexType name="SPKIDataType">
+  <sequence maxOccurs="unbounded">
+    <element name="SPKISexp" type="base64Binary"/>
+    <any namespace="##other" processContents="lax" minOccurs="0"/>
+  </sequence>
+</complexType>
+
+<!-- End SPKIData -->
+
+<!-- End KeyInfo -->
+
+<!-- Start Object (Manifest, SignatureProperty) -->
+
+<element name="Object" type="ds:ObjectType"/>
+<complexType name="ObjectType" mixed="true">
+  <sequence minOccurs="0" maxOccurs="unbounded">
+    <any namespace="##any" processContents="lax"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+  <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
+  <attribute name="Encoding" type="anyURI" use="optional"/>
+</complexType>
+
+<element name="Manifest" type="ds:ManifestType"/>
+<complexType name="ManifestType">
+  <sequence>
+    <element ref="ds:Reference" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/>
+<complexType name="SignaturePropertiesType">
+  <sequence>
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/>
+   <complexType name="SignaturePropertyType" mixed="true">
+     <choice maxOccurs="unbounded">
+       <any namespace="##other" processContents="lax"/>
+       <!-- (1,1) elements from (1,unbounded) namespaces -->
+     </choice>
+     <attribute name="Target" type="anyURI" use="required"/>
+     <attribute name="Id" type="ID" use="optional"/>
+   </complexType>
+
+<!-- End Object (Manifest, SignatureProperty) -->
+
+<!-- Start Algorithm Parameters -->
+
+<simpleType name="HMACOutputLengthType">
+  <restriction base="integer"/>
+</simpleType>
+
+<!-- Start KeyValue Element-types -->
+
+<element name="DSAKeyValue" type="ds:DSAKeyValueType"/>
+<complexType name="DSAKeyValueType">
+  <sequence>
+    <sequence minOccurs="0">
+      <element name="P" type="ds:CryptoBinary"/>
+      <element name="Q" type="ds:CryptoBinary"/>
+    </sequence>
+    <element name="G" type="ds:CryptoBinary" minOccurs="0"/>
+    <element name="Y" type="ds:CryptoBinary"/>
+    <element name="J" type="ds:CryptoBinary" minOccurs="0"/>
+    <sequence minOccurs="0">
+      <element name="Seed" type="ds:CryptoBinary"/>
+      <element name="PgenCounter" type="ds:CryptoBinary"/>
+    </sequence>
+  </sequence>
+</complexType>
+
+<element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
+<complexType name="RSAKeyValueType">
+  <sequence>
+    <element name="Modulus" type="ds:CryptoBinary"/>
+    <element name="Exponent" type="ds:CryptoBinary"/>
+  </sequence>
+</complexType>
+
+<!-- End KeyValue Element-types -->
+
+<!-- End Signature -->
+
+</schema>

--- a/application/common/installer/tizen/configuration/updates.xsd
+++ b/application/common/installer/tizen/configuration/updates.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/ns/widgets" xmlns:widgets="http://www.w3.org/ns/widgets">
+    <xs:include schemaLocation="common.xsd"/>
+    <!--
+    Widget Updates <http://www.w3.org/TR/widgets-updates/>
+    requires common.rnc
+    -->
+    <xs:element name="update-description">
+    <xs:complexType mixed="true">
+        <xs:group minOccurs="0" maxOccurs="unbounded" ref="widgets:foreignElement"/>
+        <xs:attributeGroup ref="widgets:foreignAttribute"/>
+        <xs:attribute name="href" use="required" type="xs:anyURI"/>
+    </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/application/common/installer/tizen/configuration/widgets.tizen.xsd
+++ b/application/common/installer/tizen/configuration/widgets.tizen.xsd
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Widget Configuration Document Extensions XSD For TIZEN -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tizen="http://tizen.org/ns/widgets" targetNamespace="http://tizen.org/ns/widgets">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+    <xs:simpleType name="data.boolean">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="appserviceOperationType">
+        <xs:restriction base="xs:anyURI"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="PackageType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z]{10}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="applicationIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z]{10}[.][0-9a-zA-Z]{1,52}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="screenOrientationType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+            <xs:enumeration value="auto-rotation"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="activationType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="enable"/>
+            <xs:enumeration value="disable"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="soundmodeType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="shared"/>
+            <xs:enumeration value="exclusive"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="appWidgetIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z]{10}.[0-9a-zA-Z]{1,52}.[0-9a-zA-Z]{1,}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="updatePeriodType">
+        <xs:restriction base="xs:float">
+            <xs:minInclusive value="1800"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="content">
+        <xs:complexType>
+            <xs:attribute name="src" use="required" type="xs:anyURI"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="application">
+        <xs:complexType>
+            <xs:attribute name="id" type="tizen:applicationIdType" use="required"/>
+            <xs:attribute name="package" type="tizen:PackageType" use="required"/>
+            <xs:attribute name="required_version" type="xs:float" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="setting">
+        <xs:complexType>
+            <xs:attribute name="screen-orientation" type="tizen:screenOrientationType" use="optional"/> <!-- default: portrait -->
+            <xs:attribute name="context-menu" type="tizen:activationType" use="optional"/> <!-- default: enable -->
+            <xs:attribute name="background-support" type="tizen:activationType" use="optional"/> <!-- default: enable -->
+            <xs:attribute name="encryption" type="tizen:activationType" use="optional"/> <!-- default: disable -->
+            <xs:attribute name="install-location" type="tizen:InstallLocationType" use="optional"/>
+            <xs:attribute name="nodisplay" type="tizen:data.boolean" use="optional"/> <!-- default: false -->
+            <xs:attribute name="indicator-persence" type="tizen:data.boolean" use="optional"/>
+            <xs:attribute name="backbutton-persence" type="tizen:data.boolean" use="optional"/>
+            <xs:attribute name="user-agent" use="optional"/>
+            <xs:attribute name="hwkey-event" type="tizen:activationType" use="optional"/> <!-- default: true -->
+            <xs:attribute name="sound-mode" type="tizen:soundmodeType" use="optional"/> <!-- default: shared -->
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="app-control">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:choice maxOccurs="unbounded">
+            <xs:element ref="tizen:src"/>
+            <xs:element ref="tizen:operation"/>
+            <xs:element ref="tizen:uri"/>
+            <xs:element ref="tizen:mime"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="category">
+      <xs:complexType>
+        <xs:anyAttribute processContents="lax"/>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="src">
+        <xs:complexType>
+            <xs:attribute name="name" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="operation">
+        <xs:complexType>
+            <xs:attribute name="name" type="tizen:appserviceOperationType" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="uri">
+        <xs:complexType>
+            <xs:attribute name="name" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="mime">
+      <xs:complexType>
+        <xs:attribute name="name" use="required"/>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="privilege">
+        <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:anyURI"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="content-security-policy">
+        <xs:complexType  mixed="true">
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="content-security-policy-report-only">
+        <xs:complexType  mixed="true">
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="allow-navigation">
+        <xs:complexType  mixed="true">
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="app-widget">
+        <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:element ref="tizen:box-label" minOccurs="1" maxOccurs="unbounded"/>
+                <xs:element ref="tizen:box-icon" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="tizen:box-content" minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="id" type="tizen:appWidgetIdType" use="required"/>
+            <xs:attribute name="primary" type="tizen:data.boolean" use="required"/>
+            <xs:attribute name="auto-launch" type="tizen:data.boolean" use="optional"/>
+            <xs:attribute name="update-period" type="tizen:updatePeriodType" use="optional"/>
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="box-label">
+        <xs:complexType mixed="true">
+            <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="box-icon">
+        <xs:complexType>
+        <xs:attribute name="src" use="required" type="xs:anyURI"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="box-content">
+        <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:element ref="tizen:box-size" minOccurs="1" maxOccurs="5"/>
+                <xs:element ref="tizen:pd" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="src" use="required" type="xs:anyURI"/>
+            <xs:attribute name="mouse-event" use="optional" type="tizen:data.boolean"/>
+            <xs:attribute name="touch-effect" use="optional" type="tizen:data.boolean"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="pd">
+        <xs:complexType>
+            <xs:attribute name="src" use="required" type="xs:anyURI"/>
+            <xs:attribute name="width" use="required" type="xs:int"/>
+            <xs:attribute name="height" use="required" type="xs:int"/>
+            <xs:attribute name="fast-open" use="optional" type="tizen:data.boolean"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="box-size">
+        <xs:complexType mixed="true">
+        <xs:attribute name="preview" use="optional" type="xs:anyURI"/>
+        <xs:attribute name="use-decoration" use="optional" type="tizen:data.boolean"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="InstallLocationType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="auto"/>
+            <xs:enumeration value="internal-only"/>
+            <xs:enumeration value="prefer-external"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="capability">
+        <xs:complexType mixed="true">
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="account">
+        <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:choice maxOccurs="unbounded">
+                    <xs:element ref="tizen:icon" />
+                    <xs:element ref="tizen:display-name" />
+                    <xs:element ref="tizen:capability" />
+                </xs:choice>
+            </xs:sequence>
+        <xs:attribute name="multiple-account-support" use="required" type="tizen:data.boolean"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="icon">
+      <xs:complexType mixed="true">
+        <xs:attribute name="section" use="required" type="xs:string"/>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="display-name">
+      <xs:complexType mixed="true">
+        <xs:attribute ref="xml:lang"/>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="metadata">
+        <xs:complexType>
+            <xs:attribute name="key" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="splash">
+        <xs:complexType>
+            <xs:attribute name="src" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/application/common/installer/tizen/configuration/widgets.xsd
+++ b/application/common/installer/tizen/configuration/widgets.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  RELAX NG Schema for the Widgets Family of Specifications
+  
+  This document is non-normative.
+  
+  The following is a RELAX NG schema representation of the elements,
+  and attributes, that can be used in a widget's configuration document.
+  
+  A conformance checker may use the RELAX NG for the configuration document to validate
+  elements and attributes of a configuration document within the limits of the RELAX NG
+  specification.
+  
+  Authors: David Håsäther, Marcos Cáceres, Robin Berjon
+  Contact: public-webapps@w3.org if you find any errors or have any questions
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/ns/widgets" xmlns:widgets="http://www.w3.org/ns/widgets">
+    <xs:include schemaLocation="packaging-configuration.xsd"/>
+    <xs:import schemaLocation="common.xsd"/>
+</xs:schema>

--- a/application/common/installer/tizen/configuration/xml.xsd
+++ b/application/common/installer/tizen/configuration/xml.xsd
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:widgets="http://www.w3.org/ns/widgets" xmlns:its="http://www.w3.org/2005/11/its"  targetNamespace="http://www.w3.org/XML/1998/namespace" elementFormDefault="qualified">
+    <xs:attribute name="lang" type="xs:language"/>
+</xs:schema>


### PR DESCRIPTION
Because crosswalk has replaced WRT in Tizen common image, some metadata file which provided by wrt-installer package are missed. These files are xml schema file, which is used to verify xml in widget matching Tizen
requirements. For example, widgets.tizen.xsd and widgets.xsd  are use to verify config.xml in widget is valid config.xml which should match http://www.w3.org/TR/widgets/. if the widget is not valid widget, crosswalk shouldn’t install them in Tizen platform.
