### PR TITLE
[Android] Fix XWalk extension implementation layer include voilation

### DIFF
--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -12,8 +12,7 @@
 #include "base/logging.h"
 #include "jni/XWalkExtensionAndroid_jni.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
-#include "xwalk/runtime/browser/xwalk_browser_main_parts_android.h"
-#include "xwalk/runtime/browser/xwalk_content_browser_client.h"
+#include "xwalk/extensions/common/xwalk_extension_manager.h"
 
 namespace xwalk {
 namespace extensions {
@@ -199,18 +198,17 @@ void XWalkExtensionAndroidInstance::HandleSyncMessage(
 
 static jlong GetOrCreateExtension(JNIEnv* env, jobject obj, jstring name,
                                  jstring js_api, jobjectArray js_entry_points) {
-  xwalk::XWalkBrowserMainPartsAndroid* main_parts =
-      ToAndroidMainParts(XWalkContentBrowserClient::Get()->main_parts());
+  XWalkExtensionManager* pXWalkExtensionManager = XWalkExtensionManager::Get();
 
   const char *str = env->GetStringUTFChars(name, 0);
-  XWalkExtension* extension = main_parts->LookupExtension(str);
+  XWalkExtension* extension = pXWalkExtensionManager->LookupExtension(str);
   env->ReleaseStringUTFChars(name, str);
 
   // Create a new extension object if no existing one is found.
   if (!extension) {
     extension = new XWalkExtensionAndroid(env, obj, name,
                                           js_api, js_entry_points);
-    main_parts->RegisterExtension(scoped_ptr<XWalkExtension>(extension));
+    pXWalkExtensionManager->RegisterExtension(extension);
   } else {
     static_cast<XWalkExtensionAndroid*>(extension)->BindToJavaObject(env, obj);
   }

--- a/extensions/common/xwalk_extension_manager.cc
+++ b/extensions/common/xwalk_extension_manager.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/common/xwalk_extension_manager.h"
+#include <string.h>
+#include "base/logging.h"
+
+namespace xwalk {
+namespace extensions {
+
+XWalkExtensionManager* XWalkExtensionManager::pXWalkExtensionManager = NULL;
+
+XWalkExtensionManager* XWalkExtensionManager:: Get() {
+  if (NULL == pXWalkExtensionManager)
+    pXWalkExtensionManager = new XWalkExtensionManager();
+  return pXWalkExtensionManager;
+}
+
+void XWalkExtensionManager::RegisterExtension(XWalkExtension* extension) {
+// Since the creation of extension object is driven by Java side, and each
+// Java extension is backed by a native extension object. However, the Java
+// object may be destroyed by Android lifecycle management without destroying
+// the native side object. We keep the reference to native extension object
+// to make sure we can reuse the native object if Java extension is re-created
+// on resuming.
+  extensions_.push_back(extension);
+}
+
+XWalkExtension* XWalkExtensionManager::LookupExtension(
+    const std::string& name) {
+  XWalkExtensionVector::const_iterator it = extensions_.begin();
+  for (; it != extensions_.end(); ++it) {
+    XWalkExtension* extension = *it;
+    if (name == extension->name()) return extension;
+  }
+  return NULL;
+}
+
+XWalkExtensionVector::const_iterator XWalkExtensionManager::Begin() {
+  return extensions_.begin();
+}
+
+XWalkExtensionVector::const_iterator XWalkExtensionManager::End() {
+  return extensions_.end();
+}
+
+
+}  // namespace extensions
+}  // namespace xwalk

--- a/extensions/common/xwalk_extension_manager.h
+++ b/extensions/common/xwalk_extension_manager.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_MANAGER_H_
+#define XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_MANAGER_H_
+
+#include <string>
+#include <vector>
+#include "xwalk/extensions/common/xwalk_extension.h"
+#include "xwalk/extensions/common/xwalk_extension_vector.h"
+
+namespace xwalk {
+namespace extensions {
+
+class XWalkExtensionManager {
+ public:
+  static XWalkExtensionManager* Get();
+  // XWalkExtensionAndroid needs to register its extensions on
+  // XWalkBrowserMainParts(which owns XWalkExtensonManager
+  // so they get correctly registered on-demand-
+  // by XWalkExtensionService each time a in_process Server is created.
+  void RegisterExtension(XWalkExtension* pExtension);
+  // Lookup the extension with the given name from the extension list that is
+  // already registered. Returns NULL if no such extension exists.
+  XWalkExtension* LookupExtension(const std::string& name);
+  // For iterate the extensions
+  XWalkExtensionVector::const_iterator Begin();
+  XWalkExtensionVector::const_iterator End();
+
+ protected:
+  static XWalkExtensionManager* pXWalkExtensionManager;
+  XWalkExtensionVector extensions_;
+};
+
+}  // namespace extensions
+}  // namespace xwalk
+
+#endif  // XWALK_EXTENSIONS_COMMON_XWALK_EXTENSION_MANAGER_H_

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -28,6 +28,8 @@
         'common/android/xwalk_extension_android.h',
         'common/xwalk_extension.cc',
         'common/xwalk_extension.h',
+        'common/xwalk_extension_manager.cc',
+        'common/xwalk_extension_manager.h',
         'common/xwalk_extension_messages.cc',
         'common/xwalk_extension_messages.h',
         'common/xwalk_extension_server.cc',

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -60,9 +60,11 @@ using extensions::XWalkExtension;
 XWalkBrowserMainPartsAndroid::XWalkBrowserMainPartsAndroid(
     const content::MainFunctionParams& parameters)
     : XWalkBrowserMainParts(parameters) {
+    pXWalkExtensionManager = extensions::XWalkExtensionManager::Get();
 }
 
 XWalkBrowserMainPartsAndroid::~XWalkBrowserMainPartsAndroid() {
+    if (pXWalkExtensionManager) delete pXWalkExtensionManager;
 }
 
 void XWalkBrowserMainPartsAndroid::PreEarlyInitialization() {
@@ -168,31 +170,10 @@ void XWalkBrowserMainPartsAndroid::CreateInternalExtensionsForExtensionThread(
   // to XWalkExtensionServer after this method is called. It is a rule enforced
   // by extension system that XWalkExtensionServer must own the extension
   // objects and extension instances.
-  extensions::XWalkExtensionVector::const_iterator it = extensions_.begin();
-  for (; it != extensions_.end(); ++it)
+  extensions::XWalkExtensionVector::const_iterator it =
+      pXWalkExtensionManager->Begin();
+  for (; it != pXWalkExtensionManager->End(); ++it)
     extensions->push_back(*it);
-}
-
-void XWalkBrowserMainPartsAndroid::RegisterExtension(
-    scoped_ptr<XWalkExtension> extension) {
-  // Since the creation of extension object is driven by Java side, and each
-  // Java extension is backed by a native extension object. However, the Java
-  // object may be destroyed by Android lifecycle management without destroying
-  // the native side object. We keep the reference to native extension object
-  // to make sure we can reuse the native object if Java extension is re-created
-  // on resuming.
-  extensions_.push_back(extension.release());
-}
-
-XWalkExtension* XWalkBrowserMainPartsAndroid::LookupExtension(
-    const std::string& name) {
-  extensions::XWalkExtensionVector::const_iterator it = extensions_.begin();
-  for (; it != extensions_.end(); ++it) {
-    XWalkExtension* extension = *it;
-    if (name == extension->name()) return extension;
-  }
-
-  return NULL;
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts_android.h
+++ b/runtime/browser/xwalk_browser_main_parts_android.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include "base/memory/ref_counted.h"
+#include "xwalk/extensions/common/xwalk_extension_manager.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
 
 namespace net {
@@ -31,17 +32,8 @@ class XWalkBrowserMainPartsAndroid : public XWalkBrowserMainParts {
       content::RenderProcessHost* host,
       extensions::XWalkExtensionVector* extensions) OVERRIDE;
 
-  // XWalkExtensionAndroid needs to register its extensions on
-  // XWalkBrowserMainParts so they get correctly registered on-demand
-  // by XWalkExtensionService each time a in_process Server is created.
-  void RegisterExtension(scoped_ptr<extensions::XWalkExtension> extension);
-
-  // Lookup the extension with the given name from the extension list that is
-  // already registered. Returns NULL if no such extension exists.
-  extensions::XWalkExtension* LookupExtension(const std::string& name);
-
  private:
-  extensions::XWalkExtensionVector extensions_;
+  extensions::XWalkExtensionManager *pXWalkExtensionManager;
   scoped_refptr<net::CookieStore> cookie_store_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkBrowserMainPartsAndroid);


### PR DESCRIPTION
@hmin @wang16  @halton 
Extension system should avoid to include runtime headers
BUG=XWALK-1598
The Android Extension system and runtime part are including headers files from each other. Thus they are coupled with each other. The purpose for this commit is to decouple them by add a middle layer interface called XWalkExtensionManager 