### PR TITLE
Expose real path of Virtual Root (native file system)

### DIFF
--- a/experimental/native_file_system/native_file_system_api.js
+++ b/experimental/native_file_system/native_file_system_api.js
@@ -44,10 +44,19 @@ var getDirectoryList = function() {
   extension.internal.sendSyncMessage("get");
 }
 
+var getRealPath = function(virtual_root) {
+  var _msg = {
+    cmd : "getRealPath",
+    path : virtual_root
+  }
+  return extension.internal.sendSyncMessage(_msg);
+}
+
 NativeFileSystem.prototype = new Object();
 NativeFileSystem.prototype.constructor = NativeFileSystem;
 NativeFileSystem.prototype.requestNativeFileSystem = requestNativeFileSystem;
 NativeFileSystem.prototype.getDirectoryList = getDirectoryList;
+NativeFileSystem.prototype.getRealPath = getRealPath;
 
 exports = new NativeFileSystem();
 

--- a/experimental/native_file_system/native_file_system_extension.h
+++ b/experimental/native_file_system/native_file_system_extension.h
@@ -38,6 +38,7 @@ class NativeFileSystemInstance : public XWalkExtensionInstance {
 
   // XWalkExtensionInstance implementation.
   virtual void HandleMessage(scoped_ptr<base::Value> msg) OVERRIDE;
+  virtual void HandleSyncMessage(scoped_ptr<base::Value> msg) OVERRIDE;
 
  private:
   XWalkExtensionFunctionHandler handler_;


### PR DESCRIPTION
Add a function, getRealPath(), to native_file_system object. Developer
passes virtual root name to this function and get full path of this
virtual root.

BUG=XWALK-2455
