### PR TITLE
Change the header file

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -6,13 +6,13 @@
 #define XWALK_RUNTIME_BROWSER_UI_NATIVE_APP_WINDOW_TIZEN_H_
 
 #include "base/memory/scoped_ptr.h"
-#include "content/browser/screen_orientation/screen_orientation_provider.h"
+#include "third_party/WebKit/public/platform/WebScreenOrientationLockType.h"
+#include "ui/aura/window_observer.h"
 #include "xwalk/runtime/browser/ui/screen_orientation.h"
 #include "xwalk/runtime/browser/ui/native_app_window_views.h"
 #include "xwalk/tizen/mobile/sensor/sensor_provider.h"
 #include "xwalk/tizen/mobile/ui/tizen_system_indicator_widget.h"
 #include "xwalk/tizen/mobile/ui/widget_container_view.h"
-#include "ui/aura/window_observer.h"
 
 namespace xwalk {
 


### PR DESCRIPTION
The current file doesn't use any type defined in screen_orientation_provider.h
It included it because of type blink::WebScreenOrientationLockType. So use
WebScreenOrientationLockType.h instead of screen_orientation_provider.h which
is easy to understand.
