### PR TITLE
[Android] The LaunchScreen dialog follows the activity window flags

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkLaunchScreenManager.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkLaunchScreenManager.java
@@ -105,12 +105,12 @@ public class XWalkLaunchScreenManager
 
                 mLaunchScreenDialog = new Dialog(mLibContext,
                                                  android.R.style.Theme_Holo_Light_NoActionBar);
-                if ((mActivity.getWindow().getAttributes().flags &
-                     WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
-                    mLaunchScreenDialog.getWindow().setFlags(
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                }
+
+                int parentVisibility = mActivity.getWindow().getDecorView().getSystemUiVisibility();
+                WindowManager.LayoutParams parentParams = mActivity.getWindow().getAttributes();
+                mLaunchScreenDialog.getWindow().getDecorView().setSystemUiVisibility(parentVisibility);
+                mLaunchScreenDialog.getWindow().setAttributes(parentParams);
+
                 mLaunchScreenDialog.setOnKeyListener(new Dialog.OnKeyListener() {
                     @Override
                     public boolean onKey(DialogInterface arg0, int keyCode,


### PR DESCRIPTION
Instead of check whether the activity is in fullscreen mode, just follow the activity window flags.

BUG=XWALK-2294
