### PR TITLE
WebSetting plugin implementation - xwalk part

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -121,6 +122,7 @@ class Application : public Runtime::Observer,
   virtual base::FilePath GetSplashScreenPath();
 
   std::set<Runtime*> runtimes_;
+  RuntimeContext* runtime_context_;
   scoped_refptr<ApplicationData> const data_;
   // The application's render process host.
   content::RenderProcessHost* render_process_host_;
@@ -159,7 +161,6 @@ class Application : public Runtime::Observer,
 
   void NotifyTermination();
 
-  RuntimeContext* runtime_context_;
   Observer* observer_;
 
   std::map<std::string, std::string> name_perm_map_;

--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -13,6 +14,8 @@
 #include "content/browser/screen_orientation/screen_orientation_dispatcher_host.h"
 #include "content/browser/screen_orientation/screen_orientation_provider.h"
 
+#include "xwalk/runtime/browser/runtime_context.h"
+#include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
 #include "xwalk/runtime/browser/ui/native_app_window.h"
 #include "xwalk/runtime/browser/ui/native_app_window_tizen.h"
 #include "xwalk/runtime/common/xwalk_common_messages.h"
@@ -101,6 +104,8 @@ ApplicationTizen::ApplicationTizen(
 #if defined(USE_OZONE)
   ui::PlatformEventSource::GetInstance()->AddPlatformEventObserver(this);
 #endif
+  cookie_manager_ = scoped_ptr<CookieManager>(
+      new CookieManager(id(), runtime_context_));
 }
 
 ApplicationTizen::~ApplicationTizen() {
@@ -203,6 +208,15 @@ void ApplicationTizen::DidProcessEvent(
   }
 }
 #endif
+
+void ApplicationTizen::RemoveAllCookies() {
+  cookie_manager_->RemoveAllCookies();
+}
+
+void ApplicationTizen::SetUserAgentString(
+    const std::string& user_agent_string) {
+  cookie_manager_->SetUserAgentString(render_process_host_, user_agent_string);
+}
 
 }  // namespace application
 }  // namespace xwalk

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -1,11 +1,15 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 #ifndef XWALK_APPLICATION_BROWSER_APPLICATION_TIZEN_H_
 #define XWALK_APPLICATION_BROWSER_APPLICATION_TIZEN_H_
 
+#include <string>
+
 #include "base/event_types.h"
 #include "xwalk/application/browser/application.h"
+#include "xwalk/application/common/tizen/cookie_manager.h"
 
 #if defined(USE_OZONE)
 #include "ui/events/platform/platform_event_observer.h"
@@ -26,6 +30,9 @@ class ApplicationTizen :  // NOLINT
   void Suspend();
   void Resume();
 
+  void RemoveAllCookies();
+  void SetUserAgentString(const std::string& user_agent_string);
+
  private:
   friend class Application;
   ApplicationTizen(scoped_refptr<ApplicationData> data,
@@ -39,6 +46,7 @@ class ApplicationTizen :  // NOLINT
   virtual void DidProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
 #endif
 
+  scoped_ptr<CookieManager> cookie_manager_;
   bool is_suspended_;
 };
 

