### PR TITLE
Cleanup printed output. Showtask list

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -66,7 +66,7 @@ def ReplaceInvalidChars(value, mode='default'):
     invalid_chars = '\/:.*?"<>|- '
   for c in invalid_chars:
     if mode == 'apkname' and c in value:
-      print("Illegal character: '%s' is replaced with '_'" % c)
+      print('Illegal character: "%s" replaced with "_"' % c)
     value = value.replace(c, '_')
   return value
 
@@ -126,6 +126,10 @@ def Prepare(app_info, compressor):
 
   # 1) copy template project to app_dir
   CleanDir(app_dir)
+  if not os.path.isdir(template_app_dir):
+    print('Error: The template directory could not be found (%s).' %
+          template_app_dir)
+    sys.exit(7)
   shutil.copytree(template_app_dir, app_dir)
 
   # 2) replace app_dir 'src' dir with template 'src' dir
@@ -271,7 +275,7 @@ def ReplaceString(file_path, src, dest):
 
 def SetVariable(file_path, string_line, variable, value):
   function_string = ('%sset%s(%s);\n' %
-                    ('        ', variable, value))
+                     ('        ', variable, value))
   temp_file_path = file_path + '.backup'
   file_handle = open(temp_file_path, 'w+')
   for line in open(file_path):
@@ -335,7 +339,7 @@ def CopyExtensionFile(extension_name, suffix, src_path, dest_path):
   dest_extension_path = os.path.join(dest_path, extension_name)
   if os.path.exists(dest_extension_path):
     # TODO: Refine it by renaming it internally.
-    print('Error: duplicated extension names "%s" are found. Please rename it.'
+    print('Error: duplicate extension names were found (%s). Please rename it.'
           % extension_name)
     sys.exit(9)
   else:
@@ -387,7 +391,7 @@ def CustomizeExtensions(app_info, extensions):
   extension_json_list = []
   for source_path in extension_paths:
     if not os.path.exists(source_path):
-      print('Error: can\'t find the extension directory \'%s\'.' % source_path)
+      print('Error: can not find the extension directory \'%s\'.' % source_path)
       sys.exit(9)
     # Remove redundant separators to avoid empty basename.
     source_path = os.path.normpath(source_path)
@@ -403,7 +407,7 @@ def CustomizeExtensions(app_info, extensions):
     file_name = extension_name + '.json'
     src_file = os.path.join(source_path, file_name)
     if not os.path.isfile(src_file):
-      print('Error: %s is not found in %s.' % (file_name, source_path))
+      print('Error: %s was not found in %s.' % (file_name, source_path))
       sys.exit(9)
     else:
       src_file_handle = open(src_file)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -552,8 +552,8 @@ class TestMakeApk(unittest.TestCase):
     self.checkApks('Example', '1.0.0', keystore_path)
     Clean('Example', '1.0.0')
 
-    keystore_path_with_space = os.path.join(
-      'test_data', 'keystore', 'test keystore')
+    keystore_path_with_space = os.path.join('test_data', 'keystore',
+                                            'test keystore')
     shutil.copy2(keystore_path, keystore_path_with_space)
     keystore_path = os.path.join('test_data', 'keystore',
                                  'xwalk-test.keystore')
@@ -615,8 +615,8 @@ class TestMakeApk(unittest.TestCase):
            '--manifest=%s' % manifest_path, self._mode]
     out = RunCommand(cmd)
     self.addCleanup(Clean, 'Example', '1.0.0')
-    self.assertIn('WARNING: app.launch.local_path is deprecated for Crosswalk',
-                  out)
+    self.assertIn('Warning: The following fields have been deprecated', out)
+    self.assertIn('app.launch.local_path', out)
     Clean('Example', '1.0.0')
 
     manifest_path = os.path.join('test_data', 'manifest', 'deprecated',
@@ -624,7 +624,8 @@ class TestMakeApk(unittest.TestCase):
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
            '--manifest=%s' % manifest_path, self._mode]
     out = RunCommand(cmd)
-    self.assertIn('WARNING: launch_path is deprecated for Crosswalk', out)
+    self.assertIn('Warning: The following fields have been deprecated', out)
+    self.assertIn('launch_path', out)
     Clean('Example', '1.0.0')
 
     manifest_path = os.path.join('test_data', 'manifest', 'deprecated',
@@ -632,7 +633,8 @@ class TestMakeApk(unittest.TestCase):
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
            '--manifest=%s' % manifest_path, self._mode]
     out = RunCommand(cmd)
-    self.assertIn('WARNING: permissions is deprecated for Crosswalk', out)
+    self.assertIn('Warning: The following fields have been deprecated', out)
+    self.assertIn('permissions', out)
     Clean('Example', '1.0.0')
 
     manifest_path = os.path.join('test_data', 'manifest',
@@ -640,8 +642,8 @@ class TestMakeApk(unittest.TestCase):
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
            '--manifest=%s' % manifest_path, self._mode]
     out = RunCommand(cmd)
