### PR TITLE
[Android] Bring back enableRemoteDebugging API temporally

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -763,13 +763,16 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     }
 
     /**
-     * Enables remote debugging and returns the URL at which the dev tools server is listening
-     * for commands. The allowedUid argument can be used to specify the uid of the process that is
-     * permitted to connect.
-     * TODO(yongsheng): how to enable this in XWalkPreferencesInternal?
+     * Enables remote debugging and returns the URL at which the dev tools
+     * server is listening for commands.
+     * The allowedUid argument can be used to specify the uid of the process
+     * that is permitted to connect.
+     * TODO(wang16): Hide or remove this API after new API for getting remote
+     *               debugging url available.
      *
      * @hide
      */
+    @XWalkAPI
     public String enableRemoteDebugging(int allowedUid) {
         if (mContent == null) return null;
         checkThreadSafety();


### PR DESCRIPTION
Some embedders needs to get the web socket url for remote
debugging their app. The legacy API enableRemoteDebugging
returns the url but it is inaccessible.
Bring it back before the new API to get the debugging url
available.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2689
(cherry picked from commit e8aea8eaa530754eb4fd89fb8ddf8d306b888097)