--- a/application/browser/linux/running_application_object.h
+++ b/application/browser/linux/running_application_object.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -44,6 +45,14 @@ class RunningApplicationObject : public dbus::ManagedObject {
                   bool success);
 
   void OnTerminate(dbus::MethodCall* method_call,
+                   dbus::ExportedObject::ResponseSender response_sender);
+
+  void SetUserAgentStringOnIOThread(const std::string& user_agent_string);
+
+  void OnRemoveAllCookies(dbus::MethodCall* method_call,
+                   dbus::ExportedObject::ResponseSender response_sender);
+
+  void OnSetUserAgentString(dbus::MethodCall* method_call,
                    dbus::ExportedObject::ResponseSender response_sender);
 
   void OnGetExtensionProcessChannel(

--- a/application/common/tizen/cookie_manager.cc
+++ b/application/common/tizen/cookie_manager.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2014 Samsung Electronics Co., Ltd. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/tizen/cookie_manager.h"
+
+#include "base/bind.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/render_process_host.h"
+#include "net/cookies/cookie_monster.h"
+#include "net/cookies/cookie_store.h"
+#include "net/url_request/url_request_context.h"
+#include "net/url_request/url_request_context_getter.h"
+
+#include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
+#include "xwalk/runtime/common/xwalk_common_messages.h"
+
+namespace xwalk {
+
+CookieManager::CookieManager(
+    const std::string& app_id,
+    RuntimeContext* runtime_context)
+      : app_id_(app_id),
+        runtime_context_(runtime_context) {
+}
+
+void CookieManager::CookieDeleted(bool success) {
+  if (!success)
+    LOG(ERROR) << "Removal of cookie failed.";
+}
+
+void CookieManager::DeleteSessionOnlyOriginCookies(
+    const net::CookieList& cookies) {
+  net::URLRequestContext* request_context = runtime_context_->
+      GetURLRequestContextGetterById(
+          std::string(app_id_))->GetURLRequestContext();
+  if (!request_context)
+    return;
+  net::CookieMonster* cookie_monster =
+      request_context->cookie_store()->GetCookieMonster();
+  for (net::CookieList::const_iterator it = cookies.begin();
+       it != cookies.end(); ++it) {
+    cookie_monster->DeleteCanonicalCookieAsync(*it,
+        base::Bind(&CookieManager::CookieDeleted,
+                   base::Unretained(this)));
+  }
+}
+
+void CookieManager::DeleteCookiesOnIOThread(
+    const std::string& url,
+    const std::string& cookie_name) {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::IO));
+  net::URLRequestContext* request_context = runtime_context_->
+      GetURLRequestContextGetterById(app_id_)->GetURLRequestContext();
+  net::CookieStore* cookie_store = request_context->cookie_store();
+  cookie_store->GetCookieMonster()->GetAllCookiesAsync(
+      base::Bind(&CookieManager::DeleteSessionOnlyOriginCookies,
+                 base::Unretained(this)));
+}
+
+void CookieManager::RemoveAllCookies() {
+  content::BrowserThread::PostTask(
+      content::BrowserThread::IO, FROM_HERE, base::Bind(
+          &CookieManager::DeleteCookiesOnIOThread,
+          base::Unretained(this), "", ""));
+}
+
+void CookieManager::SetUserAgentString(
+    content::RenderProcessHost* render_process_host,
+    const std::string& user_agent_string) {
+  render_process_host->Send(
+      new ViewMsg_UserAgentStringChanged(user_agent_string));
+}
+
+}  // namespace xwalk

--- a/application/common/tizen/cookie_manager.h
+++ b/application/common/tizen/cookie_manager.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2014 Samsung Electronics Co., Ltd. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_TIZEN_COOKIE_MANAGER_H_
+#define XWALK_APPLICATION_COMMON_TIZEN_COOKIE_MANAGER_H_
+
+#include <string>
+
+#include "net/cookies/canonical_cookie.h"
+
+#include "xwalk/runtime/browser/runtime_context.h"
+
+namespace xwalk {
+
+class CookieManager {
+ public:
+  CookieManager(const std::string& app_id, RuntimeContext* runtime_context);
+  void RemoveAllCookies();
+  void SetUserAgentString(content::RenderProcessHost* render_process_host,
+                          const std::string& user_agent_string);
+ private:
+  void CookieDeleted(bool success);
+  void DeleteSessionOnlyOriginCookies(const net::CookieList& cookies);
+  void DeleteCookiesOnIOThread(const std::string& url,
+                               const std::string& cookie_name);
+
+  const std::string app_id_;
+  RuntimeContext* runtime_context_;
+};
+
+}  // namespace xwalk
+#endif  // XWALK_APPLICATION_COMMON_TIZEN_COOKIE_MANAGER_H_

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -82,6 +82,8 @@
             'tizen/application_storage.h',
             'tizen/application_storage_impl.cc',
             'tizen/application_storage_impl.h',
