### PR TITLE
[Tizen] Remove unused variable.

### DIFF
--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -273,9 +273,6 @@ bool PackageInstaller::PlatformInstall(ApplicationData* app_data) {
 }
 
 bool PackageInstaller::PlatformUninstall(const std::string& app_id) {
-  base::FilePath data_dir;
-  CHECK(PathService::Get(xwalk::DIR_DATA_PATH, &data_dir));
-
   // args for pkgmgr
   const char* pkgmgr_argv[5];
   pkgmgr_argv[2] = "-k";


### PR DESCRIPTION
Removed code was no longer used since removing xwalk-pkg-helper in commit 880057e.
