### PR TITLE
[Android] Fix the accessibility problem of reflection helper

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/ReflectionHelper.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/ReflectionHelper.java
@@ -302,13 +302,26 @@ public class ReflectionHelper {
                 methodName = "getWrapper";
             }
             try {
-                method = clazz.getMethod(methodName);
+                method = clazz.getDeclaredMethod(methodName);
             } catch (NoSuchMethodException e) {
                 handleException(e);
             }
-            if (method != null) sBridgeWrapperMap.put(clazz, method);
+
+            if (method == null)  {
+                return invokeMethod(method, instance);
+            } else {
+                sBridgeWrapperMap.put(clazz, method);
+            }
         }
-        return invokeMethod(method, instance);
+
+        if (method.isAccessible()) return invokeMethod(method, instance);
+
+        // This is to enable the accessibility of getBridge temporarily.
+        // It's not public for documentation generating.
+        method.setAccessible(true);
+        Object ret = invokeMethod(method, instance);
+        method.setAccessible(false);
+        return ret;
     }
 
     private static boolean isWrapper() {


### PR DESCRIPTION
In wrapper type of reflection, getBridge method is not
public for document generating. This causes potential
accessibility problem when converting wrapper type to
bridge type. So in reflection helper, if the method to
be invoked is not accessible, enable it temporarily and
reset the status after invoked.
