### PR TITLE
Create project build directory in temp directory

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Copyright (c) 2013,2014 Intel Corporation. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
@@ -13,6 +13,7 @@ import re
 import shutil
 import stat
 import sys
+import tempfile
 
 # get xwalk absolute path so we can run this script from any location
 xwalk_dir = os.path.dirname(os.path.abspath(__file__))
@@ -25,6 +26,7 @@ from handle_xml import AddElementAttributeAndText
 from handle_xml import EditElementAttribute
 from handle_xml import EditElementValueByNodeName
 from handle_permissions import HandlePermissions
+from util import CleanDir, CreateAndCopyDir
 from xml.dom import minidom
 
 TEMPLATE_DIR_NAME = 'template'
@@ -115,25 +117,24 @@ def Prepare(app_info, compressor):
   """Copy the Android template project to a new app project
      named app_info.app_name
   """
-  # create new app_dir in xwalk_dir
+  # create new app_dir in temp dir
   app_name = app_info.android_name
-  app_dir = os.path.join(xwalk_dir, app_name)
+  app_dir = os.path.join(tempfile.gettempdir(), app_name)
   app_package = app_info.package
   app_root = app_info.app_root
   template_app_dir = os.path.join(xwalk_dir, TEMPLATE_DIR_NAME)
 
   # 1) copy template project to app_dir
-  if os.path.exists(app_dir):
-    shutil.rmtree(app_dir)
+  CleanDir(app_dir)
   shutil.copytree(template_app_dir, app_dir)
 
   # 2) replace app_dir 'src' dir with template 'src' dir
-  shutil.rmtree(os.path.join(app_dir, 'src'))
+  CleanDir(os.path.join(app_dir, 'src'))
   template_src_root = os.path.join(template_app_dir, 'src', 'org', 'xwalk',
                                    'app', 'template')
 
   # 3) Create directory tree from app package (org.xyz.foo -> src/org/xyz/foo)
-  #    and copy AppTemplateActivity.java to <app_name>Activity.java 
+  #    and copy AppTemplateActivity.java to <app_name>Activity.java
   template_activity_file = os.path.join(template_src_root,
                                         'AppTemplateActivity.java')
   if not os.path.isfile(template_activity_file):
@@ -151,8 +152,7 @@ def Prepare(app_info, compressor):
   # 4) Copy all HTML source from app_root to app_dir
   if app_root:
     app_assets_dir = os.path.join(app_dir, 'assets', 'www')
-    if os.path.isdir(app_assets_dir):
-      shutil.rmtree(app_assets_dir)
+    CleanDir(app_assets_dir)
     shutil.copytree(app_root, app_assets_dir)
     if compressor:
       CompressSourceFiles(app_assets_dir, compressor)
@@ -168,7 +168,8 @@ def EncodingUnicodeValue(value):
 
 
 def CustomizeStringXML(name, description):
-  strings_path = os.path.join(xwalk_dir, name, 'res', 'values', 'strings.xml')
+  strings_path = os.path.join(tempfile.gettempdir(), name, 'res', 'values',
+                              'strings.xml')
   if not os.path.isfile(strings_path):
     print ('Please make sure strings_xml'
            ' exists under template folder.')
@@ -185,7 +186,8 @@ def CustomizeStringXML(name, description):
 
 
 def CustomizeThemeXML(name, fullscreen, manifest):
-  theme_path = os.path.join(xwalk_dir, name, 'res', 'values-v14', 'theme.xml')
+  theme_path = os.path.join(tempfile.gettempdir(), name, 'res', 'values-v14',
+                            'theme.xml')
   if not os.path.isfile(theme_path):
     print('Error: theme.xml is missing in the build tool.')
     sys.exit(6)
@@ -211,6 +213,7 @@ def CustomizeXML(app_info, description, icon_dict, manifest, permissions):
   orientation = app_info.orientation
   package = app_info.package
   app_name = app_info.app_name
