### PR TITLE
Speed-up builds by changing RPM compression method and level

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -15,6 +15,12 @@
 %define _disable_nacl 0
 %endif
 
+# adjust compression algorithm to speed up RPMS creation
+# source RPM and debug RPMS are big and take too much time
+# when using standard (lzma) compression
+%define _source_payload w3.gzdio
+%define _binary_payload w3.gzdio
+
 Name:           crosswalk
 Version:        10.38.220.0
 Release:        0


### PR DESCRIPTION
Partially fixes XWALK-2571
Result               BEFORE              AFTER
writting src rpm     374s                  80s   gain x4
wrtting binary rpm   1821                  170s gain x10

Signed-off-by: Stephane Desneux stephane.desneux@open.eurogiciel.org
