### PR TITLE
Fix Tizen Backend 

### DIFF
--- a/application/tools/tizen/xwalk_backend_wrapper.sh
+++ b/application/tools/tizen/xwalk_backend_wrapper.sh
@@ -31,20 +31,7 @@ done
 
 if [ "`whoami`" == "root" ]
 then
-    #
-    # TODO(t.iwanek): fix me
-    # this is workaround that will work only for 'app' user
-    # pkgmgr-server is running as root and then backend too
-    # 1) backend need to know the user
-    #  or
-    # 2) pkgmgr must change user before launching backend
-    #
-
-    # Find requesting process...
-    #  (will fail for multiple installation at same time)
-    user=`ps aux | grep -v 'grep' | grep pkgcmd | cut -f1 -d" "`
-
-    su - ${user} -c "/usr/bin/xwalkctl ${option} ${id} ${key} ${keyvalue} ${quiet}"
+	exit 1
 else
     # correct UID was set by pkgmgr
     /usr/bin/xwalkctl ${option} ${id} ${key} ${keyvalue} ${quiet}

--- a/application/tools/tizen/xwalk_tizen_user.cc
+++ b/application/tools/tizen/xwalk_tizen_user.cc
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <pwd.h>
 #include <grp.h>
+#include <tzplatform_config.h>
 
 int xwalk_tizen_check_user_app(void) {
   char* buffer = NULL;
@@ -33,7 +34,41 @@ int xwalk_tizen_check_user_app(void) {
   } else {
     if ( (!current_g) || (
         strcmp(current_g->gr_name, "users") &&
-        strcmp(current_g->gr_name, "app"))) {
+        strcmp(current_g->gr_name, "app") )) {
+      fprintf(stderr, "group '%s' is not allowed :",
+          current_g ? current_g->gr_name : "<NULL>");
+      fprintf(stderr, "launching an application will not work\n");
+      free(buffer);
+      return -EINVAL;
+    }
+  }
+  return 0;
+}
+
+int xwalk_tizen_check_user_for_xwalkctl(void) {
+  char* buffer = NULL;
+  int err = 0;
+  struct group grp;
+  struct group* current_g;
+  int64_t len = sysconf(_SC_GETGR_R_SIZE_MAX);
+  if (len == -1)
+    len = 1024;
+  buffer = reinterpret_cast<char*>(malloc((size_t)len));
+  if (!buffer)
+    return -EINVAL;
+
+  err = getgrgid_r(getgid(), &grp, buffer, len, &current_g);
+  if (err) {
+  fprintf(stderr, "group can't be determined");
+    fprintf(stderr, "launching an application will not work\n");
+    free(buffer);
+    return -EINVAL;
+  } else {
+    if ( (!current_g) || (
+        strcmp(current_g->gr_name, "users") &&
+        strcmp(current_g->gr_name, "app") &&
+        (strcmp(current_g->gr_name, "root") &&
+         getuid() == tzplatform_getuid(TZ_SYS_GLOBALAPP_USER)))) {
       fprintf(stderr, "group '%s' is not allowed :",
             current_g ? current_g->gr_name : "<NULL>");
       fprintf(stderr, "launching an application will not work\n");

--- a/application/tools/tizen/xwalk_tizen_user.h
+++ b/application/tools/tizen/xwalk_tizen_user.h
@@ -12,5 +12,6 @@
 // This is a Tizen specific workaround.
 
 int xwalk_tizen_check_user_app(void);
+int xwalk_tizen_check_user_for_xwalkctl(void);
 
 #endif  // XWALK_APPLICATION_TOOLS_TIZEN_XWALK_TIZEN_USER_H_

--- a/application/tools/tizen/xwalkctl_main.cc
+++ b/application/tools/tizen/xwalkctl_main.cc
@@ -134,7 +134,7 @@ int main(int argc, char* argv[]) {
   g_type_init();
 #endif
 
-  if (xwalk_tizen_check_user_app())
+  if (xwalk_tizen_check_user_for_xwalkctl())
     exit(1);
 
   context = g_option_context_new("- Crosswalk Application Management");

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -56,6 +56,7 @@
           'type': 'none',
           'variables': {
             'packages': [
+              'libtzplatform-config',
               'ail',
               'dlog',
               'pkgmgr-parser',

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -238,7 +238,7 @@ install -p -D src/out/Release/xwalk %{buildroot}%{_libdir}/xwalk/xwalk
 install -p -D src/out/Release/xwalkctl %{buildroot}%{_bindir}/xwalkctl
 install -p -D src/out/Release/xwalk-launcher %{buildroot}%{_bindir}/xwalk-launcher
 # xwalk-pkg-helper needs to be set-user-ID-root so it can finish the installation process.
-install -m 06755 -p -D src/out/Release/xwalk-pkg-helper %{buildroot}%{_bindir}/xwalk-pkg-helper
+install -m 0755 -p -D src/out/Release/xwalk-pkg-helper %{buildroot}%{_bindir}/xwalk-pkg-helper
 install -p -D src/out/Release/lib/libxwalk-backendlib.so %{buildroot}%{_libdir}/xwalk/libxwalk-backendlib.so
 install -p -D src/xwalk/application/tools/tizen/xwalk_backend_wrapper.sh %{buildroot}%{_libdir}/xwalk/xwalk_backend_wrapper.sh
 


### PR DESCRIPTION
Align the wrapper script to have the correct behavior
Remove setuid bit in package-helper
Adapt the user check function for xwalkctl binary

BUG=XWALK-1731

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
Signed-off-by: Sabera Djelti (sdi2) sabera.djelti@open.eurogiciel.org
