### PR TITLE
[Android] Re-enable NativeFileSystem instrumentation test

### DIFF
--- a/runtime/renderer/isolated_file_system.cc
+++ b/runtime/renderer/isolated_file_system.cc
@@ -52,15 +52,22 @@ void IsolatedFileSystem::GetIsolatedFileSystem(
   CHECK(data_source);
   GURL context_url(data_source->request().url());
 
-  std::string name(fileapi::GetIsolatedFileSystemName(context_url.GetOrigin(),
-                                                      file_system_id));
+  // In instrument test, context_url.GetOrigin() returns emtpy string.
+  // That causes app crash. So assign "file:///" as default value to
+  // origin to avoid this.
+  GURL origin("file:///");
+  if (!context_url.SchemeIs(url::kDataScheme) &&
+      !context_url.GetOrigin().is_empty()) {
+    origin = context_url.GetOrigin();
+  }
+  std::string name(fileapi::GetIsolatedFileSystemName(origin, file_system_id));
 
   // The optional second argument is the subfolder within the isolated file
   // system at which to root the DOMFileSystem we're returning to the caller.
   std::string optional_root_name = "";
 
   blink::WebURL root(GURL(fileapi::GetIsolatedFileSystemRootURIString(
-      context_url.GetOrigin(),
+      origin,
       file_system_id,
       optional_root_name)));
   v8::Isolate* isolate = v8::Isolate::GetCurrent();

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/NativeFileSystemTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/NativeFileSystemTest.java
@@ -16,7 +16,6 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
 public class NativeFileSystemTest extends XWalkRuntimeClientTestBase {
     // @SmallTest
     // @Feature({"NativeFileSystem"})
-    @DisabledTest
     public void testNativeFileSystem() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/NativeFileSystemTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/NativeFileSystemTest.java
@@ -16,7 +16,6 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
 public class NativeFileSystemTest extends XWalkRuntimeClientTestBase {
     // @SmallTest
     // @Feature({"NativeFileSystem"})
-    @DisabledTest
     public void testNativeFileSystem() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(


### PR DESCRIPTION
Root cause:
Instrument test loads test page as "Data URI scheme". Such type of URI
dosen't have URL origin. An empty URL origin will cause crash.

Fix:
Give a default value, "file:///", to URL origin to avoid crash.

Related to XWALK-99
