### PR TITLE
[REG] Fixed regression error that NaCl module failed to load

### DIFF
--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -74,11 +74,10 @@ int XWalkMainDelegate::RunProcess(const std::string& process_type,
 }
 
 #if defined(OS_POSIX) && !defined(OS_ANDROID)
-content::ZygoteForkDelegate* XWalkMainDelegate::ZygoteStarting() {
-#if defined(DISABLE_NACL)
-  return NULL;
-#else
-  return new nacl::NaClForkDelegate(true);
+void XWalkMainDelegate::ZygoteStarting(
+    ScopedVector<content::ZygoteForkDelegate>* delegates) {
+#if !defined(DISABLE_NACL)
+  nacl::AddNaClZygoteForkDelegates(delegates);
 #endif
 }
 

--- a/runtime/app/xwalk_main_delegate.h
+++ b/runtime/app/xwalk_main_delegate.h
@@ -27,7 +27,8 @@ class XWalkMainDelegate : public content::ContentMainDelegate {
   virtual int RunProcess(const std::string& process_type,
       const content::MainFunctionParams& main_function_params) OVERRIDE;
 #if defined(OS_POSIX) && !defined(OS_ANDROID)
-  virtual content::ZygoteForkDelegate* ZygoteStarting();
+  virtual void ZygoteStarting(
+      ScopedVector<content::ZygoteForkDelegate>* delegates) OVERRIDE;
 #endif
   virtual content::ContentBrowserClient* CreateContentBrowserClient() OVERRIDE;
   virtual content::ContentRendererClient*

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -47,6 +47,10 @@
 #include "xwalk/runtime/renderer/tizen/xwalk_render_view_ext_tizen.h"
 #endif
 
+#if !defined(DISABLE_NACL)
+#include "components/nacl/renderer/nacl_helper.h"
+#endif
+
 namespace xwalk {
 
 namespace {
@@ -138,6 +142,10 @@ void XWalkContentRendererClient::RenderFrameCreated(
 
 #if defined(ENABLE_PLUGINS)
   new PepperHelper(render_frame);
+#endif
+
+#if !defined(DISABLE_NACL)
+  new nacl::NaClHelper(render_frame);
 #endif
 }
 

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -405,6 +405,7 @@
                     '../components/nacl.gyp:nacl_common',
                     '../components/nacl.gyp:nacl_renderer',
                     '../components/nacl.gyp:nacl_helper',
+                    '../components/nacl.gyp:nacl_linux',
                     '../native_client/src/trusted/service_runtime/linux/nacl_bootstrap.gyp:nacl_helper_bootstrap',
                   ],
                 }],


### PR DESCRIPTION
When rolling Chromium to version 37.0.2062.76, the interface
content::ContentMainDelegate::ZygoteStarting has been changed,
which makes it fails to call the old implementation in
xwalk::XWalkMainDelegate. implemented it as indicated by chrome.

Also according to patch 1d7be68, nacl::NaClHelper is introduced
with the refactor of MessageChannel to control the in-process
and out-of-process message queue behavior, which should be created
inside xwalk::XWalkContentRendererClient::RenderFrameCreated when
NaCl is enabled.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2297
