### PR TITLE
[Tizen] Enable context menu settings.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -90,6 +90,7 @@ Application::Application(
       security_mode_enabled_(false),
       runtime_context_(runtime_context),
       observer_(NULL),
+      window_show_state_(ui::SHOW_STATE_DEFAULT),
       remote_debugging_enabled_(false),
       weak_factory_(this) {
   DCHECK(runtime_context_);
@@ -229,6 +230,7 @@ bool Application::Launch(const LaunchParams& launch_params) {
   params.state = is_wgt ?
       GetWindowShowState<Manifest::TYPE_WIDGET>(launch_params):
       GetWindowShowState<Manifest::TYPE_MANIFEST>(launch_params);
+  window_show_state_ = params.state;
 
   params.splash_screen_path = GetSplashScreenPath();
 

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -112,6 +112,9 @@ class Application : public Runtime::Observer,
 
   void set_observer(Observer* observer) { observer_ = observer; }
 
+  // FIXME(xinchao): This method will be deprecated soon.
+  ui::WindowShowState window_show_state() const { return window_show_state_; }
+
  protected:
   Application(scoped_refptr<ApplicationData> data, RuntimeContext* context);
   virtual bool Launch(const LaunchParams& launch_params);
@@ -162,6 +165,8 @@ class Application : public Runtime::Observer,
   void NotifyTermination();
 
   Observer* observer_;
+
+  ui::WindowShowState window_show_state_;
 
   std::map<std::string, std::string> name_perm_map_;
   // Application's session permissions.

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -114,6 +114,7 @@ const char kAllowNavigationKey[] = "widget.allow-navigation.#text";
 const char kCSPReportOnlyKey[] =
     "widget.content-security-policy-report-only.#text";
 const char kTizenSettingKey[] = "widget.setting";
+const char kTizenContextMenuKey[] = "widget.setting.@context-menu";
 const char kTizenHardwareKey[] = "widget.setting.@hwkey-event";
 const char kTizenEncryptionKey[] = "widget.setting.@encryption";
 const char kTizenMetaDataKey[] = "widget.metadata";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -96,6 +96,7 @@ namespace application_widget_keys {
   extern const char kAllowNavigationKey[];
   extern const char kCSPReportOnlyKey[];
   extern const char kTizenSettingKey[];
+  extern const char kTizenContextMenuKey[];
   extern const char kTizenHardwareKey[];
   extern const char kTizenEncryptionKey[];
   extern const char kTizenMetaDataKey[];

--- a/application/common/manifest_handlers/tizen_setting_handler.cc
+++ b/application/common/manifest_handlers/tizen_setting_handler.cc
@@ -49,6 +49,10 @@ bool TizenSettingHandler::Parse(scoped_refptr<ApplicationData> application,
   manifest->GetString(keys::kTizenEncryptionKey, &encryption);
   app_info->set_encryption_enabled(encryption == "enable");
 
+  std::string context_menu;
+  manifest->GetString(keys::kTizenContextMenuKey, &context_menu);
+  app_info->set_context_menu_enabled(context_menu != "disable");
+
   application->SetManifestData(keys::kTizenSettingKey,
                                app_info.release());
   return true;
@@ -82,6 +86,15 @@ bool TizenSettingHandler::Validate(
   if (!encryption.empty() && encryption != "enable" &&
       encryption != "disable") {
     *error = std::string("The encryption value must be 'enable'/'disable', "
+                         "or not specified in configuration file.");
+    return false;
+  }
+  std::string context_menu;
+  manifest->GetString(keys::kTizenContextMenuKey, &context_menu);
+  if (!context_menu.empty() &&
+      context_menu != "enable" &&
+      context_menu != "disable") {
+    *error = std::string("The context-menu value must be 'enable'/'disable', "
                          "or not specified in configuration file.");
     return false;
   }

--- a/application/common/manifest_handlers/tizen_setting_handler.h
+++ b/application/common/manifest_handlers/tizen_setting_handler.h
@@ -38,10 +38,16 @@ class TizenSettingInfo : public ApplicationData::ManifestData {
   void set_encryption_enabled(bool enabled) { encryption_enabled_ = enabled; }
   bool encryption_enabled() const { return encryption_enabled_; }
 
+  void set_context_menu_enabled(bool enabled) {
+    context_menu_enabled_ = enabled;
+  }
+  bool context_menu_enabled() const { return context_menu_enabled_; }
+
  private:
   bool hwkey_enabled_;
   ScreenOrientation screen_orientation_;
   bool encryption_enabled_;
+  bool context_menu_enabled_;
 };
 
 class TizenSettingHandler : public ManifestHandler {

--- a/runtime/browser/tizen/render_view_context_menu_impl.cc
+++ b/runtime/browser/tizen/render_view_context_menu_impl.cc
@@ -1,0 +1,258 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/tizen/render_view_context_menu_impl.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "components/renderer_context_menu/views/toolkit_delegate_views.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/web_contents.h"
+#include "third_party/WebKit/public/web/WebContextMenuData.h"
+
+namespace xwalk {
+using blink::WebContextMenuData;
+
+namespace {
+
+enum {
+  // Nativation
+  CMD_BACK = 0,
+  CMD_FORWARD,
+  CMD_RELOAD,
+
+  // Link
+  CMD_OPEN_LINK_NEW_ACTIVITY,
+
+  // Edit
+  CMD_UNDO,
+  CMD_REDO,
+  CMD_CUT,
+  CMD_COPY,
+  CMD_PASTE,
+  CMD_PASTE_AND_MATCH_STYLE,
+  CMD_DELETE,
+  CMD_SELECT_ALL,
+  CMD_LAST,
+};
+
+// Max number of custom command ids allowd.
+const int kNumCustomCommandIds = 1000;
+
+// TODO(oshima): Move IDS for context menus to components/renderer_context_menu
+// and replace hardcoded strings below.
+void AppendPageItems(ui::SimpleMenuModel* menu_model) {
+  menu_model->AddItem(CMD_BACK, base::ASCIIToUTF16("Back"));
+  menu_model->AddItem(CMD_FORWARD, base::ASCIIToUTF16("Forward"));
+  menu_model->AddItem(CMD_RELOAD, base::ASCIIToUTF16("Reload"));
+  menu_model->AddSeparator(ui::NORMAL_SEPARATOR);
+}
+
+void AppendLinkItems(const content::ContextMenuParams& params,
+                     ui::SimpleMenuModel* menu_model) {
+  if (!params.link_url.is_empty())
+    menu_model->AddItem(CMD_OPEN_LINK_NEW_ACTIVITY,
+                        base::ASCIIToUTF16("Open Link"));
+}
+
+void AppendEditableItems(ui::SimpleMenuModel* menu_model) {
+  menu_model->AddItem(CMD_UNDO, base::ASCIIToUTF16("Undo"));
+  menu_model->AddItem(CMD_REDO, base::ASCIIToUTF16("Redo"));
+  menu_model->AddSeparator(ui::NORMAL_SEPARATOR);
+  menu_model->AddItem(CMD_CUT, base::ASCIIToUTF16("Cut"));
+  menu_model->AddItem(CMD_COPY, base::ASCIIToUTF16("Copy"));
+  menu_model->AddItem(CMD_PASTE, base::ASCIIToUTF16("Paste"));
+  menu_model->AddItem(CMD_PASTE_AND_MATCH_STYLE,
+                      base::ASCIIToUTF16("Paste as plain text"));
+  menu_model->AddItem(CMD_DELETE, base::ASCIIToUTF16("Delete"));
+  menu_model->AddSeparator(ui::NORMAL_SEPARATOR);
+  menu_model->AddItem(CMD_SELECT_ALL, base::ASCIIToUTF16("Select All"));
+}
+
+}  // namespace
+
+RenderViewContextMenuImpl::RenderViewContextMenuImpl(
+    content::RenderFrameHost* render_frame_host,
+    const content::ContextMenuParams& params)
+    : RenderViewContextMenuBase(render_frame_host, params) {
+  SetContentCustomCommandIdRange(CMD_LAST, CMD_LAST + kNumCustomCommandIds);
+  // TODO(oshima): Support other types
+  set_content_type(
+      new ContextMenuContentType(source_web_contents_, params, true));
+  set_toolkit_delegate(scoped_ptr<ToolkitDelegate>(new ToolkitDelegateViews));
+}
+
+RenderViewContextMenuImpl::~RenderViewContextMenuImpl() {
+}
+
+void RenderViewContextMenuImpl::RunMenuAt(views::Widget* parent,
+                                          const gfx::Point& point,
+                                          ui::MenuSourceType type) {
+  static_cast<ToolkitDelegateViews*>(toolkit_delegate())
+      ->RunMenuAt(parent, point, type);
+}
+
+void RenderViewContextMenuImpl::InitMenu() {
+  RenderViewContextMenuBase::InitMenu();
+  bool needs_separator = false;
+  if (content_type_->SupportsGroup(ContextMenuContentType::ITEM_GROUP_PAGE)) {
+    AppendPageItems(&menu_model_);
+    needs_separator = true;
+  }
+
+  if (content_type_->SupportsGroup(ContextMenuContentType::ITEM_GROUP_LINK)) {
+    if (needs_separator)
+      AddSeparator();
+    AppendLinkItems(params_, &menu_model_);
+    needs_separator = true;
+  }
+
+  if (content_type_->SupportsGroup(
+          ContextMenuContentType::ITEM_GROUP_EDITABLE)) {
+    if (needs_separator)
+      AddSeparator();
+    AppendEditableItems(&menu_model_);
+  }
+}
+
+void RenderViewContextMenuImpl::RecordShownItem(int id) {
+  // TODO(oshima): Imelement UMA stats. crbug.com/401673
+  NOTIMPLEMENTED();
+}
+
+void RenderViewContextMenuImpl::RecordUsedItem(int id) {
+  // TODO(oshima): Imelement UMA stats. crbug.com/401673
+  NOTIMPLEMENTED();
+}
+
+void RenderViewContextMenuImpl::NotifyMenuShown() {
+}
+
+void RenderViewContextMenuImpl::NotifyURLOpened(
+    const GURL& url,
+    content::WebContents* new_contents) {
+}
+
+bool RenderViewContextMenuImpl::GetAcceleratorForCommandId(
+    int command_id,
+    ui::Accelerator* accelerator) {
+  NOTIMPLEMENTED();
+  return false;
+}
+
+bool RenderViewContextMenuImpl::IsCommandIdChecked(int command_id) const {
+  return false;
+}
+
+bool RenderViewContextMenuImpl::IsCommandIdEnabled(int command_id) const {
+  {
+    bool enabled = false;
+    if (RenderViewContextMenuBase::IsCommandIdKnown(command_id, &enabled))
+      return enabled;
+  }
+  switch (command_id) {
+    // Navigation
+    case CMD_BACK:
+      return source_web_contents_->GetController().CanGoBack();
+    case CMD_FORWARD:
+      return source_web_contents_->GetController().CanGoForward();
+    case CMD_RELOAD:
+      return true;
+
+    // Link
+    case CMD_OPEN_LINK_NEW_ACTIVITY:
+      return params_.link_url.is_valid();
+
+    // Editable
+    case CMD_UNDO:
+      return !!(params_.edit_flags & WebContextMenuData::CanUndo);
+
+    case CMD_REDO:
+      return !!(params_.edit_flags & WebContextMenuData::CanRedo);
+
+    case CMD_CUT:
+      return !!(params_.edit_flags & WebContextMenuData::CanCut);
+
+    case CMD_COPY:
+      return !!(params_.edit_flags & WebContextMenuData::CanCopy);
+
+    case CMD_PASTE:
+    case CMD_PASTE_AND_MATCH_STYLE:
+      return !!(params_.edit_flags & WebContextMenuData::CanPaste);
+
+    case CMD_DELETE:
+      return !!(params_.edit_flags & WebContextMenuData::CanDelete);
+
+    case CMD_SELECT_ALL:
+      return !!(params_.edit_flags & WebContextMenuData::CanSelectAll);
+  }
+  return false;
+}
+
+void RenderViewContextMenuImpl::ExecuteCommand(int command_id,
+                                               int event_flags) {
+  RenderViewContextMenuBase::ExecuteCommand(command_id, event_flags);
+  if (command_executed_)
+    return;
+  command_executed_ = true;
+  switch (command_id) {
+    // Navigation
+    case CMD_BACK:
+      source_web_contents_->GetController().GoBack();
+      break;
+    case CMD_FORWARD:
+      source_web_contents_->GetController().GoForward();
+      break;
+    case CMD_RELOAD:
+      source_web_contents_->GetController().Reload(true);
+      break;
+
+    // Link
+    case CMD_OPEN_LINK_NEW_ACTIVITY:
+      OpenURL(
+          params_.link_url,
+          params_.frame_url.is_empty() ? params_.page_url : params_.frame_url,
+          NEW_WINDOW,
+          ui::PAGE_TRANSITION_LINK);
+      break;
+
+    // Editable
+    case CMD_UNDO:
+      source_web_contents_->Undo();
+      break;
+
+    case CMD_REDO:
+      source_web_contents_->Redo();
+      break;
+
+    case CMD_CUT:
+      source_web_contents_->Cut();
+      break;
+
+    case CMD_COPY:
+      source_web_contents_->Copy();
+      break;
+
+    case CMD_PASTE:
+      source_web_contents_->Paste();
+      break;
+
+    case CMD_PASTE_AND_MATCH_STYLE:
+      source_web_contents_->PasteAndMatchStyle();
+      break;
+
+    case CMD_DELETE:
+      source_web_contents_->Delete();
+      break;
+
+    case CMD_SELECT_ALL:
+      source_web_contents_->SelectAll();
+      break;
+  }
+}
+
+void RenderViewContextMenuImpl::HandleAuthorizeAllPlugins() {
+}
+
+}  // namespace xwalk

--- a/runtime/browser/tizen/render_view_context_menu_impl.h
+++ b/runtime/browser/tizen/render_view_context_menu_impl.h
@@ -1,0 +1,54 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_TIZEN_RENDER_VIEW_CONTEXT_MENU_IMPL_H_
+#define XWALK_RUNTIME_BROWSER_TIZEN_RENDER_VIEW_CONTEXT_MENU_IMPL_H_
+
+#include "components/renderer_context_menu/render_view_context_menu_base.h"
+
+namespace views {
+class Widget;
+}
+
+namespace gfx {
+class Point;
+}
+
+namespace xwalk {
+
+class RenderViewContextMenuImpl : public RenderViewContextMenuBase {
+ public:
+  RenderViewContextMenuImpl(content::RenderFrameHost* render_frame_host,
+                            const content::ContextMenuParams& params);
+  virtual ~RenderViewContextMenuImpl();
+
+  void RunMenuAt(views::Widget* parent,
+                 const gfx::Point& point,
+                 ui::MenuSourceType type);
+
+ private:
+  // RenderViewContextMenuBase:
+  void InitMenu() override;
+  void RecordShownItem(int id) override;
+  void RecordUsedItem(int id) override;
+  void NotifyMenuShown() override;
+  void NotifyURLOpened(const GURL& url,
+                               content::WebContents* new_contents) override;
+  void HandleAuthorizeAllPlugins() override;
+
+  // ui::SimpleMenuModel:
+  bool GetAcceleratorForCommandId(
+      int command_id,
+      ui::Accelerator* accelerator) override;
+  bool IsCommandIdChecked(int command_id) const override;
+  bool IsCommandIdEnabled(int command_id) const override;
+  void ExecuteCommand(int command_id, int event_flags) override;
+
+  DISALLOW_COPY_AND_ASSIGN(RenderViewContextMenuImpl);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_TIZEN_RENDER_VIEW_CONTEXT_MENU_IMPL_H_

--- a/runtime/browser/tizen/xwalk_web_contents_view_delegate.cc
+++ b/runtime/browser/tizen/xwalk_web_contents_view_delegate.cc
@@ -1,0 +1,169 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/tizen/xwalk_web_contents_view_delegate.h"
+
+#include "components/web_modal/popup_manager.h"
+#include "components/web_modal/single_web_contents_dialog_manager.h"
+#include "components/web_modal/web_contents_modal_dialog_host.h"
+#include "components/web_modal/web_contents_modal_dialog_manager.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/render_widget_host_view.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_delegate.h"
+#include "content/public/browser/web_contents_view_delegate.h"
+#include "ui/aura/client/screen_position_client.h"
+#include "ui/aura/window.h"
+#include "xwalk/application/browser/application.h"
+#include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/browser/application_service.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
+
+namespace xwalk {
+namespace {
+
+scoped_ptr<RenderViewContextMenuImpl> BuildMenu(
+    content::WebContents* web_contents,
+    const content::ContextMenuParams& params) {
+  scoped_ptr<RenderViewContextMenuImpl> menu;
+  content::RenderFrameHost* focused_frame = web_contents->GetFocusedFrame();
+  // If the frame tree does not have a focused frame at this point, do not
+  // bother creating RenderViewContextMenuViews.
+  // This happens if the frame has navigated to a different page before
+  // ContextMenu message was received by the current RenderFrameHost.
+  if (focused_frame) {
+    menu.reset(new RenderViewContextMenuImpl(focused_frame, params));
+    menu->Init();
+  }
+  return menu.Pass();
+}
+}  // namespace
+
+XWalkWebContentsViewDelegate::XWalkWebContentsViewDelegate(
+    content::WebContents* web_contents,
+    xwalk::application::ApplicationService* app_service)
+    : web_contents_(web_contents),
+      app_service_(app_service) {
+}
+
+XWalkWebContentsViewDelegate::~XWalkWebContentsViewDelegate() {
+}
+
+void XWalkWebContentsViewDelegate::ShowContextMenu(
+    content::RenderFrameHost* render_frame_host,
+    const content::ContextMenuParams& params) {
+  int render_process_id = render_frame_host->GetProcess()->GetID();
+  application::Application* app = XWalkRunner::GetInstance()->app_system()->
+      application_service()->GetApplicationByRenderHostID(render_process_id);
+  if (!app)
+    return;
+
+  application::TizenSettingInfo* info =
+      static_cast<application::TizenSettingInfo*>(
+          app->data()->GetManifestData(
+              application_widget_keys::kTizenSettingKey));
+  if (info && !info->context_menu_enabled())
+    return;
+
+  ShowMenu(BuildMenu(
+      content::WebContents::FromRenderFrameHost(render_frame_host), params));
+}
+
+content::WebDragDestDelegate*
+XWalkWebContentsViewDelegate::GetDragDestDelegate() {
+  return NULL;
+}
+
+void XWalkWebContentsViewDelegate::StoreFocus() {
+}
+
+void XWalkWebContentsViewDelegate::RestoreFocus() {
+}
+
+bool XWalkWebContentsViewDelegate::Focus() {
+  web_modal::PopupManager* popup_manager =
+      web_modal::PopupManager::FromWebContents(web_contents_);
+  if (popup_manager)
+    popup_manager->WasFocused(web_contents_);
+  return false;
+}
+
+void XWalkWebContentsViewDelegate::TakeFocus(bool reverse) {
+}
+
+void XWalkWebContentsViewDelegate::SizeChanged(const gfx::Size& size) {
+}
+
+void* XWalkWebContentsViewDelegate::CreateRenderWidgetHostViewDelegate(
+    content::RenderWidgetHost* render_widget_host) {
+  return NULL;
+}
+
+void XWalkWebContentsViewDelegate::ShowMenu(
+    scoped_ptr<RenderViewContextMenuImpl> menu) {
+  context_menu_.reset(menu.release());
+
+  if (!context_menu_.get())
+    return;
+
+  // Menus need a Widget to work. If we're not the active tab we won't
+  // necessarily be in a widget.
+  views::Widget* top_level_widget = GetTopLevelWidget();
+  if (!top_level_widget)
+    return;
+
+  const content::ContextMenuParams& params = context_menu_->params();
+  // Don't show empty menus.
+  if (context_menu_->menu_model().GetItemCount() == 0)
+    return;
+
+  gfx::Point screen_point(params.x, params.y);
+
+  // Convert from target window coordinates to root window coordinates.
+  aura::Window* target_window = GetActiveNativeView();
+  aura::Window* root_window = target_window->GetRootWindow();
+  aura::client::ScreenPositionClient* screen_position_client =
+      aura::client::GetScreenPositionClient(root_window);
+  if (screen_position_client) {
+    screen_position_client->ConvertPointToScreen(target_window,
+                                                 &screen_point);
+  }
+  // Enable recursive tasks on the message loop so we can get updates while
+  // the context menu is being displayed.
+  base::MessageLoop::ScopedNestableTaskAllower allow(
+      base::MessageLoop::current());
+  context_menu_->RunMenuAt(
+      top_level_widget, screen_point, params.source_type);
+}
+
+aura::Window* XWalkWebContentsViewDelegate::GetActiveNativeView() {
+  return web_contents_->GetFullscreenRenderWidgetHostView()
+      ? web_contents_->GetFullscreenRenderWidgetHostView()
+      ->GetNativeView()
+      : web_contents_->GetNativeView();
+}
+
+views::Widget* XWalkWebContentsViewDelegate::GetTopLevelWidget() {
+  return views::Widget::GetTopLevelWidgetForNativeView(GetActiveNativeView());
+}
+
+views::FocusManager* XWalkWebContentsViewDelegate::GetFocusManager() {
+  views::Widget* toplevel_widget = GetTopLevelWidget();
+  return toplevel_widget ? toplevel_widget->GetFocusManager() : NULL;
+}
+
+void XWalkWebContentsViewDelegate::SetInitialFocus() {
+  if (web_contents_->FocusLocationBarByDefault()) {
+    if (web_contents_->GetDelegate())
+      web_contents_->GetDelegate()->SetFocusToLocationBar(false);
+  } else {
+    web_contents_->Focus();
+  }
+}
+
+}  // namespace xwalk

--- a/runtime/browser/tizen/xwalk_web_contents_view_delegate.h
+++ b/runtime/browser/tizen/xwalk_web_contents_view_delegate.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_TIZEN_XWALK_WEB_CONTENTS_VIEW_DELEGATE_H_
+#define XWALK_RUNTIME_BROWSER_TIZEN_XWALK_WEB_CONTENTS_VIEW_DELEGATE_H_
+
+#include "content/public/browser/web_drag_dest_delegate.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_view_delegate.h"
+#include "content/public/common/context_menu_params.h"
+#include "ui/views/widget/widget.h"
+#include "xwalk/application/browser/application_service.h"
+#include "xwalk/runtime/browser/tizen/render_view_context_menu_impl.h"
+
+namespace xwalk {
+
+class XWalkWebContentsViewDelegate : public content::WebContentsViewDelegate {
+ public:
+  XWalkWebContentsViewDelegate(
+      content::WebContents* web_contents,
+      xwalk::application::ApplicationService* app_service);
+  virtual ~XWalkWebContentsViewDelegate();
+
+  // Overridden from WebContentsViewDelegate:
+  void ShowContextMenu(content::RenderFrameHost* render_frame_host,
+                       const content::ContextMenuParams& params) override;
+  content::WebDragDestDelegate* GetDragDestDelegate() override;
+  void StoreFocus() override;
+  void RestoreFocus() override;
+  bool Focus() override;
+  void TakeFocus(bool reverse) override;
+  void SizeChanged(const gfx::Size& size) override;
+  virtual void* CreateRenderWidgetHostViewDelegate(
+      content::RenderWidgetHost* render_widget_host);
+
+#if defined(TOOLKIT_VIEWS) || defined(USE_AURA)
+  void ShowDisambiguationPopup(
+      const gfx::Rect& target_rect,
+      const SkBitmap& zoomed_bitmap,
+      const gfx::NativeView content,
+      const base::Callback<void(ui::GestureEvent*)>& gesture_cb,
+      const base::Callback<void(ui::MouseEvent*)>& mouse_cb) override {
+    NOTIMPLEMENTED();
+  }
+
+  void HideDisambiguationPopup() override { NOTIMPLEMENTED(); }
+#endif
+
+ private:
+  aura::Window* GetActiveNativeView();
+  views::Widget* GetTopLevelWidget();
+  views::FocusManager* GetFocusManager();
+  void SetInitialFocus();
+  void ShowMenu(scoped_ptr<RenderViewContextMenuImpl> menu);
+
+  content::WebContents* web_contents_;
+  xwalk::application::ApplicationService* app_service_;
+  scoped_ptr<RenderViewContextMenuImpl> context_menu_;
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkWebContentsViewDelegate);
+};
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_TIZEN_XWALK_WEB_CONTENTS_VIEW_DELEGATE_H_

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -68,6 +68,7 @@
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/manifest_handlers/navigation_handler.h"
 #include "xwalk/runtime/browser/runtime_platform_util.h"
+#include "xwalk/runtime/browser/tizen/xwalk_web_contents_view_delegate.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 #endif
 
@@ -168,6 +169,9 @@ XWalkContentBrowserClient::GetWebContentsViewDelegate(
     content::WebContents* web_contents) {
 #if defined(OS_ANDROID)
   return new XWalkWebContentsViewDelegate(web_contents);
+#elif defined(OS_TIZEN)
+  return new XWalkWebContentsViewDelegate(
+      web_contents, xwalk_runner_->app_system()->application_service());
 #else
   return NULL;
 #endif

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -301,6 +301,8 @@
             'sysapps/sysapps_resources.gyp:xwalk_sysapps_resources',
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
             '<(DEPTH)/third_party/jsoncpp/jsoncpp.gyp:jsoncpp',
+            '../components/components.gyp:web_modal',
+            '../components/components.gyp:renderer_context_menu',
           ],
           'cflags': [
             '<!@(pkg-config --cflags libtzplatform-config)',
@@ -314,9 +316,15 @@
             'experimental/native_file_system/virtual_root_provider_tizen.cc',
             'runtime/browser/tizen/tizen_locale_listener.cc',
             'runtime/browser/tizen/tizen_locale_listener.h',
+            'runtime/browser/tizen/xwalk_web_contents_view_delegate.cc',
+            'runtime/browser/tizen/xwalk_web_contents_view_delegate.h',
+            'runtime/browser/tizen/render_view_context_menu_impl.cc',
+            'runtime/browser/tizen/render_view_context_menu_impl.h',
           ],
           'sources!':[
             'runtime/browser/runtime_platform_util_linux.cc',
+            'runtime/browser/android/xwalk_web_contents_view_delegate.cc',
+            'runtime/browser/android/xwalk_web_contents_view_delegate.h',
           ],
         }],
         ['OS=="android"',{


### PR DESCRIPTION
In Tizen specific section 0230: Tizen Settings, it's said: the context menu should
be displayed when the user long-presses, for example, an image, text, or
link. This patch will implement this feature. The related feature is XWALK-1491
