### PR TITLE
[Tizen] Reword Crosswalk's summary in the spec file.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -18,7 +18,7 @@
 Name:           crosswalk
 Version:        9.38.202.0
 Release:        0
-Summary:        Crosswalk is an app runtime based on Chromium
+Summary:        Chromium-based app runtime
 License:        (BSD-3-Clause and LGPL-2.1+)
 Group:          Web Framework/Web Run Time
 Url:            https://github.com/otcshare/crosswalk


### PR DESCRIPTION
rpmlint currently complains about Crosswalk's Summary entry in its spec
file:

  W: name-repeated-in-summary C Crosswalk
  The name of the package is repeated in its summary. This is often
  redundant information and looks silly in various programs' output.
  Make the summary brief and to the point without including redundant
  information in it.

Follow the suggestion and remove "Crosswalk" from the text.
