### PR TITLE
[REG] make_apk.py should print commands in verbose mode

### DIFF
--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import log
 import os
 import shutil
 import sys
@@ -15,7 +16,7 @@ def CopyToPathWithName(root, name, final_path, rename):
     return False
   origin_path = os.path.join(root, name)
   if not os.path.exists(origin_path):
-    print('Error: \'' + origin_path + '\' not found.')
+    log.Error('Error: \'' + origin_path + '\' not found.')
     sys.exit(6)
   if not os.path.exists(final_path):
     os.makedirs(final_path)
@@ -117,7 +118,7 @@ def CustomizeBackground(background_color,
   background_path = os.path.join(xwalk_dir, sanitized_name, 'res',
                                  'drawable', 'launchscreen_bg.xml')
   if not os.path.isfile(background_path):
-    print('Error: launchscreen_bg.xml is missing in the build tool.')
+    log.Error('Error: launchscreen_bg.xml is missing in the build tool.')
     sys.exit(6)
 
   has_background = False

--- a/app/tools/android/extension_manager.py
+++ b/app/tools/android/extension_manager.py
@@ -7,6 +7,7 @@
 
 import fnmatch
 import json
+import log
 import optparse
 import os
 import sys
@@ -96,13 +97,13 @@ def HandleAdd(git_url, extensions_path, name=None):
     name = git_url.split('/')[-1].split('.')[0]
   if not os.path.isdir(extensions_path):
     if os.path.isfile(extensions_path):
-      print("WARNING: Please remove file %s" % (extensions_path))
+      log.WarningInfo("WARNING: Please remove file %s" % (extensions_path))
       sys.exit(1)
     else:
       os.mkdir(extensions_path)
   local_extension_path = os.path.join(extensions_path, name)
   if os.path.exists(local_extension_path):
-    print("ERROR: You already have a repo named \"%s\"." % name)
+    log.Error("ERROR: You already have a repo named \"%s\"." % name)
     return 
   os.mkdir(local_extension_path)
   #Only support git.
@@ -117,11 +118,11 @@ def HandleRemove(remove_name, extensions_path):
   if os.path.exists(extension_path):
     CleanDir(extension_path)
   else:
-    print("ERROR: Don't have extension \"%s\"" % (remove_name))
+    log.Error("ERROR: Don't have extension \"%s\"" % (remove_name))
 
 
 def PrintExtensionInfo(extension_name, extensions_path):
-  print("{0} {1}".format(
+  log.Info("{0} {1}".format(
       "+" if GetExtensionStatus(extension_name, extensions_path) else "-",
       extension_name))
 
@@ -155,10 +156,10 @@ def HandleVersion():
   version_path = \
       os.path.join(os.path.dirname(os.path.realpath(__file__)), "VERSION")
   if os.path.isfile(version_path):
-    print(GetVersion("VERSION"))
+    log.Info(GetVersion("VERSION"))
   else:
-    print ("ERROR: VERSION was not found, so Crosswalk\'s version could not"
-           "be determined.")
+    log.Error("ERROR: VERSION was not found, so Crosswalk\'s version could not"
+              "be determined.")
 
 
 def main(argv):

--- a/app/tools/android/handle_permissions.py
+++ b/app/tools/android/handle_permissions.py
@@ -15,6 +15,7 @@ python handle_permissions.py --jsonfile=/path/to/manifest.json
 --manifest=/path/to/AndroidManifest.xml
 """
 
+import log
 import optparse
 import os
 import sys
@@ -61,8 +62,8 @@ def HandlePermissions(permissions, xmldoc):
 
     for permission in permissions.split(':'):
       if permission.lower() not in list(permission_mapping_table.keys()):
-        print('Error: permission \'%s\' related API is not supported.'
-              % permission)
+        log.Error('Error: permission \'%s\' related API is not supported.'
+                  % permission)
         sys.exit(1)
       permission_item = permission_mapping_table.get(permission.lower())
       if permission_item:
@@ -89,17 +90,17 @@ def main(argv):
     parser.print_help()
     return 0
   if not options.jsonfile:
-    print('Please set the manifest.json file.')
+    log.Error('Please set the manifest.json file.')
     return 1
   if not options.manifest:
-    print('Please set the AndroidManifest.xml file.')
+    log.Error('Please set the AndroidManifest.xml file.')
     return 1
   try:
     json_parser = ManifestJsonParser(os.path.expanduser(options.jsonfile))
     if json_parser.GetPermissions():
       options.permissions = json_parser.GetPermissions()
   except SystemExit as ec:
-    print('Exiting with error code: %d' % ec.code)
+    log.Error('Exiting with error code: %d' % ec.code)
     return ec.code
   try:
     xmldoc = minidom.parse(options.manifest)
@@ -108,7 +109,7 @@ def main(argv):
     xmldoc.writexml(file_handle)
     file_handle.close()
   except (ExpatError, IOError):
-    print('There is an error in AndroidManifest.xml.')
+    log.Error('There is an error in AndroidManifest.xml.')
     return 1
   return 0
 

--- a/app/tools/android/log.py
+++ b/app/tools/android/log.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# pylint: disable=W0612
+
+import os
+import sys
+import time
+
+
+# Constants from the Windows API
+STD_OUTPUT_HANDLE = -11
+
+FOREGROUND_BLUE      = 0x0001
+FOREGROUND_GREEN     = 0x0002
+FOREGROUND_CYAN      = 0x0003
+FOREGROUND_RED       = 0x0004
+FOREGROUND_MAGENTA   = 0x0005
+FOREGROUND_YELLOW    = 0x0006
+FOREGROUND_INTENSITY = 0x08
+
+
+def IsWindows():
+  return sys.platform == 'cygwin' or sys.platform.startswith('win')
+
+
+def IsColorTerminal():
+  if not hasattr(sys.stdout, 'isatty'):
+    return False
+  if not sys.stdout.isatty():
+    return False
+  if 'COLORTERM' in os.environ:
+    return True
+  term = os.environ.get('TERM', 'dumb').lower()
+  if term in ('xterm', 'linux') or 'color' in term:
+    return True
+  return False
+
+
+if not IsColorTerminal():
+  import ctypes
+  stdout_handle = ctypes.windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+
+
+def GetCsbiAttributes(handle):
+  if not IsColorTerminal():
+    import struct
+    csbi = ctypes.create_string_buffer(22)
+    res = ctypes.windll.kernel32.GetConsoleScreenBufferInfo(handle, csbi)
+    assert res
+    (bufx, bufy, curx, cury, wattr, left, top, right, bottom,
+     maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+    return wattr
+
+
+if not IsColorTerminal():
+  reset = GetCsbiAttributes(stdout_handle)
+
+
+def SetColor(color):
+  if not IsColorTerminal():
+    return ctypes.windll.kernel32.SetConsoleTextAttribute(stdout_handle, color)
+
+
+def ResetColor():
+  if not IsColorTerminal():
+    SetColor(reset)
+
+
+# ANSI escape sequences
+HEADER = '\033[95m'  # Magenta
+OKBLUE = '\033[94m'  # Blue
+OKGREEN = '\033[92m' # Green
+WARNING = '\033[93m' # Yellow
+FAIL = '\033[91m'    # Red
+ENDC = '\033[0m'     # End
+BOLD = "\033[1m"     # Bold
+
+
+def Info(msg):
+  if not IsColorTerminal():
+    SetColor(FOREGROUND_GREEN)
+    print msg
+    ResetColor()
+  else:
+    print OKGREEN + msg + ENDC
+
+
+def VerboseCommand(msg):
+  if not IsColorTerminal():
+    SetColor(FOREGROUND_MAGENTA | FOREGROUND_INTENSITY)
+    print msg
+    ResetColor()
+  else:
+    print BOLD + HEADER + msg + ENDC
+
+
+def VerboseOutput(msg):
+  if not IsColorTerminal():
+    SetColor(FOREGROUND_BLUE)
+    print msg
+    ResetColor()
+  else:
+    print OKBLUE + msg + ENDC
+
+
+def WarningInfo(msg):
+  if not IsColorTerminal():
+    SetColor(FOREGROUND_YELLOW)
+    print msg
+    ResetColor()
+  else:
+    print WARNING + msg + ENDC
+
+
+def Error(msg):
+  if not IsColorTerminal():
+    SetColor(FOREGROUND_RED)
+    print msg
+    ResetColor()
+  else:
+    print FAIL + msg + ENDC
+
+
+def ProgressBar():
+  if not IsColorTerminal():
+    SetColor(FOREGROUND_GREEN)
+    sys.stdout.write('#' + '->' + "\b\b")
+    ResetColor()
+  else:
+    sys.stdout.write(OKGREEN + '#' + '->' + "\b\b" + ENDC)
+  sys.stdout.flush()
+  time.sleep(0.5)

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -6,6 +6,7 @@
 # pylint: disable=F0401
 
 import json
+import log
 import optparse
 import os
 import re
@@ -60,11 +61,12 @@ def Which(name):
   return None
 
 
-def GetAndroidApiLevel(android_path):
+def GetAndroidApiLevel(android_path, options):
   """Get Highest Android target level installed.
      return -1 if no targets have been found.
   """
-  target_output = RunCommand([android_path, 'list', 'target', '-c'])
+  target_output = RunCommand([android_path, 'list', 'target', '-c'],
+                             options.verbose)
   target_regex = re.compile(r'android-(\d+)')
   targets = [int(i) for i in target_regex.findall(target_output)]
   targets.extend([-1])
@@ -92,7 +94,7 @@ def ParseManifest(options):
   elif parser.GetAppLocalPath():
     options.app_local_path = parser.GetAppLocalPath()
   else:
-    print('Error: there is no app launch path defined in manifest.json.')
+    log.Error('Error: there is no app launch path defined in manifest.json.')
     sys.exit(9)
   if parser.GetAppRoot():
     options.app_root = parser.GetAppRoot()
@@ -110,17 +112,17 @@ def ParseXPK(options, out_dir):
   cmd = ['python', os.path.join (xwalk_dir, 'parse_xpk.py'),
          '--file=%s' % os.path.expanduser(options.xpk),
          '--out=%s' % out_dir]
-  RunCommand(cmd)
+  RunCommand(cmd, options.verbose)
   if options.manifest:
-    print ('Use the manifest from XPK by default '
-           'when "--xpk" option is specified, and '
-           'the "--manifest" option would be ignored.')
+    log.Error('Use the manifest from XPK by default '
+              'when "--xpk" option is specified, and '
+              'the "--manifest" option would be ignored.')
     sys.exit(7)
 
   if os.path.isfile(os.path.join(out_dir, 'manifest.json')):
     options.manifest = os.path.join(out_dir, 'manifest.json')
   else:
-    print('XPK doesn\'t contain manifest file.')
+    log.Error('XPK doesn\'t contain manifest file.')
     sys.exit(8)
 
 
@@ -157,8 +159,8 @@ def MakeVersionCode(options):
   if options.app_versionCodeBase:
     b = str(options.app_versionCodeBase)
     if len(b) > 7:
-      print('Version code base must be 7 digits or less: '
-            'versionCodeBase=%s' % (b))
+      log.Error('Version code base must be 7 digits or less: '
+                'versionCodeBase=%s' % (b))
       sys.exit(12)
   # zero pad to 7 digits, middle digits can be used for other
   # features, according to recommendation in URL
@@ -181,12 +183,12 @@ def GetExtensionBinaryPathList():
                                              item,
                                              data["binary_path"])
       else:
-        print("The extension \"%s\" doesn't exists." % item)
+        log.Error("The extension \"%s\" doesn't exists." % item)
         sys.exit(1)
     if os.path.isdir(extension_binary_path):
       local_extension_list.append(extension_binary_path)
     else:
-      print("The extension \"%s\" doesn't exists." % item)
+      log.Error("The extension \"%s\" doesn't exists." % item)
       sys.exit(1)
 
   return local_extension_list
@@ -237,13 +239,13 @@ def Customize(options, app_info, manifest):
 def Execution(options, name):
   android_path = Which('android')
   if android_path is None:
-    print('The "android" binary could not be found. Check your Android SDK '
-          'installation and your PATH environment variable.')
+    log.Error('The "android" binary could not be found. Check your Android SDK '
+              'installation and your PATH environment variable.')
     sys.exit(1)
 
-  api_level = GetAndroidApiLevel(android_path)
+  api_level = GetAndroidApiLevel(android_path, options)
   if api_level < 14:
-    print('Please install Android API level (>=14) first.')
+    log.Error('Please install Android API level (>=14) first.')
     sys.exit(3)
   target_string = 'android-%d' % api_level
 
@@ -252,7 +254,7 @@ def Execution(options, name):
     if options.keystore_alias:
       key_alias = options.keystore_alias
     else:
-      print('Please provide an alias name of the developer key.')
+      log.Error('Please provide an alias name of the developer key.')
       sys.exit(6)
     if options.keystore_passcode:
       key_code = options.keystore_passcode
@@ -263,8 +265,9 @@ def Execution(options, name):
     else:
       key_alias_code = None
   else:
-    print ('Use xwalk\'s keystore by default for debugging. '
-           'Please switch to your keystore when distributing it to app market.')
+    log.WarningInfo('Use xwalk\'s keystore by default for debugging. Please '
+                    'switch to your keystore when distributing it to app '
+                    'market.')
     key_store = os.path.join(xwalk_dir, 'xwalk-debug.keystore')
     key_alias = 'xwalkdebugkey'
     key_code = 'xwalkdebug'
@@ -273,7 +276,7 @@ def Execution(options, name):
   # Check whether ant is installed.
   ant_path = Which('ant')
   if ant_path is None:
-    print('Ant could not be found. Please make sure it is installed.')
+    log.Error('Ant could not be found. Please make sure it is installed.')
     sys.exit(4)
 
   # Update android project for app and xwalk_core_library.
@@ -284,13 +287,13 @@ def Execution(options, name):
   if options.mode == 'embedded':
     RunCommand([android_path, 'update', 'lib-project',
                 '--path', os.path.join(xwalk_dir, name, 'xwalk_core_library'),
-                '--target', target_string])
+                '--target', target_string], options.verbose)
     update_project_cmd.extend(['-l', 'xwalk_core_library'])
   else:
     # Shared mode doesn't need xwalk_runtime_java.jar.
     os.remove(os.path.join(xwalk_dir, name, 'libs', 'xwalk_runtime_java.jar'))
 
-  RunCommand(update_project_cmd)
+  RunCommand(update_project_cmd, options.verbose)
 
   # Check whether external extensions are included.
   extensions_string = 'xwalk-extensions'
@@ -308,7 +311,7 @@ def Execution(options, name):
     # xwalk_core_library.
     arch = ConvertArchNameToArchFolder(options.arch)
     if not arch:
-      print ('Invalid CPU arch: %s.' % arch)
+      log.Error('Invalid CPU arch: %s.' % arch)
       sys.exit(10)
     library_lib_path = os.path.join(xwalk_dir, name, 'xwalk_core_library',
                                     'libs')
@@ -320,8 +323,8 @@ def Execution(options, name):
     if ContainsNativeLibrary(native_lib_path):
       shutil.copytree(native_lib_path, os.path.join(library_lib_path, arch))
     else:
-      print('No %s native library has been found for creating a Crosswalk '
-            'embedded APK.' % arch)
+      log.Error('No %s native library has been found for creating a Crosswalk '
+                'embedded APK.' % arch)
       sys.exit(10)
 
   ant_cmd = [ant_path, 'release', '-f',
@@ -334,10 +337,31 @@ def Execution(options, name):
     ant_cmd.extend(['-Dkey.store.password=%s' % key_code])
   if key_alias_code:
     ant_cmd.extend(['-Dkey.alias.password=%s' % key_alias_code])
-  ant_result = subprocess.call(ant_cmd)
+
+  if options.verbose:
+    log.VerboseCommand('Verbose: Command "%s" is running:' % ' '.join(ant_cmd))
+  else:
+    log.Info('The package is building. Please wait.')
+
+  proc = subprocess.Popen(ant_cmd, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE)
+
+  if not options.verbose:
+    while proc.poll() is None:
+      log.ProgressBar()
+
+  for line in iter(proc.stdout.readline,''):
+    if options.verbose:
+      log.VerboseOutput(line.decode('utf-8', 'replace').strip())
+    else:
+      log.Info(line.decode('utf-8', 'replace').strip())
+
+  proc.communicate()
+  ant_result = proc.returncode
+
   if ant_result != 0:
-    print('Command "%s" exited with non-zero exit code %d'
-          % (' '.join(ant_cmd), ant_result))
+    log.Error('Command "%s" exited with non-zero exit code %d'
+              % (' '.join(ant_cmd), ant_result))
     sys.exit(ant_result)
 
   src_file = os.path.join(xwalk_dir, name, 'bin', '%s-release.apk' % name)
@@ -358,36 +382,36 @@ def PrintPackageInfo(options, name, packaged_archs):
     package_name_version += '_' + options.app_version
 
   if len(packaged_archs) == 0:
-    print ('A non-platform specific APK for the web application "%s" was '
-           'generated successfully at\n%s.apk. It requires a shared Crosswalk '
-           'Runtime to be present.'
-           % (name, package_name_version))
+    log.Info('A non-platform specific APK for the web application "%s" was '
+             'generated successfully at\n%s.apk. It requires a shared '
+             'Crosswalk Runtime to be present.'
+             % (name, package_name_version))
     return
 
   for arch in packaged_archs:
-    print ('An APK for the web application "%s" including the Crosswalk '
-           'Runtime built for %s was generated successfully, which can be '
-           'found at\n%s_%s.apk.'
-           % (name, arch, package_name_version, arch))
+    log.Info('An APK for the web application "%s" including the Crosswalk '
+             'Runtime built for %s was generated successfully, which can be '
+             'found at\n%s_%s.apk.'
+             % (name, arch, package_name_version, arch))
 
   all_archs = set(AllArchitectures())
 
   if len(packaged_archs) != len(all_archs):
     missed_archs = all_archs - set(packaged_archs)
-    print ('\n\nWARNING: ')
-    print ('This APK will only work on %s based Android devices. Consider '
-           'building for %s as well.' %
-           (', '.join(packaged_archs), ', '.join(missed_archs)))
+    log.WarningInfo('\n\nWARNING: ')
+    log.WarningInfo('This APK will only work on %s based Android devices. '
+                    'Consider building for %s as well.' %
+                    (', '.join(packaged_archs), ', '.join(missed_archs)))
   else:
-    print ('\n\n%d APKs were created for %s devices. '
-           % (len(all_archs), ', '.join(all_archs)))
-    print ('Please install the one that matches the processor architecture '
-           'of your device.\n\n')
-    print ('If you are going to submit this application to an application '
-           'store, please make sure you submit both packages.\nInstructions '
-           'for submitting multiple APKs to Google Play Store are available '
-           'here:\nhttps://software.intel.com/en-us/html5/articles/submitting'
-           '-multiple-crosswalk-apk-to-google-play-store')
+    log.Info('\n\n%d APKs were created for %s devices. '
+             % (len(all_archs), ', '.join(all_archs)))
+    log.Info('Please install the one that matches the processor architecture '
+             'of your device.\n\n')
+    log.Info('If you are going to submit this application to an application '
+             'store, please make sure you submit both packages.\nInstructions '
+             'for submitting multiple APKs to Google Play Store are available '
+             'here:\nhttps://software.intel.com/en-us/html5/articles/submitting'
+             '-multiple-crosswalk-apk-to-google-play-store')
 
 def MakeApk(options, app_info, manifest):
   Customize(options, app_info, manifest)
@@ -428,11 +452,11 @@ def MakeApk(options, app_info, manifest):
           Execution(options, name)
           packaged_archs.append(options.arch)
         else:
-          print('Warning: failed to create package for arch "%s" '
-                'due to missing native library' % arch)
+          log.WarningInfo('Warning: failed to create package for arch "%s" '
+                          'due to missing native library' % arch)
 
       if len(packaged_archs) == 0:
-        print('No packages created, aborting')
+        log.Error('No packages created, aborting')
         sys.exit(13)
 
   PrintPackageInfo(options, name, packaged_archs)
@@ -569,7 +593,7 @@ def main(argv):
 
   if options.version:
     if os.path.isfile('VERSION'):
-      print(GetVersion('VERSION'))
+      log.Info(GetVersion('VERSION'))
       return 0
     else:
       parser.error('VERSION was not found, so Crosswalk\'s version could not '
@@ -584,7 +608,7 @@ def main(argv):
   if options.app_root and not options.manifest:
     manifest_path = os.path.join(options.app_root, 'manifest.json')
     if os.path.exists(manifest_path):
-      print('Using manifest.json distributed with the application.')
+      log.Info('Using manifest.json distributed with the application.')
       options.manifest = manifest_path
 
   app_info = AppInfo()
@@ -612,9 +636,9 @@ def main(argv):
     if options.permissions:
       permission_list = options.permissions.split(':')
     else:
-      print('Warning: all supported permissions on Android port are added. '
-            'Refer to https://github.com/crosswalk-project/'
-            'crosswalk-website/wiki/Crosswalk-manifest')
+      log.WarningInfo('Warning: all supported permissions on Android port are '
+                      'added Refer to https://github.com/crosswalk-project/'
+                      'crosswalk-website/wiki/Crosswalk-manifest')
       permission_list = permission_mapping_table.keys()
     options.permissions = HandlePermissionList(permission_list)
     options.icon_dict = {}
@@ -635,8 +659,8 @@ def main(argv):
   if (options.app_root and options.app_local_path and
       not os.path.isfile(os.path.join(options.app_root,
                                       options.app_local_path))):
-    print('Please make sure that the local path file of launching app '
-          'does exist.')
+    log.Error('Please make sure that the local path file of launching app '
+              'does exist.')
     sys.exit(7)
 
   if options.target_dir:
@@ -656,4 +680,14 @@ def main(argv):
 
 
 if __name__ == '__main__':
-  sys.exit(main(sys.argv))
+  try:
+    sys.exit(main(sys.argv))
+  except SystemExit as ec:
+    if ec.code == 0:
+      log.Info('Build Finished!')
+    else:
+      log.Error('Exiting with error code %s' % ec)
+  except KeyboardInterrupt:
+    log.Error('Exiting with KeyboardInterrupt!')
+  finally:
+    log.ResetColor()

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -14,6 +14,7 @@ python manifest_json_parser.py --jsonfile=/path/to/manifest.json
 """
 
 import json
+import log
 import optparse
 import os
 import re
@@ -35,8 +36,8 @@ def HandlePermissionList(permission_list):
   reg_permission = re.compile(r'^[a-zA-Z\.]*$')
   for permission in permissions:
     if not reg_permission.match(permission):
-      print('\'Permissions\' field error, only alphabets and '
-            '\'.\' are allowed.')
+      log.Error('\'Permissions\' field error, only alphabets and '
+                '\'.\' are allowed.')
       sys.exit(1)
   return ':'.join(permissions)
 
@@ -59,8 +60,9 @@ def ParseLaunchScreen(ret_dict, launch_screen_dict, orientation):
 
 
 def PrintDeprecationWarning(item):
-  print ('WARNING: %s is deprecated for Crosswalk. Please follow '
-         'https://www.crosswalk-project.org/#documentation/manifest.' % item)
+  log.WarningInfo('WARNING: %s is deprecated for Crosswalk. Please follow '
+                  'https://www.crosswalk-project.org/#documentation/manifest.'
+                  % item)
 
 
 class ManifestJsonParser(object):
@@ -78,10 +80,10 @@ class ManifestJsonParser(object):
       self.data_src = json.JSONDecoder().decode(input_src)
       self.ret_dict = self._output_items()
     except (TypeError, ValueError, IOError) as error:
-      print('There is a parser error in manifest.json file: %s' % error)
+      log.Error('There is a parser error in manifest.json file: %s' % error)
       sys.exit(1)
     except KeyError as error:
-      print('There is a field error in manifest.json file: %s' % error)
+      log.Error('There is a field error in manifest.json file: %s' % error)
       sys.exit(1)
     finally:
       input_file.close()
@@ -110,13 +112,13 @@ class ManifestJsonParser(object):
     """
     ret_dict = {}
     if 'name' not in self.data_src:
-      print('Error: no \'name\' field in manifest.json file.')
+      log.Error('Error: no \'name\' field in manifest.json file.')
       sys.exit(1)
     ret_dict['app_name'] = self.data_src['name']
     ret_dict['version'] = ''
     if 'version' in self.data_src and 'xwalk_version' in self.data_src:
-      print('WARNING: the value in "version" will be ignored and support '
-            'for it will be removed in the future.')
+      log.WarningInfo('WARNING: the value in "version" will be ignored and '
+                      'support for it will be removed in the future.')
       ret_dict['version'] = self.data_src['xwalk_version']
     elif 'xwalk_version' in self.data_src:
       ret_dict['version'] = self.data_src['xwalk_version']
@@ -159,8 +161,8 @@ class ManifestJsonParser(object):
     app_root = file_path_prefix
     ret_dict['description'] = ''
     if 'description' in self.data_src and 'xwalk_description' in self.data_src:
-      print('WARNING: the value in "description" will be ignored and support '
-            'for it will be removed in the future.')
+      log.WarningInfo('WARNING: the value in "description" will be ignored '
+                      'and support for it will be removed in the future.')
       ret_dict['description'] = self.data_src['xwalk_description']
     elif 'xwalk_description' in self.data_src:
       ret_dict['description'] = self.data_src['xwalk_description']
@@ -176,7 +178,7 @@ class ManifestJsonParser(object):
         permission_list = self.data_src['xwalk_permissions']
         ret_dict['permissions'] = HandlePermissionList(permission_list)
       except (TypeError, ValueError, IOError):
-        print('\'Permissions\' field error in manifest.json file.')
+        log.Error('\'Permissions\' field error in manifest.json file.')
         sys.exit(1)
     elif 'permissions' in self.data_src:
       PrintDeprecationWarning('permissions')
@@ -184,7 +186,7 @@ class ManifestJsonParser(object):
         permission_list = self.data_src['permissions']
         ret_dict['permissions'] = HandlePermissionList(permission_list)
       except (TypeError, ValueError, IOError):
-        print('\'Permissions\' field error in manifest.json file.')
+        log.Error('\'Permissions\' field error in manifest.json file.')
         sys.exit(1)
     orientation = {'landscape':'landscape',
                    'landscape-primary':'landscape',

--- a/app/tools/android/parse_xpk.py
+++ b/app/tools/android/parse_xpk.py
@@ -17,6 +17,7 @@ https://github.com/crosswalk-project/crosswalk-website/wiki/Crosswalk-package-ma
 This file is used by make_apk.py.
 """
 
+import log
 import optparse
 import os
 import struct
@@ -45,7 +46,7 @@ errorMessageMap = {
 
 
 def HandleError(err_code):
-  print('Error: %s' % errorMessageMap[err_code])
+  log.Error('Error: %s' % errorMessageMap[err_code])
   sys.exit(err_code)
 
 

--- a/app/tools/android/util.py
+++ b/app/tools/android/util.py
@@ -5,7 +5,7 @@
 # found in the LICENSE file.
 # pylint: disable=F0401
 
-
+import log
 import os
 import re
 import shutil
@@ -30,10 +30,12 @@ def RunCommand(command, verbose=False, shell=False):
     output = proc.communicate()[0]
     result = proc.returncode
     if verbose:
-      print(output.decode("utf-8").strip())
+      log.VerboseCommand('Verbose: Command "%s" is running:'
+                          % ' '.join(command))
+      log.VerboseOutput(output.decode("utf-8").strip())
     if result != 0:
-      print ('Command "%s" exited with non-zero exit code %d'
-             % (' '.join(command), result))
+      log.Error('Command "%s" exited with non-zero exit code %d'
+                % (' '.join(command), result))
       sys.exit(result)
     return output.decode("utf-8")
   else:


### PR DESCRIPTION
1 The print color and log levels.
  Green        : log.Info(),
  Blue         : log.VerboseCommand(),
  Bold Magenta : log.VerboseOutput(),
  Yellow       : log.WarningInfo(),
  Red          : log.Error()

2 Print progressbar when running time-consuming command "ant release" without verbose mode.
3 Use ANSI escape sequences on Linux.
4 The no support ANSI sequences console(e.g Windows) requires ctypes, which is included
  with Python 2.5 or later.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2181