### PR TITLE
[Android][REG] Packaging tool does not work with python 3.0+

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -63,7 +63,7 @@ def RunCommand(command, verbose=False, shell=False):
       print ('Command "%s" exited with non-zero exit code %d'
              % (' '.join(command), result))
       sys.exit(result)
-    return output
+    return output.decode("utf-8")
 
 
 def Which(name):
@@ -84,7 +84,7 @@ def GetAndroidApiLevel():
   """
   target_output = RunCommand(['android', 'list', 'target', '-c'])
   target_regex = re.compile(r'android-(\d+)')
-  targets = map(int, target_regex.findall(target_output))
+  targets = [int(i) for i in target_regex.findall(target_output)]
   targets.extend([-1])
   return max(targets)
 


### PR DESCRIPTION
1. command output is a bytes-like object in python3.0+,
   re.findall can't use a string pattern on a bytes-like object,
   encode the bytes-like object to str to fix that.
2. map function will return a map object in python3.0+,
   'map' object has no attribute 'extend',
   not use map function to fix that.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2303
