### PR TITLE
[REG] Fixed Build failure when sometimes command output contain SOFT HYPHEN(0xad)

### DIFF
--- a/app/tools/android/util.py
+++ b/app/tools/android/util.py
@@ -30,12 +30,12 @@ def RunCommand(command, verbose=False, shell=False):
     output = proc.communicate()[0]
     result = proc.returncode
     if verbose:
-      print(output.decode("utf-8").strip())
+      print(output.decode("utf-8", 'replace').strip())
     if result != 0:
       print ('Command "%s" exited with non-zero exit code %d'
              % (' '.join(command), result))
       sys.exit(result)
-    return output.decode("utf-8")
+    return output.decode("utf-8", 'replace')
   else:
     return None
 


### PR DESCRIPTION
[REG] Fixed Build failure when command output contain SOFT HYPHEN(0xad)

Change "decode([encoding])" to "decode([encoding], [errors='replace'])" to  make sure 0xad (usaully on Windows) don't cause error when decoding.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2468
