### PR TITLE
DEPS.xwalk: Roll v8-crosswalk (5e109ca -> 9b7376c).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -19,7 +19,7 @@
 
 chromium_crosswalk_rev = '04ba13a65546e6e6309e560b9a2491b904ed57a8'
 blink_crosswalk_rev = '92e5d6adee53362b3f5aaec11bcb0526d5f0715d'
-v8_crosswalk_rev = '5e109ca3baf1e06955c33dbe8852f1eba5a88dc2'
+v8_crosswalk_rev = '9b7376c845d7ba58715f4ffd9a80fd670b021360'
 ozone_wayland_rev = 'd301e5c546a7dea0de8fde5b07a2a57afd02103b'
 
 crosswalk_git = 'https://github.com/crosswalk-project'


### PR DESCRIPTION
9b7376c Merge pull request #54 from huningxin/fix_mark_compact
2f3f719 Fix invalid object access in SIMD types after heap mark compact.
