### PR TITLE
Remove application storage from the desktop code path

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -109,12 +109,10 @@ class Application : public Runtime::Observer,
                      StoredPermission perm);
   bool CanRequestURL(const GURL& url) const;
 
+  void set_observer(Observer* observer) { observer_ = observer; }
+
  protected:
-  // We enforce ApplicationService ownership.
-  friend class ApplicationService;
-  Application(scoped_refptr<ApplicationData> data,
-              RuntimeContext* context,
-              Observer* observer);
+  Application(scoped_refptr<ApplicationData> data, RuntimeContext* context);
   virtual bool Launch(const LaunchParams& launch_params);
   virtual void InitSecurityPolicy();
 
@@ -134,6 +132,10 @@ class Application : public Runtime::Observer,
   }
 
  private:
+  // We enforce ApplicationService ownership.
+  friend class ApplicationService;
+  static scoped_ptr<Application> Create(scoped_refptr<ApplicationData> data,
+      RuntimeContext* context);
   // Runtime::Observer implementation.
   virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE;
   virtual void OnRuntimeRemoved(Runtime* runtime) OVERRIDE;

--- a/application/browser/application_service_tizen.cc
+++ b/application/browser/application_service_tizen.cc
@@ -1,0 +1,77 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/application_service_tizen.h"
+
+#include <string>
+#include <vector>
+
+#include "xwalk/application/browser/application.h"
+#include "xwalk/application/common/application_storage.h"
+#include "xwalk/application/common/id_util.h"
+#include "xwalk/runtime/browser/runtime_context.h"
+
+namespace xwalk {
+
+namespace application {
+
+namespace {
+
+const base::FilePath::CharType kApplicationDataDirName[] =
+    FILE_PATH_LITERAL("Storage/ext");
+
+base::FilePath GetStoragePartitionPath(
+    const base::FilePath& base_path, const std::string& app_id) {
+  return base_path.Append(kApplicationDataDirName).Append(app_id);
+}
+
+void CollectUnusedStoragePartitions(RuntimeContext* context,
+                                    ApplicationStorage* storage) {
+  std::vector<std::string> app_ids;
+  if (!storage->GetInstalledApplicationIDs(app_ids))
+    return;
+
+  scoped_ptr<base::hash_set<base::FilePath> > active_paths(
+      new base::hash_set<base::FilePath>()); // NOLINT
+
+  for (unsigned i = 0; i < app_ids.size(); ++i) {
+    active_paths->insert(
+        GetStoragePartitionPath(context->GetPath(), app_ids.at(i)));
+  }
+
+  content::BrowserContext::GarbageCollectStoragePartitions(
+      context, active_paths.Pass(), base::Bind(&base::DoNothing));
+}
+
+}  // namespace
+
+ApplicationServiceTizen::ApplicationServiceTizen(
+    RuntimeContext* runtime_context)
+  : ApplicationService(runtime_context),
+    application_storage_(new ApplicationStorage(runtime_context->GetPath())) {
+  CollectUnusedStoragePartitions(runtime_context, application_storage_.get());
+}
+
+ApplicationServiceTizen::~ApplicationServiceTizen() {
+}
+
+Application* ApplicationServiceTizen::LaunchFromAppID(
+    const std::string& id, const Application::LaunchParams& params) {
+  if (!IsValidApplicationID(id)) {
+     LOG(ERROR) << "The input parameter is not a valid app id: " << id;
+     return NULL;
+  }
+
+  scoped_refptr<ApplicationData> app_data =
+    application_storage_->GetApplicationData(id);
+  if (!app_data) {
+    LOG(ERROR) << "Application with id " << id << " is not installed.";
+    return NULL;
+  }
+
+  return Launch(app_data, params);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/browser/application_service_tizen.h
+++ b/application/browser/application_service_tizen.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_APPLICATION_SERVICE_TIZEN_H_
+#define XWALK_APPLICATION_BROWSER_APPLICATION_SERVICE_TIZEN_H_
+
+#include <string>
+
+#include "xwalk/application/browser/application_service.h"
+
+namespace xwalk {
+
+namespace application {
+
+class ApplicationStorage;
+
+// The application service manages launch and termination of the applications.
+class ApplicationServiceTizen : public ApplicationService {
+ public:
+  virtual ~ApplicationServiceTizen();
+  // Launch an installed application using application id.
+  Application* LaunchFromAppID(
+      const std::string& id,
+      const Application::LaunchParams& params = Application::LaunchParams());
+
+ private:
+  friend class ApplicationService;
+  explicit ApplicationServiceTizen(RuntimeContext* runtime_context);
+  // Note : do not export app storage from this class! We need consider
+  // making ApplicationSystemTizen (owning the storage) instead.
+  scoped_ptr<ApplicationStorage> application_storage_;
+};
+
+inline ApplicationServiceTizen* ToApplicationServiceTizen(
+    ApplicationService* service) {
+  return static_cast<ApplicationServiceTizen*>(service);
+}
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_APPLICATION_SERVICE_TIZEN_H_

--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -29,8 +29,6 @@ namespace xwalk {
 namespace application {
 
 class ApplicationService;
-class ApplicationServiceProvider;
-class ApplicationStorage;
 
 // The ApplicationSystem manages the creation and destruction of services which
 // related to applications' runtime model.
@@ -47,16 +45,13 @@ class ApplicationSystem {
     return application_service_.get();
   }
 
-  ApplicationStorage* application_storage() {
-    return application_storage_.get();
-  }
-
   // Launches an application based on the given command line, there are
   // different ways to inform which application should be launched
   //
   // (1) app_id from the binary name (used in Tizen);
-  // (2) app_id passed in the command line;
+  // (2) app_id passed in the command line (used in Tizen);
   // (3) launching a directory that contains an extracted package.
+  // (4) launching from the path to the packaged application file.
   //
   // The parameter `url` contains the current URL Crosswalk is considering to
   // load, and the output parameter `run_default_message_loop` controls whether
@@ -66,7 +61,7 @@ class ApplicationSystem {
   // line, so the caller shouldn't try to load the url by itself.
   bool LaunchFromCommandLine(const base::CommandLine& cmd_line,
                              const GURL& url,
-                             bool& run_default_message_loop_);
+                             bool& run_default_message_loop_);  // NOLINT
 
   void CreateExtensions(content::RenderProcessHost* host,
                         extensions::XWalkExtensionVector* extensions);
@@ -75,12 +70,8 @@ class ApplicationSystem {
   explicit ApplicationSystem(RuntimeContext* runtime_context);
 
  private:
-  template <typename T>
-  bool LaunchWithCommandLineParam(const T& param,
-                                  const base::CommandLine& cmd_line);
   // Note: initialization order matters.
-  xwalk::RuntimeContext* runtime_context_;
-  scoped_ptr<ApplicationStorage> application_storage_;
+  RuntimeContext* runtime_context_;
   scoped_ptr<ApplicationService> application_service_;
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationSystem);

--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -76,9 +76,8 @@ class ScreenOrientationProviderTizen :
 
 ApplicationTizen::ApplicationTizen(
     scoped_refptr<ApplicationData> data,
-    RuntimeContext* runtime_context,
-    Application::Observer* observer)
-    : Application(data, runtime_context, observer),
+    RuntimeContext* runtime_context)
+    : Application(data, runtime_context),
       is_suspended_(false) {
 #if defined(USE_OZONE)
   ui::PlatformEventSource::GetInstance()->AddPlatformEventObserver(this);

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -27,11 +27,9 @@ class ApplicationTizen :  // NOLINT
   void Resume();
 
  private:
-  // We enforce ApplicationService ownership.
-  friend class ApplicationService;
+  friend class Application;
   ApplicationTizen(scoped_refptr<ApplicationData> data,
-                   RuntimeContext* context,
-                   Application::Observer* observer);
+                   RuntimeContext* context);
   virtual bool Launch(const LaunchParams& launch_params) OVERRIDE;
 
   virtual base::FilePath GetSplashScreenPath() OVERRIDE;

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -67,27 +67,6 @@ scoped_refptr<ApplicationData> ApplicationData::Create(
 }
 
 // static
-scoped_refptr<ApplicationData> ApplicationData::Create(
-    const GURL& url,
-    std::string* error_message) {
-  const std::string& url_spec = url.spec();
-  DCHECK(!url_spec.empty());
-  const std::string& app_id = GenerateId(url_spec);
-
-  base::DictionaryValue manifest;
-  // FIXME: define permissions!
-  manifest.SetString(application_manifest_keys::kStartURLKey, url_spec);
-  // FIXME: Why use URL as name?
-  manifest.SetString(application_manifest_keys::kNameKey, url_spec);
-  manifest.SetString(application_manifest_keys::kXWalkVersionKey, "0");
-  scoped_refptr<ApplicationData> application_data =
-      ApplicationData::Create(base::FilePath(), EXTERNAL_URL,
-                              manifest, app_id, error_message);
-
-  return application_data;
-}
-
-// static
 GURL ApplicationData::GetBaseURLFromApplicationId(
     const std::string& application_id) {
   return GURL(std::string(xwalk::application::kApplicationScheme) +

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -72,9 +72,6 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
       const std::string& explicit_id,
       std::string* error_message);
 
-  static scoped_refptr<ApplicationData> Create(const GURL& url,
-                                               std::string* error_message);
-
   Manifest::Type GetType() const;
 
   // Returns an absolute url to a resource inside of an application. The

--- a/application/common/application_storage.h
+++ b/application/common/application_storage.h
@@ -5,7 +5,6 @@
 #ifndef XWALK_APPLICATION_COMMON_APPLICATION_STORAGE_H_
 #define XWALK_APPLICATION_COMMON_APPLICATION_STORAGE_H_
 
-#include <map>
 #include <string>
 #include <vector>
 

--- a/application/test/application_browsertest.cc
+++ b/application/test/application_browsertest.cc
@@ -59,7 +59,7 @@ void ApplicationBrowserTest::CreateExtensions(
 }
 
 IN_PROC_BROWSER_TEST_F(ApplicationBrowserTest, ApiTest) {
-  Application* app = application_sevice()->Launch(
+  Application* app = application_sevice()->LaunchFromUnpackedPath(
       test_data_dir_.Append(FILE_PATH_LITERAL("api")));
   ASSERT_TRUE(app);
   test_runner_->WaitForTestNotification();

--- a/application/test/application_multi_app_test.cc
+++ b/application/test/application_multi_app_test.cc
@@ -22,7 +22,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
   ApplicationService* service = application_sevice();
   const size_t currently_running_count = service->active_applications().size();
   // Launch the first app.
-  Application* app1 = service->Launch(
+  Application* app1 = service->LaunchFromUnpackedPath(
       test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app1")));
   ASSERT_TRUE(app1);
   // Wait for app is fully loaded.
@@ -36,12 +36,12 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
 
   // Verify that no new App instance was created, if one exists
   // with the same ID.
-  Application* failed_app1 = service->Launch(
+  Application* failed_app1 = service->LaunchFromUnpackedPath(
       test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app1")));
   ASSERT_FALSE(failed_app1);
 
   // Launch the second app.
-  Application* app2 = service->Launch(
+  Application* app2 = service->LaunchFromUnpackedPath(
       test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app2")));
   ASSERT_TRUE(app2);
   // Wait for app is fully loaded.

--- a/application/test/application_testapi_test.cc
+++ b/application/test/application_testapi_test.cc
@@ -13,7 +13,7 @@ class ApplicationTestApiTest : public ApplicationBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(ApplicationTestApiTest, TestApiTest) {
-  Application* app = application_sevice()->Launch(
+  Application* app = application_sevice()->LaunchFromUnpackedPath(
       test_data_dir_.Append(FILE_PATH_LITERAL("testapi")));
   ASSERT_TRUE(app);
   test_runner_->WaitForTestNotification();

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -66,6 +66,8 @@
           'sources': [
             'browser/application_tizen.cc',
             'browser/application_tizen.h',
+            'browser/application_service_tizen.cc',
+            'browser/application_service_tizen.h',
           ],
         }],
       ],


### PR DESCRIPTION
Remove application storage from the desktop code path
(make it Tizen-only). The AppliactionServiceTizen object
was added to own the application storage.

This patch also encapsulates application launching within
the ApplicationService object, and contains multiple code
cleanups.
