### PR TITLE
[Tizen][Linux] Support the following URI schemes: tel:, sms:, mailto:.

### DIFF
--- a/runtime/browser/runtime_platform_util_android.cc
+++ b/runtime/browser/runtime_platform_util_android.cc
@@ -30,4 +30,8 @@ bool IsVisible(gfx::NativeView view) {
   return true;
 }
 
+void OpenExternal(const GURL& url) {
+  NOTIMPLEMENTED();
+}
+
 }  // namespace platform_util

--- a/runtime/browser/runtime_platform_util_tizen.cc
+++ b/runtime/browser/runtime_platform_util_tizen.cc
@@ -4,10 +4,14 @@
 
 #include "xwalk/runtime/browser/runtime_platform_util.h"
 
+#include "base/bind.h"
 #include "base/file_util.h"
 #include "base/logging.h"
 #include "base/process/kill.h"
 #include "base/process/launch.h"
+#include "dbus/bus.h"
+#include "dbus/message.h"
+#include "dbus/object_proxy.h"
 #include "url/gurl.h"
 
 namespace platform_util {
@@ -16,9 +20,95 @@ namespace {
 // In some Tizen releases, there exists a system browser called 'MiniBrowser',
 // which we can use to open an external link from a web app.
 const char kWebBrowserPath[] = "/usr/bin/MiniBrowser";
+
+typedef base::Callback<void (const GURL&, dbus::MessageWriter*)> ParamsWriter;
+
+struct ProtocolDBusServiceInfo {
+  const char* scheme;
+  const char* service;
+  const char* interface;
+  const char* method;
+  const char* object_path;
+  ParamsWriter params_writer;
+};
+
+void ParseAndWriteTelParams(const GURL& url,
+                            dbus::MessageWriter* dbus_writer) {
+  // Phone number
+  dbus_writer->AppendString(url.GetContent());
+  // Always don't auto dial
+  dbus_writer->AppendBool(false);
+}
+
+void ParseAndWriteMailParams(const GURL& uri,
+                             dbus::MessageWriter* dbus_writer) {
+}
+
+void ParseAndWriteSmsParams(const GURL& url,
+                            dbus::MessageWriter* dbus_writer) {
+  // Support the case sms:12345678?body=Hello
+  std::string query = url.query();
+  std::string content = url.GetContent();
+  // Extract the phone number
+  const std::string number = content.substr(0, content.find(query) - 1);
+  // Remove "body="
+  const std::string body = query.erase(0, 5);
+
+  dbus_writer->AppendString(number);
+  dbus_writer->AppendString(body);
+  // Always don't auto dial
+  dbus_writer->AppendBool(false);
+}
+
+const ProtocolDBusServiceInfo protocol_dbus_services[] = {
+  {"tel", "org.tizen.dialer", "org.tizen.dialer.Control", "Dial", "/",
+      base::Bind(ParseAndWriteTelParams)},
+  {"mailto", "org.tizen.email_service", "org.tizen.email_service", "Launch",
+      "/org/tizen/email_service",
+      base::Bind(ParseAndWriteMailParams)},
+  {"sms", "org.tizen.dialer", "org.tizen.dialer.Control", "Send", "/",
+      base::Bind(ParseAndWriteSmsParams)},
+};
+
+bool CallDbusService(const ProtocolDBusServiceInfo& info,
+                     const GURL& url) {
+  const dbus::ObjectPath dbus_path(info.object_path);
+
+  dbus::Bus::Options options;
+  scoped_refptr<dbus::Bus> bus(new dbus::Bus(options));
+  dbus::ObjectProxy* app_proxy =
+      bus->GetObjectProxy(info.service, dbus_path);
+  if (!app_proxy) {
+    VLOG(1) << "app_proxy failed.";
+    return false;
+  }
+
+  dbus::MethodCall method_call(info.interface, info.method);
+  dbus::MessageWriter writer(&method_call);
+  info.params_writer.Run(url, &writer);
+
+  app_proxy->CallMethod(&method_call,
+                        dbus::ObjectProxy::TIMEOUT_USE_DEFAULT,
+                        dbus::ObjectProxy::EmptyResponseCallback());
+
+  return true;
+}
 }  // namespace
 
+bool HandleExternalProtocol(const GURL& url) {
+  for (size_t i = 0; i < arraysize(protocol_dbus_services); ++i) {
+    const ProtocolDBusServiceInfo& info = protocol_dbus_services[i];
+    if (url.SchemeIs(info.scheme)) {
+      return CallDbusService(info, url);
+    }
+  }
+  return true;
+}
+
 void OpenExternal(const GURL& url) {
+  if (HandleExternalProtocol(url))
+    return;
+
   if (url.SchemeIsHTTPOrHTTPS()) {
     LOG(INFO) << "Open in WebBrowser.";
     std::vector<std::string> argv;

--- a/runtime/browser/runtime_resource_dispatcher_host_delegate.h
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate.h
@@ -16,6 +16,7 @@ class RuntimeResourceDispatcherHostDelegate
   virtual ~RuntimeResourceDispatcherHostDelegate();
 
   static void ResourceDispatcherHostCreated();
+  static scoped_ptr<RuntimeResourceDispatcherHostDelegate> Create();
 
   virtual void RequestBeginning(
       net::URLRequest* request,

--- a/runtime/browser/runtime_resource_dispatcher_host_delegate_android.h
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate_android.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <utility>
 
-#include "base/lazy_instance.h"
 #include "content/public/browser/content_browser_client.h"
 #include "xwalk/runtime/browser/runtime_resource_dispatcher_host_delegate.h"
 
@@ -30,8 +29,6 @@ class RuntimeResourceDispatcherHostDelegateAndroid
  public:
   RuntimeResourceDispatcherHostDelegateAndroid();
   virtual ~RuntimeResourceDispatcherHostDelegateAndroid();
-
-  static void ResourceDispatcherHostCreated();
 
   virtual void RequestBeginning(
       net::URLRequest* request,
@@ -69,8 +66,6 @@ class RuntimeResourceDispatcherHostDelegateAndroid
                                  int render_frame_id,
                                  IoThreadClientThrottle* pending_throttle);
  private:
-  friend struct base::DefaultLazyInstanceTraits<
-      RuntimeResourceDispatcherHostDelegateAndroid>;
   // These methods must be called on IO thread.
   void OnIoThreadClientReadyInternal(int new_render_process_id,
                                      int new_render_frame_id);

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -17,6 +17,7 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/resource_context.h"
+#include "content/public/browser/resource_dispatcher_host.h"
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/main_function_params.h"
@@ -51,7 +52,6 @@
 #include "xwalk/runtime/browser/android/xwalk_cookie_access_policy.h"
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
 #include "xwalk/runtime/browser/android/xwalk_web_contents_view_delegate.h"
-#include "xwalk/runtime/browser/runtime_resource_dispatcher_host_delegate_android.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_android.h"
 #include "xwalk/runtime/common/android/xwalk_globals_android.h"
 #else
@@ -348,12 +348,12 @@ content::BrowserPpapiHost*
   return NULL;
 }
 
-#if defined(OS_ANDROID)
 void XWalkContentBrowserClient::ResourceDispatcherHostCreated() {
-  RuntimeResourceDispatcherHostDelegateAndroid::
-  ResourceDispatcherHostCreated();
+  resource_dispatcher_host_delegate_ =
+      (RuntimeResourceDispatcherHostDelegate::Create()).Pass();
+  content::ResourceDispatcherHost::Get()->SetDelegate(
+      resource_dispatcher_host_delegate_.get());
 }
-#endif
 
 content::SpeechRecognitionManagerDelegate*
     XWalkContentBrowserClient::GetSpeechRecognitionManagerDelegate() {

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -12,6 +12,7 @@
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/common/main_function_params.h"
 #include "xwalk/runtime/browser/runtime_geolocation_permission_context.h"
+#include "xwalk/runtime/browser/runtime_resource_dispatcher_host_delegate.h"
 
 namespace content {
 class BrowserContext;
@@ -136,8 +137,8 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
   virtual content::BrowserPpapiHost* GetExternalBrowserPpapiHost(
       int plugin_process_id) OVERRIDE;
 
-#if defined(OS_ANDROID)
-  virtual void ResourceDispatcherHostCreated();
+#if defined(OS_ANDROID) || defined(OS_TIZEN)  || defined(OS_LINUX)
+  virtual void ResourceDispatcherHostCreated() OVERRIDE;
 #endif
 
   virtual void GetStoragePartitionConfigForSite(
@@ -153,6 +154,12 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
 
   XWalkBrowserMainParts* main_parts() { return main_parts_; }
 
+#if defined(OS_ANDROID)
+  RuntimeResourceDispatcherHostDelegate* resource_dispatcher_host_delegate() {
+    return resource_dispatcher_host_delegate_.get();
+  }
+#endif
+
  private:
   XWalkRunner* xwalk_runner_;
   net::URLRequestContextGetter* url_request_context_getter_;
@@ -160,6 +167,9 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
     geolocation_permission_context_;
   XWalkBrowserMainParts* main_parts_;
   RuntimeContext* runtime_context_;
+
+  scoped_ptr<RuntimeResourceDispatcherHostDelegate>
+      resource_dispatcher_host_delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkContentBrowserClient);
 };


### PR DESCRIPTION
Explanation:

1 Override "content::RuntimeResourceDispatcherHostDelegate::HandleExternalProtocol" in according child class to implement the platform-specific surpporting:
    (1) On TizenIVI, through DBus to invoke corresponding default system application.
    (2) On Linux, use XDG utils.
    (3) On Android, it's been implemented already, keep unchanged.
2 In "XWalkContentBrowserClient::ResourceDispatcherHostCreated" triger the resource_dispatcher_host_delegate to be set.
3 The main reason to implemented the Linux part is to verify our design, the code of function "XDGUtil" is copied  from chrome directly. 
BUG=https://crosswalk-project.org/jira/browse/XWALK-1501
