### PR TITLE
[Tizen][Runtime] Enable hosted app support on Tizen.

### DIFF
--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -46,6 +46,8 @@ const char kAttributePrefix[] = "@";
 const char kNamespaceKey[] = "@namespace";
 const char kTextKey[] = "#text";
 
+const char kContentKey[] = "content";
+
 const xmlChar kWidgetNodeKey[] = "widget";
 const xmlChar kNameNodeKey[] = "name";
 const xmlChar kDescriptionNodeKey[] = "description";
@@ -63,7 +65,8 @@ const char kDirRLOKey[] = "rlo";
 const char* kSingletonElements[] = {
   "allow-navigation",
   "content-security-policy-report-only",
-  "content-security-policy"
+  "content-security-policy",
+  "content"
 };
 
 inline char* ToCharPointer(void* ptr) {
@@ -206,7 +209,14 @@ bool GetPackageType(const std::string& application_id,
 bool IsSingletonElement(const std::string& name) {
   for (int i = 0; i < arraysize(kSingletonElements); ++i)
     if (kSingletonElements[i] == name)
+#if defined(OS_TIZEN)
+      // On Tizen platform, need to check namespace of 'content'
+      // element further, a content element with tizen namespace
+      // will replace the one with widget namespace.
+      return name != kContentKey;
+#else
       return true;
+#endif
   return false;
 }
 
@@ -289,6 +299,19 @@ base::DictionaryValue* LoadXMLNode(
       continue;
     } else if (IsSingletonElement(sub_node_name)) {
       continue;
+#if defined(OS_TIZEN)
+    } else if (sub_node_name == kContentKey) {
+      std::string current_namespace, new_namespace;
+      base::DictionaryValue* current_value;
+      value->GetDictionary(sub_node_name, &current_value);
+
+      current_value->GetString(kNamespaceKey, &current_namespace);
+      sub_value->GetString(kNamespaceKey, &new_namespace);
+      if (current_namespace != new_namespace &&
+          new_namespace == kTizenNamespacePrefix)
+        value->Set(sub_node_name, sub_value);
+      continue;
+#endif
     }
 
     base::Value* temp;

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -120,6 +120,7 @@ const char kTizenMetaDataNameKey[] = "@key";
 const char kTizenMetaDataValueKey[] = "@value";
 const char kTizenSplashScreenKey[] = "widget.splash-screen";
 const char kTizenSplashScreenSrcKey[] = "@src";
+const char kContentNamespace[] = "widget.content.@namespace";
 #endif
 
 }  // namespace application_widget_keys

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -100,6 +100,7 @@ namespace application_widget_keys {
   extern const char kTizenMetaDataValueKey[];
   extern const char kTizenSplashScreenKey[];
   extern const char kTizenSplashScreenSrcKey[];
+  extern const char kContentNamespace[];
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -78,6 +78,15 @@ Manifest::Manifest(SourceType source_type,
     } else if (data_->Get(keys::kLaunchLocalPathKey, NULL)) {
       type_ = TYPE_PACKAGED_APP;
     }
+#if defined(OS_TIZEN)
+  } else if (HasPath(widget_keys::kContentNamespace)) {
+    std::string ns;
+    if (data_->GetString(widget_keys::kContentNamespace, &ns) &&
+        ns == kTizenNamespacePrefix)
+      type_ = TYPE_HOSTED_APP;
+    else
+      type_ = TYPE_PACKAGED_APP;
+#endif
   }
 
   if (data_->HasKey(widget_keys::kWidgetKey) &&

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -247,7 +247,7 @@ bool XWalkContentRendererClient::WillSendRequest(blink::WebFrame* frame,
 #endif
   // if under WARP mode.
   if (url.GetOrigin() == app_url.GetOrigin() ||
-      frame->document().securityOrigin().canRequest(url)) {
+      blink::WebSecurityOrigin::create(app_url).canRequest(url)) {
     LOG(INFO) << "[PASS] " << origin_url.spec() << " request " << url.spec();
     return false;
   }


### PR DESCRIPTION
On Tizen, a web application use `<tizen:content>` to set entry page will be recognized as hosted app, and will cover the element `<content>` without  tizen namespace.This patch will enable this feature in Crosswalk
runtime.

BUG=XWALK-1492
