### PR TITLE
[Android] Unregister broadcast receiver for notification properly

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNotificationServiceImpl.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNotificationServiceImpl.java
@@ -84,7 +84,9 @@ public class XWalkNotificationServiceImpl implements XWalkNotificationService {
 
     @Override
     public void shutdown() {
-        unregisterReceiver();
+        if (!mExistNotificationIds.isEmpty()) {
+            unregisterReceiver();
+        }
         mBridge = null;
     }
 
@@ -257,6 +259,7 @@ public class XWalkNotificationServiceImpl implements XWalkNotificationService {
         if (mExistNotificationIds.isEmpty()) {
             Log.i(TAG, "notifications are all cleared," +
                     "unregister broadcast receiver for close pending intent");
+            unregisterReceiver();
         } else {
             registerReceiver();
         }
@@ -275,15 +278,11 @@ public class XWalkNotificationServiceImpl implements XWalkNotificationService {
         } catch (AndroidRuntimeException e) {
             //FIXME(wang16): The exception will happen when there are multiple xwalkviews in one activity.
             //               Remove it after notification service supports multi-views.
-            mNotificationCloseReceiver = null;
             Log.w(TAG, e.getLocalizedMessage());
         }
     }
 
     private void unregisterReceiver() {
-        if (mNotificationCloseReceiver != null) {
-            mView.getActivity().unregisterReceiver(mNotificationCloseReceiver);
-            mNotificationCloseReceiver = null;
-        }
+        mView.getActivity().unregisterReceiver(mNotificationCloseReceiver);
     }
 }


### PR DESCRIPTION
Unregister non-regsitered broadcast receiver will cause
crash on Android. The condition to detect whether the broadcast
receiver has been registered to receive Notification close
pending intent is change by commit eeeb8eeab.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2356