+  app_dir = os.path.join(tempfile.gettempdir(), name)
   # Chinese character with unicode get from 'manifest.json' will cause
   # 'UnicodeEncodeError' when finally wrote to 'AndroidManifest.xml'.
   app_name = EncodingUnicodeValue(app_name)
@@ -219,7 +222,7 @@ def CustomizeXML(app_info, description, icon_dict, manifest, permissions):
   # append a space before '@' or '?' to fix that.
   if app_name.startswith('@') or app_name.startswith('?'):
     app_name = ' ' + app_name
-  manifest_path = os.path.join(xwalk_dir, name, 'AndroidManifest.xml')
+  manifest_path = os.path.join(app_dir, 'AndroidManifest.xml')
   if not os.path.isfile(manifest_path):
     print ('Please make sure AndroidManifest.xml'
            ' exists under template folder.')
@@ -251,7 +254,7 @@ def CustomizeXML(app_info, description, icon_dict, manifest, permissions):
     EditElementAttribute(xmldoc, 'application', 'android:icon',
                          '@drawable/%s' % icon_name)
 
-  file_handle = open(os.path.join(xwalk_dir, name, 'AndroidManifest.xml'), 'w')
+  file_handle = open(os.path.join(app_dir, 'AndroidManifest.xml'), 'w')
   xmldoc.writexml(file_handle, encoding='utf-8')
   file_handle.close()
 
@@ -282,12 +285,12 @@ def SetVariable(file_path, string_line, variable, value):
 def CustomizeJava(app_info, app_url, app_local_path, keep_screen_on):
   name = app_info.android_name
   package = app_info.package
-  app_pkg_dir = os.path.join(xwalk_dir, name, 'src',
-                             package.replace('.', os.path.sep))
+  app_dir = os.path.join(tempfile.gettempdir(), name)
+  app_pkg_dir = os.path.join(app_dir, 'src', package.replace('.', os.path.sep))
   dest_activity = os.path.join(app_pkg_dir, name + 'Activity.java')
   ReplaceString(dest_activity, 'org.xwalk.app.template', package)
   ReplaceString(dest_activity, 'AppTemplate', name)
