### PR TITLE
[Tizen] Reinstall option of backend

### DIFF
--- a/application/common/installer/package_installer.cc
+++ b/application/common/installer/package_installer.cc
@@ -98,6 +98,10 @@ bool PackageInstaller::PlatformUpdate(ApplicationData* updated_data) {
   return true;
 }
 
+bool PackageInstaller::PlatformReinstall(const base::FilePath& path) {
+  return false;
+}
+
 bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
   // FIXME(leandro): Installation is not robust enough -- should any step
   // fail, it can't roll back to a consistent state.
@@ -361,6 +365,10 @@ bool PackageInstaller::Uninstall(const std::string& id) {
     result = false;
 
   return result;
+}
+
+bool PackageInstaller::Reinstall(const base::FilePath& path) {
+  return PlatformReinstall(path);
 }
 
 void PackageInstaller::ContinueUnfinishedTasks() {

--- a/application/common/installer/package_installer.h
+++ b/application/common/installer/package_installer.h
@@ -24,6 +24,8 @@ class PackageInstaller {
   bool Install(const base::FilePath& path, std::string* id);
   bool Uninstall(const std::string& id);
   bool Update(const std::string& id, const base::FilePath& path);
+  bool Reinstall(const base::FilePath& path);
+
   void ContinueUnfinishedTasks();
 
   virtual void SetQuiet(bool quiet);
@@ -38,6 +40,8 @@ class PackageInstaller {
   virtual bool PlatformInstall(ApplicationData* data);
   virtual bool PlatformUninstall(ApplicationData* data);
   virtual bool PlatformUpdate(ApplicationData* updated_data);
+
+  virtual bool PlatformReinstall(const base::FilePath& path);
 
   ApplicationStorage* storage_;
 };

--- a/application/common/installer/package_installer_tizen.cc
+++ b/application/common/installer/package_installer_tizen.cc
@@ -339,5 +339,31 @@ bool PackageInstallerTizen::PlatformUpdate(ApplicationData* app_data) {
   return true;
 }
 
+bool PackageInstallerTizen::PlatformReinstall(const base::FilePath& path) {
+  CommandLine cmdline(kPkgHelper);
+  cmdline.AppendSwitchPath("--reinstall", path);
+  if (quiet_)
+    cmdline.AppendSwitch("-q");
+  if (!key_.empty()) {
+    cmdline.AppendSwitchASCII("--key", key_);
+  }
+
+  int exit_code;
+  std::string output;
+
+  if (!base::GetAppOutputWithExitCode(cmdline, &output, &exit_code)) {
+    LOG(ERROR) << "Could not launch installer helper";
+    return false;
+  }
+
+  if (exit_code != 0) {
+    LOG(ERROR) << "Could not reinstall application: "
+               << output << " (" << exit_code << ")";
+    return false;
+  }
+
+  return true;
+}
+
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/installer/package_installer_tizen.h
+++ b/application/common/installer/package_installer_tizen.h
@@ -26,6 +26,8 @@ class PackageInstallerTizen : public PackageInstaller {
   virtual bool PlatformUninstall(ApplicationData* data) OVERRIDE;
   virtual bool PlatformUpdate(ApplicationData* data) OVERRIDE;
 
+  virtual bool PlatformReinstall(const base::FilePath& path) OVERRIDE;
+
  private:
   bool quiet_;
   std::string key_;

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -38,6 +38,7 @@ namespace {
 char* install_path = NULL;
 char* uninstall_id = NULL;
 #if defined(OS_TIZEN)
+char* reinstall_path = NULL;
 char* operation_key = NULL;
 int quiet = 0;
 #endif
@@ -55,6 +56,8 @@ GOptionEntry entries[] = {
   { "continue", 'c' , 0, G_OPTION_ARG_NONE, &continue_tasks,
     "Continue the previous unfinished tasks.", NULL},
 #if defined(OS_TIZEN)
+  { "reinstall", 'r', 0, G_OPTION_ARG_STRING, &reinstall_path,
+    "Reinstall the application with path", "PATH" },
   { "key", 'k', 0, G_OPTION_ARG_STRING, &operation_key,
     "Unique operation key", "KEY" },
   { "quiet", 'q', 0, G_OPTION_ARG_NONE, &quiet,
@@ -188,6 +191,10 @@ int main(int argc, char* argv[]) {
     }
   } else if (uninstall_id) {
     success = installer->Uninstall(uninstall_id);
+#if defined(OS_TIZEN)
+  } else if (reinstall_path) {
+    success = installer->Reinstall(base::FilePath(reinstall_path));
+#endif
   } else if (debugging_port >= 0) {
 #if defined(SHARED_PROCESS_MODE)
     // Deal with the case "xwalkctl -d PORT_NUMBER"

--- a/application/tools/tizen/xwalk_backend_wrapper.sh
+++ b/application/tools/tizen/xwalk_backend_wrapper.sh
@@ -22,9 +22,9 @@ do
               keyvalue="$2"
               shift
               ;;
-        "-r") echo "Reinstall not supported"
-              exit 128 # ErrorNotSupportRDSUpdate == 128
-              ;; #TODO(t.iwanek) fix me - sending signals for reinstall option
+        "-r") option="-r"
+              id="$2"
+              ;;
     esac
     shift
 done

--- a/application/tools/tizen/xwalk_package_helper.cc
+++ b/application/tools/tizen/xwalk_package_helper.cc
@@ -23,6 +23,7 @@ namespace {
 char* install_option = NULL;
 char* update_option = NULL;
 char* uninstall_option = NULL;
+char* reinstall_option = NULL;
 char* operation_key = NULL;
 char* xml_path = NULL;
 char* icon_path = NULL;
@@ -35,6 +36,8 @@ GOptionEntry entries[] = {
     "Path of the application to be updated", "APPID" },
   { "uninstall", 'd', 0, G_OPTION_ARG_STRING, &uninstall_option,
     "Uninstall the application with this appid", "APPID" },
+  { "reinstall", 'r', 0, G_OPTION_ARG_STRING, &reinstall_option,
+    "Path of the application to be reinstalled", "APPID" },
   { "key", 'k', 0, G_OPTION_ARG_STRING, &operation_key,
     "Unique operation key", "KEY" },
   { "quiet", 'q', 0, G_OPTION_ARG_NONE, &quiet,
@@ -86,8 +89,10 @@ int main(int argc, char *argv[]) {
     appId = uninstall_option;
   } else if (update_option) {
     appId = update_option;
+  } else if (reinstall_option) {
+    appId = reinstall_option;
   } else {
-    fprintf(stderr, "Use: --install, --uninstall or --update\n");
+    fprintf(stderr, "Use: --install, --uninstall, --update or --reinstall\n");
     exit(1);
   }
 
@@ -127,6 +132,14 @@ int main(int argc, char *argv[]) {
     }
 
     result = helper.UpdateApplication(xml_path, icon_path);
+  } else if (reinstall_option) {
+    if (operation_key) {
+      pkgmgr_argv[0] = "-r";
+      pkgmgr_argv[1] = reinstall_option;  // this value is ignored by pkgmgr
+      helper.InitializePkgmgrSignal((quiet ? 5 : 4), pkgmgr_argv);
+    }
+
+    result = helper.ReinstallApplication();
   }
 
   // Convention is to return 0 on success.

--- a/application/tools/tizen/xwalk_package_installer_helper.cc
+++ b/application/tools/tizen/xwalk_package_installer_helper.cc
@@ -40,6 +40,9 @@ const char PKGMGR_START_UNINSTALL[] = "uninstall";
 // Value for update.
 const char PKGMGR_START_UPDATE[] = "update";
 
+// Value for update.
+const char PKGMGR_START_REINSTALL[] = "reinstall";
+
 // Notification about end of installation with status.
 const char PKGMGR_END_KEY[] = "end";
 
@@ -150,6 +153,13 @@ bool PackageInstallerHelper::UpdateApplication(
   bool ret = UpdateApplicationInternal(xmlpath, iconpath);
   SendSignal(PKGMGR_END_KEY, ToEndStatus(ret));
   return ret;
+}
+
+bool PackageInstallerHelper::ReinstallApplication() {
+  SendSignal(PKGMGR_START_KEY, PKGMGR_START_REINSTALL);
+  // FIXME not implemented, just send signal abotu failure
+  SendSignal(PKGMGR_END_KEY, ToEndStatus(false));
+  return false;
 }
 
 bool PackageInstallerHelper::InstallApplicationInternal(

--- a/application/tools/tizen/xwalk_package_installer_helper.h
+++ b/application/tools/tizen/xwalk_package_installer_helper.h
@@ -20,6 +20,7 @@ class PackageInstallerHelper {
   bool UninstallApplication();
   bool UpdateApplication(const std::string& xmlpath,
                          const std::string& iconpath);
+  bool ReinstallApplication();
 
  private:
   bool InstallApplicationInternal(const std::string& xmlpath,


### PR DESCRIPTION
This commit  adds "-r" option for xwalkctl.
xwalkctl may be called with this option by package manager to reinstall app in specific way may be implemented later. 

For now, we need just to signal pkgmgr that reinstallation fails to prevent hanging requesting process.

BUG=XWALK-2458
