### PR TITLE
[Android] Add onStart and onStop to XWalkExtensionClient

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -68,6 +68,7 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
     public void onStart() {
         super.onStart();
         tryLoadRuntimeView();
+        mRuntimeView.onStart();
     }
 
     @Override
@@ -80,6 +81,12 @@ public abstract class XWalkRuntimeActivityBase extends Activity implements Cross
     public void onResume() {
         super.onResume();
         mRuntimeView.onResume();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mRuntimeView.onStop();
     }
 
     @Override

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeClient.java
@@ -29,8 +29,10 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
     private Method mLoadAppFromUrl;
     private Method mLoadAppFromManifest;
     private Method mOnCreate;
+    private Method mOnStart;
     private Method mOnResume;
     private Method mOnPause;
+    private Method mOnStop;
     private Method mOnDestroy;
     private Method mOnActivityResult;
     private Method mOnNewIntent;
@@ -65,8 +67,10 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
         mLoadAppFromUrl = lookupMethod("loadAppFromUrl", String.class);
         mLoadAppFromManifest = lookupMethod("loadAppFromManifest", String.class);
         mOnCreate = lookupMethod("onCreate");
+        mOnStart = lookupMethod("onStart");
         mOnResume = lookupMethod("onResume");
         mOnPause = lookupMethod("onPause");
+        mOnStop = lookupMethod("onStop");
         mOnDestroy = lookupMethod("onDestroy");
         mOnActivityResult = lookupMethod("onActivityResult", int.class, int.class, Intent.class);
         mOnNewIntent = lookupMethod("onNewIntent", Intent.class);
@@ -178,6 +182,14 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
     }
 
     /**
+     * Tell runtime that the application is on starting. This can make runtime
+     * be aware of application life cycle.
+     */
+    public void onStart() {
+        invokeMethod(mOnStart, mInstance);
+    }
+
+    /**
      * Tell runtime that the application is on resuming. This can make runtime
      * be aware of application life cycle.
      */