-  manifest_file = os.path.join(xwalk_dir, name, 'assets/www', 'manifest.json')
+  manifest_file = os.path.join(app_dir, 'assets', 'www', 'manifest.json')
   if os.path.isfile(manifest_file):
     ReplaceString(
         dest_activity,
@@ -299,8 +302,7 @@ def CustomizeJava(app_info, app_url, app_local_path, keep_screen_on):
         ReplaceString(dest_activity, 'file:///android_asset/www/index.html',
                       app_url)
     elif app_local_path:
-      if os.path.isfile(os.path.join(xwalk_dir, name, 'assets/www',
-                                     app_local_path)):
+      if os.path.isfile(os.path.join(app_dir, 'assets', 'www', app_local_path)):
         ReplaceString(dest_activity, 'file:///android_asset/www/index.html',
                       'app://' + package + '/' + app_local_path)
       else:
@@ -368,12 +370,12 @@ def CustomizeExtensions(app_info, extensions):
   if not extensions:
     return
   name = app_info.android_name
-  apk_path = os.path.join(xwalk_dir, name)
-  apk_assets_path = os.path.join(apk_path, 'assets')
+  app_dir = os.path.join(tempfile.gettempdir(), name)
+  apk_assets_path = os.path.join(app_dir, 'assets')
   extensions_string = 'xwalk-extensions'
 
   # Set up the target directories and files.
-  dest_jar_path = os.path.join(apk_path, extensions_string)
+  dest_jar_path = os.path.join(app_dir, extensions_string)
   os.mkdir(dest_jar_path)
   dest_js_path = os.path.join(apk_assets_path, extensions_string)
   os.mkdir(dest_js_path)
@@ -420,7 +422,7 @@ def CustomizeExtensions(app_info, extensions):
       json_output['jsapi'] = js_path_prefix + json_output['jsapi']
       extension_json_list.append(json_output)
       # Merge the permissions of extensions into AndroidManifest.xml.
-      manifest_path = os.path.join(xwalk_dir, name, 'AndroidManifest.xml')
+      manifest_path = os.path.join(app_dir, 'AndroidManifest.xml')
       xmldoc = minidom.parse(manifest_path)
       if ('permissions' in json_output):
         # Get used permission list to avoid repetition as "--permissions"
@@ -453,13 +455,15 @@ def CustomizeExtensions(app_info, extensions):
 def GenerateCommandLineFile(app_info, xwalk_command_line):
   if xwalk_command_line == '':
     return
-  assets_path = os.path.join(xwalk_dir, app_info.android_name, 'assets')
+  assets_path = os.path.join(tempfile.gettempdir(), app_info.android_name,
+                             'assets')
   file_path = os.path.join(assets_path, 'xwalk-command-line')
   command_line_file = open(file_path, 'w')
   command_line_file.write('xwalk ' + xwalk_command_line)
 
 
 def CustomizeIconByDict(name, app_root, icon_dict):
+  app_dir = os.path.join(tempfile.gettempdir(), name)
   icon_name = None
   drawable_dict = {'ldpi': [1, 37], 'mdpi': [37, 72], 'hdpi': [72, 96],
                    'xhdpi': [96, 120], 'xxhdpi': [120, 144],
@@ -477,7 +481,7 @@ def CustomizeIconByDict(name, app_root, icon_dict):
     for kd, vd in drawable_dict.items():
       for item in icon_list:
         if item[0] >= vd[0] and item[0] < vd[1]:
-          drawable_path = os.path.join(xwalk_dir, name, 'res', 'drawable-' + kd)
+          drawable_path = os.path.join(app_dir, 'res', 'drawable-' + kd)
           if not os.path.exists(drawable_path):
             os.makedirs(drawable_path)
           icon = os.path.join(app_root, item[1])
@@ -496,7 +500,7 @@ def CustomizeIconByDict(name, app_root, icon_dict):
 
 def CustomizeIconByOption(name, icon):
   if os.path.isfile(icon):
-    drawable_path = os.path.join(xwalk_dir, name, 'res', 'drawable')
+    drawable_path = os.path.join(tempfile.gettempdir(), name, 'res', 'drawable')
     if not os.path.exists(drawable_path):
       os.makedirs(drawable_path)
     icon_file = os.path.basename(icon)
@@ -505,7 +509,7 @@ def CustomizeIconByOption(name, icon):
     icon_name = os.path.splitext(icon_file)[0]
     return icon_name
   else:
-    print('Error: "%s" does not exist.')
+    print('Error: "%s" does not exist.' % icon)
     sys.exit(6)
 
 
@@ -588,6 +592,8 @@ def main():
           'Crosswalk is powered by Chromium and supports Chromium command line.'
           'For example, '
           '--xwalk-command-line=\'--chromium-command-1 --xwalk-command-2\'')
+  info = ('Create an Android project directory at this location. ')
+  parser.add_option('--project-dir', help=info)
   parser.add_option('--xwalk-command-line', default='', help=info)
   info = ('Minify and obfuscate javascript and css.'
           '--compressor: compress javascript and css.'
@@ -625,9 +631,18 @@ def main():
                  options.permissions, options.app_url, options.app_local_path,
                  options.keep_screen_on, options.extensions, None,
                  options.xwalk_command_line, options.compressor)
+
+    # build project is now in /tmp/<name>. Copy to project_dir
+    if options.project_dir:
+      src_dir = os.path.join(tempfile.gettempdir(), app_info.android_name)
+      dest_dir = os.path.join(options.project_dir, app_info.android_name)
+      CreateAndCopyDir(src_dir, dest_dir, True)
+
   except SystemExit as ec:
     print('Exiting with error code: %d' % ec.code)
     return ec.code
+  finally:
+    CleanDir(os.path.join(tempfile.gettempdir(), app_info.android_name))
   return 0
 
 

--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -7,8 +7,7 @@
 import os
 import shutil
 import sys
-
-xwalk_dir = os.path.dirname(os.path.abspath(__file__))
+import tempfile
 
 def CopyToPathWithName(root, name, final_path, rename):
   if name == '':
@@ -30,7 +29,8 @@ def CopyToPathWithName(root, name, final_path, rename):
 
 
 def CopyDrawables(image_dict, orientation, sanitized_name, name, app_root):
-  drawable = os.path.join(xwalk_dir, sanitized_name, 'res', 'drawable')
+  drawable = os.path.join(tempfile.gettempdir(), sanitized_name, 'res',
+                          'drawable')
   if orientation == 'landscape':
     drawable = drawable + '-land'
   elif orientation == 'portrait':
@@ -114,7 +114,7 @@ def CustomizeBackground(background_color,
                         orientation,
                         sanitized_name,
                         app_root):
-  background_path = os.path.join(xwalk_dir, sanitized_name, 'res',
+  background_path = os.path.join(tempfile.gettempdir(), sanitized_name, 'res',
                                  'drawable', 'launchscreen_bg.xml')
   if not os.path.isfile(background_path):
     print('Error: launchscreen_bg.xml is missing in the build tool.')

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -133,6 +133,7 @@ class TestMakeApk(unittest.TestCase):
     if options.mode == 'embedded':
       native_library_dir = os.path.join('xwalk_core_library', 'libs')
       native_library_temp_dir = 'temp'
+      Clean('temp', '0') # May be left over from aborted tests
       shutil.copytree(native_library_dir, native_library_temp_dir)
       for root, _, files in os.walk(native_library_dir):
         if 'libxwalkcore.so' in files:
@@ -232,7 +233,8 @@ class TestMakeApk(unittest.TestCase):
     cmd = ['python', 'make_apk.py', '--name=Example',
            '--package=org.xwalk.example', '--app-version=1.0.0',
            '--description=a sample application',
-           '--app-url=http://www.intel.com', self._mode]
+           '--app-url=http://www.intel.com',
+           '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -248,7 +250,9 @@ class TestMakeApk(unittest.TestCase):
            '--package=org.xwalk.example', '--app-version=1.0.0',
            '--description=a sample application',
            '--app-versionCode=3',
-           '--app-url=http://www.intel.com', self._mode]
+           '--app-url=http://www.intel.com',
+           '--project-dir=.',
+           self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -274,7 +278,9 @@ class TestMakeApk(unittest.TestCase):
            '--description=a sample application',
            '--app-versionCodeBase=3',
            arch,
-           '--app-url=http://www.intel.com', self._mode]
+           '--app-url=http://www.intel.com',
+           '--project-dir=.',
+           self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -298,7 +304,9 @@ class TestMakeApk(unittest.TestCase):
            '--description=a sample application',
            '--app-versionCodeBase=30000000',
            arch,
