### PR TITLE
[Tizen] Fix bug on intalling widget failed

### DIFF
--- a/application/common/installer/tizen/signature_validator.cc
+++ b/application/common/installer/tizen/signature_validator.cc
@@ -186,7 +186,7 @@ bool CheckProfileURI(const xwalk::application::SignatureData& signature_data) {
 bool CheckReference(
     const xwalk::application::SignatureData& signature_data) {
   base::FilePath widget_path = signature_data.GetExtractedWidgetPath();
-  int prefix_length = widget_path.value().length() + 1;
+  int prefix_length = widget_path.value().length();
   std::string file_name;
   std::set<std::string> reference_set = signature_data.reference_set();
   base::FileEnumerator iter(widget_path, true, base::FileEnumerator::FILES);


### PR DESCRIPTION
It is caused by temp value in local function used by outer function.
And for contructor of WGTPACKGE should set is_valid_ to false when
error happens.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2403