-    self.assertIn('WARNING: icons defined as dictionary form is deprecated',
-                  out)
+    self.assertIn('Warning: The following fields have been deprecated', out)
+    self.assertIn('icons', out)
     Clean('Example', '1.0.0')
 
     manifest_path = os.path.join('test_data', 'manifest', 'deprecated',
@@ -649,7 +651,8 @@ class TestMakeApk(unittest.TestCase):
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
            '--manifest=%s' % manifest_path, self._mode]
     out = RunCommand(cmd)
-    self.assertIn('WARNING: description is deprecated for Crosswalk', out)
+    self.assertIn('Warning: The following fields have been deprecated', out)
+    self.assertIn('description', out)
     Clean('Example', '1.0.0')
 
     manifest_path = os.path.join('test_data', 'manifest', 'deprecated',
@@ -657,7 +660,8 @@ class TestMakeApk(unittest.TestCase):
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
            '--manifest=%s' % manifest_path, self._mode]
     out = RunCommand(cmd)
-    self.assertIn('WARNING: version is deprecated for Crosswalk', out)
+    self.assertIn('Warning: The following fields have been deprecated', out)
+    self.assertIn('version', out)
 
   def testManifestWithError(self):
     manifest_path = os.path.join('test_data', 'manifest',
@@ -715,14 +719,12 @@ class TestMakeApk(unittest.TestCase):
     self.checkApks('Example', '1.0.0')
 
   def testExtensionsWithNonExtension(self):
-    # Test with a non-existed extension.
+    # Test with a non-existing extension.
     extension_path = 'test_data/extensions/myextension'
     cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
            '--package=org.xwalk.example', '--app-url=http://www.intel.com',
            '--extensions=%s1' % extension_path, self._mode, '--verbose']
     out = RunCommand(cmd)
-    error_msg = 'Error: can\'t find the extension directory'
-    self.assertTrue(out.find(error_msg) != -1)
     self.assertTrue(out.find('Exiting with error code: 9') != -1)
 
   def testExtensionWithPermissions(self):
@@ -936,7 +938,7 @@ class TestMakeApk(unittest.TestCase):
         for img_type in img_types:
           name = orientation + '_' + img_type + '_' + dimension
           path_tmp = os.path.join(launch_screen_path, name)
-          _file = open(path_tmp,'w+')
+          _file = open(path_tmp, 'w+')
           _file.write(name)
           _file.close()
     # Run Test.
@@ -945,8 +947,8 @@ class TestMakeApk(unittest.TestCase):
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
            '--manifest=%s' % manifest_path, self._mode]
     out = RunCommand(cmd)
-    self.assertTrue(
-        out.find('WARNING: launch_screen is deprecated for Crosswalk') != -1)
+    self.assertIn('Warning: The following fields have been deprecated', out)
+    self.assertTrue(out.find('launch_screen') != -1)
     Clean('Example', '1.0.0')
     manifest_path = os.path.join('test_data', 'launchScreen', 'manifest.json')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -58,9 +58,13 @@ def ParseLaunchScreen(ret_dict, launch_screen_dict, orientation):
           sub_dict['image_border'])
 
 
-def PrintDeprecationWarning(item):
-  print ('WARNING: %s is deprecated for Crosswalk. Please follow '
-         'https://www.crosswalk-project.org/#documentation/manifest.' % item)
+def PrintDeprecationWarning(deprecated_items):
+  if len(deprecated_items) > 0:
+    print ('  Warning: The following fields have been deprecated for '
+           'Crosswalk:\n   %s' %
+           ', '.join([str(item) for item in deprecated_items]))
+    print ('  Please follow: https://www.crosswalk-project.org/#documentation/'
+           'manifest.')
 
 
 class ManifestJsonParser(object):