-           '--app-url=http://www.intel.com', self._mode]
+           '--app-url=http://www.intel.com',
+           '--project-dir=.',
+           self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -307,7 +315,9 @@ class TestMakeApk(unittest.TestCase):
   def testPermissions(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--permissions=geolocation',
-           '--app-url=http://www.intel.com', self._mode]
+           '--app-url=http://www.intel.com',
+           '--project-dir=.',
+           self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -439,7 +449,7 @@ class TestMakeApk(unittest.TestCase):
     icon = os.path.join('test_data', 'manifest', 'icons', 'icon_96.png')
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '--icon=%s' % icon, self._mode]
+           '--icon=%s' % icon, '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -452,7 +462,7 @@ class TestMakeApk(unittest.TestCase):
     manifest_path = os.path.join('test_data', 'manifest', 'manifest_icon.json')
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '--manifest=%s' % manifest_path, self._mode]
+           '--manifest=%s' % manifest_path, '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -464,7 +474,7 @@ class TestMakeApk(unittest.TestCase):
   def testFullscreen(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '-f', self._mode]
+           '-f', '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     theme = 'Example/res/values-v14/theme.xml'
@@ -479,7 +489,7 @@ class TestMakeApk(unittest.TestCase):
   def testEnableRemoteDebugging(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '--enable-remote-debugging', self._mode]
