### PR TITLE
[Android] Clear FLAG_FORCE_NOT_FULLSCREEN for all devices not only for KitKat

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -136,6 +136,14 @@ public class XWalkUIClientInternal {
     public void onFullscreenToggled(XWalkViewInternal view, boolean enterFullscreen) {
         Activity activity = view.getActivity();
         if (enterFullscreen) {
+            if ((activity.getWindow().getAttributes().flags &
+                    WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN) != 0) {
+                mOriginalForceNotFullscreen = true;
+                activity.getWindow().clearFlags(
+                        WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+            } else {
+                mOriginalForceNotFullscreen = false;
+            }
             if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
                 mSystemUiFlag = mDecorView.getSystemUiVisibility();
                 mDecorView.setSystemUiVisibility(
@@ -145,14 +153,6 @@ public class XWalkUIClientInternal {
                         View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
                         View.SYSTEM_UI_FLAG_FULLSCREEN |
                         View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-                if ((activity.getWindow().getAttributes().flags &
-                        WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN) != 0) {
-                    mOriginalForceNotFullscreen = true;
-                    activity.getWindow().clearFlags(
-                            WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                } else {
-                    mOriginalForceNotFullscreen = false;
-                }
             } else {
                 if ((activity.getWindow().getAttributes().flags &
                         WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
@@ -163,12 +163,12 @@ public class XWalkUIClientInternal {
                 }
             }
         } else {
+            if (mOriginalForceNotFullscreen) {
+                activity.getWindow().addFlags(
+                        WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+            }
             if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
                 mDecorView.setSystemUiVisibility(mSystemUiFlag);
-                if (mOriginalForceNotFullscreen) {
-                    activity.getWindow().addFlags(
-                            WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                }
             } else {
                 // Clear the activity fullscreen flag.
                 if (!mOriginalFullscreen) {


### PR DESCRIPTION
FORCE_NOT_FULLSCREEN_FLAG is prior to FULLSCREEN_FLAG on some devices,
Record whether the FLAG_FORCE_NOT_FULLSCREEN is set before entering
fullscreen and clear it if so. Add the flag back if necessary when
exiting fullscreen.

Previous commit a00f56e
is not covering device prior to KitKat, this commit cover all devices.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2150
