### PR TITLE
[Android] Compress AAR packages generated with Python's zipfile.

### DIFF
--- a/build/android/generate_xwalk_core_library_aar.py
+++ b/build/android/generate_xwalk_core_library_aar.py
@@ -44,7 +44,7 @@ def main():
   )
 
   aar_path = os.path.join(options.target, 'xwalk_core_library.aar')
-  with zipfile.ZipFile(aar_path, 'w') as aar_file:
+  with zipfile.ZipFile(aar_path, 'w', zipfile.ZIP_DEFLATED) as aar_file:
     for src, dest in files:
       aar_file.write(src, dest)
     for src, dest in dirs:


### PR DESCRIPTION
By default, Python's zipfile module will store the files in the ZIP
archives it creates uncompressed, which makes the architecture-specific
AAR archives we host in 01.org quite big. x86 AAR packages are more than
double the size of a compressed ZIP archive, for example (43M vs 20M).

Fix this by explicitly creating ZipFile with zipfile.ZIP_DEFLATED.

BUG=XWALK-2688
