### PR TITLE
Remove warning about LOG macro redefinition

### DIFF
--- a/application/tools/tizen/xwalk_platform_installer.cc
+++ b/application/tools/tizen/xwalk_platform_installer.cc
@@ -6,6 +6,12 @@
 
 #include <assert.h>
 #include <pkgmgr/pkgmgr_parser.h>
+
+#include <pkgmgr_installer.h>
+// logging and dlog uses same macro name
+// to avoid warnings we need to undefine dlog's one
+#undef LOG
+
 #include <tzplatform_config.h>
 
 #include <string>

--- a/application/tools/tizen/xwalk_platform_installer.h
+++ b/application/tools/tizen/xwalk_platform_installer.h
@@ -5,11 +5,11 @@
 #ifndef XWALK_APPLICATION_TOOLS_TIZEN_XWALK_PLATFORM_INSTALLER_H_
 #define XWALK_APPLICATION_TOOLS_TIZEN_XWALK_PLATFORM_INSTALLER_H_
 
-#include <pkgmgr_installer.h>
-
 #include <string>
 
 #include "base/files/file_path.h"
+
+struct pkgmgr_installer;
 
 class PlatformInstaller {
  public:


### PR DESCRIPTION
This was probably introduced by one of my changes.
