### PR TITLE
[Android] Add xwalk_app_template_apk to xwalk_app_template's dependency 

### DIFF
--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -128,6 +128,7 @@
       'type': 'none',
       'dependencies': [
         'xwalk_app_runtime_java',
+        'xwalk_app_template_apk',
         'xwalk_runtime_java',
         'xwalk_core_library',
       ],


### PR DESCRIPTION
xwalk_app_template_apk is to verify the correctness of xwalk_app_template
before creating the package of it.
Set the dependency although, xwalk_app_template doesn't rely on
xwalk_app_template_apk to build.
