### PR TITLE
[Android] Multiple profile support

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
@@ -130,6 +130,15 @@ public class XWalkPreferencesInternal {
             "support-multiple-windows";
 
     /**
+     * The key string to set xwalk profile name.
+     * User data will be kept separated for different profiles.
+     * Profile needs to be set before any XWalkView instance created.
+     * @since 3.0
+     */
+    @XWalkAPI
+    public static final String PROFILE_NAME = "profile-name";
+
+    /**
      * The key string to enable/disable javascript.
      * TODO(wang16): Remove this after cordova removes its dependency.
      */
@@ -150,6 +159,7 @@ public class XWalkPreferencesInternal {
                 ALLOW_UNIVERSAL_ACCESS_FROM_FILE, new PreferenceValue(false));
         sPrefMap.put(SUPPORT_MULTIPLE_WINDOWS, new PreferenceValue(true));
         sPrefMap.put(ENABLE_EXTENSIONS, new PreferenceValue(true));
+        sPrefMap.put(PROFILE_NAME, new PreferenceValue("Default"));
     }
 
     /**

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSwitches.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSwitches.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+/**
+ * Contains all of the command line switches for crosswalk
+ */
+public abstract class XWalkSwitches {
+    // Native switch - xwalk_switches::kXWalkProfileName
+    public static final String PROFILE_NAME = "profile-name";
+
+    // Prevent instantiation.
+    private XWalkSwitches() {}
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -185,6 +185,9 @@ class XWalkViewDelegate {
                     throw new RuntimeException("Cannot initialize Crosswalk Core", e);
                 }
                 DeviceUtils.addDeviceSpecificUserAgentSwitch(context);
+                CommandLine.getInstance().appendSwitchWithValue(
+                        XWalkSwitches.PROFILE_NAME,
+                        XWalkPreferencesInternal.getStringValue(XWalkPreferencesInternal.PROFILE_NAME));
                 try {
                     BrowserStartupController.get(context).startBrowserProcessesSync(
                         true);

--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -104,6 +104,10 @@ base::FilePath RuntimeContext::GetPath() const {
   base::FilePath result;
 #if defined(OS_ANDROID)
   CHECK(PathService::Get(base::DIR_ANDROID_APP_DATA, &result));
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kXWalkProfileName))
+    result = result.Append(
+        cmd_line->GetSwitchValuePath(switches::kXWalkProfileName));
 #else
   CHECK(PathService::Get(xwalk::DIR_DATA_PATH, &result));
 #endif

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -36,6 +36,7 @@
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 namespace {
 
@@ -131,6 +132,10 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopRun() {
   if (!PathService::Get(base::DIR_ANDROID_APP_DATA, &user_data_dir)) {
     NOTREACHED() << "Failed to get app data directory for Crosswalk";
   }
+  CommandLine* command_line = CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kXWalkProfileName))
+    user_data_dir = user_data_dir.Append(
+        command_line->GetSwitchValuePath(switches::kXWalkProfileName));
 
   base::FilePath cookie_store_path = user_data_dir.Append(
       FILE_PATH_LITERAL("Cookies"));

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -28,4 +28,9 @@ const char kXWalkAllowExternalExtensionsForRemoteSources[] =
 // state, e.g. cache, localStorage etc.
 const char kXWalkDataPath[] = "data-path";
 
+#if defined(OS_ANDROID)
+// Specifies the separated folder to save user data on Android.
+const char kXWalkProfileName[] = "profile-name";
+#endif
+
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_RUNTIME_COMMON_XWALK_SWITCHES_H_
 #define XWALK_RUNTIME_COMMON_XWALK_SWITCHES_H_
 
+#include "build/build_config.h"
+
 // Defines all command line switches for XWalk.
 namespace switches {
 
@@ -15,6 +17,10 @@ extern const char kFullscreen[];
 extern const char kListFeaturesFlags[];
 extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
 extern const char kXWalkDataPath[];
+
+#if defined(OS_ANDROID)
+extern const char kXWalkProfileName[];
+#endif
 
 }  // namespace switches
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ProfileTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ProfileTest.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+import android.app.Activity;
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+import org.xwalk.core.XWalkPreferences;
+
+/**
+ * Test suite for XWalkPreferences.PROFILE_NAME.
+ */
+public class ProfileTest extends XWalkViewTestBase {
+    private final static String TEST_PROFILE_NAME = "test-profile";
+
+    private boolean deleteDir(File f) {
+        if (f.isDirectory()) {
+            File[] files = f.listFiles();
+            if (files == null) return true;
+            for (File subFile : files) {
+                deleteDir(subFile);
+            }
+        }
+        return f.delete();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        final Activity activity = getActivity();
+        String appDataDir = activity.getFilesDir().getParent();
+        File userDataDir = new File(appDataDir + File.separator + "app_xwalkcore" +
+                File.separator + TEST_PROFILE_NAME);
+        File defaultUserDataDir = new File(appDataDir + File.separator + "app_xwalkcore" +
+                File.separator + "Default");
+        deleteDir(userDataDir);
+        deleteDir(defaultUserDataDir);
+        XWalkPreferences.setValue(XWalkPreferences.PROFILE_NAME, TEST_PROFILE_NAME);
+        super.setUp();
+    }
+
+    @SmallTest
+    @Feature({"Profile"})
+    public void testCustomizeProfile() throws Throwable {
+        final String url = "file:///android_asset/www/index.html";
+        loadUrlSync(url);
+        final Activity activity = getActivity();
+        String appDataDir = activity.getFilesDir().getParent();
+        File userDataDir = new File(appDataDir + File.separator + "app_xwalkcore" +
+                File.separator + TEST_PROFILE_NAME);
+        File defaultUserDataDir = new File(appDataDir + File.separator + "app_xwalkcore" +
+                File.separator + "Default");
+        assertTrue(userDataDir.isDirectory());
+        assertFalse(defaultUserDataDir.exists());
+    }
+}


### PR DESCRIPTION
Add profile in the path of disk files used to save
user data. Embedder can specify profile by XWalkPreferences.

The profile must be set before any XWalkView instance created
to take effect.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2375
