### PR TITLE
[Android] Embedding API version 3.0

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -698,7 +698,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     // TODO(yongsheng): make it static?
     @XWalkAPI
     public String getAPIVersion() {
-        return "2.1";
+        return "3.0";
     }
 
     /**


### PR DESCRIPTION
New APIs in 3.0:
XWalkPreferences.JAVASCRIPT_CAN_OPEN_WINDOW;
XWalkPreferences.ALLOW_UNIVERSAL_ACCESS_FROM_FILE;
XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS;
XWalkPreferences.PROFILE_NAME;
XWalkPreferences.setValue(String key, int value);
XWalkPreferences.setValue(String key, String value);
XWalkPreferences.getBooleanValue(String key);
XWalkPreferences.getIntegerValue(String key);
XWalkPreferences.getStringValue(String key);

Deprecated API in 3.0:
boolean XWalkPreferences.getValue(String key);