+           '--enable-remote-debugging', '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     activity = 'Example/src/org/xwalk/example/ExampleActivity.java'
@@ -492,7 +502,9 @@ class TestMakeApk(unittest.TestCase):
     manifest_path = os.path.join('test_data', 'manifest', 'manifest.json')
     cmd = ['python', 'make_apk.py', '--enable-remote-debugging',
            '--package=org.xwalk.example',
-           '--manifest=%s' % manifest_path, self._mode]
+           '--manifest=%s' % manifest_path,
+           '--project-dir=.',
+           self._mode]
     RunCommand(cmd)
     activity = 'Example/src/org/xwalk/example/ExampleActivity.java'
     with open(activity, 'r') as content_file:
@@ -533,7 +545,8 @@ class TestMakeApk(unittest.TestCase):
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
            '--keystore-path=%s' % keystore_path, '--keystore-alias=xwalk-test',
            '--keystore-passcode=xwalk-test',
-           '--keystore-alias-passcode=xwalk-test', self._mode]
+           '--keystore-alias-passcode=xwalk-test',
+           '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.assertTrue(os.path.isdir('Example'))
     self.checkApks('Example', '1.0.0', keystore_path)
@@ -549,7 +562,8 @@ class TestMakeApk(unittest.TestCase):
            '--keystore-path=%s' % keystore_path_with_space,
            '--keystore-alias=xwalk test',
            '--keystore-passcode=xwalk-test',
-           '--keystore-alias-passcode=xwalk test', self._mode]
+           '--keystore-alias-passcode=xwalk test',
+           '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.assertTrue(os.path.isdir('Example'))
     self.checkApks('Example', '1.0.0', keystore_path_with_space)
@@ -558,7 +572,7 @@ class TestMakeApk(unittest.TestCase):
   def testManifest(self):
     manifest_path = os.path.join('test_data', 'manifest', 'manifest.json')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
-           '--manifest=%s' % manifest_path, self._mode]
+           '--manifest=%s' % manifest_path, '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -588,7 +602,7 @@ class TestMakeApk(unittest.TestCase):
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_app_launch_local_path.json')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
-           '--manifest=%s' % manifest_path, self._mode]
+           '--manifest=%s' % manifest_path, '--project-dir=.', self._mode]
     out = RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     self.assertTrue(out.find('no app launch path') == -1)
@@ -683,7 +697,7 @@ class TestMakeApk(unittest.TestCase):
     extension_path = 'test_data/extensions/myextension'
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '--extensions=%s' % extension_path, self._mode]
+           '--extensions=%s' % extension_path, '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     self.assertTrue(os.path.exists('Example'))
@@ -718,7 +732,8 @@ class TestMakeApk(unittest.TestCase):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-root=%s' % test_entry_root,
            '--app-local-path=contactextension.html',
-           '--extensions=%s' % extension_path, self._mode]
+           '--extensions=%s' % extension_path,
+           '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     self.assertTrue(os.path.exists('Example'))
@@ -733,7 +748,7 @@ class TestMakeApk(unittest.TestCase):
   def testXPK(self):
     xpk_file = os.path.join('test_data', 'xpk', 'example.xpk')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
-           '--xpk=%s' % xpk_file, self._mode]
+           '--xpk=%s' % xpk_file, '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     self.assertTrue(os.path.exists('Example'))
@@ -742,7 +757,7 @@ class TestMakeApk(unittest.TestCase):
   def testXPKWithError(self):
     xpk_file = os.path.join('test_data', 'xpk', 'error.xpk')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
