### PR TITLE
[TIZEN] Manage the package  update correctly

### DIFF
--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -335,7 +335,7 @@ bool PackageInstaller::PlatformUpdate(ApplicationData* app_data) {
     platform_installer.InitializePkgmgrSignal((quiet_ ? 5 : 4), pkgmgr_argv);
   }
 
-  if (!platform_installer.InstallApplication(new_xml_path, icon))
+  if (!platform_installer.UpdateApplication(new_xml_path, icon))
     return false;
 
   app_dir_cleaner.Dismiss();


### PR DESCRIPTION
Call platform_installer.UpdateApplication() instead of  platform_installer.InstallApplication()

BUG=XWALK-2782

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
