### PR TITLE
[Android] Increase the open files limit

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -68,6 +68,10 @@ XWalkBrowserMainPartsAndroid::~XWalkBrowserMainPartsAndroid() {
 void XWalkBrowserMainPartsAndroid::PreEarlyInitialization() {
   net::NetworkChangeNotifier::SetFactory(
       new net::NetworkChangeNotifierFactoryAndroid());
+  // As Crosswalk uses in-process mode, that's easier than Chromium
+  // to reach the default limit(1024) of open files per process on
+  // Android. So increase the limit to 4096 explicitly.
+  base::SetFdLimit(4096);
 
   CommandLine::ForCurrentProcess()->AppendSwitch(
       cc::switches::kCompositeToMailbox);


### PR DESCRIPTION
As Crosswalk uses in-process mode, that's easier than Chromium
to reach the default limit(1024) of open files per process on
Android. So increase the limit to 4096 explicitly.

BUG=XWALK-2655
(Cherry-picked from commit 0f297dcce839bcd4e1158bb3a7483ce19bba7fde)
