### PR TITLE
[Android] Expose setNetworkAvailable method to XWalkView for CordovaWebView

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -747,6 +747,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      *
      * @hide
      */
+    @XWalkAPI
     public void setNetworkAvailable(boolean networkUp) {
         if (mContent == null) return;
         checkThreadSafety();


### PR DESCRIPTION
To keep compatible with CordovaWebView, XWalkView.setNetworkAvailable
is required.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2385
