### PR TITLE
[Android] Fixed that long press on text will crash in shared mode

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -20,9 +20,10 @@ import org.xwalk.app.runtime.extension.XWalkRuntimeExtensionManager;
 import org.xwalk.app.runtime.XWalkRuntimeView;
 import org.xwalk.core.SharedXWalkExceptionHandler;
 import org.xwalk.core.SharedXWalkView;
+import org.xwalk.core.XWalkActivity;
 import org.xwalk.core.XWalkPreferences;
 
-public abstract class XWalkRuntimeActivityBase extends Activity {
+public abstract class XWalkRuntimeActivityBase extends XWalkActivity {
 
     private static final String DEFAULT_LIBRARY_APK_URL = null;
 

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkCoreProviderImpl.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkCoreProviderImpl.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.view.View;
 import android.widget.FrameLayout;
 
+import org.xwalk.app.XWalkRuntimeActivityBase;
 import org.xwalk.core.SharedXWalkView;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkPreferences;
@@ -26,10 +27,10 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
     public XWalkCoreProviderImpl(Context context, Activity activity) {
         mContext = context;
         mActivity = activity;
-        init(context, activity);
+        init(context, (XWalkRuntimeActivityBase)activity);
     }
 
-    private void init(Context context, Activity activity) {
+    private void init(Context context, XWalkRuntimeActivityBase activity) {
         // TODO(yongsheng): do customizations for XWalkView. There will
         // be many callback classes which are needed to be implemented.
         mXWalkView = new SharedXWalkView(context, activity);

--- a/runtime/android/core/src/org/xwalk/core/SharedXWalkView.java
+++ b/runtime/android/core/src/org/xwalk/core/SharedXWalkView.java
@@ -15,19 +15,18 @@ public class SharedXWalkView extends XWalkView {
 
     private static boolean initialized = false;
 
-    public SharedXWalkView(Context context, AttributeSet attrs,
+    public SharedXWalkView(XWalkActivity context, AttributeSet attrs,
             SharedXWalkExceptionHandler handler) {
         super(verifyActivity(context), attrs);
     }
 
-    public SharedXWalkView(Context context, Activity activity) {
+    public SharedXWalkView(Context context, XWalkActivity activity) {
         super(context, verifyActivity(activity));
     }
 
-    private static Activity verifyActivity(Context context) {
-        assert context instanceof Activity;
+    private static Activity verifyActivity(XWalkActivity context) {
         if (!initialized) initialize(context, null);
-        return (Activity) context;
+        return context;
     }
 
     public static void initialize(Context context, SharedXWalkExceptionHandler handler) {

--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -1,0 +1,20 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.app.Activity;
+import android.content.res.Resources;
+
+/**
+ * XWalkActiviy is to support cross package resource loading.
+ * It provides method to allow overriding getResources() behavior.
+ */
+public abstract class XWalkActivity extends Activity {
+
+    @Override
+    public Resources getResources() {
+        return getApplicationContext().getResources();
+    }
+}


### PR DESCRIPTION
The ActionMode will use Activity to inflate layout, which in
shared mode, it will fail due to incorret context to search
for resources.

Introduce XWalkActivity for Embedders who want to use Shared
mode to inherit for the Activity will contain SharedXWalkView.

Besides, some layout ids exist in both app and library context.
Add detection of whether the stack trace is from library or
app to try use the correct resource first.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2712
