### PR TITLE
restoring of XDK agents work (cherry-pick of commit from master)

### DIFF
--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -190,7 +190,8 @@ void XWalkDevToolsServer::Start(bool allow_debug_permission) {
   net::UnixDomainServerSocket::AuthCallback auth_callback =
       allow_debug_permission ?
           base::Bind(&AuthorizeSocketAccessWithDebugPermission) :
-          base::Bind(&content::CanUserConnectToDevTools);
+          base::Bind(&XWalkDevToolsServer::CanUserConnectToDevTools,
+              base::Unretained(this));
 
   protocol_handler_ = content::DevToolsHttpHandler::Start(
       new net::deprecated::UnixDomainListenSocketWithAbstractNamespaceFactory(


### PR DESCRIPTION
restored functionality of XDK agents (AppPreview and AppPreviewXWalk) broken since xwalk9. The fix consist in checking of uid passed thorough AllowConnectionFromUid and only if uid is not eq to the stored, call chromium corresponded function to check

(cherry picked from commit cc7f50ed1a9c1d6fea05af4098f61bbdfe32350f)
