### PR TITLE
[Android] Add NFC to permission mapping table.

### DIFF
--- a/app/tools/android/handle_permissions.py
+++ b/app/tools/android/handle_permissions.py
@@ -38,6 +38,7 @@ permission_mapping_table = {
     'devicecapabilities': [],
     'fullscreen': [],
     'iap': ['com.android.vending.BILLING'],
+    'nfc': ['android.permission.NFC'],
     'presentation': [],
     'rawsockets': [],
     'screenorientation': [],


### PR DESCRIPTION
By this, user can use make_apk.py to package their application
with NFC extension with correct permission, for example:
$ python make_apk.py --name=apkname --package=org.xwalk.example
  --permissions=nfc --extensions=...

BUG=XWALK-2728
(cherry picked from commit 62e1e10382f8c31ec1aecf8a7be856708a820e90)
