### PR TITLE
Restore application on AE_RESUME.

### DIFF
--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -123,6 +123,14 @@ void ApplicationTizen::Hide() {
   }
 }
 
+void ApplicationTizen::Show() {
+  DCHECK(!runtimes_.empty());
+  for (Runtime* runtime : runtimes_) {
+    if (auto window = runtime->window())
+      window->Restore();
+  }
+}
+
 bool ApplicationTizen::Launch(const LaunchParams& launch_params) {
   if (Application::Launch(launch_params)) {
     DCHECK(web_contents_);

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -27,6 +27,7 @@ class ApplicationTizen :  // NOLINT
  public:
   virtual ~ApplicationTizen();
   void Hide();
+  void Show();
   void Suspend();
   void Resume();
 

--- a/application/browser/linux/running_application_object.cc
+++ b/application/browser/linux/running_application_object.cc
@@ -269,6 +269,7 @@ void RunningApplicationObject::OnResume(
   }
 
   ToApplicationTizen(application_)->Resume();
+  ToApplicationTizen(application_)->Show();
 
   scoped_ptr<dbus::Response> response =
       dbus::Response::FromMethodCall(method_call);


### PR DESCRIPTION
Tizen application framework use AE_RESUME event to bring an hidden (or minimized) application on top of all applications (restored if minimized) and gain focus.

BUG=XWALK-2578