@@ -108,7 +112,9 @@ class ManifestJsonParser(object):
     fullscreen:       The fullscreen flag of the application.
     launch_screen:    The launch screen configuration.
     """
+    print ("Checking manifest file")
     ret_dict = {}
+    deprecated_items = []
     if 'name' not in self.data_src:
       print('Error: no \'name\' field in manifest.json file.')
       sys.exit(1)
@@ -121,17 +127,17 @@ class ManifestJsonParser(object):
     elif 'xwalk_version' in self.data_src:
       ret_dict['version'] = self.data_src['xwalk_version']
     elif 'version' in self.data_src:
-      PrintDeprecationWarning('version')
+      deprecated_items.append('version')
       ret_dict['version'] = self.data_src['version']
     if 'start_url' in self.data_src:
       app_url = self.data_src['start_url']
     elif 'launch_path' in self.data_src:
-      PrintDeprecationWarning('launch_path')
+      deprecated_items.append('launch_path')
       app_url = self.data_src['launch_path']
     elif ('app' in self.data_src and
           'launch' in self.data_src['app'] and
           'local_path' in self.data_src['app']['launch']):
-      PrintDeprecationWarning('app.launch.local_path')
+      deprecated_items.append('app.launch.local_path')
       app_url = self.data_src['app']['launch']['local_path']
     else:
       app_url = ''
@@ -144,7 +150,7 @@ class ManifestJsonParser(object):
     if 'icons' in self.data_src:
       icons = self.data_src['icons']
       if type(icons) == dict:
-        PrintDeprecationWarning('icons defined as dictionary form')
+        deprecated_items.append('icons defined as index:value')
         ret_dict['icons'] = icons
       elif type(icons) == list:
         icons_dict = {}
@@ -165,7 +171,7 @@ class ManifestJsonParser(object):
     elif 'xwalk_description' in self.data_src:
       ret_dict['description'] = self.data_src['xwalk_description']
     elif 'description' in self.data_src:
-      PrintDeprecationWarning('description')
+      deprecated_items.append('description')
       ret_dict['description'] = self.data_src['description']
     ret_dict['app_url'] = app_url
     ret_dict['app_root'] = app_root
@@ -179,7 +185,7 @@ class ManifestJsonParser(object):
         print('\'Permissions\' field error in manifest.json file.')
         sys.exit(1)
     elif 'permissions' in self.data_src:
-      PrintDeprecationWarning('permissions')
+      deprecated_items.append('permissions')
       try:
         permission_list = self.data_src['permissions']
         ret_dict['permissions'] = HandlePermissionList(permission_list)
@@ -211,11 +217,13 @@ class ManifestJsonParser(object):
       ParseLaunchScreen(ret_dict, launch_screen_dict, 'portrait')
       ParseLaunchScreen(ret_dict, launch_screen_dict, 'landscape')
     elif 'launch_screen' in self.data_src:
-      PrintDeprecationWarning('launch_screen')
+      deprecated_items.append('launch_screen')
       launch_screen_dict = self.data_src['launch_screen']
       ParseLaunchScreen(ret_dict, launch_screen_dict, 'default')
       ParseLaunchScreen(ret_dict, launch_screen_dict, 'portrait')
       ParseLaunchScreen(ret_dict, launch_screen_dict, 'landscape')
+
+    PrintDeprecationWarning(deprecated_items)
     return ret_dict
 
   def ShowItems(self):
@@ -232,29 +240,29 @@ class ManifestJsonParser(object):
     print("orientation: %s" % self.GetOrientation())
     print("fullscreen: %s" % self.GetFullScreenFlag())
     print('launch_screen.default.background_color: %s' %
-        self.GetLaunchScreenBackgroundColor('default'))
+          self.GetLaunchScreenBackgroundColor('default'))
     print('launch_screen.default.background_image: %s' %
-        self.GetLaunchScreenBackgroundImage('default'))
+          self.GetLaunchScreenBackgroundImage('default'))
     print('launch_screen.default.image: %s' %
-        self.GetLaunchScreenImage('default'))
+          self.GetLaunchScreenImage('default'))
     print('launch_screen.default.image_border: %s' %
-        self.GetLaunchScreenImageBorder('default'))
+          self.GetLaunchScreenImageBorder('default'))
     print('launch_screen.portrait.background_color: %s' %
-        self.GetLaunchScreenBackgroundColor('portrait'))
+          self.GetLaunchScreenBackgroundColor('portrait'))
     print('launch_screen.portrait.background_image: %s' %
-        self.GetLaunchScreenBackgroundImage('portrait'))
+          self.GetLaunchScreenBackgroundImage('portrait'))
     print('launch_screen.portrait.image: %s' %
-        self.GetLaunchScreenImage('portrait'))
+          self.GetLaunchScreenImage('portrait'))
     print('launch_screen.portrait.image_border: %s' %
-        self.GetLaunchScreenImageBorder('portrait'))
+          self.GetLaunchScreenImageBorder('portrait'))
     print('launch_screen.landscape.background_color: %s' %
-        self.GetLaunchScreenBackgroundColor('landscape'))
+          self.GetLaunchScreenBackgroundColor('landscape'))
     print('launch_screen.landscape.background_image: %s' %
-        self.GetLaunchScreenBackgroundImage('landscape'))
+          self.GetLaunchScreenBackgroundImage('landscape'))
     print('launch_screen.landscape.image: %s' %
-        self.GetLaunchScreenImage('landscape'))
+          self.GetLaunchScreenImage('landscape'))
     print('launch_screen.landscape.image_border: %s' %
-        self.GetLaunchScreenImageBorder('landscape'))
+          self.GetLaunchScreenImageBorder('landscape'))
 
   def GetAppName(self):
     """Return the application name."""


### PR DESCRIPTION
 This change includes the following:
- Display task list executing
- Combine redundant messages
- Check system requirements up front
- Show error from main ant package build process on error
- Check for existence of 'template' directory before accessing
- Capture KeyboardInterrupt exception to gracefully exit on Ctl+C