-           '--xpk=%s' % xpk_file, self._mode]
+           '--xpk=%s' % xpk_file, '--project-dir=.', self._mode]
     out = RunCommand(cmd)
     error_msg = 'XPK doesn\'t contain manifest file'
     self.assertTrue(out.find(error_msg) != -1)
@@ -751,7 +766,7 @@ class TestMakeApk(unittest.TestCase):
   def testOrientation(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '--orientation=landscape', self._mode]
+           '--orientation=landscape', '--project-dir=.', self._mode]
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     manifest = 'Example/AndroidManifest.xml'
@@ -814,7 +829,7 @@ class TestMakeApk(unittest.TestCase):
   def testVerbose(self):
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '--verbose', self._mode]
+           '--verbose', '--project-dir=.', self._mode]
     result = RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     self.assertTrue(result.find('aapt') != -1)
@@ -845,7 +860,8 @@ class TestMakeApk(unittest.TestCase):
            '--name=Example',
            '--orientation=landscape',
            '--package=org.xwalk.example',
-           '--permissions=geolocation']
+           '--permissions=geolocation',
+           '--project-dir=.']
     RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
     activity = 'Example/src/org/xwalk/example/ExampleActivity.java'
@@ -899,7 +915,8 @@ class TestMakeApk(unittest.TestCase):
            '--app-version=1.0.0',
            '--name=Example',
            '--package=org.xwalk.example',
-           '--verbose']
+           '--verbose',
+           '--project-dir=.']
     RunCommand(cmd)
     manifest = 'Example/AndroidManifest.xml'
     if not os.path.exists(manifest):
@@ -933,7 +950,7 @@ class TestMakeApk(unittest.TestCase):
     Clean('Example', '1.0.0')
     manifest_path = os.path.join('test_data', 'launchScreen', 'manifest.json')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
-           '--manifest=%s' % manifest_path, self._mode]
+           '--manifest=%s' % manifest_path, '--project-dir=.', self._mode]
     RunCommand(cmd)
     # Check theme.xml.
     theme_path = os.path.join('Example', 'res', 'values-v14', 'theme.xml')
@@ -1015,7 +1032,8 @@ class TestMakeApk(unittest.TestCase):
            '--name=%s' % name,
            '--package=org.xwalk.example',
            '--compressor',
-           '--app-root=%s' % app_root]
+           '--app-root=%s' % app_root,
+           '--project-dir=.']
     RunCommand(cmd)
     CompareSizeForCompressor('all', css_file, 'css', name, fun)
     CompareSizeForCompressor('all', js_file, 'js', name, fun)
@@ -1024,7 +1042,8 @@ class TestMakeApk(unittest.TestCase):
            '--name=%s' % name,
            '--package=org.xwalk.example',
            '--app-root=%s' % app_root,
-           '--compressor']
+           '--compressor',
+           '--project-dir=.']
     RunCommand(cmd)
     CompareSizeForCompressor('all', css_file, 'css', name, fun)
     CompareSizeForCompressor('all', js_file, 'js', name, fun)
@@ -1033,7 +1052,8 @@ class TestMakeApk(unittest.TestCase):
            '--name=%s' % name,
            '--package=org.xwalk.example',
            '--compressor=js',
-           '--app-root=%s' % app_root]
+           '--app-root=%s' % app_root,
+           '--project-dir=.']
     RunCommand(cmd)
     CompareSizeForCompressor('js', js_file, 'js', name, fun)
 
@@ -1041,14 +1061,16 @@ class TestMakeApk(unittest.TestCase):
            '--name=%s' % name,
            '--package=org.xwalk.example',
            '--compressor=css',
