### PR TITLE
[Tizen] Implement "xwalkctl -d PORT_NUMBER" to dynamically enable remote debugging mode

### DIFF
--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -11,6 +11,7 @@
 
 #include "xwalk/application/browser/linux/running_application_object.h"
 #include "xwalk/application/common/application_data.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 
 namespace {
 
@@ -59,6 +60,13 @@ RunningApplicationsManager::RunningApplicationsManager(
   application_service_->AddObserver(this);
 
   adaptor_.manager_object()->ExportMethod(
+      kRunningManagerDBusInterface, "EnableRemoteDebugging",
+      base::Bind(&RunningApplicationsManager::OnRemoteDebuggingEnabled,
+                 weak_factory_.GetWeakPtr()),
+      base::Bind(&RunningApplicationsManager::OnExported,
+                 weak_factory_.GetWeakPtr()));
+
+  adaptor_.manager_object()->ExportMethod(
       kRunningManagerDBusInterface, "Launch",
       base::Bind(&RunningApplicationsManager::OnLaunch,
                  weak_factory_.GetWeakPtr()),
@@ -94,6 +102,33 @@ scoped_ptr<dbus::Response> CreateError(dbus::MethodCall* method_call,
 }
 
 }  // namespace
+
+void RunningApplicationsManager::OnRemoteDebuggingEnabled(
+    dbus::MethodCall* method_call,
+    dbus::ExportedObject::ResponseSender response_sender) {
+  dbus::MessageReader reader(method_call);
+  unsigned int debugging_port;
+
+  if (!reader.PopUint32(&debugging_port)) {
+    scoped_ptr<dbus::Response> response =
+        CreateError(method_call,
+                    "Error parsing message. Missing arguments.");
+    response_sender.Run(response.Pass());
+    return;
+  }
+
+  if (debugging_port != 0) {
+    XWalkRunner::GetInstance()->EnableRemoteDebugging(debugging_port);
+  } else {
+    XWalkRunner::GetInstance()->DisableRemoteDebugging();
+  }
+
+  scoped_ptr<dbus::Response> response =
+      dbus::Response::FromMethodCall(method_call);
+  dbus::MessageWriter writer(response.get());
+  writer.AppendUint32(debugging_port);
+  response_sender.Run(response.Pass());
+}
 
 void RunningApplicationsManager::OnLaunch(
     dbus::MethodCall* method_call,

--- a/application/browser/linux/running_applications_manager.h
+++ b/application/browser/linux/running_applications_manager.h
@@ -46,6 +46,9 @@ class RunningApplicationsManager : public ApplicationService::Observer {
                   const std::string& method_name,
                   bool success);
 
+  void OnRemoteDebuggingEnabled(dbus::MethodCall* method_call,
+                                dbus::ExportedObject::ResponseSender sender);
+
   void virtual WillDestroyApplication(Application* app) OVERRIDE;
 
   dbus::ObjectPath AddObject(const std::string& app_id,

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -29,7 +29,6 @@
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
-#include "xwalk/runtime/browser/devtools/remote_debugging_server.h"
 #include "xwalk/runtime/browser/nacl_host/nacl_browser_delegate_impl.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_context.h"
@@ -204,12 +203,8 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     std::string port_str =
         command_line->GetSwitchValueASCII(switches::kRemoteDebuggingPort);
     int port;
-    const char* local_ip = "0.0.0.0";
-    if (base::StringToInt(port_str, &port) && port > 0 && port < 65535) {
-      remote_debugging_server_.reset(
-          new RemoteDebuggingServer(xwalk_runner_->runtime_context(),
-              local_ip, port, std::string()));
-    }
+    base::StringToInt(port_str, &port);
+    xwalk_runner_->EnableRemoteDebugging(port);
   }
 
   NativeAppWindow::Initialize();

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -22,7 +22,6 @@ class RenderProcessHost;
 
 namespace xwalk {
 
-class RemoteDebuggingServer;
 class XWalkRunner;
 
 namespace extensions {
@@ -70,9 +69,6 @@ class XWalkBrowserMainParts : public content::BrowserMainParts {
 
   // True if we need to run the default message loop defined in content.
   bool run_default_message_loop_;
-
-  // Remote debugger server.
-  scoped_ptr<RemoteDebuggingServer> remote_debugging_server_;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkBrowserMainParts);

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -4,6 +4,7 @@
 
 #include "xwalk/runtime/browser/xwalk_runner.h"
 
+#include <string>
 #include <vector>
 #include "base/command_line.h"
 #include "base/logging.h"
@@ -14,6 +15,7 @@
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/runtime/browser/application_component.h"
+#include "xwalk/runtime/browser/devtools/remote_debugging_server.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/storage_component.h"
 #include "xwalk/runtime/browser/sysapps_component.h"
@@ -83,6 +85,7 @@ void XWalkRunner::PostMainMessageLoopRun() {
   DestroyComponents();
   extension_service_.reset();
   runtime_context_.reset();
+  DisableRemoteDebugging();
 }
 
 void XWalkRunner::CreateComponents() {
@@ -167,6 +170,19 @@ void XWalkRunner::OnRenderProcessHostGone(content::RenderProcessHost* host) {
   if (!extension_service_)
     return;
   extension_service_->OnRenderProcessDied(host);
+}
+
+void XWalkRunner::EnableRemoteDebugging(int port) {
+  const char* local_ip = "0.0.0.0";
+  if (port > 0 && port < 65535) {
+    remote_debugging_server_.reset(
+        new RemoteDebuggingServer(runtime_context(),
+            local_ip, port, std::string()));
+  }
+}
+
+void XWalkRunner::DisableRemoteDebugging() {
+  remote_debugging_server_.reset();
 }
 
 // static

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -24,6 +24,7 @@ namespace xwalk {
 
 class RuntimeContext;
 class ApplicationComponent;
+class RemoteDebuggingServer;
 class SysAppsComponent;
 class XWalkComponent;
 class XWalkContentBrowserClient;
@@ -76,6 +77,9 @@ class XWalkRunner {
   // Stages of main parts. See content/browser_main_parts.h for description.
   virtual void PreMainMessageLoopRun();
   virtual void PostMainMessageLoopRun();
+
+  void EnableRemoteDebugging(int port);
+  void DisableRemoteDebugging();
 
  protected:
   XWalkRunner();
@@ -131,6 +135,9 @@ class XWalkRunner {
   ScopedVector<XWalkComponent> components_;
 
   ApplicationComponent* app_component_;
+
+  // Remote debugger server.
+  scoped_ptr<RemoteDebuggingServer> remote_debugging_server_;
 
   // These variables are used to export some values from the browser process
   // side to the extension side, such as application IDs and whatnot.


### PR DESCRIPTION
With this patch, to enable remote debugging, we don't need to modify the
configure file "/usr/lib/systemd/user/xwalk.service" and restart the xwalk
service anymore.

Usage:
  xwalkctl -d 9222     #enabled remote debugging at port '9222'
  xwalkctl -d 0        #disable remote debugging

Explanation of code:
In "RunningApplicationsManager", add a interface "OnEnableRemoteDebugging" to receive DBus remote-call from "xwalkctl_main.cc". 
The  "RunningApplicationsManager::OnEnableRemoteDebugging" invokes "XWalkBrowserMainPartsTizen::EnableRemoteDebugging" finally. 

BUG=https://crosswalk-project.org/jira/browse/XWALK-2058
