### PR TITLE
[Tizen] xwalk-launcher add an option "-d" to enable/disable remote debugging mode.

### DIFF
--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -11,6 +11,7 @@
 
 #include "xwalk/application/browser/linux/running_application_object.h"
 #include "xwalk/application/common/application_data.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 namespace {
 
@@ -59,6 +60,13 @@ RunningApplicationsManager::RunningApplicationsManager(
   application_service_->AddObserver(this);
 
   adaptor_.manager_object()->ExportMethod(
+      kRunningManagerDBusInterface, "EnableRemoteDebugging",
+      base::Bind(&RunningApplicationsManager::OnEnableRemoteDebugging,
+                 weak_factory_.GetWeakPtr()),
+      base::Bind(&RunningApplicationsManager::OnExported,
+                 weak_factory_.GetWeakPtr()));
+
+  adaptor_.manager_object()->ExportMethod(
       kRunningManagerDBusInterface, "Launch",
       base::Bind(&RunningApplicationsManager::OnLaunch,
                  weak_factory_.GetWeakPtr()),
@@ -94,6 +102,33 @@ scoped_ptr<dbus::Response> CreateError(dbus::MethodCall* method_call,
 }
 
 }  // namespace
+
+void RunningApplicationsManager::OnEnableRemoteDebugging(
+    dbus::MethodCall* method_call,
+    dbus::ExportedObject::ResponseSender response_sender) {
+  dbus::MessageReader reader(method_call);
+  unsigned int debugging_port;
+
+  if (!reader.PopUint32(&debugging_port)) {
+    scoped_ptr<dbus::Response> response =
+        CreateError(method_call,
+                    "Error parsing message. Missing arguments.");
+    response_sender.Run(response.Pass());
+    return;
+  }
+
+  if (debugging_port != 0) {
+    XWalkRunner::GetInstance()->EnableRemoteDebugging(true, debugging_port);
+  } else {
+    XWalkRunner::GetInstance()->EnableRemoteDebugging(false);
+  }
+
+  scoped_ptr<dbus::Response> response =
+      dbus::Response::FromMethodCall(method_call);
+  dbus::MessageWriter writer(response.get());
+  writer.AppendUint32(debugging_port);
+  response_sender.Run(response.Pass());
+}
 
 void RunningApplicationsManager::OnLaunch(
     dbus::MethodCall* method_call,

--- a/application/browser/linux/running_applications_manager.h
+++ b/application/browser/linux/running_applications_manager.h
@@ -46,6 +46,9 @@ class RunningApplicationsManager : public ApplicationService::Observer {
                   const std::string& method_name,
                   bool success);
 
+  void OnEnableRemoteDebugging(dbus::MethodCall* method_call,
+                               dbus::ExportedObject::ResponseSender sender);
+
   void virtual WillDestroyApplication(Application* app) OVERRIDE;
 
   dbus::ObjectPath AddObject(const std::string& app_id,

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -4,6 +4,7 @@
 
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 
+#include <string>
 #include "base/file_util.h"
 #include "base/files/file_path.h"
 #include "content/public/browser/render_process_host.h"
@@ -12,6 +13,7 @@
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
+#include "xwalk/runtime/browser/devtools/remote_debugging_server.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "ui/gl/gl_switches.h"
@@ -57,6 +59,19 @@ void XWalkBrowserMainPartsTizen::PreMainMessageLoopRun() {
   }
 
   XWalkBrowserMainParts::PreMainMessageLoopRun();
+}
+
+void XWalkBrowserMainPartsTizen::EnableRemoteDebugging(bool enable, int port) {
+  if (enable) {
+    const char* local_ip = "0.0.0.0";
+    if (port > 0 && port < 65535) {
+      remote_debugging_server_.reset(
+          new RemoteDebuggingServer(xwalk_runner_->runtime_context(),
+              local_ip, port, std::string()));
+    }
+  } else {
+    remote_debugging_server_.reset();
+  }
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts_tizen.h
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.h
@@ -20,6 +20,8 @@ class XWalkBrowserMainPartsTizen : public XWalkBrowserMainParts {
   virtual void PreMainMessageLoopStart() OVERRIDE;
   virtual void PreMainMessageLoopRun() OVERRIDE;
 
+  void EnableRemoteDebugging(bool enable, int port);
+
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkBrowserMainPartsTizen);
 };

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -19,6 +19,7 @@
 #include "xwalk/runtime/browser/sysapps_component.h"
 #include "xwalk/runtime/browser/xwalk_app_extension_bridge.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
+#include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 #include "xwalk/runtime/browser/xwalk_component.h"
 #include "xwalk/runtime/browser/xwalk_content_browser_client.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
@@ -167,6 +168,14 @@ void XWalkRunner::OnRenderProcessHostGone(content::RenderProcessHost* host) {
   if (!extension_service_)
     return;
   extension_service_->OnRenderProcessDied(host);
+}
+
+void XWalkRunner::EnableRemoteDebugging(bool enable, int port) {
+  XWalkBrowserMainPartsTizen* main_parts_tizen =
+      static_cast<XWalkBrowserMainPartsTizen*> (
+          content_browser_client_->main_parts());
+  if (main_parts_tizen)
+    main_parts_tizen->EnableRemoteDebugging(enable, port);
 }
 
 // static

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -77,6 +77,8 @@ class XWalkRunner {
   virtual void PreMainMessageLoopRun();
   virtual void PostMainMessageLoopRun();
 
+  void EnableRemoteDebugging(bool enable, int port = 0);
+
  protected:
   XWalkRunner();
 


### PR DESCRIPTION
Use "xwalkctl -d PORT_NUMBER" to dynamically control remote debugging mode
and not require re-launch xwalk service.

Usage:
  -d, --debugging_port     Enable remote debugging, port number 0 means to disable

Example:
app:~> xwalkctl --debugging_port 9222
Remote debugging enabled at port '9222'
app:~> xwalkctl -d 0
Remote debugging has been disabled

BUG=https://crosswalk-project.org/jira/browse/XWALK-2058
