### PR TITLE
Widget Interface - getItem() must return null if there is no item

### DIFF
--- a/application/extension/application_widget_api.js
+++ b/application/extension/application_widget_api.js
@@ -101,7 +101,8 @@ var WidgetStorage = function() {
   }
 
   this.getItem = function(itemKey) {
-    return _itemStorage[String(itemKey)];
+    var item = _itemStorage[String(itemKey)];
+    return item !== undefined ? item : null;
   }
 
   this.setItem = function(itemKey, itemValue) {


### PR DESCRIPTION
Spec: http://dev.w3.org/html5/webstorage/#dom-storage-getitem

BUG=XWALK-2777
