### PR TITLE
[Android] Fix video can't exit full screen mode

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegateAdapter.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegateAdapter.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
 import android.view.KeyEvent;
+import org.chromium.content.browser.ContentVideoView;
 
 class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
 
@@ -63,6 +64,10 @@ class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
 
     @Override
     public void toggleFullscreen(boolean enterFullscreen) {
+        if (!enterFullscreen) {
+            ContentVideoView videoView = ContentVideoView.getContentVideoView();
+            if (videoView != null) videoView.exitFullscreen(false);
+        }
         if (mXWalkContentsClient != null) mXWalkContentsClient.onToggleFullscreen(enterFullscreen);
     }
 


### PR DESCRIPTION
Upstream patch https://codereview.chromium.org/292573004 has changed some fullscreen video playback behavior
This change is to update XWalk with similar change to support to exit video Fullscreen
BUG=XWALK-2654
