### PR TITLE
[Tizen][Desktop] Disable viewport meta

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -98,7 +98,6 @@ XWalkBrowserMainParts::~XWalkBrowserMainParts() {
 void XWalkBrowserMainParts::PreMainMessageLoopStart() {
   CommandLine* command_line = CommandLine::ForCurrentProcess();
   command_line->AppendSwitch(switches::kEnableViewport);
-  command_line->AppendSwitch(switches::kEnableViewportMeta);
 
   command_line->AppendSwitch(xswitches::kEnableOverlayScrollbars);
 

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -106,6 +106,8 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   command_line->AppendSwitch(
       switches::kDisableOverlayFullscreenVideoSubtitle);
 
+  command_line->AppendSwitch(switches::kEnableViewportMeta);
+
   XWalkBrowserMainParts::PreMainMessageLoopStart();
 
   startup_url_ = GURL();


### PR DESCRIPTION
The apps using viewport meta are displayed wrongly
(not usable actually, see the related bug description).

Same problems observed with content shell on Linux.

This patch provides a temporary solution: disable viewport
meta tag.

BUG=XWALK-2577