-           '--app-root=%s' % app_root]
+           '--app-root=%s' % app_root,
+           '--project-dir=.']
     RunCommand(cmd)
     CompareSizeForCompressor('css', css_file, 'css', name, fun)
 
     cmd = ['python', 'customize.py',
            '--name=%s' % name,
            '--package=org.xwalk.example',
-           '--app-root=%s' % app_root]
+           '--app-root=%s' % app_root,
+           '--project-dir=.']
     RunCommand(cmd)
     CompareSizeForCompressor(None, css_file, 'css', name, fun)
     CompareSizeForCompressor(None, js_file, 'js', name, fun)
@@ -1057,7 +1079,8 @@ class TestMakeApk(unittest.TestCase):
            '--name=%s' % name,
            '--package=org.xwalk.example',
            '--app-root=%s' % app_root,
-           '--compressor=other']
+           '--compressor=other',
+           '--project-dir=.']
     RunCommand(cmd)
     CompareSizeForCompressor(None, css_file, 'css', name, fun)
     CompareSizeForCompressor(None, js_file, 'js', name, fun)
@@ -1078,14 +1101,15 @@ class TestMakeApk(unittest.TestCase):
     xml_path = 'Example/AndroidManifest.xml'
     piece_content = 'android:label="%s"' % '你好'
     cmd = ['python', 'make_apk.py', '--name=你好', '--app-version=1.0.0',
-           '--package=org.xwalk.example', '--app-url=http://www.intel.com']
+           '--package=org.xwalk.example', '--app-url=http://www.intel.com',
+           '--project-dir=.']
     RunCommand(cmd)
     self.VerifyResultInXMLFile(xml_path, piece_content)
 
     manifest_path = os.path.join('test_data', 'manifest', 'invalidchars',
                                  'manifest_with_chinese_name.json')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
-           '--manifest=%s' % manifest_path]
+           '--manifest=%s' % manifest_path, '--project-dir=.']
     RunCommand(cmd)
     self.VerifyResultInXMLFile(xml_path, piece_content)
 
@@ -1095,14 +1119,14 @@ class TestMakeApk(unittest.TestCase):
     piece_content = '<string name="description">%s</string>' % '你好'
     cmd = ['python', 'make_apk.py', '--name=hello', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
-           '--description=你好']
+           '--description=你好', '--project-dir=.']
     RunCommand(cmd)
     self.VerifyResultInXMLFile(xml_path, piece_content)
 
     manifest_path = os.path.join('test_data', 'manifest',
                                  'manifest_description_dbcs.json')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
-           '--manifest=%s' % manifest_path]
+           '--manifest=%s' % manifest_path, '--project-dir=.']
     RunCommand(cmd)
     piece_content = '"description">%s</string>' % '你好 a sample description'
     self.VerifyResultInXMLFile(xml_path, piece_content)

--- a/app/tools/android/util.py
+++ b/app/tools/android/util.py
@@ -49,3 +49,23 @@ def GetVersion(path):
   version_str += ('.').join(version_nums)
   file_handle.close()
   return version_str
+
+
+def CreateAndCopyDir(src_dir, dest_dir, delete_if_exists=False):
+  if not os.path.isdir(src_dir):
+    return False
+  # create path, except last directory (handled by copytree)
+  pre_dest_dir = os.path.dirname(dest_dir)
+  if not os.path.isdir(pre_dest_dir):
+    try:
+      os.makedirs(pre_dest_dir)  # throws exception on error
+    except OSError:
+      return False
+  if os.path.exists(dest_dir):
+    if delete_if_exists:
+      shutil.rmtree(dest_dir)
+    else:
+      return False
+  shutil.copytree(src_dir, dest_dir)
+  return True
+


### PR DESCRIPTION
 The build directory will be created in the system temp directory.
 Added two options:
  --project-dir=DIR Allow saving the build directory to a location
  --project-only      Skip creation of APKs.  Just save the project dir
 Modified make_apk_test.py to include option "--project_dir=." in tests

 Bug=XWALK-2394
