### PR TITLE
[Android] Fix the resource not found issue of ActionMode menu inflater.

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -20,6 +21,7 @@ import org.xwalk.app.runtime.extension.XWalkRuntimeExtensionManager;
 import org.xwalk.app.runtime.XWalkRuntimeView;
 import org.xwalk.core.SharedXWalkExceptionHandler;
 import org.xwalk.core.SharedXWalkView;
+import org.xwalk.core.XWalkApplication;
 import org.xwalk.core.XWalkPreferences;
 
 public abstract class XWalkRuntimeActivityBase extends Activity {
@@ -114,6 +116,11 @@ public abstract class XWalkRuntimeActivityBase extends Activity {
         super.onActivityResult(requestCode, resultCode, data);
         if (mRuntimeView != null) mRuntimeView.onActivityResult(requestCode, resultCode, data);
         if (mExtensionManager != null) mExtensionManager.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public Resources getResources() {
+        return XWalkApplication.getApplication().getResources();
     }
 
     private String getLibraryApkDownloadUrl() {

--- a/runtime/android/core/src/org/xwalk/core/XWalkApplication.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkApplication.java
@@ -32,7 +32,7 @@ public class XWalkApplication extends Application {
         mRes = new XWalkMixedResources(super.getResources(), res);
     }
 
-    static XWalkApplication getApplication() {
+    public static XWalkApplication getApplication() {
         return gApp;
     }
 }


### PR DESCRIPTION
The ActionMode menu inflaterer use the activity context to get the resources,
which leads to menu resource not found exception. Fix it by in XWalkRuntimeActivityBase.

BUG=XWALK-2712
