### PR TITLE
Allow running make_apk.py from any directory

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -14,6 +14,10 @@ import shutil
 import stat
 import sys
 
+# get xwalk absolute path so we can run this script from any location
+xwalk_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(xwalk_dir)
+
 from app_info import AppInfo
 from customize_launch_screen import CustomizeLaunchScreen
 from handle_xml import AddElementAttribute
@@ -23,6 +27,7 @@ from handle_xml import EditElementValueByNodeName
 from handle_permissions import HandlePermissions
 from xml.dom import minidom
 
+TEMPLATE_DIR_NAME = 'template'
 
 def VerifyPackageName(value):
   regex = r'^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$'
@@ -107,31 +112,50 @@ def CompressSourceFiles(app_root, compressor):
 
 
 def Prepare(app_info, compressor):
-  name = app_info.android_name
-  package = app_info.package
+  """Copy the Android template project to a new app project
+     named app_info.app_name
+  """
+  # create new app_dir in xwalk_dir
+  app_name = app_info.android_name
+  app_dir = os.path.join(xwalk_dir, app_name)
+  app_package = app_info.package
   app_root = app_info.app_root
-  if os.path.exists(name):
-    shutil.rmtree(name)
-  shutil.copytree('template', name)
-  shutil.rmtree(os.path.join(name, 'src'))
-  src_root = os.path.join('template', 'src', 'org', 'xwalk', 'app', 'template')
-  src_activity = os.path.join(src_root, 'AppTemplateActivity.java')
-  if not os.path.isfile(src_activity):
-    print ('Please make sure that the java file'
-           ' of activity does exist.')
+  template_app_dir = os.path.join(xwalk_dir, TEMPLATE_DIR_NAME)
+
+  # 1) copy template project to app_dir
+  if os.path.exists(app_dir):
+    shutil.rmtree(app_dir)
+  shutil.copytree(template_app_dir, app_dir)
+
+  # 2) replace app_dir 'src' dir with template 'src' dir
+  shutil.rmtree(os.path.join(app_dir, 'src'))
+  template_src_root = os.path.join(template_app_dir, 'src', 'org', 'xwalk',
+                                   'app', 'template')
+
+  # 3) Create directory tree from app package (org.xyz.foo -> src/org/xyz/foo)
+  #    and copy AppTemplateActivity.java to <app_name>Activity.java 
+  template_activity_file = os.path.join(template_src_root,
+                                        'AppTemplateActivity.java')
+  if not os.path.isfile(template_activity_file):
+    print ('Error: The template file %s was not found. '
+           'Please make sure this file exists.' % template_activity_file)
     sys.exit(7)
-  root_path = os.path.join(name, 'src', package.replace('.', os.path.sep))
-  if not os.path.exists(root_path):
-    os.makedirs(root_path)
-  dest_activity = name + 'Activity.java'
-  shutil.copyfile(src_activity, os.path.join(root_path, dest_activity))
+  app_pkg_dir = os.path.join(app_dir, 'src',
+                             app_package.replace('.', os.path.sep))
+  if not os.path.exists(app_pkg_dir):
+    os.makedirs(app_pkg_dir)
+  app_activity_file = app_name + 'Activity.java'
+  shutil.copyfile(template_activity_file,
+                  os.path.join(app_pkg_dir, app_activity_file))
+
+  # 4) Copy all HTML source from app_root to app_dir
   if app_root:
-    assets_path = os.path.join(name, 'assets', 'www')
-    if os.path.isdir(assets_path):
-      shutil.rmtree(assets_path)
-    shutil.copytree(app_root, assets_path)
+    app_assets_dir = os.path.join(app_dir, 'assets', 'www')
+    if os.path.isdir(app_assets_dir):
+      shutil.rmtree(app_assets_dir)
+    shutil.copytree(app_root, app_assets_dir)
     if compressor:
