### PR TITLE
Postpone launching xwalk daemon service until wayland is initialized

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -26,6 +26,7 @@ Source:         %{name}.tar
 Source1:        xwalk.in
 Source2:        org.crosswalkproject.Runtime1.service
 Source3:        xwalk.service.in
+Source4:        xwalk-wayland-ready.path
 Source1001:     crosswalk.manifest
 Source1002:     %{name}.xml.in
 Source1003:     %{name}.png
@@ -226,6 +227,7 @@ ninja %{?_smp_mflags} -C src/out/Release xwalk xwalkctl xwalk_launcher xwalk-pkg
 # Binaries.
 install -p -D %{SOURCE2} %{buildroot}%{_dbusservicedir}/org.crosswalkproject.Runtime1.service
 install -p -D xwalk.service %{buildroot}%{_systemduserservicedir}/xwalk.service
+install -p -D %{SOURCE4} %{buildroot}%{_systemduserservicedir}/xwalk-wayland-ready.path
 install -p -D src/out/Release/xwalk %{buildroot}%{_libdir}/xwalk/xwalk
 install -p -D src/out/Release/xwalkctl %{buildroot}%{_bindir}/xwalkctl
 install -p -D src/out/Release/xwalk-launcher %{buildroot}%{_bindir}/xwalk-launcher
@@ -282,4 +284,5 @@ mkdir -p %{_manifestdir_ro}
 %{_desktop_icondir}/%{name}.png
 %{_dbusservicedir}/org.crosswalkproject.Runtime1.service
 %{_systemduserservicedir}/xwalk.service
+%{_systemduserservicedir}/xwalk-wayland-ready.path
 %{_datadir}/xwalk/*

--- a/packaging/xwalk-wayland-ready.path
+++ b/packaging/xwalk-wayland-ready.path
@@ -1,0 +1,7 @@
+# Description=Path to activate xwalk after wayland is initialized
+[Path]
+PathExists=/run/user/%U/wayland-0
+Unit=xwalk.service
+
+[Install]
+WantedBy=weston.target


### PR DESCRIPTION
If xwalk daemon service is launched prior to wayland, it may be failed to launch.
This fix provides a systemd.path(http://www.freedesktop.org/software/systemd/man/systemd.path.html) file to configure a specific condition to launch xwalk daemon service. That can ensure xwalk daemon service is launched after wayland initialization.

At Tizen side, corresponding changes should be made to add a symlink to the path file under default.target.wants, like below:
ln -sf xwalk-wayland-ready.path default.target.wants/

BUG=TC-1533
