### PR TITLE
[Android] Change the super class of XWalkRuntimeView to LinearLayout

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeView.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeView.java
@@ -8,7 +8,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.util.AttributeSet;
-import android.widget.FrameLayout;
+import android.widget.LinearLayout;
 
 /**
  * This class is to provide public APIs which are called by web application
@@ -21,7 +21,7 @@ import android.widget.FrameLayout;
 // Implementation notes.
 // Please be careful to change any public APIs for the backward compatibility
 // is very important to us. Don't change any of them without permisson.
-public class XWalkRuntimeView extends FrameLayout {
+public class XWalkRuntimeView extends LinearLayout {
     // The actual implementation to hide the internals to API users.
     private XWalkRuntimeViewProvider mProvider;
 
@@ -54,10 +54,11 @@ public class XWalkRuntimeView extends FrameLayout {
 
     private void init(Context context, Activity activity) {
         mProvider = XWalkRuntimeViewProviderFactory.getProvider(context, activity);
+        setOrientation(LinearLayout.VERTICAL);
         this.addView(mProvider.getView(),
-                new FrameLayout.LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT));
+                new LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        LinearLayout.LayoutParams.MATCH_PARENT));
     }
 
     /**


### PR DESCRIPTION
Advertising extension, refer to
https://github.com/crosswalk-project/crosswalk-android-extensions/pull/25,
will insert the ad view, which cannot cover the HTML content. Currently, the
supper class of XWalkRuntimeView is FrameLayout, which isn't able to shrink
when a view is inserted. So it will be replaced by LinearLayout.
