### PR TITLE
[Android] Fix that getBridge() method will be in javadoc

### DIFF
--- a/tools/reflection_generator/wrapper_generator.py
+++ b/tools/reflection_generator/wrapper_generator.py
@@ -37,7 +37,7 @@ ${ENUM_SECTION}
     private final static String BRIDGE_CLASS = "${BRIDGE_CLASS_FULL_NAME}";
     private Object bridge;
 
-    public Object getBridge() {
+    Object getBridge() {
         return bridge;
     }
 ${CREATE_INTERNALLY_CONSTRUCORS}


### PR DESCRIPTION
getBridge() is for internal to use, should not be public.
Update the generator script.
