### PR TITLE
[Android] Detect device cpu abi more precisely

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.core.internal;
 
+import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
@@ -232,5 +233,21 @@ class XWalkViewDelegate {
 
     static {
         sRunningOnIA = Build.CPU_ABI.equalsIgnoreCase("x86");
+        if (!sRunningOnIA) {
+            // This is not the final decision yet.
+            // With latest Houdini, an app with ARM binary will see system abi as if it's running on
+            // arm device. Here needs some further check for real system abi.
+            try {
+                Process process = Runtime.getRuntime().exec("getprop ro.product.cpu.abi");
+                InputStreamReader ir = new InputStreamReader(process.getInputStream());
+                BufferedReader input = new BufferedReader(ir);
+                String abi = input.readLine();
+                sRunningOnIA = abi.contains("x86");
+                input.close();
+                ir.close();
+            } catch (IOException e) {
+                Log.w(TAG, Log.getStackTraceString(e));
+            }
+        }
     }
 }


### PR DESCRIPTION
With latest Houdini, if an app contains arm binaries,
the app will see system abi as if it's running on
an arm device. In detail, android.os.Build.CPU_ABI will
be "armeabli-v7a", as well as System.getProperty("os.arch").

The new approach is to read output of "getprop" command
out of process.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2653
