### PR TITLE
[Tizen] Compile fixes of Browsertests and Unittests

### DIFF
--- a/application/common/manifest_handlers/csp_handler_unittest.cc
+++ b/application/common/manifest_handlers/csp_handler_unittest.cc
@@ -73,7 +73,7 @@ TEST_F(CSPHandlerTest, CSP) {
 #if defined(OS_TIZEN)
 TEST_F(CSPHandlerTest, WGTEmptyCSP) {
   manifest.SetString(widget_keys::kNameKey, "no name");
-  manifest.SetString(widget_keys::kXWalkVersionKey, "0");
+  manifest.SetString(widget_keys::kVersionKey, "0");
   manifest.SetString(widget_keys::kCSPKey, "");
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());
@@ -83,7 +83,7 @@ TEST_F(CSPHandlerTest, WGTEmptyCSP) {
 
 TEST_F(CSPHandlerTest, WGTCSP) {
   manifest.SetString(widget_keys::kNameKey, "no name");
-  manifest.SetString(widget_keys::kXWalkVersionKey, "0");
+  manifest.SetString(widget_keys::kVersionKey, "0");
   manifest.SetString(widget_keys::kCSPKey, "default-src    'self'   ");
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());

--- a/application/common/manifest_handlers/navigation_handler_unittest.cc
+++ b/application/common/manifest_handlers/navigation_handler_unittest.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/manifest.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace xwalk {
@@ -19,14 +20,15 @@ class NavigationHandlerTest: public testing::Test {
  public:
   virtual void SetUp() OVERRIDE {
     manifest.SetString(keys::kNameKey, "no name");
-    manifest.SetString(keys::kXWalkVersionKey, "0");
+    manifest.SetString(keys::kVersionKey, "0");
   }
 
   scoped_refptr<ApplicationData> CreateApplication() {
     std::string error;
     scoped_refptr<ApplicationData> application = ApplicationData::Create(
-        base::FilePath(), ApplicationData::LOCAL_DIRECTORY,
-        manifest, "", &error);
+        base::FilePath(), std::string(), ApplicationData::LOCAL_DIRECTORY,
+        make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
+        &error);
     return application;
   }
 
@@ -50,7 +52,7 @@ TEST_F(NavigationHandlerTest, OneNavigation) {
   manifest.SetString(keys::kAllowNavigationKey, "http://www.sample.com");
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  EXPECT_EQ(application->GetManifest()->type(), Manifest::TYPE_WIDGET);
   const NavigationInfo* info = GetNavigationInfo(application);
   EXPECT_TRUE(info);
   const std::vector<std::string>& list = info->GetAllowedDomains();
@@ -62,7 +64,7 @@ TEST_F(NavigationHandlerTest, Navigations) {
                      "http://www.sample1.com www.sample2.com");
   scoped_refptr<ApplicationData> application = CreateApplication();
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(application->GetPackageType(), Manifest::TYPE_WGT);
+  EXPECT_EQ(application->GetManifest()->type(), Manifest::TYPE_WIDGET);
   const NavigationInfo* info = GetNavigationInfo(application);
   EXPECT_TRUE(info);
   const std::vector<std::string>& list = info->GetAllowedDomains();

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -43,7 +43,7 @@ namespace {
 
 // Used when running in single-process mode.
 #if defined(OS_TIZEN)
-base::LazyInstance<XWalkContentRendererClientTizen>::Leaky
+base::LazyInstance<xwalk::XWalkContentRendererClientTizen>::Leaky
         g_xwalk_content_renderer_client = LAZY_INSTANCE_INITIALIZER;
 #else
 base::LazyInstance<XWalkContentRendererClient>::Leaky


### PR DESCRIPTION
This commit fixes buildbreaks of browsertests and unittests.

BUG=XWALK-538 (part of)
