### PR TITLE
Gardening M38: Contents client now needs to own NotificationDelegate

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -597,16 +597,14 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @CalledByNative
     private void showNotification(String title, String message, String replaceId,
-            int notificationId, long delegate) {
-        // FIXME(wang16): use replaceId to replace exist notification. It happens when
-        //                a notification with same name and tag fires.
+            int notificationId) {
         mNotificationService.showNotification(
-                title, message, replaceId, notificationId, delegate);
+                title, message, replaceId, notificationId);
     }
 
     @CalledByNative
-    private void cancelNotification(int notificationId, long delegate) {
-        mNotificationService.cancelNotification(notificationId, delegate);
+    private void cancelNotification(int notificationId) {
+        mNotificationService.cancelNotification(notificationId);
     }
 
     void confirmJsResult(int id, String prompt) {
@@ -624,24 +622,24 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         nativeExitFullscreen(mNativeContentsClientBridge, nativeWebContents);
     }
 
-    public void notificationDisplayed(long delegate) {
+    public void notificationDisplayed(int id) {
         if (mNativeContentsClientBridge == 0) return;
-        nativeNotificationDisplayed(mNativeContentsClientBridge, delegate);
+        nativeNotificationDisplayed(mNativeContentsClientBridge, id);
     }
 
-    public void notificationError(long delegate) {
+    public void notificationError(int id) {
         if (mNativeContentsClientBridge == 0) return;
-        nativeNotificationError(mNativeContentsClientBridge, delegate);
+        nativeNotificationError(mNativeContentsClientBridge, id);
     }
 
-    public void notificationClicked(int id, long delegate) {
+    public void notificationClicked(int id) {
         if (mNativeContentsClientBridge == 0) return;
-        nativeNotificationClicked(mNativeContentsClientBridge, id, delegate);
+        nativeNotificationClicked(mNativeContentsClientBridge, id);
     }
 
-    public void notificationClosed(int id, boolean byUser, long delegate) {
+    public void notificationClosed(int id, boolean byUser) {
         if (mNativeContentsClientBridge == 0) return;
-        nativeNotificationClosed(mNativeContentsClientBridge, id, byUser, delegate);
+        nativeNotificationClosed(mNativeContentsClientBridge, id, byUser);
     }
 
     void setDownloadListener(DownloadListener listener) {
@@ -681,10 +679,10 @@ class XWalkContentsClientBridge extends XWalkContentsClient
             String prompt);
     private native void nativeCancelJsResult(long nativeXWalkContentsClientBridge, int id);
     private native void nativeExitFullscreen(long nativeXWalkContentsClientBridge, long nativeWebContents);
-    private native void nativeNotificationDisplayed(long nativeXWalkContentsClientBridge, long delegate);
-    private native void nativeNotificationError(long nativeXWalkContentsClientBridge, long delegate);
-    private native void nativeNotificationClicked(long nativeXWalkContentsClientBridge, int id, long delegate);
-    private native void nativeNotificationClosed(long nativeXWalkContentsClientBridge, int id, boolean byUser, long delegate);
+    private native void nativeNotificationDisplayed(long nativeXWalkContentsClientBridge, int id);
+    private native void nativeNotificationError(long nativeXWalkContentsClientBridge, int id);
+    private native void nativeNotificationClicked(long nativeXWalkContentsClientBridge, int id);
+    private native void nativeNotificationClosed(long nativeXWalkContentsClientBridge, int id, boolean byUser);
     private native void nativeOnFilesSelected(long nativeXWalkContentsClientBridge,
             int processId, int renderId, int mode_flags, String filepath, String displayName);
     private native void nativeOnFilesNotSelected(long nativeXWalkContentsClientBridge,

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNotificationService.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNotificationService.java
@@ -10,9 +10,9 @@ import android.graphics.Bitmap;
 interface XWalkNotificationService {
     public void setBridge(XWalkContentsClientBridge bridge);
     public void showNotification(
-            String title, String message, String replaceId, int notificationId, long delegate);
+            String title, String message, String replaceId, int notificationId);
     public void updateNotificationIcon(int notificationId, Bitmap icon);
-    public void cancelNotification(int notificationId, long delegate);
+    public void cancelNotification(int notificationId);
     public void shutdown();
     public boolean maybeHandleIntent(Intent intent);
 }

--- a/runtime/browser/android/xwalk_contents_client_bridge.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge.h
@@ -64,7 +64,7 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase {
   virtual void ShowNotification(
       const content::ShowDesktopNotificationHostMsgParams& params,
       content::RenderFrameHost* render_frame_host,
-      content::DesktopNotificationDelegate* delegate,
+      scoped_ptr<content::DesktopNotificationDelegate> delegate,
       base::Closure* cancel_callback)
       OVERRIDE;
   virtual void UpdateNotificationIcon(
@@ -91,11 +91,10 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase {
   void ConfirmJsResult(JNIEnv*, jobject, int id, jstring prompt);
   void CancelJsResult(JNIEnv*, jobject, int id);
   void ExitFullscreen(JNIEnv*, jobject, jlong web_contents);
-  void NotificationDisplayed(JNIEnv*, jobject, jlong delegate);
-  void NotificationError(JNIEnv*, jobject, jlong delegate);
-  void NotificationClicked(JNIEnv*, jobject, jint id, jlong delegate);
-  void NotificationClosed(JNIEnv*, jobject, jint id, bool by_user,
-    jlong delegate);
+  void NotificationDisplayed(JNIEnv*, jobject, jint id);
+  void NotificationError(JNIEnv*, jobject, jint id);
+  void NotificationClicked(JNIEnv*, jobject, jint id);
+  void NotificationClosed(JNIEnv*, jobject, jint id, bool by_user);
   void OnFilesSelected(
       JNIEnv*, jobject, int process_id, int render_id,
       int mode, jstring filepath, jstring display_name);

--- a/runtime/browser/android/xwalk_contents_client_bridge_base.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge_base.h
@@ -67,7 +67,7 @@ class XWalkContentsClientBridgeBase {
   virtual void ShowNotification(
       const content::ShowDesktopNotificationHostMsgParams& params,
       content::RenderFrameHost* render_frame_host,
-      content::DesktopNotificationDelegate* delegate,
+      scoped_ptr<content::DesktopNotificationDelegate> delegate,
       base::Closure* cancel_callback)
       = 0;
   virtual void UpdateNotificationIcon(

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -291,7 +291,7 @@ void XWalkContentBrowserClient::ShowDesktopNotification(
   XWalkContentsClientBridgeBase* bridge =
       XWalkContentsClientBridgeBase::FromRenderFrameHost(render_frame_host);
   bridge->ShowNotification(params, render_frame_host,
-      delegate.get(), cancel_callback);
+      delegate.Pass(), cancel_callback);
 #endif
 }
 


### PR DESCRIPTION
According to upstream commit e4c9ef21d. Crosswalk on Android need
similar approach to own NotificationDelegate for each web
notification.

Use ScopedPtrHashMap for it.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2404
