### PR TITLE
[REG] Fixed NaCl loading issue introduced by rebase.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -406,6 +406,7 @@
                     '../components/nacl.gyp:nacl_helper',
                     '../components/nacl.gyp:nacl_linux',
                     '../native_client/src/trusted/service_runtime/linux/nacl_bootstrap.gyp:nacl_helper_bootstrap',
+                    '../ppapi/native_client/src/trusted/plugin/plugin.gyp:nacl_trusted_plugin',
                   ],
                 }],
             ],


### PR DESCRIPTION
According to the upstream change 01167110, the trusted plugin is
linked into the renderer directly instead of loading as a module
in runtime, and the ppGoogleNaClPlugin module has been removed;
so we need to change the plugin loading codes in
XWalkContentClient::AddPepperPlugins.
