### PR TITLE
[Tizen] No need to show crosswalk icon on ivi-ux-ico

### DIFF
--- a/packaging/crosswalk.xml.in
+++ b/packaging/crosswalk.xml.in
@@ -3,7 +3,7 @@
 	<label>crosswalk</label>
 	<author email="cameo-dev@linux.intel.com" href="www.intel.com">XWalk Dev</author>
 	<description>crosswalk</description>
-	<ui-application appid="crosswalk" exec="/usr/lib/xwalk/xwalk" nodisplay="false" multiple="false" type="capp" taskmanage="true">
+	<ui-application appid="crosswalk" exec="/usr/lib/xwalk/xwalk" nodisplay="true" multiple="false" type="capp" taskmanage="true">
 		<label>crosswalk</label>
 		<icon>crosswalk.png</icon>
 	</ui-application>


### PR DESCRIPTION
The icon of crosswalk is shown on ivi-ux-ico which is not correct.
This fix modifies the crosswalk config file to not show its icon by default.

BUT=TC-1708
