### PR TITLE
[Tizen][Runtime] Change to initialize access whitelist when webkit has been initialized.

### DIFF
--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -155,10 +155,6 @@ void XWalkContentRendererClient::DidCreateScriptContext(
     int extension_group, int world_id) {
   if (extension_controller_)
     extension_controller_->DidCreateScriptContext(frame, context);
-#if !defined(OS_ANDROID)
-  xwalk_render_process_observer_->DidCreateScriptContext(
-      frame, context, extension_group, world_id);
-#endif
 }
 
 void XWalkContentRendererClient::DidCreateModuleSystem(

--- a/runtime/renderer/xwalk_render_process_observer_generic.cc
+++ b/runtime/renderer/xwalk_render_process_observer_generic.cc
@@ -63,20 +63,15 @@ bool XWalkRenderProcessObserver::OnControlMessageReceived(
 
 void XWalkRenderProcessObserver::WebKitInitialized() {
   is_webkit_initialized_ = true;
-}
-
-void XWalkRenderProcessObserver::OnRenderProcessShutdown() {
-  is_webkit_initialized_ = false;
-}
-
-void XWalkRenderProcessObserver::DidCreateScriptContext(
-    blink::WebFrame* frame, v8::Handle<v8::Context> context,
-    int extension_group, int world_id) {
   for (std::vector<AccessWhitelistItem>::iterator it = access_whitelist.begin();
        it != access_whitelist.end(); ++it)
     AddAccessWhiteListEntry(it->source_, it->dest_, it->allow_subdomains_);
 
   access_whitelist.clear();
+}
+
+void XWalkRenderProcessObserver::OnRenderProcessShutdown() {
+  is_webkit_initialized_ = false;
 }
 
 void XWalkRenderProcessObserver::OnSetAccessWhiteList(const GURL& source,

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -28,10 +28,6 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   XWalkRenderProcessObserver();
   virtual ~XWalkRenderProcessObserver();
 
-  void DidCreateScriptContext(
-      blink::WebFrame* frame,  v8::Handle<v8::Context> context,
-      int extension_group, int world_id);
-
   // content::RenderProcessObserver implementation.
   virtual bool OnControlMessageReceived(const IPC::Message& message) OVERRIDE;
   virtual void WebKitInitialized() OVERRIDE;


### PR DESCRIPTION
After rebase to M37, in some conditions, there's no need to create javascript
context, so it's not a right place to init the access whitelist. This patch
will change to do it after webkit engine initialized.

BUG=XWALK-2295
