### PR TITLE
[Tizen][Runtime]Implement screen-orientation feature.

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -121,6 +121,7 @@ const char kTizenMetaDataValueKey[] = "@value";
 const char kTizenSplashScreenKey[] = "widget.splash-screen";
 const char kTizenSplashScreenSrcKey[] = "@src";
 const char kContentNamespace[] = "widget.content.@namespace";
+const char kTizenScreenOrientationKey[] = "widget.setting.@screen-orientation";
 #endif
 
 }  // namespace application_widget_keys

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -102,6 +102,7 @@ namespace application_widget_keys {
   extern const char kTizenSplashScreenKey[];
   extern const char kTizenSplashScreenSrcKey[];
   extern const char kContentNamespace[];
+  extern const char kTizenScreenOrientationKey[];
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/manifest_handlers/tizen_setting_handler.h
+++ b/application/common/manifest_handlers/tizen_setting_handler.h
@@ -20,11 +20,24 @@ class TizenSettingInfo : public ApplicationData::ManifestData {
   TizenSettingInfo();
   virtual ~TizenSettingInfo();
 
+  enum ScreenOrientation {
+    PORTRAIT,
+    LANDSCAPE,
+    AUTO
+  };
+
   void set_hwkey_enabled(bool enabled) { hwkey_enabled_ = enabled; }
   bool hwkey_enabled() const { return hwkey_enabled_; }
 
+  void set_screen_orientation(ScreenOrientation orientation) {
+    screen_orientation_ = orientation;
+  }
+
+  ScreenOrientation screen_orientation() const { return screen_orientation_; }
+
  private:
   bool hwkey_enabled_;
+  ScreenOrientation screen_orientation_;
 };
 
 class TizenSettingHandler : public ManifestHandler {


### PR DESCRIPTION
According to Tizen core spec feature XWALK-1491, add a setting attribute "screen-orientation" in Tizen configure file.
This attribute controls whether screen orietation is locked or not. Its value can be one of "portrait", "landscape", "auto-rotation", and the default value should be "portrait".