+            'tizen/cookie_manager.cc',
+            'tizen/cookie_manager.h',
             'tizen/package_query.cc',
             'tizen/package_query.h',
             'tizen/signature_data.h',

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -195,6 +196,16 @@ content::PushMessagingService* RuntimeContext::GetPushMessagingService() {
 
 content::SSLHostStateDelegate* RuntimeContext::GetSSLHostStateDelegate() {
   return NULL;
+}
+
+RuntimeURLRequestContextGetter* RuntimeContext::GetURLRequestContextGetterById(
+    const std::string& pkg_id) {
+  for (PartitionPathContextGetterMap::iterator it = context_getters_.begin();
+       it != context_getters_.end(); ++it) {
+    if (it->first.find(pkg_id))
+      return it->second.get();
+  }
+  return 0;
 }
 
 net::URLRequestContextGetter* RuntimeContext::CreateRequestContext(

--- a/runtime/browser/runtime_context.h
+++ b/runtime/browser/runtime_context.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -72,6 +73,9 @@ class RuntimeContext
   virtual quota::SpecialStoragePolicy* GetSpecialStoragePolicy() OVERRIDE;
   virtual content::PushMessagingService* GetPushMessagingService() OVERRIDE;
   virtual content::SSLHostStateDelegate* GetSSLHostStateDelegate() OVERRIDE;
+
+  RuntimeURLRequestContextGetter* GetURLRequestContextGetterById(
+      const std::string& pkg_id);
   net::URLRequestContextGetter* CreateRequestContext(
       content::ProtocolHandlerMap* protocol_handlers,
       content::URLRequestInterceptorScopedVector request_interceptors);

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -1,8 +1,11 @@
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 // Multiply-included file, no traditional include guard.
+#include <string>
+
 #include "content/public/common/common_param_traits.h"
 #include "ipc/ipc_channel_handle.h"
 #include "ipc/ipc_message_macros.h"
@@ -41,6 +44,11 @@ IPC_MESSAGE_CONTROL2(ViewMsg_EnableSecurityMode,    // NOLINT
 
 IPC_MESSAGE_CONTROL1(ViewMsg_SuspendJSEngine,  // NOLINT
                      bool /* is suspend */)
+
+#if defined(OS_TIZEN)
+IPC_MESSAGE_CONTROL1(ViewMsg_UserAgentStringChanged,  // NOLINT
+                     std::string /*new user agent string*/)
+#endif
 
 IPC_MESSAGE_ROUTED1(ViewMsg_HWKeyPressed, int /*keycode*/)  // NOLINT
 

--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -23,6 +24,10 @@
 #include "xwalk/application/common/constants.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
+#if (defined(OS_TIZEN))
+#include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
+#include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
+#endif
 
 const char* const xwalk::XWalkContentClient::kNaClPluginName = "Native Client";
 
@@ -111,6 +116,25 @@ std::string XWalkContentClient::GetProduct() const {
 }
 
 std::string XWalkContentClient::GetUserAgent() const {
+#if (defined(OS_TIZEN))
+  // TODO(jizydorczyk):
+  // const_cast below is required to invoke ContentClient::renderer() method,
+  // I think there is no reason for ContentClient::renderer() in content API
+  // to be non-const as it doesn't change any data, so it should be changed in
+  // chromium code later.
+  XWalkContentClient* content_client = const_cast<XWalkContentClient*>(this);
+  content::ContentRendererClient* content_renderer_client =
+      content_client->renderer();
+  if (content_renderer_client) {
+    XWalkContentRendererClientTizen* content_renderer_client_tizen =
+        static_cast<XWalkContentRendererClientTizen*>(
+            content_renderer_client);
+    const std::string& user_agent_string = content_renderer_client_tizen->
+        GetOverridenUserAgent();
+    if (!user_agent_string.empty())
+      return user_agent_string;
+  }
+#endif
   return xwalk::GetUserAgent();
 }
 

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -109,6 +110,12 @@ void XWalkContentRendererClientTizen::GetNavigationErrorStrings(
                            "<h1>NET ERROR : %s</h1></body></html>",
                            net::ErrorToString(error.reason).c_str());
   }
+}
+
+std::string XWalkContentRendererClientTizen::GetOverridenUserAgent() const {
+  if (!xwalk_render_process_observer_)
+    return "";
+  return xwalk_render_process_observer_->GetOverridenUserAgent();
 }
 
 }  // namespace xwalk

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -31,6 +32,7 @@ class XWalkContentRendererClientTizen : public XWalkContentRendererClient {
       const blink::WebURLError& error,
       std::string* error_html,
       base::string16* error_description) OVERRIDE;
