### PR TITLE
 [Android] Allow concurrent builds using make_apk.py

### DIFF
--- a/app/tools/android/customize_launch_screen.py
+++ b/app/tools/android/customize_launch_screen.py
@@ -7,7 +7,8 @@
 import os
 import shutil
 import sys
-import tempfile
+
+from util import GetBuildDir
 
 def CopyToPathWithName(root, name, final_path, rename):
   if name == '':
@@ -29,7 +30,7 @@ def CopyToPathWithName(root, name, final_path, rename):
 
 
 def CopyDrawables(image_dict, orientation, sanitized_name, name, app_root):
-  drawable = os.path.join(tempfile.gettempdir(), sanitized_name, 'res',
+  drawable = os.path.join(GetBuildDir(sanitized_name), 'res',
                           'drawable')
   if orientation == 'landscape':
     drawable = drawable + '-land'
@@ -114,7 +115,7 @@ def CustomizeBackground(background_color,
                         orientation,
                         sanitized_name,
                         app_root):
-  background_path = os.path.join(tempfile.gettempdir(), sanitized_name, 'res',
+  background_path = os.path.join(GetBuildDir(sanitized_name), 'res',
                                  'drawable', 'launchscreen_bg.xml')
   if not os.path.isfile(background_path):
     print('Error: launchscreen_bg.xml is missing in the build tool.')

--- a/app/tools/android/util.py
+++ b/app/tools/android/util.py
@@ -11,6 +11,15 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+
+build_dir = None
+
+def GetBuildDir(name):
+  global build_dir
+  if not build_dir:
+    build_dir = tempfile.mkdtemp(prefix="%s-" % name)
+  return build_dir
 
 
 def CleanDir(path):


### PR DESCRIPTION
- Set temp directory to a random value using tempfile.mkdtemp that enables
  multiple simultaneous builds to happen on the same system
- Fixed icon_dict being "None" when manifest file passed in without any path
  
  Bug=XWALK-2650
  Bug=XWALK-2664
