### PR TITLE
[Tizen] Fix secure-storage dependency

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -111,6 +111,7 @@ BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(scim)
 %endif
 Requires:  ca-certificates-tizen
+Requires:  ss-server
 
 %description
 Crosswalk is an app runtime based on Chromium. It is an open source project started by the Intel Open Source Technology Center (http://www.01.org).


### PR DESCRIPTION
Added dependency for ss-server, as it is required for application encryption key storage on Tizen.

BUG=XWALK-2707
