### PR TITLE
[Tizen][Runtime] Postpone native window initialization and display.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -23,6 +23,7 @@
 #include "xwalk/application/common/manifest_handlers/warp_handler.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_context.h"
+#include "xwalk/runtime/browser/runtime_defered_ui_strategy.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 
 #if defined(OS_TIZEN)
@@ -90,7 +91,7 @@ Application::Application(
       security_mode_enabled_(false),
       runtime_context_(runtime_context),
       observer_(NULL),
-      ui_strategy_(new RuntimeUIStrategy),
+      ui_strategy_(new RuntimeDeferedUIStrategy),
       remote_debugging_enabled_(false),
       weak_factory_(this) {
   DCHECK(runtime_context_);

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -113,6 +113,8 @@ class Application : public Runtime::Observer,
 
   void set_observer(Observer* observer) { observer_ = observer; }
 
+  RuntimeUIStrategy* ui_strategy() { return ui_strategy_.get(); }
+
  protected:
   Application(scoped_refptr<ApplicationData> data, RuntimeContext* context);
   virtual bool Launch(const LaunchParams& launch_params);

--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -269,6 +269,8 @@ void XWalkExtensionProcessHost::OnRenderChannelCreated(
   is_extension_process_channel_ready_ = true;
   ep_rp_channel_handle_ = handle;
   ReplyChannelHandleToRenderProcess();
+  if (delegate_)
+    delegate_->OnRenderChannelCreated(render_process_host_->GetID());
 }
 
 void XWalkExtensionProcessHost::ReplyChannelHandleToRenderProcess() {

--- a/extensions/browser/xwalk_extension_process_host.h
+++ b/extensions/browser/xwalk_extension_process_host.h
@@ -45,6 +45,8 @@ class XWalkExtensionProcessHost
     virtual bool OnRegisterPermissions(int render_process_id,
                                        const std::string& extension_name,
                                        const std::string& perm_table);
+    virtual void OnRenderChannelCreated(int render_process_id) {}
+
    protected:
     ~Delegate() {}
   };

--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -479,5 +479,10 @@ bool XWalkExtensionService::OnRegisterPermissions(
                                         extension_name, perm_table);
 }
 
+void XWalkExtensionService::OnRenderChannelCreated(int render_process_id) {
+  CHECK(delegate_);
+  delegate_->RenderChannelCreated(render_process_id);
+}
+
 }  // namespace extensions
 }  // namespace xwalk

--- a/extensions/browser/xwalk_extension_service.h
+++ b/extensions/browser/xwalk_extension_service.h
@@ -51,6 +51,7 @@ class XWalkExtensionService : public content::NotificationObserver,
     virtual void ExtensionProcessCreated(
         int render_process_id,
         const IPC::ChannelHandle& channel_handle) {}
+    virtual void RenderChannelCreated(int render_process_id) {}
 
    protected:
     ~Delegate() {}
@@ -103,6 +104,7 @@ class XWalkExtensionService : public content::NotificationObserver,
   virtual void OnExtensionProcessCreated(
       int render_process_id,
       const IPC::ChannelHandle handle) OVERRIDE;
+  virtual void OnRenderChannelCreated(int render_process_id) OVERRIDE;
 
   virtual void OnCheckAPIAccessControl(
       int render_process_id,

--- a/runtime/browser/runtime_defered_ui_strategy.cc
+++ b/runtime/browser/runtime_defered_ui_strategy.cc
@@ -1,0 +1,31 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/runtime_defered_ui_strategy.h"
+
+#include "xwalk/runtime/browser/runtime.h"
+
+namespace xwalk {
+RuntimeDeferedUIStrategy::RuntimeDeferedUIStrategy()
+    : defered_show_(true) {}
+
+RuntimeDeferedUIStrategy::~RuntimeDeferedUIStrategy() {}
+
+void RuntimeDeferedUIStrategy::Show(
+    Runtime* runtime, const NativeAppWindow::CreateParams& params) {
+  if (!defered_show_) {
+    RuntimeUIStrategy::Show(runtime, params);
+    return;
+  }
+
+  runtime_map_[runtime] = params;
+}
+
+void RuntimeDeferedUIStrategy::ShowStoredRuntimes() {
+  for (const auto& item : runtime_map_) {
+    RuntimeUIStrategy::Show(item.first, item.second);
+  }
+  defered_show_ = false;
+}
+}  // namespace xwalk

--- a/runtime/browser/runtime_defered_ui_strategy.h
+++ b/runtime/browser/runtime_defered_ui_strategy.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_RUNTIME_DEFERED_UI_STRATEGY_H_
+#define XWALK_RUNTIME_BROWSER_RUNTIME_DEFERED_UI_STRATEGY_H_
+
+#include <map>
+
+#include "xwalk/runtime/browser/runtime_ui_strategy.h"
+#include "xwalk/runtime/browser/ui/native_app_window.h"
+
+namespace xwalk {
+class Runtime;
+
+class RuntimeDeferedUIStrategy : public RuntimeUIStrategy {
+ public:
+  RuntimeDeferedUIStrategy();
+  virtual ~RuntimeDeferedUIStrategy();
+
+  // Override from RuntimeUIStrategy.
+  virtual void Show(Runtime* runtime,
+                    const NativeAppWindow::CreateParams& params) OVERRIDE;
+
+  void ShowStoredRuntimes();
+
+ private:
+  std::map<Runtime*, NativeAppWindow::CreateParams> runtime_map_;
+  bool defered_show_;
+};
+
+inline RuntimeDeferedUIStrategy*
+ToRuntimeDeferedUIStrategy(RuntimeUIStrategy* ui_strategy) {
+  return static_cast<RuntimeDeferedUIStrategy*>(ui_strategy);
+}
+}  // namespace xwalk
+#endif  // XWALK_RUNTIME_BROWSER_RUNTIME_DEFERED_UI_STRATEGY_H_

--- a/runtime/browser/xwalk_app_extension_bridge.h
+++ b/runtime/browser/xwalk_app_extension_bridge.h
@@ -42,6 +42,7 @@ class XWalkAppExtensionBridge
   virtual void ExtensionProcessCreated(
       int render_process_id,
       const IPC::ChannelHandle& channel_handle) OVERRIDE;
+  virtual void RenderChannelCreated(int render_process_id) OVERRIDE;
 
  private:
   application::ApplicationSystem* app_system_;

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -158,6 +158,8 @@
         'runtime/browser/runtime.h',
         'runtime/browser/runtime_context.cc',
         'runtime/browser/runtime_context.h',
+        'runtime/browser/runtime_defered_ui_strategy.cc',
+        'runtime/browser/runtime_defered_ui_strategy.h',
         'runtime/browser/runtime_download_manager_delegate.cc',
         'runtime/browser/runtime_download_manager_delegate.h',
         'runtime/browser/runtime_file_select_helper.cc',


### PR DESCRIPTION
Runtime::AttachWindow() is time costing in Browser::UI thread.
Unfortunately during this peroid, extension process requires sync talk
with Browser::UI to set up dbus proxy, moreover, render process
initialization is also delayed due to LaunchInternal() can't be called
on time.

The PR will show native window after EP finishes DBus sync calls.

BUG=XWALK-2520
