### PR TITLE
[Android] Remove xwalk_core_library_java.jar from the AAR package.

### DIFF
--- a/build/android/generate_xwalk_core_library_aar.py
+++ b/build/android/generate_xwalk_core_library_aar.py
@@ -35,6 +35,12 @@ def main():
                   'xwalk_core_library_java.jar'),
      'classes.jar'),
   )
+  # This is a list of files that will not be packaged: mostly a blacklist of
+  # files within |dirs|.
+  exclude_files = (
+    os.path.join(options.target, 'xwalk_core_library', 'libs',
+                 'xwalk_core_library_java.jar'),
+  )
 
   aar_path = os.path.join(options.target, 'xwalk_core_library.aar')
   with zipfile.ZipFile(aar_path, 'w') as aar_file:
@@ -45,6 +51,8 @@ def main():
         for f in files:
           real_path = os.path.join(root, f)
           zip_path = os.path.join(dest, os.path.relpath(root, src), f)
+          if real_path in exclude_files:
+            continue
           aar_file.write(real_path, zip_path)
 
   return 0


### PR DESCRIPTION
This fixes another regression inherited from the previous version of the
script, and is also required for XWALK-1930: xwalk_core_library_java.jar
is not supposed to be packaged twice, it should be present as
classes.jar and not be part of jni/.
