### PR TITLE
[Tizen] Fix of backendlib - pkg_plugin_get_app_detail_info_from_package should validate widget path

### DIFF
--- a/application/tools/tizen/xwalk_backend_plugin.cc
+++ b/application/tools/tizen/xwalk_backend_plugin.cc
@@ -85,7 +85,6 @@ int PkgmgrBackendPlugin::DetailedInfoPkg(
     return kPkgmgrPluginFalse;
   }
 
-
   base::ScopedTempDir dir;
   dir.CreateUniqueTempDir();
   scoped_refptr<xwalk::application::ApplicationData> app_data =
@@ -203,6 +202,8 @@ PkgmgrBackendPlugin::GetApplicationDataFromPkg(const std::string& pkg_path,
 
   scoped_ptr<xwalk::application::Package> package =
       xwalk::application::Package::Create(base::FilePath(pkg_path));
+  if (!package)
+    return nullptr;
   package->ExtractToTemporaryDir(&unpacked_dir);
   std::string app_id = package->Id();
 


### PR DESCRIPTION
If pkgmgr-server passes path that is not valid widget path,
this will lead to crash of pkgmgr-server. Function
pkg_plugin_get_app_detail_info_from_package of backendlib
should check if valid package data can be received from
given path.

BUG=XWALK-2683