-      CompressSourceFiles(assets_path, compressor)
+      CompressSourceFiles(app_assets_dir, compressor)
 
 
 def EncodingUnicodeValue(value):
@@ -144,7 +168,7 @@ def EncodingUnicodeValue(value):
 
 
 def CustomizeStringXML(name, description):
-  strings_path = os.path.join(name, 'res', 'values', 'strings.xml')
+  strings_path = os.path.join(xwalk_dir, name, 'res', 'values', 'strings.xml')
   if not os.path.isfile(strings_path):
     print ('Please make sure strings_xml'
            ' exists under template folder.')
@@ -161,7 +185,7 @@ def CustomizeStringXML(name, description):
 
 
 def CustomizeThemeXML(name, fullscreen, manifest):
-  theme_path = os.path.join(name, 'res', 'values-v14', 'theme.xml')
+  theme_path = os.path.join(xwalk_dir, name, 'res', 'values-v14', 'theme.xml')
   if not os.path.isfile(theme_path):
     print('Error: theme.xml is missing in the build tool.')
     sys.exit(6)
@@ -195,7 +219,7 @@ def CustomizeXML(app_info, description, icon_dict, manifest, permissions):
   # append a space before '@' or '?' to fix that.
   if app_name.startswith('@') or app_name.startswith('?'):
     app_name = ' ' + app_name
-  manifest_path = os.path.join(name, 'AndroidManifest.xml')
+  manifest_path = os.path.join(xwalk_dir, name, 'AndroidManifest.xml')
   if not os.path.isfile(manifest_path):
     print ('Please make sure AndroidManifest.xml'
            ' exists under template folder.')
@@ -227,7 +251,7 @@ def CustomizeXML(app_info, description, icon_dict, manifest, permissions):
     EditElementAttribute(xmldoc, 'application', 'android:icon',
                          '@drawable/%s' % icon_name)
 
-  file_handle = open(os.path.join(name, 'AndroidManifest.xml'), 'w')
+  file_handle = open(os.path.join(xwalk_dir, name, 'AndroidManifest.xml'), 'w')
   xmldoc.writexml(file_handle, encoding='utf-8')
   file_handle.close()
 
@@ -258,11 +282,12 @@ def SetVariable(file_path, string_line, variable, value):
 def CustomizeJava(app_info, app_url, app_local_path, keep_screen_on):
   name = app_info.android_name
   package = app_info.package
-  root_path = os.path.join(name, 'src', package.replace('.', os.path.sep))
-  dest_activity = os.path.join(root_path, name + 'Activity.java')
+  app_pkg_dir = os.path.join(xwalk_dir, name, 'src',
+                             package.replace('.', os.path.sep))
+  dest_activity = os.path.join(app_pkg_dir, name + 'Activity.java')
   ReplaceString(dest_activity, 'org.xwalk.app.template', package)
   ReplaceString(dest_activity, 'AppTemplate', name)
