### PR TITLE
restored functionality of XDK agents (AppPreview and AppPreviewXWalk) 

### DIFF
--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -229,7 +229,8 @@ void XWalkDevToolsServer::Start(bool allow_debug_permission) {
   net::UnixDomainServerSocket::AuthCallback auth_callback =
       allow_debug_permission ?
           base::Bind(&AuthorizeSocketAccessWithDebugPermission) :
-          base::Bind(&content::CanUserConnectToDevTools);
+          base::Bind(&XWalkDevToolsServer::CanUserConnectToDevTools,
+              base::Unretained(this));
 
   scoped_ptr<content::DevToolsHttpHandler::ServerSocketFactory> factory(
       new UnixDomainServerSocketFactory(socket_name_));


### PR DESCRIPTION
broken in xwalk9. The fix consist in checking of uid passed thorough AllowConnectionFromUid and only if uid is not eq to the stored, call chromium corresponded function to check

XDK has two apps on device - AppPreview and AppPreviewXWalk(aka APX). The first abstracts the communication with XDK to the device and only if it's required it runs APX and set up a connection with its DevTools.
