### PR TITLE
[Tizen] Implement "MediaStream" manifest permission check.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -23,6 +23,7 @@
 #include "xwalk/application/common/application_storage.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/constants.h"
+#include "xwalk/application/common/manifest_handlers/permissions_handler.h"
 #include "xwalk/application/common/manifest_handlers/warp_handler.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_context.h"
@@ -351,6 +352,20 @@ bool Application::SetPermission(PermissionType type,
     return data_->SetPermission(permission_name, perm);
 
   NOTREACHED();
+  return false;
+}
+
+bool Application::HasPermission(const std::string& permission_name) const {
+  DCHECK(data());
+  PermissionsInfo* info = static_cast<PermissionsInfo*>(
+      data()->GetManifestData(application_manifest_keys::kPermissionsKey));
+
+  if (info) {
+    const PermissionSet& permissions = info->GetAPIPermissions();
+    PermissionSet::const_iterator it =
+      std::find(permissions.begin(), permissions.end(), permission_name);
+    return (it != permissions.end());
+  }
   return false;
 }
 

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -122,6 +122,7 @@ class Application : public Runtime::Observer,
   bool SetPermission(PermissionType type,
                      const std::string& permission_name,
                      StoredPermission perm);
+  bool HasPermission(const std::string& permission_name) const;
   bool CanRequestURL(const GURL& url) const;
 
  protected:

--- a/runtime/browser/media/media_capture_devices_dispatcher.h
+++ b/runtime/browser/media/media_capture_devices_dispatcher.h
@@ -16,6 +16,8 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/media_stream_request.h"
 
+namespace xwalk {
+
 // This singleton is used to receive updates about media events from the content
 // layer. Based on chrome/browser/media/media_capture_devices_dispatcher.[h|cc].
 class XWalkMediaCaptureDevicesDispatcher : public content::MediaObserver {
@@ -118,5 +120,7 @@ class XWalkMediaCaptureDevicesDispatcher : public content::MediaObserver {
   // A list of observers for the device update notifications.
   ObserverList<Observer> observers_;
 };
+
+}  // namespace xwalk
 
 #endif  // XWALK_RUNTIME_BROWSER_MEDIA_MEDIA_CAPTURE_DEVICES_DISPATCHER_H_

--- a/runtime/browser/runtime_geolocation_permission_context.cc
+++ b/runtime/browser/runtime_geolocation_permission_context.cc
@@ -87,18 +87,7 @@ RuntimeGeolocationPermissionContext::RequestGeolocationPermissionOnUIThread(
       app_service->GetApplicationByRenderHostID(render_view_id);
 
   if (application) {
-    DCHECK(application->data());
-    application::PermissionsInfo* info =
-      static_cast<application::PermissionsInfo*>(
-      application->data()->GetManifestData(
-          application_manifest_keys::kPermissionsKey));
-
-    if (info) {
-      const application::PermissionSet& permissions = info->GetAPIPermissions();
-      application::PermissionSet::const_iterator it =
-          std::find(permissions.begin(), permissions.end(), "geolocation");
-      has_geolocation_permission = it != permissions.end();
-    }
+    has_geolocation_permission = application->HasPermission("geolocation");
   }
 
   result_callback.Run(has_geolocation_permission);


### PR DESCRIPTION
To implement "MediaStream" manifest permission check for Tizen Crosswalk. This patch is one of series of patches to resolve bug XWALK-553. 

Spec:

https://github.com/crosswalk-project/crosswalk-website/wiki/zzz_archive-%5BManifest-permissions%5D

Test case:

As the attached xpk in the followed comment, if the manifest includes
<pre>"xwalk_permissions": [ "MediaStream"]</pre>
Then,  the JS call "navigator.getUserMedia" will trigger permission check.

Bug:

BUG=https://crosswalk-project.org/jira/browse/XWALK-553

