### PR TITLE
[Runtime] Add "-c" option for xwalkctl for restarting aborted install/update tasks

### DIFF
--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -215,6 +215,14 @@ bool IsSingletonElement(const std::string& name) {
 namespace xwalk {
 namespace application {
 
+FileDeleter::FileDeleter(const base::FilePath& path, bool recursive)
+    : path_(path),
+      recursive_(recursive) {}
+
+FileDeleter::~FileDeleter() {
+  base::DeleteFile(path_, recursive_);
+}
+
 // Load XML node into Dictionary structure.
 // The keys for the XML node to Dictionary mapping are described below:
 // XML                                 Dictionary

--- a/application/common/application_file_util.h
+++ b/application/common/application_file_util.h
@@ -26,6 +26,19 @@ namespace application {
 
 class ApplicationData;
 
+class FileDeleter {
+ public:
+  FileDeleter(const base::FilePath& path, bool recursive);
+  ~FileDeleter();
+
+  void Dismiss() { path_.clear(); }
+  const base::FilePath& path() const { return path_; }
+
+ private:
+  base::FilePath path_;
+  bool recursive_;
+};
+
 // Loads and validates an application from the specified directory. Returns NULL
 // on failure, with a description of the error in |error|.
 scoped_refptr<ApplicationData> LoadApplication(

--- a/application/common/installer/package_installer.h
+++ b/application/common/installer/package_installer.h
@@ -24,6 +24,7 @@ class PackageInstaller {
   bool Install(const base::FilePath& path, std::string* id);
   bool Uninstall(const std::string& id);
   bool Update(const std::string& id, const base::FilePath& path);
+  void ContinueUnfinishedTasks();
 
  protected:
   explicit PackageInstaller(ApplicationStorage* storage);

--- a/application/common/installer/package_installer_tizen.cc
+++ b/application/common/installer/package_installer_tizen.cc
@@ -20,6 +20,7 @@
 #include "base/process/launch.h"
 #include "third_party/libxml/chromium/libxml_utils.h"
 #include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/application_file_util.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/manifest_handlers/tizen_application_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_metadata_handler.h"
@@ -43,28 +44,6 @@ const base::FilePath kDefaultIcon(
 
 const std::string kServicePrefix("xwalk-service.");
 const std::string kAppIdPrefix("xwalk.");
-
-class FileDeleter {
- public:
-  FileDeleter(const base::FilePath& path, bool recursive)
-      : path_(path),
-        recursive_(recursive) {}
-
-  ~FileDeleter() {
-    if (path_.empty())
-      return;
-
-    base::DeleteFile(path_, recursive_);
-  }
-
-  void Dismiss() {
-    path_.clear();
-  }
-
- private:
-  base::FilePath path_;
-  bool recursive_;
-};
 
 void WriteMetaDataElement(
     XmlWriter& writer, // NOLINT

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -35,6 +35,7 @@ static char* install_path;
 static char* uninstall_appid;
 
 static gint debugging_port = -1;
+static gboolean continue_tasks = FALSE;
 
 static GOptionEntry entries[] = {
   { "install", 'i', 0, G_OPTION_ARG_STRING, &install_path,
@@ -43,6 +44,8 @@ static GOptionEntry entries[] = {
     "Uninstall the application with this appid", "APPID" },
   { "debugging_port", 'd', 0, G_OPTION_ARG_INT, &debugging_port,
     "Enable remote debugging, port number 0 means to disable", NULL },
+  { "continue", 'c' , 0, G_OPTION_ARG_NONE, &continue_tasks,
+    "Continue the previous unfinished tasks.", NULL},
   { NULL }
 };
 
@@ -139,6 +142,13 @@ int main(int argc, char* argv[]) {
   scoped_ptr<PackageInstaller> installer =
       PackageInstaller::Create(storage.get());
 
+  if (continue_tasks) {
+    g_print("trying to continue previous unfinished tasks.\n");
+    installer->ContinueUnfinishedTasks();
+    success = true;
+    g_print("Previous tasks have been finished.\n");
+  }
+
   if (install_path) {
     std::string app_id;
     const base::FilePath& path = base::FilePath(install_path);
@@ -156,7 +166,7 @@ int main(int argc, char* argv[]) {
 #else
     g_print("Couldn't enable remote debugging for no shared process mode!");
 #endif
-  } else {
+  } else if (!continue_tasks) {
     success = list_applications(storage.get());
   }
 


### PR DESCRIPTION
Crosswalk runtime should have a mechanism to restart the aborted install or
update tasks which are stopped by accident like power off. This patch will
enable this feature, user can restart these tasks by command 'xwalkctl
-c|--continue'. This patch related to bug:
https://crosswalk-project.org/jira/browse/XWALK-1565
