### PR TITLE
[Desktop] Implement app launch from the manifest path

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -150,9 +150,9 @@ class Application : public Runtime::Observer,
 
   // Try to extract the URL from different possible keys for entry points in the
   // manifest, returns it and the entry point used.
-  template <Package::Type> GURL GetStartURL();
+  template <Manifest::Type> GURL GetStartURL();
 
-  template <Package::Type>
+  template <Manifest::Type>
   ui::WindowShowState GetWindowShowState(const LaunchParams& params);
 
   GURL GetAbsoluteURLFromKey(const std::string& key);

--- a/application/browser/application_protocols.cc
+++ b/application/browser/application_protocols.cc
@@ -247,7 +247,7 @@ ApplicationProtocolHandler::MaybeCreateJob(
   if (application) {
     directory_path = application->Path();
 
-    const char* csp_key = GetCSPKey(application->GetPackageType());
+    const char* csp_key = GetCSPKey(application->manifest_type());
     const CSPInfo* csp_info = static_cast<CSPInfo*>(
           application->GetManifestData(csp_key));
     if (csp_info) {
@@ -262,10 +262,8 @@ ApplicationProtocolHandler::MaybeCreateJob(
     }
   }
 
-  const std::string& path = request->url().path();
-
   std::list<std::string> locales;
-  if (application && application->GetPackageType() == Package::WGT) {
+  if (application && application->manifest_type() == Manifest::TYPE_WIDGET) {
     GetUserAgentLocales(GetSystemLocale(), locales);
     GetUserAgentLocales(application->GetManifest()->default_locale(), locales);
   }

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -39,10 +39,10 @@ class ApplicationService : public Application::Observer {
   static scoped_ptr<ApplicationService> Create(
     RuntimeContext* runtime_context);
 
-  // Launch an application using path to a local directory which
-  // contains manifest file of an unpacked application.
-  Application* LaunchFromUnpackedPath(
-      const base::FilePath& path,
+  // Launch an unpacked application using path to the manifest file
+  // of an unpacked application.
+  Application* LaunchFromManifestPath(
+      const base::FilePath& path, Manifest::Type manifest_type,
       const Application::LaunchParams& params = Application::LaunchParams());
 
   // Launch an application using path to its package file.

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -92,16 +92,25 @@ bool ApplicationSystem::LaunchFromCommandLine(
     return true;
   }
 
-  if (base::DirectoryExists(path)) {  // Handles unpacked application.
-    run_default_message_loop = application_service_->LaunchFromUnpackedPath(
-        path, launch_params(cmd_line));
-    return true;
-  }
+  if (!base::PathExists(path))
+    return false;
 
   if (path.MatchesExtension(FILE_PATH_LITERAL(".xpk")) ||
       path.MatchesExtension(FILE_PATH_LITERAL(".wgt"))) {
     run_default_message_loop = application_service_->LaunchFromPackagePath(
         path, launch_params(cmd_line));
+    return true;
+  }
+
+  if (path.MatchesExtension(FILE_PATH_LITERAL(".json"))) {
+    run_default_message_loop = application_service_->LaunchFromManifestPath(
+        path, Manifest::TYPE_MANIFEST, launch_params(cmd_line));
+    return true;
+  }
+
+  if (path.MatchesExtension(FILE_PATH_LITERAL(".xml"))) {
+    run_default_message_loop = application_service_->LaunchFromManifestPath(
+        path, Manifest::TYPE_WIDGET, launch_params(cmd_line));
     return true;
   }
 

--- a/application/common/application_file_util.h
+++ b/application/common/application_file_util.h
@@ -22,8 +22,6 @@ class FilePath;
 namespace xwalk {
 namespace application {
 
-class ApplicationData;
-
 class FileDeleter {
  public:
   FileDeleter(const base::FilePath& path, bool recursive);
@@ -37,32 +35,20 @@ class FileDeleter {
   bool recursive_;
 };
 
+// Loads an application manifest from the specified directory. Returns NULL
+// on failure, with a description of the error in |error|.
+scoped_ptr<Manifest> LoadManifest(
+    const base::FilePath& file_path, Manifest::Type type, std::string* error);
+
+base::FilePath GetManifestPath(
+    const base::FilePath& app_directory, Manifest::Type type);
+
 // Loads and validates an application from the specified directory. Returns NULL
 // on failure, with a description of the error in |error|.
 scoped_refptr<ApplicationData> LoadApplication(
-    const base::FilePath& application_root,
-    ApplicationData::SourceType source_type,
+    const base::FilePath& app_root, const std::string& app_id,
+    ApplicationData::SourceType source_type, Manifest::Type manifest_type,
     std::string* error);
-
-// The same as LoadApplication except use the provided |application_id|.
-scoped_refptr<ApplicationData> LoadApplication(
-    const base::FilePath& application_root,
-    const std::string& application_id,
-    ApplicationData::SourceType source_type,
-    std::string* error);
-
-scoped_refptr<ApplicationData> LoadApplication(
-    const base::FilePath& application_root,
-    const std::string& application_id,
-    ApplicationData::SourceType source_type,
-    Package::Type package_type,
-    std::string* error);
-
-// Loads an application manifest from the specified directory. Returns NULL
-// on failure, with a description of the error in |error|.
-base::DictionaryValue* LoadManifest(const base::FilePath& application_root,
-                                    Package::Type package_type,
-                                    std::string* error);
 
 // Get a relative file path from an app:// URL.
 base::FilePath ApplicationURLToRelativeFilePath(const GURL& url);

--- a/application/common/application_file_util_unittest.cc
+++ b/application/common/application_file_util_unittest.cc
@@ -41,7 +41,8 @@ TEST_F(ApplicationFileUtilTest, LoadApplicationWithValidPath) {
 
   std::string error;
   scoped_refptr<ApplicationData> application(LoadApplication(
-          install_dir, ApplicationData::LOCAL_DIRECTORY, &error));
+          install_dir, std::string(), ApplicationData::LOCAL_DIRECTORY,
+          Manifest::TYPE_MANIFEST, &error));
   ASSERT_TRUE(application != NULL);
   EXPECT_EQ("The first application that I made.", application->Description());
 }
@@ -60,7 +61,8 @@ TEST_F(ApplicationFileUtilTest,
 
   std::string error;
   scoped_refptr<ApplicationData> application(LoadApplication(
-          install_dir, ApplicationData::LOCAL_DIRECTORY, &error));
+          install_dir, std::string(), ApplicationData::LOCAL_DIRECTORY,
+          Manifest::TYPE_WIDGET, &error));
   ASSERT_TRUE(application == NULL);
   ASSERT_FALSE(error.empty());
   ASSERT_STREQ("Manifest file is missing or unreadable.", error.c_str());
@@ -80,7 +82,8 @@ TEST_F(ApplicationFileUtilTest,
 
   std::string error;
   scoped_refptr<ApplicationData> application(LoadApplication(
-          install_dir, ApplicationData::LOCAL_DIRECTORY, &error));
+          install_dir, std::string(), ApplicationData::LOCAL_DIRECTORY,
+          Manifest::TYPE_MANIFEST, &error));
   ASSERT_TRUE(application == NULL);
   ASSERT_FALSE(error.empty());
   ASSERT_STREQ("Manifest is not valid JSON."
@@ -89,13 +92,15 @@ TEST_F(ApplicationFileUtilTest,
 }
 
 static scoped_refptr<ApplicationData> LoadApplicationManifest(
-    base::DictionaryValue* manifest,
+    base::DictionaryValue* values,
     const base::FilePath& manifest_dir,
     ApplicationData::SourceType location,
     int extra_flags,
     std::string* error) {
+  scoped_ptr<Manifest> manifest = make_scoped_ptr(
+      new Manifest(make_scoped_ptr(values->DeepCopy())));
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      manifest_dir, location, *manifest, std::string(), error);
+      manifest_dir, std::string(), location, manifest.Pass(), error);
   return application;
 }
 

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -147,37 +147,37 @@ const char kManifestUnreadable[] =
 
 namespace application {
 
-const char* GetNameKey(Package::Type package_type) {
-  if (package_type == Package::WGT)
+const char* GetNameKey(Manifest::Type manifest_type) {
+  if (manifest_type == Manifest::TYPE_WIDGET)
     return application_widget_keys::kNameKey;
 
   return application_manifest_keys::kNameKey;
 }
 
-const char* GetVersionKey(Package::Type package_type) {
-  if (package_type == Package::WGT)
+const char* GetVersionKey(Manifest::Type manifest_type) {
+  if (manifest_type == Manifest::TYPE_WIDGET)
     return application_widget_keys::kVersionKey;
 
   return application_manifest_keys::kXWalkVersionKey;
 }
 
-const char* GetCSPKey(Package::Type package_type) {
-  if (package_type == Package::WGT)
+const char* GetCSPKey(Manifest::Type manifest_type) {
+  if (manifest_type == Manifest::TYPE_WIDGET)
     return application_widget_keys::kCSPKey;
 
   return application_manifest_keys::kCSPKey;
 }
 
 #if defined(OS_TIZEN)
-const char* GetTizenAppIdKey(Package::Type package_type) {
-  if (package_type == Package::WGT)
+const char* GetTizenAppIdKey(Manifest::Type manifest_type) {
+  if (manifest_type == Manifest::TYPE_WIDGET)
     return application_widget_keys::kTizenAppIdKey;
 
   return application_manifest_keys::kTizenAppIdKey;
 }
 
-const char* GetIcon128Key(Package::Type package_type) {
-  if (package_type == Package::WGT)
+const char* GetIcon128Key(Manifest::Type manifest_type) {
+  if (manifest_type == Manifest::TYPE_WIDGET)
     return application_widget_keys::kIcon128Key;
 
   return application_manifest_keys::kIcon128Key;

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -6,7 +6,7 @@
 #define XWALK_APPLICATION_COMMON_APPLICATION_MANIFEST_CONSTANTS_H_
 
 #include "xwalk/application/common/manifest.h"
-#include "xwalk/application/common/package/package.h"
+
 // Keys used in JSON representation of applications.
 namespace xwalk {
 namespace application_manifest_keys {
@@ -119,11 +119,11 @@ namespace application_manifest_errors {
 }  // namespace application_manifest_errors
 
 namespace application {
-const char* GetNameKey(Package::Type type);
-const char* GetCSPKey(Package::Type type);
+const char* GetNameKey(Manifest::Type type);
+const char* GetCSPKey(Manifest::Type type);
 #if defined(OS_TIZEN)
-const char* GetTizenAppIdKey(Package::Type type);
-const char* GetIcon128Key(Package::Type type);
+const char* GetTizenAppIdKey(Manifest::Type type);
+const char* GetIcon128Key(Manifest::Type type);
 #endif
 }  // namespace application
 }  // namespace xwalk

--- a/application/common/id_util.cc
+++ b/application/common/id_util.cc
@@ -101,10 +101,7 @@ std::string PkgIdToAppId(const std::string& id) {
 
 bool IsValidApplicationID(const std::string& id) {
 #if defined(OS_TIZEN)
-  if (IsValidWGTID(id) ||
-      IsValidXPKID(id))
-    return true;
-  return false;
+  return (IsValidWGTID(id) || IsValidXPKID(id));
 #endif
 
   std::string temp = base::StringToLowerASCII(id);

--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -63,29 +63,10 @@ scoped_ptr<List> ExpandUserAgentLocalesList(const scoped_ptr<List>& list) {
 
 }  // namespace
 
-Manifest::Manifest(scoped_ptr<base::DictionaryValue> value)
+Manifest::Manifest(scoped_ptr<base::DictionaryValue> value, Type type)
     : data_(value.Pass()),
       i18n_data_(new base::DictionaryValue),
-      type_(TYPE_UNKNOWN) {
-  // FIXME: Hosted apps can contain start_url. Below is wrong.
-  if (data_->Get(keys::kStartURLKey, NULL)) {
-    type_ = TYPE_PACKAGED_APP;
-  } else if (data_->HasKey(keys::kAppKey)) {
-    if (data_->Get(keys::kLaunchWebURLKey, NULL)) {
-      type_ = TYPE_HOSTED_APP;
-    } else if (data_->Get(keys::kLaunchLocalPathKey, NULL)) {
-      type_ = TYPE_PACKAGED_APP;
-    }
-#if defined(OS_TIZEN)
-  } else if (HasPath(widget_keys::kContentNamespace)) {
-    std::string ns;
-    if (data_->GetString(widget_keys::kContentNamespace, &ns) &&
-        ns == kTizenNamespacePrefix)
-      type_ = TYPE_HOSTED_APP;
-    else
-      type_ = TYPE_PACKAGED_APP;
-#endif
-  }
+      type_(type) {
 
   if (data_->HasKey(widget_keys::kWidgetKey) &&
       data_->Get(widget_keys::kWidgetKey, NULL))
@@ -181,8 +162,8 @@ bool Manifest::GetList(
 
 Manifest* Manifest::DeepCopy() const {
   Manifest* manifest = new Manifest(
-      scoped_ptr<base::DictionaryValue>(data_->DeepCopy()));
-  manifest->SetApplicationID(application_id_);
+      scoped_ptr<base::DictionaryValue>(data_->DeepCopy()),
+      type());
   return manifest;
 }
 

--- a/application/common/manifest.h
+++ b/application/common/manifest.h
@@ -23,16 +23,13 @@ namespace application {
 class Manifest {
  public:
   enum Type {
-    TYPE_UNKNOWN = 0,
-    TYPE_HOSTED_APP,
-    TYPE_PACKAGED_APP
+    TYPE_MANIFEST,  // Corresponds to w3c.github.io/manifest
+    TYPE_WIDGET     // Corresponds to http://www.w3.org/TR/widgets
   };
 
-  explicit Manifest(scoped_ptr<base::DictionaryValue> value);
+  explicit Manifest(
+      scoped_ptr<base::DictionaryValue> value, Type type = TYPE_MANIFEST);
   ~Manifest();
-
-  const std::string& GetApplicationID() const { return application_id_; }
-  void SetApplicationID(const std::string& id) { application_id_ = id; }
 
   // Returns false and |error| will be non-empty if the manifest is malformed.
   // |warnings| will be populated if there are keys in the manifest that cannot
@@ -40,10 +37,7 @@ class Manifest {
   bool ValidateManifest(std::string* error) const;
 
   // Returns the manifest type.
-  Type GetType() const { return type_; }
-
-  bool IsPackaged() const { return type_ == TYPE_PACKAGED_APP; }
-  bool IsHosted() const { return type_ == TYPE_HOSTED_APP; }
+  Type type() const { return type_; }
 
   // These access the wrapped manifest value, returning false when the property
   // does not exist or if the manifest type can't access it.
@@ -97,11 +91,6 @@ class Manifest {
   // Returns true if the application can specify the given |path|.
   bool CanAccessPath(const std::string& path) const;
   bool CanAccessKey(const std::string& key) const;
-
-  // A persistent, globally unique ID. An application's ID is used in things
-  // like directory structures and URLs, and is expected to not change across
-  // versions.
-  std::string application_id_;
 
 #if defined(OS_TIZEN)
   // Unique package id for tizen platform

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -59,8 +59,8 @@ ManifestHandlerRegistry::~ManifestHandlerRegistry() {
 }
 
 ManifestHandlerRegistry*
-ManifestHandlerRegistry::GetInstance(Package::Type package_type) {
-  if (package_type == Package::WGT)
+ManifestHandlerRegistry::GetInstance(Manifest::Type type) {
+  if (type == Manifest::TYPE_WIDGET)
     return GetInstanceForWGT();
   return GetInstanceForXPK();
 }
@@ -75,7 +75,7 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   handlers.push_back(new WidgetHandler);
   handlers.push_back(new WARPHandler);
 #if defined(OS_TIZEN)
-  handlers.push_back(new CSPHandler(Package::WGT));
+  handlers.push_back(new CSPHandler(Manifest::TYPE_WIDGET));
   handlers.push_back(new NavigationHandler);
   handlers.push_back(new TizenApplicationHandler);
   handlers.push_back(new TizenSettingHandler);
@@ -94,7 +94,7 @@ ManifestHandlerRegistry::GetInstanceForXPK() {
   std::vector<ManifestHandler*> handlers;
   // FIXME: Add manifest handlers here like this:
   // handlers.push_back(new xxxHandler);
-  handlers.push_back(new CSPHandler(Package::XPK));
+  handlers.push_back(new CSPHandler(Manifest::TYPE_MANIFEST));
   handlers.push_back(new PermissionsHandler);
   xpk_registry_ = new ManifestHandlerRegistry(handlers);
   return xpk_registry_;
@@ -114,7 +114,7 @@ bool ManifestHandlerRegistry::ParseAppManifest(
        iter != handlers_.end(); ++iter) {
     ManifestHandler* handler = iter->second;
     if (application->GetManifest()->HasPath(iter->first) ||
-        handler->AlwaysParseForType(application->GetType())) {
+        handler->AlwaysParseForType(application->manifest_type())) {
       handlers_by_order[order_map_[handler]] = handler;
     }
   }
@@ -134,7 +134,7 @@ bool ManifestHandlerRegistry::ValidateAppManifest(
        iter != handlers_.end(); ++iter) {
     ManifestHandler* handler = iter->second;
     if ((application->GetManifest()->HasPath(iter->first) ||
-         handler->AlwaysValidateForType(application->GetType())) &&
+         handler->AlwaysValidateForType(application->manifest_type())) &&
         !handler->Validate(application, error))
       return false;
   }
@@ -143,8 +143,8 @@ bool ManifestHandlerRegistry::ValidateAppManifest(
 
 // static
 void ManifestHandlerRegistry::SetInstanceForTesting(
-    ManifestHandlerRegistry* registry, Package::Type package_type) {
-  if (package_type == Package::WGT) {
+    ManifestHandlerRegistry* registry, Manifest::Type type) {
+  if (type == Manifest::TYPE_WIDGET) {
     widget_registry_ = registry;
     return;
   }

--- a/application/common/manifest_handler.h
+++ b/application/common/manifest_handler.h
@@ -54,8 +54,7 @@ class ManifestHandlerRegistry {
  public:
   ~ManifestHandlerRegistry();
 
-  static ManifestHandlerRegistry* GetInstance(
-      Package::Type package_type);
+  static ManifestHandlerRegistry* GetInstance(Manifest::Type type);
 
   bool ParseAppManifest(
        scoped_refptr<ApplicationData> application, base::string16* error);
@@ -75,7 +74,7 @@ class ManifestHandlerRegistry {
 
   // Sets a new global registry, for testing purposes.
   static void SetInstanceForTesting(ManifestHandlerRegistry* registry,
-                                    Package::Type package_type);
+                                    Manifest::Type type);
 
   static ManifestHandlerRegistry* GetInstanceForWGT();
   static ManifestHandlerRegistry* GetInstanceForXPK();

--- a/application/common/manifest_handler_unittest.cc
+++ b/application/common/manifest_handler_unittest.cc
@@ -31,14 +31,14 @@ class ScopedTestingManifestHandlerRegistry {
       : registry_(
           new ManifestHandlerRegistry(handlers)),
         prev_registry_(
-          ManifestHandlerRegistry::GetInstance(Package::XPK)) {
+          ManifestHandlerRegistry::GetInstance(Manifest::TYPE_MANIFEST)) {
     ManifestHandlerRegistry::SetInstanceForTesting(
-        registry_.get(), Package::XPK);
+        registry_.get(), Manifest::TYPE_MANIFEST);
   }
 
   ~ScopedTestingManifestHandlerRegistry() {
     ManifestHandlerRegistry::SetInstanceForTesting(
-        prev_registry_, Package::XPK);
+        prev_registry_, Manifest::TYPE_MANIFEST);
   }
 
   scoped_ptr<ManifestHandlerRegistry> registry_;
@@ -219,10 +219,9 @@ TEST_F(ManifestHandlerTest, DependentHandlers) {
   manifest.SetInteger("g", 6);
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(),
+      base::FilePath(), std::string(),
       ApplicationData::LOCAL_DIRECTORY,
-      manifest,
-      "",
+      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
       &error);
   EXPECT_TRUE(application.get());
   // A, B, C.EZ, C.D, K
@@ -247,10 +246,9 @@ TEST_F(ManifestHandlerTest, FailingHandlers) {
   // Succeeds when "a" is not recognized.
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(),
+      base::FilePath(), std::string(),
       ApplicationData::LOCAL_DIRECTORY,
-      manifest_a,
-      "",
+      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest_a.DeepCopy()))),
       &error);
   EXPECT_TRUE(application.get());
 
@@ -264,10 +262,9 @@ TEST_F(ManifestHandlerTest, FailingHandlers) {
   registry.reset(new ScopedTestingManifestHandlerRegistry(handlers));
 
   application = ApplicationData::Create(
-      base::FilePath(),
+      base::FilePath(), std::string(),
       ApplicationData::LOCAL_DIRECTORY,
-      manifest_a,
-      "",
+      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest_a.DeepCopy()))),
       &error);
   EXPECT_FALSE(application.get());
   EXPECT_EQ("A", error);
@@ -285,10 +282,9 @@ TEST_F(ManifestHandlerTest, Validate) {
   manifest.SetInteger("b", 2);
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(),
+      base::FilePath(), std::string(),
       ApplicationData::LOCAL_DIRECTORY,
-      manifest,
-      "",
+      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
       &error);
   EXPECT_TRUE(application.get());
 

--- a/application/common/manifest_handlers/csp_handler.cc
+++ b/application/common/manifest_handlers/csp_handler.cc
@@ -21,8 +21,8 @@ CSPInfo::CSPInfo() {
 CSPInfo::~CSPInfo() {
 }
 
-CSPHandler::CSPHandler(Package::Type type)
-    : package_type_(type) {
+CSPHandler::CSPHandler(Manifest::Type type)
+    : type_(type) {
 }
 
 CSPHandler::~CSPHandler() {
@@ -30,11 +30,11 @@ CSPHandler::~CSPHandler() {
 
 bool CSPHandler::Parse(scoped_refptr<ApplicationData> application,
                        base::string16* error) {
-  if (package_type_ != application->GetPackageType())
+  if (type_ != application->manifest_type())
     return false;
   scoped_ptr<CSPInfo> csp_info(new CSPInfo);
   std::string policies_str;
-  const char* csp_key = GetCSPKey(package_type_);
+  const char* csp_key = GetCSPKey(type_);
   if (application->GetManifest()->HasPath(csp_key) &&
       !application->GetManifest()->GetString(csp_key, &policies_str)) {
     *error = base::ASCIIToUTF16(
@@ -62,11 +62,11 @@ bool CSPHandler::Parse(scoped_refptr<ApplicationData> application,
 }
 
 bool CSPHandler::AlwaysParseForType(Manifest::Type type) const {
-  return package_type_ == Package::XPK;
+  return type_ == Manifest::TYPE_MANIFEST;
 }
 
 std::vector<std::string> CSPHandler::Keys() const {
-  return std::vector<std::string>(1, GetCSPKey(package_type_));
+  return std::vector<std::string>(1, GetCSPKey(type_));
 }
 
 }  // namespace application

--- a/application/common/manifest_handlers/csp_handler.h
+++ b/application/common/manifest_handlers/csp_handler.h
@@ -32,7 +32,7 @@ class CSPInfo : public ApplicationData::ManifestData {
 
 class CSPHandler : public ManifestHandler {
  public:
-  explicit CSPHandler(Package::Type type);
+  explicit CSPHandler(Manifest::Type type);
   virtual ~CSPHandler();
 
   virtual bool Parse(scoped_refptr<ApplicationData> application,
@@ -41,7 +41,7 @@ class CSPHandler : public ManifestHandler {
   virtual std::vector<std::string> Keys() const OVERRIDE;
 
  private:
-  Package::Type package_type_;
+  Manifest::Type type_;
 
   DISALLOW_COPY_AND_ASSIGN(CSPHandler);
 };

--- a/application/common/manifest_handlers/csp_handler_unittest.cc
+++ b/application/common/manifest_handlers/csp_handler_unittest.cc
@@ -18,16 +18,17 @@ class CSPHandlerTest: public testing::Test {
  public:
   scoped_refptr<ApplicationData> CreateApplication() {
     std::string error;
-    scoped_refptr<ApplicationData> application = ApplicationData::Create(
-        base::FilePath(), ApplicationData::LOCAL_DIRECTORY,
-        manifest, "", &error);
-    return application;
+    scoped_refptr<ApplicationData> app_data = ApplicationData::Create(
+        base::FilePath(), std::string(), ApplicationData::LOCAL_DIRECTORY,
+        make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
+        &error);
+    return app_data;
   }
 
   const CSPInfo* GetCSPInfo(
       scoped_refptr<ApplicationData> application) {
     const CSPInfo* info = static_cast<CSPInfo*>(
-        application->GetManifestData(GetCSPKey(application->GetPackageType())));
+        application->GetManifestData(GetCSPKey(application->manifest_type())));
     return info;
   }
 

--- a/application/common/manifest_handlers/permissions_handler_unittest.cc
+++ b/application/common/manifest_handlers/permissions_handler_unittest.cc
@@ -34,10 +34,9 @@ TEST_F(PermissionsHandlerTest, NonePermission) {
   manifest.SetString(keys::kXWalkVersionKey, "0");
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(),
+      base::FilePath(), std::string(),
       ApplicationData::LOCAL_DIRECTORY,
-      manifest,
-      "",
+      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
       &error);
   EXPECT_TRUE(application.get());
   EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0);
@@ -51,10 +50,9 @@ TEST_F(PermissionsHandlerTest, EmptyPermission) {
   manifest.Set(keys::kPermissionsKey, permissions);
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(),
+      base::FilePath(), std::string(),
       ApplicationData::LOCAL_DIRECTORY,
-      manifest,
-      "",
+      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
       &error);
   EXPECT_TRUE(application.get());
   EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0);
@@ -69,10 +67,9 @@ TEST_F(PermissionsHandlerTest, DeviceAPIPermission) {
   manifest.Set(keys::kPermissionsKey, permissions);
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(),
+      base::FilePath(), std::string(),
       ApplicationData::LOCAL_DIRECTORY,
-      manifest,
-      "",
+      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
       &error);
   EXPECT_TRUE(application.get());
   const PermissionSet& permission_list =

--- a/application/common/manifest_handlers/warp_handler_unittest.cc
+++ b/application/common/manifest_handlers/warp_handler_unittest.cc
@@ -23,8 +23,10 @@ class WARPHandlerTest: public testing::Test {
   scoped_refptr<ApplicationData> CreateApplication() {
     std::string error;
     scoped_refptr<ApplicationData> application = ApplicationData::Create(
-        base::FilePath(), ApplicationData::LOCAL_DIRECTORY,
-        manifest, "", &error);
+        base::FilePath(), std::string(), ApplicationData::LOCAL_DIRECTORY,
+        make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()),
+                                     Manifest::TYPE_WIDGET)),
+        &error);
     return application;
   }
 
@@ -53,7 +55,7 @@ TEST_F(WARPHandlerTest, OneWARP) {
   manifest.Set(keys::kAccessKey, warp);
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(application->GetPackageType(), Package::WGT);
+  EXPECT_EQ(application->manifest_type(), Manifest::TYPE_WIDGET);
   const WARPInfo* info = GetWARPInfo(application);
   EXPECT_TRUE(info);
   scoped_ptr<base::ListValue> list(info->GetWARP()->DeepCopy());
@@ -77,7 +79,7 @@ TEST_F(WARPHandlerTest, WARPs) {
 
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(application->GetPackageType(), Package::WGT);
+  EXPECT_EQ(application->manifest_type(), Manifest::TYPE_WIDGET);
 
   const WARPInfo* info = GetWARPInfo(application);
   EXPECT_TRUE(info);

--- a/application/common/manifest_handlers/widget_handler_unittest.cc
+++ b/application/common/manifest_handlers/widget_handler_unittest.cc
@@ -55,8 +55,10 @@ class WidgetHandlerTest: public testing::Test {
     const base::DictionaryValue& manifest) {
     std::string error;
     scoped_refptr<ApplicationData> application = ApplicationData::Create(
-        base::FilePath(), ApplicationData::LOCAL_DIRECTORY,
-        manifest, "", &error);
+        base::FilePath(), std::string(), ApplicationData::LOCAL_DIRECTORY,
+        make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()),
+                                     Manifest::TYPE_WIDGET)),
+        &error);
     return application;
   }
 
@@ -162,7 +164,7 @@ TEST_F(WidgetHandlerTest,
   scoped_refptr<ApplicationData> application;
   application = CreateApplication(*(manifest.get()));
   EXPECT_TRUE(application);
-  EXPECT_EQ(application->GetPackageType(), Package::WGT);
+  EXPECT_EQ(application->manifest_type(), Manifest::TYPE_WIDGET);
   // Get widget info from this application.
   WidgetInfo* info = GetWidgetInfo(application);
   EXPECT_TRUE(info);
@@ -193,8 +195,8 @@ TEST_F(WidgetHandlerTest,
   // Create an application use this manifest,
   scoped_refptr<ApplicationData> application;
   application = CreateApplication(*(manifest.get()));
-  EXPECT_TRUE(application);
-  EXPECT_EQ(application->GetPackageType(), Package::WGT);
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(application->manifest_type(), Manifest::TYPE_WIDGET);
   // Get widget info from this application.
   WidgetInfo* info = GetWidgetInfo(application);
   EXPECT_TRUE(info);

--- a/application/common/manifest_unittest.cc
+++ b/application/common/manifest_unittest.cc
@@ -26,13 +26,6 @@ class ManifestTest : public testing::Test {
   ManifestTest() : default_value_("test") {}
 
  protected:
-  void AssertType(Manifest* manifest, Manifest::Type type) {
-    EXPECT_EQ(type, manifest->GetType());
-    EXPECT_EQ(type == Manifest::TYPE_PACKAGED_APP,
-              manifest->IsPackaged());
-    EXPECT_EQ(type == Manifest::TYPE_HOSTED_APP, manifest->IsHosted());
-  }
-
   // Helper function that replaces the Manifest held by |manifest| with a copy
   // with its |key| changed to |value|. If |value| is NULL, then |key| will
   // instead be deleted.
@@ -63,8 +56,6 @@ TEST_F(ManifestTest, ApplicationData) {
   std::string error;
   EXPECT_TRUE(manifest->ValidateManifest(&error));
   EXPECT_TRUE(error.empty());
-  // TODO(xiang): warnings will not be empty after enable manifest features
-  // AssertType(manifest.get(), Manifest::TYPE_HOSTED_AP);
 
   // The unknown key 'unknown_key' should be accesible.
   std::string value;
@@ -91,21 +82,6 @@ TEST_F(ManifestTest, ApplicationTypes) {
   std::string error;
   EXPECT_TRUE(manifest->ValidateManifest(&error));
   EXPECT_TRUE(error.empty());
-
-  // Platform app.
-  MutateManifest(
-      &manifest, keys::kStartURLKey,
-      new base::StringValue("main.html"));
-  AssertType(manifest.get(), Manifest::TYPE_PACKAGED_APP);
-  MutateManifest(
-      &manifest, keys::kStartURLKey, NULL);
-
-  // Hosted app.
-  MutateManifest(
-      &manifest, keys::kLaunchWebURLKey, new base::StringValue("foo"));
-  AssertType(manifest.get(), Manifest::TYPE_HOSTED_APP);
-  MutateManifest(
-      &manifest, keys::kLaunchWebURLKey, NULL);
 }
 
 }  // namespace application

--- a/application/common/package/package.h
+++ b/application/common/package/package.h
@@ -12,6 +12,7 @@
 #include "base/files/scoped_file.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/memory/scoped_ptr.h"
+#include "xwalk/application/common/manifest.h"
 
 namespace xwalk {
 namespace application {
@@ -22,16 +23,12 @@ namespace application {
 //  XPKPackage::Validate()
 class Package {
  public:
-  enum Type {
-    WGT,
-    XPK
-  };
-
   virtual ~Package();
   bool IsValid() const { return is_valid_; }
   const std::string& Id() const { return id_; }
   const std::string& name() const { return name_; }
-  Type type() const { return type_; }
+  // Returns the type of the manifest which the package contains.
+  Manifest::Type manifest_type() const { return manifest_type_; }
   // Factory method for creating a package
   static scoped_ptr<Package> Create(const base::FilePath& path);
   // The function will unzip the XPK/WGT file and return the target path where
@@ -54,7 +51,7 @@ class Package {
   base::ScopedTempDir temp_dir_;
   // Represent if the package has been extracted.
   bool is_extracted_;
-  Type type_;
+  Manifest::Type manifest_type_;
 };
 
 }  // namespace application

--- a/application/common/package/wgt_package.cc
+++ b/application/common/package/wgt_package.cc
@@ -30,7 +30,7 @@ WGTPackage::WGTPackage(const base::FilePath& path)
   : Package(path) {
   if (!base::PathExists(path))
     return;
-  type_ = WGT;
+  manifest_type_ = Manifest::TYPE_WIDGET;
   base::FilePath extracted_path;
   // FIXME : we should not call 'extract' here!
   if (!ExtractToTemporaryDir(&extracted_path))

--- a/application/common/package/xpk_package.cc
+++ b/application/common/package/xpk_package.cc
@@ -26,7 +26,7 @@ XPKPackage::XPKPackage(const base::FilePath& path)
   : Package(path) {
   if (!base::PathExists(path))
     return;
-  type_ = XPK;
+  manifest_type_ = Manifest::TYPE_MANIFEST;
   scoped_ptr<base::ScopedFILE> file(
       new base::ScopedFILE(base::OpenFile(path, "rb")));
   file_ = file.Pass();

--- a/application/common/security_policy.cc
+++ b/application/common/security_policy.cc
@@ -168,11 +168,11 @@ SecurityPolicyCSP::~SecurityPolicyCSP() {
 }
 
 void SecurityPolicyCSP::Enforce() {
-  Package::Type package_type = app_->data()->GetPackageType();
-  const char* scp_key = GetCSPKey(package_type);
+  Manifest::Type manifest_type = app_->data()->manifest_type();
+  const char* scp_key = GetCSPKey(manifest_type);
   CSPInfo* csp_info =
       static_cast<CSPInfo*>(app_->data()->GetManifestData(scp_key));
-  if (package_type == Package::WGT) {
+  if (manifest_type == Manifest::TYPE_WIDGET) {
 #if defined(OS_TIZEN)
     if (!csp_info || csp_info->GetDirectives().empty())
        app_->data()->SetManifestData(scp_key, GetDefaultCSPInfo());

--- a/application/common/tizen/application_storage_impl.cc
+++ b/application/common/tizen/application_storage_impl.cc
@@ -33,6 +33,21 @@ ail_cb_ret_e appinfo_get_app_id_cb(
 
 const char kXWalkPackageType[] = "wgt";
 
+bool GetPackageType(const std::string& application_id,
+                    xwalk::application::Manifest::Type* package_type) {
+  if (xwalk::application::IsValidWGTID(application_id)) {
+    *package_type = xwalk::application::Manifest::TYPE_WIDGET;
+    return true;
+  }
+
+  if (xwalk::application::IsValidXPKID(application_id)) {
+    *package_type = xwalk::application::Manifest::TYPE_MANIFEST;
+    return true;
+  }
+
+  return false;
+}
+
 }  // namespace
 
 namespace xwalk {
@@ -48,13 +63,43 @@ bool ApplicationStorageImpl::Init() {
   return true;
 }
 
+namespace {
+
+bool GetManifestType(const std::string& app_id, Manifest::Type* manifest_type) {
+  if (IsValidWGTID(app_id)) {
+    *manifest_type = Manifest::TYPE_WIDGET;
+    return true;
+  }
+
+  if (IsValidXPKID(app_id)) {
+    *manifest_type = Manifest::TYPE_MANIFEST;
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace
+
 scoped_refptr<ApplicationData> ApplicationStorageImpl::GetApplicationData(
     const std::string& app_id) {
   base::FilePath app_path = GetApplicationPath(app_id);
 
-  std::string error_str;
-  return LoadApplication(
-      app_path, app_id, ApplicationData::INTERNAL, &error_str);
+  Manifest::Type manifest_type;
+  if (!GetManifestType(app_id, &manifest_type)) {
+    LOG(ERROR) << "Failed to detect the manifest type from app id "
+               << app_id;
+    return NULL;
+  }
+
+  std::string error;
+  scoped_refptr<ApplicationData> app_data =
+     LoadApplication(
+         app_path, app_id, ApplicationData::INTERNAL, manifest_type, &error);
+  if (!app_data)
+    LOG(ERROR) << "Error occurred while trying to load application: " << error;
+
+  return app_data;
 }
 
 bool ApplicationStorageImpl::GetInstalledApplicationIDs(

--- a/application/test/application_browsertest.cc
+++ b/application/test/application_browsertest.cc
@@ -9,6 +9,7 @@
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/application/browser/application_service.h"
+#include "xwalk/application/common/application_file_util.h"
 #include "xwalk/application/test/application_browsertest.h"
 #include "xwalk/application/test/application_testapi.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
@@ -16,6 +17,8 @@
 
 using xwalk::application::Application;
 using xwalk::application::ApplicationService;
+using xwalk::application::Manifest;
+using xwalk::application::GetManifestPath;
 using namespace xwalk::extensions;  // NOLINT
 
 ApplicationBrowserTest::ApplicationBrowserTest()
@@ -59,8 +62,11 @@ void ApplicationBrowserTest::CreateExtensions(
 }
 
 IN_PROC_BROWSER_TEST_F(ApplicationBrowserTest, ApiTest) {
-  Application* app = application_sevice()->LaunchFromUnpackedPath(
-      test_data_dir_.Append(FILE_PATH_LITERAL("api")));
+  base::FilePath manifest_path =
+      GetManifestPath(test_data_dir_.Append(FILE_PATH_LITERAL("api")),
+          Manifest::TYPE_MANIFEST);
+  Application* app = application_sevice()->LaunchFromManifestPath(
+      manifest_path, Manifest::TYPE_MANIFEST);
   ASSERT_TRUE(app);
   test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);

--- a/application/test/application_multi_app_test.cc
+++ b/application/test/application_multi_app_test.cc
@@ -8,12 +8,15 @@
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/common/application_file_util.h"
 #include "xwalk/application/test/application_browsertest.h"
 #include "xwalk/application/test/application_testapi.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 
 using xwalk::application::Application;
 using xwalk::application::ApplicationService;
+using xwalk::application::Manifest;
+using xwalk::application::GetManifestPath;
 
 class ApplicationMultiAppTest : public ApplicationBrowserTest {
 };
@@ -22,8 +25,11 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
   ApplicationService* service = application_sevice();
   const size_t currently_running_count = service->active_applications().size();
   // Launch the first app.
-  Application* app1 = service->LaunchFromUnpackedPath(
-      test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app1")));
+  base::FilePath manifest_path =
+      GetManifestPath(test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app1")),
+      Manifest::TYPE_MANIFEST);
+  Application* app1 = application_sevice()->LaunchFromManifestPath(
+      manifest_path, Manifest::TYPE_MANIFEST);
   ASSERT_TRUE(app1);
   // Wait for app is fully loaded.
   test_runner_->WaitForTestNotification();
@@ -36,13 +42,16 @@ IN_PROC_BROWSER_TEST_F(ApplicationMultiAppTest, TestMultiApp) {
 
   // Verify that no new App instance was created, if one exists
   // with the same ID.
-  Application* failed_app1 = service->LaunchFromUnpackedPath(
-      test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app1")));
+  Application* failed_app1 = application_sevice()->LaunchFromManifestPath(
+      manifest_path, Manifest::TYPE_MANIFEST);
   ASSERT_FALSE(failed_app1);
 
   // Launch the second app.
-  Application* app2 = service->LaunchFromUnpackedPath(
-      test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app2")));
+  manifest_path =
+      GetManifestPath(test_data_dir_.Append(FILE_PATH_LITERAL("dummy_app2")),
+          Manifest::TYPE_MANIFEST);
+  Application* app2 = application_sevice()->LaunchFromManifestPath(
+      manifest_path, Manifest::TYPE_MANIFEST);
   ASSERT_TRUE(app2);
   // Wait for app is fully loaded.
   test_runner_->PostResultToNotificationCallback();

--- a/application/test/application_testapi_test.cc
+++ b/application/test/application_testapi_test.cc
@@ -4,17 +4,23 @@
 
 #include "content/public/test/browser_test_utils.h"
 #include "net/base/net_util.h"
+#include "xwalk/application/common/application_file_util.h"
 #include "xwalk/application/test/application_browsertest.h"
 #include "xwalk/application/test/application_testapi.h"
 
 using xwalk::application::Application;
+using xwalk::application::Manifest;
+using xwalk::application::GetManifestPath;
 
 class ApplicationTestApiTest : public ApplicationBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(ApplicationTestApiTest, TestApiTest) {
-  Application* app = application_sevice()->LaunchFromUnpackedPath(
-      test_data_dir_.Append(FILE_PATH_LITERAL("testapi")));
+  base::FilePath manifest_path =
+      GetManifestPath(test_data_dir_.Append(FILE_PATH_LITERAL("testapi")),
+      Manifest::TYPE_MANIFEST);
+  Application* app = application_sevice()->LaunchFromManifestPath(
+      manifest_path, Manifest::TYPE_MANIFEST);
   ASSERT_TRUE(app);
   test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::FAILURE);

--- a/application/tools/tizen/xwalk_backend_plugin.cc
+++ b/application/tools/tizen/xwalk_backend_plugin.cc
@@ -24,6 +24,8 @@
 #include "xwalk/application/common/tizen/package_query.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 
+using xwalk::application::Manifest;
+
 namespace {
 
 enum PkgmgrPluginBool {
@@ -167,7 +169,7 @@ void PkgmgrBackendPlugin::SaveDetailInfo(
           PKG_VALUE_STRING_LEN_MAX - 1);
 
   // xpk do not have this key in manifest
-  if (app_data->GetPackageType() == xwalk::application::Package::WGT) {
+  if (app_data->manifest_type() == Manifest::TYPE_WIDGET) {
     const xwalk::application::TizenApplicationInfo* tizen_app_info =
         static_cast<xwalk::application::TizenApplicationInfo*>(
             app_data->GetManifestData(
@@ -207,7 +209,6 @@ PkgmgrBackendPlugin::GetApplicationDataFromPkg(const std::string& pkg_path,
   std::string error;
   scoped_refptr<xwalk::application::ApplicationData> app_data = LoadApplication(
       unpacked_dir, app_id, xwalk::application::ApplicationData::TEMP_DIRECTORY,
-      package->type(), &error);
-
+      package->manifest_type(), &error);
   return app_data;
 }


### PR DESCRIPTION
This patch changes the Crosswalk application launch behavior on
desktop: instead of providing the path to the application root
directory the User now should provide path to the manifest file.
This allows us to remove the logic for "guessing" which oh the
files within the application folder should be recognized as the
manifest file.

The patch contains also multiple refactorings among which:
1) The Manifest class does not contain the app id and does not
watch whether the application is hosted or not: all these goes
to the ApplicationData class which is more appropriate.
2) Instead of binding the application config file type to the
package file extension we introduce 'Manifest::Type { TYPE_MANIFEST,
TYPE_WIDGET }' which correspond to w3c.github.io/manifest and
http://www.w3.org/TR/widgets application config specifications
accordingly. That made the code more clear and fixed a lot of
"FIXMEs".

The code size has decreased by approximately 70 LOC.
