### PR TITLE
Clarify the application start URL fetching

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -80,11 +80,10 @@ Application::Application(
       security_mode_enabled_(false),
       runtime_context_(runtime_context),
       observer_(observer),
-      entry_point_used_(Default),
       remote_debugging_enabled_(false),
       weak_factory_(this) {
   DCHECK(runtime_context_);
-  DCHECK(data_.get());
+  DCHECK(data_);
   DCHECK(observer_);
 }
 
@@ -94,90 +93,55 @@ Application::~Application() {
     render_process_host_->RemoveObserver(this);
 }
 
-bool Application::Launch(const LaunchParams& launch_params) {
-  if (!runtimes_.empty()) {
-    LOG(ERROR) << "Attempt to launch app: " << id()
-               << " that was already launched.";
-    return false;
+template<>
+GURL Application::GetStartURL<Package::WGT>() {
+  GURL url = GetAbsoluteURLFromKey(widget_keys::kLaunchLocalPathKey);
+  if (!url.is_valid()) {
+    LOG(WARNING) << "Failed to find start URL from the 'config.xml'"
+                 << "trying to find default entry page.";
+    url = GetDefaultWidgetEntryPage(data_);
   }
 
-  CHECK(!render_process_host_);
-
-  GURL url = GetStartURL(launch_params, &entry_point_used_);
-  if (!url.is_valid())
-    return false;
-
-  remote_debugging_enabled_ = launch_params.remote_debugging;
-
-  Runtime* runtime = Runtime::Create(
-      runtime_context_,
-      this, content::SiteInstance::CreateForURL(runtime_context_, url));
-  render_process_host_ = runtime->GetRenderProcessHost();
-  render_process_host_->AddObserver(this);
-  web_contents_ = runtime->web_contents();
-  InitSecurityPolicy();
-  runtime->LoadURL(url);
-
-  NativeAppWindow::CreateParams params;
-  params.net_wm_pid = launch_params.launcher_pid;
-  if (data_->GetPackageType() == Package::WGT)
-    params.state = GetWindowShowStateWGT(launch_params);
-  else
-    params.state = GetWindowShowStateXPK(launch_params);
-
-  params.splash_screen_path = GetSplashScreenPath();
-
-  runtime->AttachWindow(params);
-
-  return true;
-}
-
-GURL Application::GetStartURL(const LaunchParams& params,
-    LaunchEntryPoint* used) {
-  if (params.entry_points & StartURLKey) {
-    GURL url = GetAbsoluteURLFromKey(keys::kStartURLKey);
-    if (url.is_valid()) {
-      *used = StartURLKey;
-      return url;
-    }
-  }
-
-  if (params.entry_points & LaunchLocalPathKey) {
-    GURL url = GetAbsoluteURLFromKey(
-        GetLaunchLocalPathKey(data_->GetPackageType()));
-
-    if (!url.is_valid() && data_->GetPackageType() == Package::WGT)
-      url = GetDefaultWidgetEntryPage(data_);
-
-    if (url.is_valid()) {
+  if (url.is_valid()) {
 #if defined(OS_TIZEN)
-      if (data_->IsHostedApp() && !url.SchemeIsHTTPOrHTTPS()) {
-        LOG(ERROR) << "Hosted application should use the url start with"
-                      "http or https as its entry page.";
-        return GURL();
-      }
+    if (data_->IsHostedApp() && !url.SchemeIsHTTPOrHTTPS()) {
+      LOG(ERROR) << "Hosted apps are only supported with"
+                    "http:// or https:// scheme.";
+      return GURL();
+    }
 #endif
-      *used = LaunchLocalPathKey;
-      return url;
-    }
-  }
-
-  if (params.entry_points & URLKey) {
-    LOG(WARNING) << "Deprecated key '" << keys::kDeprecatedURLKey
-        << "' found. Please migrate to using '" << keys::kStartURLKey
-        << "' instead.";
-    GURL url = GetAbsoluteURLFromKey(keys::kDeprecatedURLKey);
-    if (url.is_valid()) {
-      *used = URLKey;
-      return url;
-    }
+    return url;
   }
 
   LOG(WARNING) << "Failed to find a valid start URL in the manifest.";
   return GURL();
 }
 
-ui::WindowShowState Application::GetWindowShowStateWGT(
+template<>
+GURL Application::GetStartURL<Package::XPK>() {
+  GURL url = GetAbsoluteURLFromKey(keys::kStartURLKey);
+  if (url.is_valid())
+    return url;
+
+  url = GetAbsoluteURLFromKey(keys::kLaunchLocalPathKey);
+  if (url.is_valid())
+    return url;
+
+  url = GetAbsoluteURLFromKey(keys::kDeprecatedURLKey);
+  if (url.is_valid()) {
+    LOG(WARNING) << "Deprecated key '" << keys::kDeprecatedURLKey
+        << "' found. Please migrate to using '" << keys::kStartURLKey
+        << "' instead.";
+    return url;
+  }
+
+  LOG(WARNING) << "Failed to find a valid start URL in the manifest.";
+  return GURL();
+}
+
+
+template<>
+ui::WindowShowState Application::GetWindowShowState<Package::WGT>(
     const LaunchParams& params) {
   if (params.force_fullscreen)
     return ui::SHOW_STATE_FULLSCREEN;
@@ -197,7 +161,8 @@ ui::WindowShowState Application::GetWindowShowStateWGT(
   return ui::SHOW_STATE_DEFAULT;
 }
 
-ui::WindowShowState Application::GetWindowShowStateXPK(
+template<>
+ui::WindowShowState Application::GetWindowShowState<Package::XPK>(
     const LaunchParams& params) {
   if (params.force_fullscreen)
     return ui::SHOW_STATE_FULLSCREEN;
@@ -212,6 +177,44 @@ ui::WindowShowState Application::GetWindowShowStateXPK(
   }
 
   return ui::SHOW_STATE_DEFAULT;
+}
+
+bool Application::Launch(const LaunchParams& launch_params) {
+  if (!runtimes_.empty()) {
+    LOG(ERROR) << "Attempt to launch app with id " << id()
+               << ", but it is already running.";
+    return false;
+  }
+
+  CHECK(!render_process_host_);
+  bool is_wgt = data_->GetPackageType() == Package::WGT;
+
+  GURL url = is_wgt ? GetStartURL<Package::WGT>():
+                      GetStartURL<Package::XPK>();
+  if (!url.is_valid())
+    return false;
+
+  remote_debugging_enabled_ = launch_params.remote_debugging;
+
+  Runtime* runtime = Runtime::Create(
+      runtime_context_,
+      this, content::SiteInstance::CreateForURL(runtime_context_, url));
+  render_process_host_ = runtime->GetRenderProcessHost();
+  render_process_host_->AddObserver(this);
+  web_contents_ = runtime->web_contents();
+  InitSecurityPolicy();
+  runtime->LoadURL(url);
+
+  NativeAppWindow::CreateParams params;
+  params.net_wm_pid = launch_params.launcher_pid;
+  params.state = is_wgt ? GetWindowShowState<Package::WGT>(launch_params):
+                          GetWindowShowState<Package::XPK>(launch_params);
+
+  params.splash_screen_path = GetSplashScreenPath();
+
+  runtime->AttachWindow(params);
+
+  return true;
 }
 
 GURL Application::GetAbsoluteURLFromKey(const std::string& key) {

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -58,24 +58,7 @@ class Application : public Runtime::Observer,
     virtual ~Observer() {}
   };
 
-  // Manifest keys that can be used as application entry points.
-  enum LaunchEntryPoint {
-    StartURLKey = 1 << 0,  // start_url
-    LaunchLocalPathKey = 1 << 1,  // app.launch.local_path
-    URLKey = 1 << 2,  // url
-    Default = StartURLKey | LaunchLocalPathKey
-  };
-  typedef unsigned LaunchEntryPoints;
-
   struct LaunchParams {
-    LaunchParams() :
-        entry_points(Default),
-        launcher_pid(0),
-        force_fullscreen(false),
-        remote_debugging(false) {}
-
-    LaunchEntryPoints entry_points;
-
     // Used only when running as service. Specifies the PID of the launcher
     // process.
     int32 launcher_pid;
@@ -165,9 +148,10 @@ class Application : public Runtime::Observer,
 
   // Try to extract the URL from different possible keys for entry points in the
   // manifest, returns it and the entry point used.
-  GURL GetStartURL(const LaunchParams& params, LaunchEntryPoint* used);
-  ui::WindowShowState GetWindowShowStateWGT(const LaunchParams& params);
-  ui::WindowShowState GetWindowShowStateXPK(const LaunchParams& params);
+  template <Package::Type> GURL GetStartURL();
+
+  template <Package::Type>
+  ui::WindowShowState GetWindowShowState(const LaunchParams& params);
 
   GURL GetAbsoluteURLFromKey(const std::string& key);
 
@@ -175,8 +159,7 @@ class Application : public Runtime::Observer,
 
   RuntimeContext* runtime_context_;
   Observer* observer_;
-  // The entry point used as part of Launch().
-  LaunchEntryPoint entry_point_used_;
+
   std::map<std::string, std::string> name_perm_map_;
   // Application's session permissions.
   StoredPermissionMap permission_map_;

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -77,7 +77,6 @@ bool ApplicationSystem::LaunchWithCommandLineParam<GURL>(
 
   Application::LaunchParams launch_params;
   launch_params.force_fullscreen = cmd_line.HasSwitch(switches::kFullscreen);
-  launch_params.entry_points = Application::StartURLKey;
   launch_params.remote_debugging =
       cmd_line.HasSwitch(switches::kRemoteDebuggingPort);
 

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -161,7 +161,6 @@ void RunningApplicationsManager::OnLaunch(
   if (GURL(app_id_or_url).spec().empty()) {
     application = application_service_->Launch(app_id_or_url, params);
   } else {
-    params.entry_points = Application::StartURLKey;
     std::string error;
     scoped_refptr<ApplicationData> application_data =
         ApplicationData::Create(GURL(app_id_or_url), &error);

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -161,13 +161,6 @@ const char* GetVersionKey(Package::Type package_type) {
   return application_manifest_keys::kXWalkVersionKey;
 }
 
-const char* GetLaunchLocalPathKey(Package::Type package_type) {
-  if (package_type == Package::WGT)
-    return application_widget_keys::kLaunchLocalPathKey;
-
-  return application_manifest_keys::kLaunchLocalPathKey;
-}
-
 const char* GetCSPKey(Package::Type package_type) {
   if (package_type == Package::WGT)
     return application_widget_keys::kCSPKey;

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -118,10 +118,7 @@ namespace application_manifest_errors {
 }  // namespace application_manifest_errors
 
 namespace application {
-
-typedef application::Manifest Manifest;
 const char* GetNameKey(Package::Type type);
-const char* GetLaunchLocalPathKey(Package::Type type);
 const char* GetCSPKey(Package::Type type);
 #if defined(OS_TIZEN)
 const char* GetTizenAppIdKey(Package::Type type);


### PR DESCRIPTION
This patch introduces a clear separation between
XPK and WGT code paths for fetching start URL.

It also removes deprecated and unneeded EntryPoints
flags from the Application class.
