### PR TITLE
enable xdg for next crosswalk rebase

### DIFF
--- a/packaging/xwalk.service.in
+++ b/packaging/xwalk.service.in
@@ -4,4 +4,5 @@ Description=Crosswalk
 [Service]
 Type=dbus
 BusName=org.crosswalkproject.Runtime1
+Environment=OZONE_WAYLAND_USE_XDG_SHELL='defined'
 ExecStart=@LIB_INSTALL_DIR@/xwalk/xwalk --external-extensions-path=@LIB_INSTALL_DIR@/tizen-extensions-crosswalk


### PR DESCRIPTION
I see that it xdg-shell is building again :

https://github.com/yejingfu/crosswalk/commit/1559b1a49c58e5280746c3e52831aea9cd1d177f

But this is not enough ... those 2 commits will be needed to enable xdg for next crosswalk rebase

Note this changeset is untested now , I just PR it to let you know

find me online if needed
