### PR TITLE
[Android] Clear FLAG_FORCE_NOT_FULLSCREEN for all devices not only for K...

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUIClient.java
@@ -130,6 +130,14 @@ public class XWalkUIClient {
     public void onFullscreenToggled(XWalkView view, boolean enterFullscreen) {
         Activity activity = view.getActivity();
         if (enterFullscreen) {
+            if ((activity.getWindow().getAttributes().flags &
+                    WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN) != 0) {
+                mOriginalForceNotFullscreen = true;
+                activity.getWindow().clearFlags(
+                        WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+            } else {
+                mOriginalForceNotFullscreen = false;
+            }
             if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
                 mSystemUiFlag = mDecorView.getSystemUiVisibility();
                 mDecorView.setSystemUiVisibility(
@@ -139,14 +147,6 @@ public class XWalkUIClient {
                         View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
                         View.SYSTEM_UI_FLAG_FULLSCREEN |
                         View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-                if ((activity.getWindow().getAttributes().flags &
-                        WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN) != 0) {
-                    mOriginalForceNotFullscreen = true;
-                    activity.getWindow().clearFlags(
-                            WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                } else {
-                    mOriginalForceNotFullscreen = false;
-                }
             } else {
                 if ((activity.getWindow().getAttributes().flags &
                         WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
@@ -157,12 +157,12 @@ public class XWalkUIClient {
                 }
             }
         } else {
+            if (mOriginalForceNotFullscreen) {
+                activity.getWindow().addFlags(
+                        WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+            }
             if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
                 mDecorView.setSystemUiVisibility(mSystemUiFlag);
-                if (mOriginalForceNotFullscreen) {
-                    activity.getWindow().addFlags(
-                            WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                }
             } else {
                 // Clear the activity fullscreen flag.
                 if (!mOriginalFullscreen) {


### PR DESCRIPTION
...itKat

FORCE_NOT_FULLSCREEN_FLAG is prior to FULLSCREEN_FLAG on some devices,
Record whether the FLAG_FORCE_NOT_FULLSCREEN is set before entering
fullscreen and clear it if so. Add the flag back if necessary when
exiting fullscreen.

Previous commit 197e872a89af18326557b92eba39f7662d706712
is not covering device prior to KitKat, this commit cover all devices.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2336
(cherry picked from commit 99269dbaf8e2a83b031d34efe849d78f581e2dfc)