-  manifest_file = os.path.join(name, 'assets/www', 'manifest.json')
+  manifest_file = os.path.join(xwalk_dir, name, 'assets/www', 'manifest.json')
   if os.path.isfile(manifest_file):
     ReplaceString(
         dest_activity,
@@ -274,7 +299,8 @@ def CustomizeJava(app_info, app_url, app_local_path, keep_screen_on):
         ReplaceString(dest_activity, 'file:///android_asset/www/index.html',
                       app_url)
     elif app_local_path:
-      if os.path.isfile(os.path.join(name, 'assets/www', app_local_path)):
+      if os.path.isfile(os.path.join(xwalk_dir, name, 'assets/www',
+                                     app_local_path)):
         ReplaceString(dest_activity, 'file:///android_asset/www/index.html',
                       'app://' + package + '/' + app_local_path)
       else:
@@ -338,7 +364,7 @@ def CustomizeExtensions(app_info, extensions):
   if not extensions:
     return
   name = app_info.android_name
-  apk_path = name
+  apk_path = os.path.join(xwalk_dir, name)
   apk_assets_path = os.path.join(apk_path, 'assets')
   extensions_string = 'xwalk-extensions'
 
@@ -390,7 +416,7 @@ def CustomizeExtensions(app_info, extensions):
       json_output['jsapi'] = js_path_prefix + json_output['jsapi']
       extension_json_list.append(json_output)
       # Merge the permissions of extensions into AndroidManifest.xml.
-      manifest_path = os.path.join(name, 'AndroidManifest.xml')
+      manifest_path = os.path.join(xwalk_dir, name, 'AndroidManifest.xml')
       xmldoc = minidom.parse(manifest_path)
       if ('permissions' in json_output):
         # Get used permission list to avoid repetition as "--permissions"
@@ -423,7 +449,7 @@ def CustomizeExtensions(app_info, extensions):
 def GenerateCommandLineFile(app_info, xwalk_command_line):
   if xwalk_command_line == '':
     return
-  assets_path = os.path.join(app_info.android_name, 'assets')
+  assets_path = os.path.join(xwalk_dir, app_info.android_name, 'assets')
   file_path = os.path.join(assets_path, 'xwalk-command-line')
   command_line_file = open(file_path, 'w')
   command_line_file.write('xwalk ' + xwalk_command_line)
@@ -447,7 +473,7 @@ def CustomizeIconByDict(name, app_root, icon_dict):
     for kd, vd in drawable_dict.items():
       for item in icon_list:
         if item[0] >= vd[0] and item[0] < vd[1]:
-          drawable_path = os.path.join(name, 'res', 'drawable-' + kd)
+          drawable_path = os.path.join(xwalk_dir, name, 'res', 'drawable-' + kd)
           if not os.path.exists(drawable_path):
             os.makedirs(drawable_path)
           icon = os.path.join(app_root, item[1])
@@ -466,7 +492,7 @@ def CustomizeIconByDict(name, app_root, icon_dict):
 
 def CustomizeIconByOption(name, icon):
   if os.path.isfile(icon):
-    drawable_path = os.path.join(name, 'res', 'drawable')
+    drawable_path = os.path.join(xwalk_dir, name, 'res', 'drawable')
     if not os.path.exists(drawable_path):
       os.makedirs(drawable_path)
     icon_file = os.path.basename(icon)
@@ -573,7 +599,7 @@ def main():
     if options.name is not None:
       app_info.android_name = options.name
     if options.app_root is None:
-      app_info.app_root = os.path.join('test_data', 'manifest')
+      app_info.app_root = os.path.join(xwalk_dir, 'test_data', 'manifest')
     else:
       app_info.app_root = options.app_root
     if options.package is not None:

--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import sys
 
+xwalk_dir = os.path.dirname(os.path.abspath(__file__))
 
 def CopyToPathWithName(root, name, final_path, rename):
   if name == '':
@@ -29,7 +30,7 @@ def CopyToPathWithName(root, name, final_path, rename):
 
 
 def CopyDrawables(image_dict, orientation, sanitized_name, name, app_root):
-  drawable = os.path.join(sanitized_name, 'res', 'drawable')
+  drawable = os.path.join(xwalk_dir, sanitized_name, 'res', 'drawable')
   if orientation == 'landscape':
     drawable = drawable + '-land'
   elif orientation == 'portrait':
@@ -113,7 +114,7 @@ def CustomizeBackground(background_color,
                         orientation,
                         sanitized_name,
                         app_root):
-  background_path = os.path.join(sanitized_name, 'res',
+  background_path = os.path.join(xwalk_dir, sanitized_name, 'res',
                                  'drawable', 'launchscreen_bg.xml')
   if not os.path.isfile(background_path):
     print('Error: launchscreen_bg.xml is missing in the build tool.')


### PR DESCRIPTION
per XWALK-2391, prepends the current location of make_apk.py when accessing files and directories assumed to be in the same directory as make_apk.py, including imports of other modules.
