### PR TITLE
DEPS.xwalk: Roll v8-crosswalk (11af067 -> 8ddfc6f).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -19,7 +19,7 @@
 
 chromium_crosswalk_rev = 'f506465773c4515957798e38250a3a7becb2bea6'
 blink_crosswalk_rev = 'db2fa6ff036de0611105c872817b487f0a88dd94'
-v8_crosswalk_rev = '11af0678615217b5dce34e7e7d6a3257a2918ca4'
+v8_crosswalk_rev = '8ddfc6f1a103ddbe20e38afeb12c3e0666c8a361'
 ozone_wayland_rev = '3372a0e23d925d5402eb16abbbe58dd82b583a5a'
 
 crosswalk_git = 'https://github.com/crosswalk-project'


### PR DESCRIPTION
8ddfc6f Merge pull request #46 from huningxin/fix-context-load
c5c44ed Temporarily disable Distributivity1 test in M37 to pass x64 trybot
5aa07fb Fix invalid native context reference in simd128-tag

BUG=XWALK-2255
