### PR TITLE
[TIZEN] Check User ID and return immediatly if Root attempts to execute x...

### DIFF
--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -62,6 +62,8 @@
             '../../../build/system.gyp:tizen',
           ],
           'sources': [
+            '../tizen/xwalk_tizen_user.cc',
+            '../tizen/xwalk_tizen_user.h',
             '../../../runtime/common/xwalk_paths.cc',
             '../../../runtime/common/xwalk_paths.h',
             '../../../runtime/common/xwalk_system_locale.cc',

--- a/application/tools/linux/xwalkctl_main.cc
+++ b/application/tools/linux/xwalkctl_main.cc
@@ -13,6 +13,7 @@
 #include "base/path_service.h"
 
 #include "xwalk/application/common/tizen/application_storage.h"
+#include "xwalk/application/tools/tizen/xwalk_tizen_user.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 
 #include "dbus/bus.h"
@@ -101,6 +102,10 @@ bool list_applications(ApplicationStorage* storage) {
 }  // namespace
 
 int main(int argc, char* argv[]) {
+#if defined(OS_TIZEN)
+  if (xwalk_tizen_check_user_for_xwalkctl())
+    exit(1);
+#endif
   GOptionContext* context = g_option_context_new("- Crosswalk Setter");
   g_option_context_add_main_entries(context, entries, NULL);
   GError* error = nullptr;


### PR DESCRIPTION
[TIZEN] Check User ID and return immediatly if Root attempt to execute xwalkctl

Root user is not allowed to manage application. This has non sense on Tizen.

So calling xwalkctl as root should return also an error.

BUG=XWALK-2749
Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
