### PR TITLE
[Android] Fix the issue about onJavascriptModalDialog was not called.

### DIFF
--- a/tools/reflection_generator/java_class.py
+++ b/tools/reflection_generator/java_class.py
@@ -376,6 +376,9 @@ class InternalJavaFileData(object):
   def UseAsInstanceInBridgeOverrideCall(self, var):
     clazz = self._class_annotations.get('instance', self._class_name)
     clazz = clazz.replace('.class', '')
+    if self.LoadJavaClass(clazz).class_annotations.get(
+        'createInternally', False):
+      return self.UseAsReturnInBridgeSuperCall(var)
     return '(%s) %s' % (self.LoadJavaClass(clazz).bridge_name, var)
 
   def UseAsReturnInBridgeSuperCall(self, var):
@@ -437,3 +440,10 @@ class InternalJavaFileData(object):
       else:
         return "org.xwalk.core.%s$%s" % (self._wrapper_name,
                                          subclass.replace('Internal', ''))
+
+  def GetInstanceJavaData(self):
+    clazz = self._class_annotations.get('instance', None)
+    if clazz:
+      clazz = clazz.replace('.class', '')
+      return self.LoadJavaClass(clazz)
+    return None

--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -28,6 +28,14 @@ def ConvertPrimitiveTypeToObject(class_name):
   return primitive_map.get(class_name, class_name)
 
 
+def HasCreateInternally(java_data):
+  java_data_instance = java_data.GetInstanceJavaData()
+  if java_data_instance:
+    return java_data_instance.HasCreateInternallyAnnotation()
+  else:
+    return java_data.HasCreateInternallyAnnotation()
+
+
 class ParamStringType(object):
   INTERNAL_DECLARE = 1
   BRIDGE_DECLARE = 2
@@ -296,7 +304,7 @@ class Method(object):
       # the way bridge uses as the condition for whether call super or
       # call wrapper in override call
       #   XWalkViewInternal view => (view instanceof XWalkViewBridge)
-      if is_internal_class:
+      if is_internal_class and not HasCreateInternally(java_data):
         return'(%s instanceof %s)' % (
             param_name,
             java_data.UseAsTypeInBridgeAndBridgeSuperCall())


### PR DESCRIPTION
This patch is to fix the issue about onJavascriptModalDialog was not called
when this function was overridden in class of XWalkUIClient.
Modify the condition for override function, if parameter is not the
instance of specified, create a new instance.

BUG=XWALK-2534
