### PR TITLE
The "TizenSettingHandler/Info" class should not depend on OZONE

### DIFF
--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -26,10 +26,10 @@
 #include "ui/events/event_constants.h"
 #include "ui/events/keycodes/keyboard_codes_posix.h"
 #include "ui/events/platform/platform_event_source.h"
-#include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
 #endif
 
 #include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_splash_screen_handler.h"
 
 namespace xwalk {


### PR DESCRIPTION
The object type TizenSettingInfo is  required also in X11 build so need to be included evenif USE_OZONE is set to off 
Signed-off-by: Manuel Bachmann manuel.bachmann@open.eurogiciel.org
Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
