### PR TITLE
[Android] Add support of getting mime type for app url scheme.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/AndroidProtocolHandler.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/AndroidProtocolHandler.java
@@ -230,7 +230,8 @@ class AndroidProtocolHandler {
             if (uri.getScheme().equals(CONTENT_SCHEME)) {
                 return context.getContentResolver().getType(uri);
                 // Asset files may have a known extension.
-            } else if (uri.getScheme().equals(FILE_SCHEME) &&
+            } else if (uri.getScheme().equals(APP_SCHEME) ||
+                       uri.getScheme().equals(FILE_SCHEME) &&
                        path.startsWith(nativeGetAndroidAssetPath())) {
                 String mimeType = URLConnection.guessContentTypeFromName(path);
                 if (mimeType != null) {


### PR DESCRIPTION
This patch is to add support of getting mime type for app url scheme.
As crosswalk supports app scheme and the local path in "iframe" was
loaded with "app://", so add conditional to get the related mime type.
The app scheme was removed in commit
12b98a8.

BUG=XWALK-2300, XWALK-2301
