### PR TITLE
[Tizen] Move platform sensor initialization out from browser UI thread.

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -53,7 +53,7 @@ static void SetWindowRotation(aura::Window* window, gfx::Display display) {
 #if defined(OS_TIZEN_MOBILE)
   // Assumes portrait display; shows overlay indicator in landscape only.
   bool useOverlay = display.rotation() == gfx::Display::ROTATE_90 ||
-      display.rotation() == gfx::Display::ROTATE_180);
+      display.rotation() == gfx::Display::ROTATE_180;
   top_view_layout()->SetUseOverlay(enableOverlay);
   indicator_widget_->SetDisplay(display);
 #endif
@@ -115,22 +115,25 @@ void NativeAppWindowTizen::Initialize() {
   DCHECK(root_window);
   root_window->AddObserver(this);
 
-  if (SensorProvider* sensor = SensorProvider::GetInstance()) {
-    sensor->AddObserver(this);
-    OnScreenOrientationChanged(sensor->GetScreenOrientation());
+  SensorProvider::GetInstance()->AddObserver(this);
+
+  if (SensorProvider::GetInstance()->connected()) {
+    OnScreenOrientationChanged(
+        SensorProvider::GetInstance()->GetScreenOrientation());
   }
 }
 
 NativeAppWindowTizen::~NativeAppWindowTizen() {
-  if (SensorProvider::GetInstance())
+  if (SensorProvider::GetInstance()->connected())
     SensorProvider::GetInstance()->RemoveObserver(this);
 }
 
 void NativeAppWindowTizen::LockOrientation(
       blink::WebScreenOrientationLockType lock) {
   orientation_lock_ = lock;
-  if (SensorProvider* sensor = SensorProvider::GetInstance())
-    OnScreenOrientationChanged(sensor->GetScreenOrientation());
+  if (SensorProvider::GetInstance()->connected())
+    OnScreenOrientationChanged(
+        SensorProvider::GetInstance()->GetScreenOrientation());
 }
 
 void NativeAppWindowTizen::ViewHierarchyChanged(
@@ -226,6 +229,11 @@ void NativeAppWindowTizen::OnScreenOrientationChanged(
 
   display_.set_rotation(rot);
   SetDisplayRotation(display_);
+}
+
+void NativeAppWindowTizen::OnSensorConnected() {
+  OnScreenOrientationChanged(
+      SensorProvider::GetInstance()->GetScreenOrientation());
 }
 
 void NativeAppWindowTizen::SetDisplayRotation(gfx::Display display) {

--- a/runtime/browser/ui/native_app_window_tizen.h
+++ b/runtime/browser/ui/native_app_window_tizen.h
@@ -40,6 +40,7 @@ class NativeAppWindowTizen
   // SensorProvider::Observer overrides:
   virtual void OnScreenOrientationChanged(
       blink::WebScreenOrientationType orientation) OVERRIDE;
+  virtual void OnSensorConnected() OVERRIDE;
 
   // NativeAppWindowViews overrides:
   virtual void Initialize() OVERRIDE;

--- a/tizen/mobile/sensor/sensor_provider.h
+++ b/tizen/mobile/sensor/sensor_provider.h
@@ -8,6 +8,7 @@
 #include <set>
 
 #include "base/memory/scoped_ptr.h"
+#include "base/synchronization/lock.h"
 #include "ui/gfx/display.h"
 #include "third_party/WebKit/public/platform/WebScreenOrientationType.h"
 
@@ -17,6 +18,8 @@ class SensorProvider {
  public:
   static SensorProvider* GetInstance();
   virtual ~SensorProvider();
+
+  bool connected() const;
 
   class Observer {
    public:
@@ -29,6 +32,8 @@ class SensorProvider {
     virtual void OnAccelerationChanged(float raw_x, float raw_y, float raw_z,
                                        float x, float y, float z) {}
     virtual void OnRotationRateChanged(float alpha, float beta, float gamma) {}
+
+    virtual void OnSensorConnected() {}
   };
 
   virtual void AddObserver(Observer* observer);
@@ -54,8 +59,13 @@ class SensorProvider {
                                      float x, float y, float z);
   virtual void OnRotationRateChanged(float alpha, float beta, float gamma);
 
+  virtual void OnSensorConnected();
+
   std::set<Observer*> observers_;
   blink::WebScreenOrientationType last_orientation_;
+
+  mutable base::Lock lock_;
+  mutable bool connected_;
 
  private:
   static scoped_ptr<SensorProvider> instance_;

--- a/tizen/mobile/sensor/tizen_data_fetcher_shared_memory.cc
+++ b/tizen/mobile/sensor/tizen_data_fetcher_shared_memory.cc
@@ -100,7 +100,7 @@ bool TizenDataFetcherSharedMemory::Start(content::ConsumerType type,
       return false;
   }
 
-  if (!started && SensorProvider::GetInstance())
+  if (!started && SensorProvider::GetInstance()->connected())
     SensorProvider::GetInstance()->AddObserver(this);
 
   return true;
@@ -130,7 +130,7 @@ bool TizenDataFetcherSharedMemory::Stop(content::ConsumerType type) {
   }
 
   if (!motion_buffer_ && !orientation_buffer_ &&
-      SensorProvider::GetInstance())
+      SensorProvider::GetInstance()->connected())
     SensorProvider::GetInstance()->RemoveObserver(this);
 
   return true;

--- a/tizen/mobile/sensor/tizen_platform_sensor.h
+++ b/tizen/mobile/sensor/tizen_platform_sensor.h
@@ -20,6 +20,7 @@
 #include <vconf.h>
 
 #include "base/native_library.h"
+#include "base/threading/thread.h"
 #include "xwalk/tizen/mobile/sensor/sensor_provider.h"
 
 namespace xwalk {
@@ -40,6 +41,10 @@ class TizenPlatformSensor : public SensorProvider {
   static void OnEventReceived(unsigned int event_type,
       sensor_event_data_t* event_data, void* udata);
   static void OnAutoRotationEnabledChanged(keynode_t* node, void* udata);
+
+  void ConnectSensor();
+
+  scoped_ptr<base::Thread> sensor_thread_;
 
   DISALLOW_COPY_AND_ASSIGN(TizenPlatformSensor);
 };


### PR DESCRIPTION
Cold start time of sample Calulator application increases to ~1080 ms on
Tizen VTC-1010 at the moment. One bottleneck is it takes long period to
initalize platform sensors inside browser main thread, which blocks native
window display and starting render message loop.

The CL moves the platform sensors initialization outside of browser main
thread. The local test result shows it shortens ~200ms of cold start
time.

BUG=XWALK-2520
