### PR TITLE
[Android] Add condition to avoid duplecated intents receiver registration.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/messaging/Messaging.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/messaging/Messaging.java
@@ -37,6 +37,7 @@ public class Messaging extends XWalkExtensionWithActivityStateListener {
 
     private MessagingSmsManager mSmsManager;
     private MessagingManager mMessagingManager;
+    private boolean isIntentFiltersRegistered = false;
 
     private void initMethodMap() {
         sMethodMap.put("msg_smsSend", new Command() {
@@ -103,7 +104,10 @@ public class Messaging extends XWalkExtensionWithActivityStateListener {
         super(NAME, jsApiContent, activity);
         mSmsManager = new MessagingSmsManager(activity, this);
         mMessagingManager = new MessagingManager(activity, this);
-        mSmsManager.registerIntentFilters();
+        if (!isIntentFiltersRegistered) {
+            mSmsManager.registerIntentFilters();
+            isIntentFiltersRegistered = true;
+        }
 
         initMethodMap();
     }
@@ -132,7 +136,12 @@ public class Messaging extends XWalkExtensionWithActivityStateListener {
 
     @Override
     public void onActivityStateChange(Activity activity, int newState) {
-        if (newState == ActivityState.STOPPED) mSmsManager.unregisterIntentFilters();
-        else if (newState == ActivityState.STARTED) mSmsManager.registerIntentFilters();
+        if (newState == ActivityState.STOPPED && isIntentFiltersRegistered) {
+            mSmsManager.unregisterIntentFilters();
+            isIntentFiltersRegistered = false;
+        } else if (newState == ActivityState.STARTED && !isIntentFiltersRegistered) {
+            mSmsManager.registerIntentFilters();
+            isIntentFiltersRegistered = true;
+        }
     }
 }


### PR DESCRIPTION
The registration existed in both constructor and onActivityStateChange()
method for MessagingSmsManager, so add a switch to avoid duplecated
registration.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2614
(cherry picked from commit 6b4e9ac44aed4c905a5ddb8556fe8e6f9a7e4abf)
