### PR TITLE
Disallow arbitrary start URLs in the Manifest

### DIFF
--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -245,7 +245,7 @@ ApplicationProtocolHandler::MaybeCreateJob(
   base::FilePath directory_path;
   std::string content_security_policy;
   if (application) {
-    directory_path = application->Path();
+    directory_path = application->path();
 
     const char* csp_key = GetCSPKey(application->manifest_type());
     const CSPInfo* csp_info = static_cast<CSPInfo*>(

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -227,10 +227,10 @@ void ApplicationService::OnApplicationTerminated(
 
   if (app_data->source_type() == ApplicationData::TEMP_DIRECTORY) {
       LOG(INFO) << "Deleting the app temporary directory "
-                << app_data->Path().AsUTF8Unsafe();
+                << app_data->path().AsUTF8Unsafe();
       content::BrowserThread::PostTask(content::BrowserThread::FILE,
           FROM_HERE, base::Bind(base::IgnoreResult(&base::DeleteFile),
-                                app_data->Path(), true /*recursive*/));
+                                app_data->path(), true /*recursive*/));
       // FIXME: So far we simply clean up all the app persistent data,
       // further we need to add an appropriate logic to handle it.
       content::BrowserContext::GarbageCollectStoragePartitions(

--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -112,7 +112,7 @@ bool ApplicationTizen::Launch(const LaunchParams& launch_params) {
 base::FilePath ApplicationTizen::GetSplashScreenPath() {
   if (TizenSplashScreenInfo* ss_info = static_cast<TizenSplashScreenInfo*>(
       data()->GetManifestData(widget_keys::kTizenSplashScreenKey))) {
-    return data()->Path().Append(FILE_PATH_LITERAL(ss_info->src()));
+    return data()->path().Append(FILE_PATH_LITERAL(ss_info->src()));
   }
   return base::FilePath();
 }

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -148,6 +148,16 @@ GURL ApplicationData::GetResourceURL(const GURL& application_url,
   return ret_val;
 }
 
+GURL ApplicationData::GetResourceURL(const std::string& relative_path) const {
+  if (!base::PathExists(path_.Append(relative_path))) {
+    LOG(ERROR) << "The path does not exist in the application directory: "
+               << relative_path;
+    return GURL();
+  }
+
+  return GetResourceURL(URL(), relative_path);
+}
+
 bool ApplicationData::Init(const std::string& explicit_id,
                            base::string16* error) {
   DCHECK(error);

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -77,9 +77,7 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   // NOTE: Static so that it can be used from multiple threads.
   static GURL GetResourceURL(const GURL& application_url,
                              const std::string& relative_path);
-  GURL GetResourceURL(const std::string& relative_path) const {
-    return GetResourceURL(URL(), relative_path);
-  }
+  GURL GetResourceURL(const std::string& relative_path) const;
 
   // Returns the base application url for a given |application_id|.
   static GURL GetBaseURLFromApplicationId(const std::string& application_id);
@@ -94,9 +92,10 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   void SetManifestData(const std::string& key, ManifestData* data);
 
   // Accessors:
-
-  const base::FilePath& Path() const { return path_; }
-  void SetPath(const base::FilePath& path) { path_ = path; }
+  const base::FilePath& path() const { return path_; }
+#if defined(OS_TIZEN)  // FIXME : This method should be removed.
+  void set_path(const base::FilePath& path) { path_ = path; }
+#endif
   const GURL& URL() const { return application_url_; }
   SourceType source_type() const { return source_type_; }
   Manifest::Type manifest_type() const { return manifest_->type(); }

--- a/application/common/manifest_handlers/tizen_splash_screen_handler.cc
+++ b/application/common/manifest_handlers/tizen_splash_screen_handler.cc
@@ -58,7 +58,7 @@ bool TizenSplashScreenHandler::Validate(
   splash_screen->GetAsDictionary(&ss_dict);
   std::string ss_src;
   ss_dict->GetString(keys::kTizenSplashScreenSrcKey, &ss_src);
-  base::FilePath path = application->Path().Append(FILE_PATH_LITERAL(ss_src));
+  base::FilePath path = application->path().Append(FILE_PATH_LITERAL(ss_src));
   if (!base::PathExists(path)) {
     *error = std::string("The splash screen image does not exist");
     return false;

--- a/application/test/application_test.cc
+++ b/application/test/application_test.cc
@@ -18,17 +18,17 @@ using xwalk::application::ApplicationService;
 using xwalk::application::Manifest;
 using xwalk::application::GetManifestPath;
 
-class ApplicationMultiAppTest : public ApplicationBrowserTest {
+class ApplicationTest : public ApplicationBrowserTest {
 };
 
-IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
+IN_PROC_BROWSER_TEST_F(ApplicationTest, TestMultiApp) {
   ApplicationService* service = application_sevice();
   const size_t currently_running_count = service->active_applications().size();
   // Launch the first app.
   base::FilePath manifest_path =
       GetManifestPath(test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app1")),
       Manifest::TYPE_MANIFEST);
-  Application* app1 = application_sevice()->LaunchFromManifestPath(
+  Application* app1 = service->LaunchFromManifestPath(
       manifest_path, Manifest::TYPE_MANIFEST);
   ASSERT_TRUE(app1);
   // Wait for app is fully loaded.
@@ -42,7 +42,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
 
   // Verify that no new App instance was created, if one exists
   // with the same ID.
-  Application* failed_app1 = application_sevice()->LaunchFromManifestPath(
+  Application* failed_app1 = service->LaunchFromManifestPath(
       manifest_path, Manifest::TYPE_MANIFEST);
   ASSERT_FALSE(failed_app1);
 
@@ -76,4 +76,13 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
   app2->Terminate();
   content::RunAllPendingInMessageLoop();
   EXPECT_EQ(service->active_applications().size(), currently_running_count);
+}
+
+IN_PROC_BROWSER_TEST_F(ApplicationTest, TestUnsafeStartURL) {
+  base::FilePath manifest_path = GetManifestPath(
+      test_data_dir_.Append(FILE_PATH_LITERAL("unsafe_start_URL")),
+      Manifest::TYPE_MANIFEST);
+  Application* app = application_sevice()->LaunchFromManifestPath(
+      manifest_path, Manifest::TYPE_MANIFEST);
+  EXPECT_EQ(NULL, app);
 }

--- a/application/test/data/unsafe_start_URL/manifest.json
+++ b/application/test/data/unsafe_start_URL/manifest.json
@@ -1,0 +1,4 @@
+{
+  "name": "unsafe",
+  "start_url": "http://unsafe.com"
+}

--- a/application/tools/tizen/xwalk_backend_plugin.cc
+++ b/application/tools/tizen/xwalk_backend_plugin.cc
@@ -36,7 +36,7 @@ enum PkgmgrPluginBool {
 // Whole app directory size in KB
 int64 CountAppTotalSize(
     scoped_refptr<xwalk::application::ApplicationData> app_data) {
-  return base::ComputeDirectorySize(app_data->Path()) / 1024;
+  return base::ComputeDirectorySize(app_data->path()) / 1024;
 }
 
 // Data directory size in KB
@@ -44,10 +44,10 @@ int64 CountAppDataSize(
     scoped_refptr<xwalk::application::ApplicationData> app_data) {
   int64 size = 0;
 
-  base::FilePath private_path = app_data->Path().Append("private");
+  base::FilePath private_path = app_data->path().Append("private");
   size += base::ComputeDirectorySize(private_path);
 
-  base::FilePath tmp_path = app_data->Path().Append("tmp");
+  base::FilePath tmp_path = app_data->path().Append("tmp");
   size += base::ComputeDirectorySize(tmp_path);
 
   return size / 1024;

--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -482,7 +482,7 @@ bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
       return false;
   }
 
-  app_data->SetPath(app_dir);
+  app_data->set_path(app_dir);
 
   if (!storage_->AddApplication(app_data)) {
     LOG(ERROR) << "Application with id " << app_data->ID()
@@ -578,7 +578,7 @@ bool PackageInstaller::Update(const std::string& app_id,
     return false;
   }
 
-  const base::FilePath& app_dir = old_app_data->Path();
+  const base::FilePath& app_dir = old_app_data->path();
   const base::FilePath tmp_dir(app_dir.value()
                                + FILE_PATH_LITERAL(".tmp"));
 

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -90,7 +90,7 @@
       'sources': [
         'application/test/application_browsertest.cc',
         'application/test/application_browsertest.h',
-        'application/test/application_multi_app_test.cc',
+        'application/test/application_test.cc',
         'application/test/application_testapi.cc',
         'application/test/application_testapi.h',
         'application/test/application_testapi_test.cc',


### PR DESCRIPTION
Before this change Crosswalk allowed app launchig from arbitrary start URL's in the manifest.json ( config.xml for widgets). which is not allowed by both W3C manifest (http://w3c.github.io/manifest/#dfn-steps-for-processing-the-start_url-member) and widget (http://www.w3.org/TR/widgets/#the-src-attribute-0) specifications.

BUG=XWALK-2535
