### PR TITLE
[Android] Temporarily disable some Core tests.

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnFullscreenToggledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnFullscreenToggledTest.java
@@ -6,6 +6,7 @@ package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
 
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 
 /**
@@ -20,8 +21,12 @@ public class OnFullscreenToggledTest extends XWalkViewTestBase {
         mOnFullscreenToggledHelper = mTestHelperBridge.getOnFullscreenToggledHelper();
     }
 
+    /*
     @SmallTest
     @Feature({"OnFullscreenToggled"})
+    See XWALK-2755.
+    */
+    @DisabledTest
     public void testOnFullscreenToggled() throws Throwable {
         final String name = "fullscreen_togged.html";
         String fileContent = getFileContent(name);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnRequestFocusTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnRequestFocusTest.java
@@ -6,6 +6,7 @@ package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
 
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 
 /**
@@ -20,8 +21,12 @@ public class OnRequestFocusTest extends XWalkViewTestBase {
         mOnRequestFocusHelper = mTestHelperBridge.getOnRequestFocusHelper();
     }
 
+    /*
     @SmallTest
     @Feature({"OnRequestFocus"})
+    See XWALK-2755.
+    */
+    @DisabledTest
     public void testOnRequestFocus() throws Throwable {
         final String url = "file:///android_asset/www/request_focus_main.html";
         int count = mOnRequestFocusHelper.getCallCount();

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OpenFileChooserTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OpenFileChooserTest.java
@@ -6,6 +6,7 @@ package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
 
+import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 
 /**
@@ -20,8 +21,12 @@ public class OpenFileChooserTest extends XWalkViewTestBase {
         mOpenFileChooserHelper = mTestHelperBridge.getOpenFileChooserHelper();
     }
 
+    /*
     @SmallTest
     @Feature({"OpenFileChooser"})
+    See XWALK-2755.
+    */
+    @DisabledTest
     public void testOpenFileChooser() throws Throwable {
         final String name = "file_chooser.html";
         String fileContent = getFileContent(name);


### PR DESCRIPTION
Disable OnFullscreenToggledTest, OnRequestFocusTest and
OpenFileChooserTest.

They have started failing due to
https://codereview.chromium.org/516753002 and
https://code.google.com/p/chromium/issues/detail?id=407643, and fixing
them will likely require getting some patches upstream.

While we do that, let's get the tests back to green to avoid letting
other regressions creep in.

Related to XWALK-2755.
