### PR TITLE
[Tizen] Add an option for "xwalk-launcher" to enalbe remote debugging only for single applictaion

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -58,6 +58,7 @@ Application::Application(
       runtime_context_(runtime_context),
       observer_(observer),
       entry_point_used_(Default),
+      remote_debugging_enabled_(false),
       weak_factory_(this) {
   DCHECK(runtime_context_);
   DCHECK(data_.get());
@@ -82,6 +83,8 @@ bool Application::Launch(const LaunchParams& launch_params) {
   GURL url = GetStartURL(launch_params, &entry_point_used_);
   if (!url.is_valid())
     return false;
+
+  remote_debugging_enabled_ = launch_params.remote_debugging;
 
   Runtime* runtime = Runtime::Create(
       runtime_context_,
@@ -226,6 +229,7 @@ int Application::GetRenderProcessHostID() const {
 
 void Application::OnRuntimeAdded(Runtime* runtime) {
   DCHECK(runtime);
+  runtime->set_remote_debugging_enabled(remote_debugging_enabled_);
   runtimes_.insert(runtime);
 }
 

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -71,7 +71,8 @@ class Application : public Runtime::Observer,
     LaunchParams() :
         entry_points(Default),
         launcher_pid(0),
-        force_fullscreen(false) {}
+        force_fullscreen(false),
+        remote_debugging(false) {}
 
     LaunchEntryPoints entry_points;
 
@@ -80,6 +81,7 @@ class Application : public Runtime::Observer,
     int32 launcher_pid;
 
     bool force_fullscreen;
+    bool remote_debugging;
   };
 
   // Closes all the application's runtimes (application pages).
@@ -180,6 +182,8 @@ class Application : public Runtime::Observer,
   StoredPermissionMap permission_map_;
   // Security policy.
   scoped_ptr<SecurityPolicy> security_policy_;
+  // Remote debugging enabled or not for this Application
+  bool remote_debugging_enabled_;
   // WeakPtrFactory should be always declared the last.
   base::WeakPtrFactory<Application> weak_factory_;
   DISALLOW_COPY_AND_ASSIGN(Application);

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -8,6 +8,7 @@
 #include "base/command_line.h"
 #include "base/file_util.h"
 #include "content/public/browser/render_process_host.h"
+#include "content/public/common/content_switches.h"
 #include "net/base/filename_util.h"
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_service.h"
@@ -53,6 +54,8 @@ bool ApplicationSystem::LaunchWithCommandLineParam(
     const T& param, const base::CommandLine& cmd_line) {
   Application::LaunchParams launch_params;
   launch_params.force_fullscreen = cmd_line.HasSwitch(switches::kFullscreen);
+  launch_params.remote_debugging =
+      cmd_line.HasSwitch(switches::kRemoteDebuggingPort);
 
   return application_service_->Launch(param, launch_params);
 }
@@ -75,6 +78,8 @@ bool ApplicationSystem::LaunchWithCommandLineParam<GURL>(
   Application::LaunchParams launch_params;
   launch_params.force_fullscreen = cmd_line.HasSwitch(switches::kFullscreen);
   launch_params.entry_points = Application::StartURLKey;
+  launch_params.remote_debugging =
+      cmd_line.HasSwitch(switches::kRemoteDebuggingPort);
 
   return !!application_service_->Launch(application_data, launch_params);
 }

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -139,10 +139,12 @@ void RunningApplicationsManager::OnLaunch(
   // We might want to pass key-value pairs if have more parameters in future.
   unsigned int launcher_pid;
   bool fullscreen;
+  bool remote_debugging;
 
   if (!reader.PopString(&app_id_or_url) ||
       !reader.PopUint32(&launcher_pid) ||
-      !reader.PopBool(&fullscreen)) {
+      !reader.PopBool(&fullscreen) ||
+      !reader.PopBool(&remote_debugging)) {
     scoped_ptr<dbus::Response> response =
         CreateError(method_call,
                     "Error parsing message. Missing arguments.");
@@ -153,6 +155,7 @@ void RunningApplicationsManager::OnLaunch(
   Application::LaunchParams params;
   params.launcher_pid = launcher_pid;
   params.force_fullscreen = fullscreen;
+  params.remote_debugging = remote_debugging;
 
   Application* application;
   if (GURL(app_id_or_url).spec().empty()) {

--- a/runtime/browser/devtools/xwalk_devtools_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.cc
@@ -135,8 +135,12 @@ void XWalkDevToolsDelegate::EnumerateTargets(TargetCallback callback) {
   for (std::vector<RenderViewHost*>::iterator it = rvh_list.begin();
        it != rvh_list.end(); ++it) {
     WebContents* web_contents = WebContents::FromRenderViewHost(*it);
-    if (web_contents)
-      targets.push_back(new Target(web_contents));
+    if (web_contents) {
+      Runtime* runtime = static_cast<Runtime*>(web_contents->GetDelegate());
+      if (runtime && runtime->remote_debugging_enabled()) {
+        targets.push_back(new Target(web_contents));
+      }
+    }
   }
   callback.Run(targets);
 }

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -74,6 +74,7 @@ Runtime::Runtime(content::WebContents* web_contents, Observer* observer)
       window_(NULL),
       weak_ptr_factory_(this),
       fullscreen_options_(NO_FULLSCREEN),
+      remote_debugging_enabled_(false),
       observer_(observer) {
   web_contents_->SetDelegate(this);
   content::NotificationService::current()->Notify(

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -78,6 +78,11 @@ class Runtime : public content::WebContentsDelegate,
 
   content::RenderProcessHost* GetRenderProcessHost();
 
+  void set_remote_debugging_enabled(bool enable) {
+    remote_debugging_enabled_ = enable;
+  }
+  bool remote_debugging_enabled() const { return remote_debugging_enabled_; }
+
 #if defined(OS_TIZEN_MOBILE)
   void CloseRootWindow();
 #endif
@@ -188,6 +193,7 @@ class Runtime : public content::WebContentsDelegate,
   };
 
   unsigned int fullscreen_options_;
+  bool remote_debugging_enabled_;
 
   Observer* observer_;
 };


### PR DESCRIPTION
Usage: xwalk-launcher -d APP_ID

If the remote-debugging-mode of xwalk service is opened by command
"xwalkctl -d DEBUGGING_PORT" or in "/usr/lib/systemd/user/xwalk.service",
the application launched with "-d" will be debuggable, and other applications
are still kept un-debuggable.

Explanation of code:
When launching application, the "debuggable" status is recorded in "Runtime", and in the "XWalkDevToolsDelegate::EnumerateTargets" we can get it to decide if put the corespondent target in the list of "discovery page" of devtools. 

BUG=https://crosswalk-project.org/jira/browse/XWALK-2058
