### PR TITLE
[Android] Try to use shared mode when CPU arch mismatches

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -179,8 +179,9 @@ public abstract class XWalkRuntimeActivityBase extends Activity {
 
     private void showRuntimeLibraryExceptionDialog(String title, String message) {
         if (!mShownNotFoundDialog) {
+            if (SharedXWalkView.isUsingLibrary()) return;
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
-            if (!SharedXWalkView.usesLibraryOutOfPackage()) {
+            if (SharedXWalkView.containsLibrary()) {
                 builder.setPositiveButton(android.R.string.ok,
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int id) {

--- a/runtime/android/core/src/org/xwalk/core/SharedXWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/SharedXWalkView.java
@@ -39,7 +39,11 @@ public class SharedXWalkView extends XWalkView {
         initialized = true;
     }
 
-    public static boolean usesLibraryOutOfPackage() {
-        return ReflectionHelper.shouldUseLibrary();
+    public static boolean containsLibrary() {
+        return !ReflectionHelper.shouldUseLibrary();
+    }
+
+    public static boolean isUsingLibrary() {
+        return ReflectionHelper.isUsingLibrary();
     }
 }


### PR DESCRIPTION
Shared mode for crosswalk is sharing java classes and
native libraries. Previously, it will try to find library
only if internal java classes are not found.
This commit extends the condition to handle CPU arch
mismatches. In that case, java classes are available but
native library is not.

Implement this by move the loading of native library ahead
to the initialization of reflection layer.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2633
