### PR TITLE
[Tizen][Runtime] Replace application Hide() with Minimize()

### DIFF
--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -95,7 +95,7 @@ void ApplicationTizen::Hide() {
   std::set<Runtime*>::iterator it = runtimes_.begin();
   for (; it != runtimes_.end(); ++it) {
     if ((*it)->window())
-      (*it)->window()->Hide();
+      (*it)->window()->Minimize();
   }
 }
 


### PR DESCRIPTION
When XDG_Shell is enabled, the Minimize() function is properly implemented, original Hide() function cannot hide current application. We should call Minimize() to really hide application.

BUG=XWALK-2578
