### PR TITLE
[Tizen] Stop unconditionally passing -Wall to the compiler.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -140,6 +140,13 @@ cp -a src/xwalk/LICENSE LICENSE.xwalk
 
 %build
 
+# Stop unconditionally passing -Wall to the compiler. Chromium has its own
+# mechanisms for deciding which parts of the code need -Wall and which need it
+# to be left out (since several pieces are built with -Werror). At least in
+# M39, this is preventing the "rtc_base" target from being built because it
+# does not expect -Wall to be passed to the compiler (see webrtc issue 3307).
+export CXXFLAGS=`echo $CXXFLAGS | sed s,-Wall,,g`
+
 # For ffmpeg on ia32. The original CFLAGS set by the gyp and config files in
 # src/third_party/ffmpeg already pass -O2 -fomit-frame-pointer, but Tizen's
 # CFLAGS end up appending -fno-omit-frame-pointer. See http://crbug.com/37246


### PR DESCRIPTION
Chromium has its own mechanisms for deciding which parts of the code
need `-Wall` and which need it to be left out (since several pieces are
built with `-Werror`).

At least in the upcoming M39, this is preventing the "rtc_base" target
from being built because it does not expect `-Wall` to be passed to the
compiler (see webrtc issue 3307).
