### PR TITLE
WidgetInterface - reconstructing DOMException is broken

### DIFF
--- a/application/extension/application_widget_common_api.js
+++ b/application/extension/application_widget_common_api.js
@@ -43,31 +43,30 @@ var CustomDOMException = function(code, message) {
     }
   }
 
-  var props = {};
   var newException;
 
   try {
-    document.removeChild({})
+    document.removeChild(document.createTextNode(""));
   } catch (e) {
-    newException = Object.create(e)
+    newException = Object.create(Object.getPrototypeOf(e));
   }
 
-  var proto = newException.__proto__;
+  var props = {
+    value: null,
+    writable: true,
+    enumerable: true,
+    configurable: true
+  };
 
-  props = Object.getOwnPropertyDescriptor(proto, "name");
   props.value = _name;
   Object.defineProperty(newException, "name", props);
-
-  props = Object.getOwnPropertyDescriptor(proto, "code");
   props.value = _code;
   Object.defineProperty(newException, "code", props);
-
-  props = Object.getOwnPropertyDescriptor(proto, "message");
   props.value = _message;
   Object.defineProperty(newException, "message", props);
 
   props.value = function() {
-    return _name + ": " + _message;
+    return this.name + ": " + this.code;
   }
   Object.defineProperty(newException, "toString", props);
 


### PR DESCRIPTION
The 'code' property is not defined in TypeError.
Therefore accessing descriptor for non existing property causes problems.

Origin of problem:
Current way of receiving native DOMException is not working.
Instead of DOMException, TypeError is received.

BUG=XWALK-2776
