### PR TITLE
[Android] User TextureView as the default rendering backend view.

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -33,6 +33,8 @@ public abstract class XWalkRuntimeActivityBase extends Activity {
 
     private boolean mRemoteDebugging = false;
 
+    private boolean mUseAnimatableView = false;
+
     private AlertDialog mLibraryNotFoundDialog = null;
 
     private XWalkRuntimeExtensionManager mExtensionManager;
@@ -124,6 +126,11 @@ public abstract class XWalkRuntimeActivityBase extends Activity {
 
     private void tryLoadRuntimeView() {
         try {
+            if (mUseAnimatableView) {
+                XWalkPreferences.setValue(XWalkPreferences.ANIMATABLE_XWALK_VIEW, true);
+            } else {
+                XWalkPreferences.setValue(XWalkPreferences.ANIMATABLE_XWALK_VIEW, false);
+            }
             mRuntimeView = new XWalkRuntimeView(this, this, null);
             mShownNotFoundDialog = false;
             if (mLibraryNotFoundDialog != null) mLibraryNotFoundDialog.cancel();
@@ -254,6 +261,10 @@ public abstract class XWalkRuntimeActivityBase extends Activity {
 
     public void setRemoteDebugging(boolean value) {
         mRemoteDebugging = value;
+    }
+
+    public void setUseAnimatableView(boolean value) {
+        mUseAnimatableView = value;
     }
 
 }

--- a/app/tools/android/app_info.py
+++ b/app/tools/android/app_info.py
@@ -22,3 +22,4 @@ class AppInfo:
     self.app_name = ''
     self.package = 'org.xwalk.app.template'
     self.remote_debugging = ''
+    self.use_animatable_view = ''

--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -286,6 +286,10 @@ def CustomizeJava(app_info, app_url, app_local_path, keep_screen_on):
     SetVariable(dest_activity,
                 'public void onCreate(Bundle savedInstanceState)',
                 'RemoteDebugging', 'true')
+  if app_info.use_animatable_view:
+    SetVariable(dest_activity,
+                'public void onCreate(Bundle savedInstanceState)',
+                'UseAnimatableView', 'true')
   if app_info.fullscreen_flag:
     SetVariable(dest_activity,
                 'super.onCreate(savedInstanceState)',
@@ -535,6 +539,9 @@ def main():
   parser.add_option('--enable-remote-debugging', action='store_true',
                     dest='enable_remote_debugging', default=False,
                     help='Enable remote debugging.')
+  parser.add_option('--use-animatable-view', action='store_true',
+                    dest='use_animatable_view', default=False,
+                    help='Enable using animatable view (TextureView).')
   parser.add_option('-f', '--fullscreen', action='store_true',
                     dest='fullscreen', default=False,
                     help='Make application fullscreen.')

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -207,6 +207,8 @@ def Customize(options, app_info, manifest):
     app_info.app_root = os.path.expanduser(options.app_root)
   if options.enable_remote_debugging:
     app_info.remote_debugging = '--enable-remote-debugging'
+  if options.use_animatable_view:
+    app_info.use_animatable_view = '--use-animatable-view'
   if options.fullscreen:
     app_info.fullscreen_flag = '-f'
   if options.orientation:
@@ -496,6 +498,9 @@ def main(argv):
   group.add_option('--enable-remote-debugging', action='store_true',
                    dest='enable_remote_debugging', default=False,
                    help='Enable remote debugging.')
+  group.add_option('--use-animatable-view', action='store_true',
+                   dest='use_animatable_view', default=False,
+                   help='Enable using animatable view (TextureView).')
   info = ('The list of external extension paths splitted by OS separators. '
           'The separators are \':\' , \';\' and \':\' on Linux, Windows and '
           'Mac OS respectively. For example, '

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -492,6 +492,31 @@ class TestMakeApk(unittest.TestCase):
     self.assertTrue(content.find('setRemoteDebugging') != -1)
     self.checkApks('Example', '1.0.0')
 
+  def testUseAnimatableView(self):
+    cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+           '--package=org.xwalk.example', '--app-url=http://www.intel.com',
+           '--use-animatable-view', self._mode]
+    RunCommand(cmd)
+    self.addCleanup(Clean, 'Example', '1.0.0')
+    activity = 'Example/src/org/xwalk/example/ExampleActivity.java'
+    with open(activity, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(activity))
+    self.assertTrue(content.find('setUseAnimatableView') != -1)
+    self.checkApks('Example', '1.0.0')
+    Clean('Example', '1.0.0')
+    manifest_path = os.path.join('test_data', 'manifest', 'manifest.json')
+    cmd = ['python', 'make_apk.py', '--use-animatable-view',
+           '--package=org.xwalk.example',
+           '--manifest=%s' % manifest_path, self._mode]
+    RunCommand(cmd)
+    activity = 'Example/src/org/xwalk/example/ExampleActivity.java'
+    with open(activity, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(activity))
+    self.assertTrue(content.find('setUseAnimatableView') != -1)
+    self.checkApks('Example', '1.0.0')
+
   def testKeystore(self):
     keystore_path = os.path.join('test_data', 'keystore',
                                  'xwalk-test.keystore')

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
@@ -78,8 +78,10 @@ public class XWalkPreferencesInternal {
 
     /**
      * The key string to enable/disable animatable XWalkViewInternal. Default value is
-     * false.
+     * true.
      *
+     * If this key is set to False, then SurfaceView will be created internally as the
+     * rendering backend.
      * If this key is set to True, the XWalkViewInternal created by Crosswalk can be
      * transformed and animated. Internally, Crosswalk is alternatively using
      * TextureView as the backend of XWalkViewInternal.
@@ -143,7 +145,7 @@ public class XWalkPreferencesInternal {
 
     static {
         sPrefMap.put(REMOTE_DEBUGGING, new PreferenceValue(false));
-        sPrefMap.put(ANIMATABLE_XWALK_VIEW, new PreferenceValue(false));
+        sPrefMap.put(ANIMATABLE_XWALK_VIEW, new PreferenceValue(true));
         sPrefMap.put(ENABLE_JAVASCRIPT, new PreferenceValue(true));
         sPrefMap.put(JAVASCRIPT_CAN_OPEN_WINDOW, new PreferenceValue(true));
         sPrefMap.put(


### PR DESCRIPTION
There are several issues with SurfaceView rendering backend, including:
(1) Can't be animated/transformed/translucent.
(2) Multiple SurfaceView overlapped in the same ViewGroup will cause undefined behavior.

Those are not issues for Chrome for Android, since Chrome for Android uses only
one SurfaceView and everything is painted/compsited inside the SurfaceView.
But for Crosswalk, we may have multiple SurfaceViews for each embedding App, so the
drawbacks of SurfaceView may cause some bugs.

This CL makes TextureView as the default rendering backend, which can overcome the
drawbacks of SurfaceView. Eventhough the TextureView increase more memory usage.

To switch back to SurfaceView,set the ANIMATABLE_XWALK_VIEW preference value to be
false before using XWalkView.

BUG=