@@ -191,6 +203,14 @@ public class XWalkRuntimeClient extends CrossPackageWrapper {
      */
     public void onPause() {
         invokeMethod(mOnPause, mInstance);
+    }
+
+    /**
+     * Tell runtime that the application is on stopping. This can make runtime
+     * be aware of application life cycle.
+     */
+    public void onStop() {
+        invokeMethod(mOnStop, mInstance);
     }
 
     /**

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
@@ -61,6 +61,12 @@ public class XWalkExtensionClient extends CrossPackageWrapper {
     }
 
     /**
+     * Called when this app is onStart.
+     */
+    public void onStart() {
+    }
+
+    /**
      * Called when this app is onResume.
      */
     public void onResume() {
@@ -70,6 +76,12 @@ public class XWalkExtensionClient extends CrossPackageWrapper {
      * Called when this app is onPause.
      */
     public void onPause() {
+    }
+
+    /**
+     * Called when this app is onStop.
+     */
+    public void onStop() {
     }
 
     /**

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -923,6 +923,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         switch (newState) {
             case ActivityState.STARTED:
                 onShow();
+                if (null != mExtensionManager) mExtensionManager.onStart();
                 break;
             case ActivityState.PAUSED:
                 pauseTimers();
@@ -937,6 +938,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
                 break;
             case ActivityState.STOPPED:
                 onHide();
+                if (null != mExtensionManager) mExtensionManager.onStop();
                 break;
             default:
                 break;

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkCoreExtensionBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkCoreExtensionBridge.java
@@ -47,6 +47,14 @@ class XWalkCoreExtensionBridge extends XWalkExtensionAndroid implements XWalkExt
         mExtension.onPause();
     }
 
+    public void onStart() {
+        mExtension.onStart();
+    }
+
+    public void onStop() {
+        mExtension.onStop();
+    }
+
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         mExtension.onActivityResult(requestCode, resultCode, data);
     }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkExtension.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkExtension.java
@@ -124,6 +124,12 @@ public abstract class XWalkExtension {
     }
 
     /**
+     * Called when this app is onStart.
+     */
+    public void onStart() {
+    }
+
+    /**
      * Called when this app is onResume.
      */
     public void onResume() {
@@ -133,6 +139,12 @@ public abstract class XWalkExtension {
      * Called when this app is onPause.
      */
     public void onPause() {
+    }
+
+    /**
+     * Called when this app is onStop.
+     */
+    public void onStop() {
     }
 
     /**

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkExtensionBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkExtensionBridge.java
@@ -54,6 +54,11 @@ interface XWalkExtensionBridge {
     public String onSyncMessage(int instanceId, String message);
 
     /**
+     * Called when the extension is required to be started.
+     */
+    public void onStart();
+
+    /**
      * Called when the extension is required to be resumed.
      */
     public void onResume();
@@ -62,6 +67,12 @@ interface XWalkExtensionBridge {
      * Called when the extension is required to be paused.
      */
     public void onPause();
+
+    /**
+     * Called when the extension is required to be stopped.
+     */
+    public void onStop();
+
 
     /**
      * Called when the extension is required to be destroyed.

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkExtensionClientImpl.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkExtensionClientImpl.java
@@ -22,8 +22,10 @@ class XWalkExtensionClientImpl extends XWalkExtension {
     private Object mExtensionClient;
     private Method mOnMessage;
     private Method mOnSyncMessage;
+    private Method mOnStart;
     private Method mOnResume;
     private Method mOnPause;
+    private Method mOnStop;
     private Method mOnDestroy;
     private Method mOnActivityResult;
 
@@ -34,8 +36,10 @@ class XWalkExtensionClientImpl extends XWalkExtension {
         mExtensionClient = extensionClient;
         mOnMessage = lookupMethod("onMessage", int.class, String.class);
         mOnSyncMessage = lookupMethod("onSyncMessage", int.class, String.class);
+        mOnStart = lookupMethod("onStart");
         mOnResume = lookupMethod("onResume");
         mOnPause = lookupMethod("onPause");
+        mOnStop = lookupMethod("onStop");
         mOnDestroy = lookupMethod("onDestroy");
         mOnActivityResult = lookupMethod("onActivityResult", int.class, int.class, Intent.class);
     }
@@ -51,6 +55,11 @@ class XWalkExtensionClientImpl extends XWalkExtension {
     }
 
     @Override
+    public void onStart() {
+        invokeMethod(mOnStart, mExtensionClient);
+    }
+
+    @Override
     public void onResume() {
         invokeMethod(mOnResume, mExtensionClient);
     }
@@ -58,6 +67,11 @@ class XWalkExtensionClientImpl extends XWalkExtension {
     @Override
     public void onPause() {
         invokeMethod(mOnPause, mExtensionClient);
+    }
+
+    @Override
+    public void onStop() {
+        invokeMethod(mOnStop, mExtensionClient);
     }
 
     @Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkExtensionManager.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/XWalkExtensionManager.java
@@ -93,6 +93,12 @@ public class XWalkExtensionManager implements XWalkExtensionContext {
         if (bridge != null) bridge.broadcastMessage(message);
     }
 
+    public void onStart() {
+        for(XWalkExtensionBridge extension: mExtensions.values()) {
+            extension.onStart();
+        }
+    }
+
     public void onResume() {
         for(XWalkExtensionBridge extension: mExtensions.values()) {
             extension.onResume();
@@ -102,6 +108,12 @@ public class XWalkExtensionManager implements XWalkExtensionContext {
     public void onPause() {
         for(XWalkExtensionBridge extension: mExtensions.values()) {
             extension.onPause();
+        }
+    }
+
+    public void onStop() {
+        for(XWalkExtensionBridge extension: mExtensions.values()) {
+            extension.onStop();
         }
     }
 

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkCoreProviderImpl.java
@@ -49,11 +49,19 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
     }
 
     @Override
+    public void onStart() {
+    }
+
+    @Override
     public void onResume() {
     }
 
     @Override
     public void onPause() {
+    }
+
+    @Override
+    public void onStop() {
     }
 
     @Override

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeView.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeView.java
@@ -99,6 +99,14 @@ public class XWalkRuntimeView extends FrameLayout {
     }
 
     /**
+     * Tell runtime that the application is on starting. This can make runtime
+     * be aware of application life cycle.
+     */
+    public void onStart() {
+        mProvider.onStart();
+    }
+
+    /**
      * Tell runtime that the application is on resuming. This can make runtime
      * be aware of application life cycle.
      */
@@ -112,6 +120,14 @@ public class XWalkRuntimeView extends FrameLayout {
      */
     public void onPause() {
         mProvider.onPause();
+    }
+
+    /**
+     * Tell runtime that the application is on stoping. This can make runtime
+     * be aware of application life cycle.
+     */
+    public void onStop() {
+        mProvider.onStop();
     }
 
     /**

--- a/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
+++ b/runtime/android/runtime/src/org/xwalk/runtime/XWalkRuntimeViewProvider.java
@@ -17,8 +17,10 @@ import android.view.View;
 interface XWalkRuntimeViewProvider {
     // For handling life cycle and activity result.
     public void onCreate();
+    public void onStart();
     public void onResume();
     public void onPause();
+    public void onStop();
     public void onDestroy();
     public void onActivityResult(int requestCode, int resultCode, Intent data);
     public boolean onNewIntent(Intent intent);

--- a/runtime/android/runtime_shell/src/org/xwalk/runtime/shell/XWalkRuntimeShellActivity.java
+++ b/runtime/android/runtime_shell/src/org/xwalk/runtime/shell/XWalkRuntimeShellActivity.java
@@ -54,6 +54,12 @@ public class XWalkRuntimeShellActivity extends Activity {
     }
 
     @Override
+    protected void onStart() {
+        super.onStart();
+        mRuntimeView.onStart();
+    }
+
+    @Override
     protected void onPause() {
         super.onPause();
         mRuntimeView.onPause();
@@ -63,6 +69,12 @@ public class XWalkRuntimeShellActivity extends Activity {
     protected void onResume() {
         super.onResume();
         mRuntimeView.onResume();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        mRuntimeView.onStop();
     }
 
     @Override


### PR DESCRIPTION
Added the onStart() and onStop() method in XWalkExtensionClient,
and also added these two functions in the related classes to
make it work for XWalkExtensionClient. For now extension developer
can override the onStart() and onStop() when the activity's
onStart() and onStop() get triggered.

BUG=XWALK-1708