+  std::string GetOverridenUserAgent() const;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkContentRendererClientTizen);

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -61,6 +62,9 @@ class XWalkContentRendererClient
                                const GURL& first_party_for_cookies,
                                GURL* new_url) OVERRIDE;
 
+ protected:
+  scoped_ptr<XWalkRenderProcessObserver> xwalk_render_process_observer_;
+
  private:
   // XWalkExtensionRendererController::Delegate implementation.
   virtual void DidCreateModuleSystem(
@@ -69,7 +73,6 @@ class XWalkContentRendererClient
   scoped_ptr<extensions::XWalkExtensionRendererController>
       extension_controller_;
 
-  scoped_ptr<XWalkRenderProcessObserver> xwalk_render_process_observer_;
 #if defined(OS_ANDROID)
   scoped_ptr<visitedlink::VisitedLinkSlave> visited_link_slave_;
 #endif

--- a/runtime/renderer/xwalk_render_process_observer_generic.cc
+++ b/runtime/renderer/xwalk_render_process_observer_generic.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -12,6 +13,7 @@
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
 #include "third_party/WebKit/public/platform/WebString.h"
 #include "xwalk/runtime/common/xwalk_common_messages.h"
+#include "xwalk/runtime/common/xwalk_content_client.h"
 
 
 namespace xwalk {
@@ -59,6 +61,9 @@ bool XWalkRenderProcessObserver::OnControlMessageReceived(
     IPC_MESSAGE_HANDLER(ViewMsg_SetAccessWhiteList, OnSetAccessWhiteList)
     IPC_MESSAGE_HANDLER(ViewMsg_EnableSecurityMode, OnEnableSecurityMode)
     IPC_MESSAGE_HANDLER(ViewMsg_SuspendJSEngine, OnSuspendJSEngine)
+#if defined(OS_TIZEN)
+    IPC_MESSAGE_HANDLER(ViewMsg_UserAgentStringChanged, OnUserAgentChanged)
+#endif
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
   return handled;
@@ -104,5 +109,16 @@ void XWalkRenderProcessObserver::OnSuspendJSEngine(bool is_suspend) {
     thread->webkit_platform_support()->ResumeSharedTimer();
   is_suspended_ = is_suspend;
 }
+
+#if defined(OS_TIZEN)
+void XWalkRenderProcessObserver::OnUserAgentChanged(
+    const std::string& userAgentString) {
+  overriden_user_agent_ = userAgentString;
+}
+
+std::string XWalkRenderProcessObserver::GetOverridenUserAgent() const {
+  return overriden_user_agent_;
+}
+#endif
 
 }  // namespace xwalk

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -41,6 +42,9 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   }
 
   const GURL& app_url() const { return app_url_; }
+#if defined(OS_TIZEN)
+  std::string GetOverridenUserAgent() const;
+#endif
 
  private:
   void OnSetAccessWhiteList(
@@ -48,6 +52,10 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   void OnEnableSecurityMode(
       const GURL& url, application::SecurityPolicy::SecurityMode mode);
   void OnSuspendJSEngine(bool is_pause);
+#if defined(OS_TIZEN)
+  void OnUserAgentChanged(const std::string& userAgentString);
+  std::string overriden_user_agent_;
+#endif
 
   bool is_webkit_initialized_;
   bool is_suspended_;


### PR DESCRIPTION
The Web setting extension defines APIs that manages the setting states of the Web view in Web application.
Properties of the Web view that can be managed via Web setting API:
- Delete all cookies saved for the web view in the Web application
- Set a custom user agent string of the web view in Web application

This commit includes setting and reading custom user agent string and
removal of application cookies on crosswalk engine side.

Result of running tct-tizen-websetting tests after this change and related change in crosswalk extensions: 22/22 tests pass.

This change concerns XWALK-1063 issue.
