### PR TITLE
[SysApps] Initialize UDPSocketObject's members in order.

### DIFF
--- a/sysapps/raw_socket/udp_socket_object.cc
+++ b/sysapps/raw_socket/udp_socket_object.cc
@@ -26,9 +26,9 @@ UDPSocketObject::UDPSocketObject()
     : has_write_pending_(false),
       is_suspended_(false),
       is_reading_(false),
-      resolver_(net::HostResolver::CreateDefaultResolver(NULL)),
       read_buffer_(new net::IOBuffer(kBufferSize)),
       write_buffer_(new net::IOBuffer(kBufferSize)),
+      resolver_(net::HostResolver::CreateDefaultResolver(NULL)),
       single_resolver_(new net::SingleRequestHostResolver(resolver_.get())) {
   handler_.Register("init",
       base::Bind(&UDPSocketObject::OnInit, base::Unretained(this)));


### PR DESCRIPTION
Fixes a -Wreorder warning:

In file included from ../../../../home/abuild/rpmbuild/BUILD/crosswalk/src/xwalk/sysapps/raw_socket/udp_socket_object.cc:5:0:
../../../../home/abuild/rpmbuild/BUILD/crosswalk/src/xwalk/sysapps/raw_socket/udp_socket_object.h: In constructor 'xwalk::sysapps::UDPSocketObject::UDPSocketObject()':
../../../../home/abuild/rpmbuild/BUILD/crosswalk/src/xwalk/sysapps/raw_socket/udp_socket_object.h:54:33: warning: 'xwalk::sysapps::UDPSocketObject::resolver_' will be initialized after [-Wreorder]
   scoped_ptrnet::HostResolver resolver_;
                                 ^
../../../../home/abuild/rpmbuild/BUILD/crosswalk/src/xwalk/sysapps/raw_socket/udp_socket_object.h:48:32: warning:   'scoped_refptrnet::IOBuffer xwalk::sysapps::UDPSocketObject::read_buffer_' [-Wreorder]
   scoped_refptrnet::IOBuffer read_buffer_;
                                ^
../../../../home/abuild/rpmbuild/BUILD/crosswalk/src/xwalk/sysapps/raw_socket/udp_socket_object.cc:25:1: warning:   when initialized here [-Wreorder]
 UDPSocketObject::UDPSocketObject()
 ^
