### PR TITLE
[Tizen] Drop privileges for extension process

### DIFF
--- a/build/system.gyp
+++ b/build/system.gyp
@@ -66,6 +66,7 @@
               'pkgmgr-installer',
               'pkgmgr',
               'secure-storage',
+              'security-manager',
               'vconf',
             ],
           },

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -82,6 +82,7 @@ BuildRequires:  pkgconfig(secure-storage)
 BuildRequires:  pkgconfig(sensor)
 BuildRequires:  pkgconfig(nspr)
 BuildRequires:  pkgconfig(nss)
+BuildRequires:  pkgconfig(security-manager)
 BuildRequires:  pkgconfig(vconf)
 BuildRequires:  pkgconfig(xmlsec1)
 %if %{with x}
@@ -300,7 +301,8 @@ fi
 %manifest %{name}.manifest
 %license AUTHORS.chromium LICENSE.chromium LICENSE.xwalk
 %{_bindir}/xwalkctl
-%{_bindir}/xwalk-launcher
+%caps(cap_mac_admin,cap_setgid=ei) %{_bindir}/xwalk-launcher
+
 %{_libdir}/xwalk/icudtl.dat
 %{_libdir}/xwalk/libffmpegsumo.so
 %if ! %{_disable_nacl}


### PR DESCRIPTION
This commit uses security-manager API to apply correct security context
for extension process.

BUG=XWALK-1731

[Verification]
  rpm -i security-manager-0.1.0-2.2.armv7l.rpm \
         libcynara-admin-0.2.2-10.1.armv7l.rpm \
         cynara-0.2.2-10.1.armv7l.rpm \
         libsecurity-manager-client-0.1.0-2.2.armv7l.rpm
  systemctl start cynara
  systemctl start security-manager
  systemctl enable security-manager
  (install and run app)

Depends on: https://github.com/crosswalk-project/crosswalk/pull/2518
