### PR TITLE
[Tizen] Installer crashes when path is directory

### DIFF
--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/file_util.h"
@@ -453,6 +454,22 @@ base::FilePath ApplicationURLToRelativeFilePath(const GURL& url) {
     return base::FilePath();
 
   return path;
+}
+
+bool CopyDirectoryContents(const base::FilePath& from,
+    const base::FilePath& to) {
+  base::FileEnumerator iter(from, false,
+      base::FileEnumerator::FILES | base::FileEnumerator::DIRECTORIES);
+  for (base::FilePath path = iter.Next(); !path.empty(); path = iter.Next()) {
+    if (iter.GetInfo().IsDirectory()) {
+      if (!base::CopyDirectory(path, to, true))
+        return false;
+    } else if (!base::CopyFile(path, to.Append(path.BaseName()))) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 }  // namespace application

--- a/application/common/application_file_util.h
+++ b/application/common/application_file_util.h
@@ -53,6 +53,10 @@ scoped_refptr<ApplicationData> LoadApplication(
 // Get a relative file path from an app:// URL.
 base::FilePath ApplicationURLToRelativeFilePath(const GURL& url);
 
+// Makes copy of directory content from one directory to another.
+bool CopyDirectoryContents(const base::FilePath& from,
+    const base::FilePath& to);
+
 }  // namespace application
 }  // namespace xwalk
 

--- a/application/common/package/package.cc
+++ b/application/common/package/package.cc
@@ -10,6 +10,7 @@
 #include "base/path_service.h"
 #include "third_party/zlib/google/zip.h"
 #include "xwalk/application/common/id_util.h"
+#include "xwalk/application/common/package/unpacked_wgt_package.h"
 #include "xwalk/application/common/package/wgt_package.h"
 #include "xwalk/application/common/package/xpk_package.h"
 
@@ -28,6 +29,10 @@ Package::~Package() {
 
 // static
 scoped_ptr<Package> Package::Create(const base::FilePath& source_path) {
+  if (base::DirectoryExists(source_path)) {
+    scoped_ptr<Package> package(new UnpackedWGTPackage(source_path));
+    return package.Pass();
+  }
   if (source_path.MatchesExtension(FILE_PATH_LITERAL(".xpk"))) {
     scoped_ptr<Package> package(new XPKPackage(source_path));
     return package.Pass();

--- a/application/common/package/unpacked_wgt_package.cc
+++ b/application/common/package/unpacked_wgt_package.cc
@@ -1,0 +1,126 @@
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/package/unpacked_wgt_package.h"
+
+#include <string>
+
+#include "base/file_util.h"
+#include "base/files/scoped_file.h"
+#include "third_party/libxml/chromium/libxml_utils.h"
+#include "xwalk/application/common/application_file_util.h"
+#include "xwalk/application/common/id_util.h"
+
+#if defined(OS_TIZEN)
+#include "xwalk/application/common/tizen/signature_validator.h"
+#endif
+
+namespace xwalk {
+namespace application {
+namespace {
+
+#if defined(OS_TIZEN)
+const char kIdNodeName[] = "application";
+#else
+const char kIdNodeName[] = "widget";
+#endif
+
+}
+
+UnpackedWGTPackage::UnpackedWGTPackage(const base::FilePath& path)
+    : Package(path) {
+  if (!base::PathExists(path))
+    return;
+  manifest_type_ = Manifest::TYPE_WIDGET;
+  base::FilePath extracted_path = path;
+
+  XmlReader xml;
+  if (!xml.LoadFile(extracted_path.Append(FILE_PATH_LITERAL("config.xml"))
+                    .MaybeAsASCII())) {
+    LOG(ERROR) << "Unable to load WGT package config.xml file.";
+    return;
+  }
+
+  while (!xml.SkipToElement()) {
+    if (!xml.Read()) {
+      LOG(ERROR) << "Unable to read WGT package config.xml file.";
+      return;
+    }
+  }
+
+  std::string value;
+  while (xml.Read()) {
+    std::string node_name = xml.NodeName();
+    if (node_name == kIdNodeName) {
+      xml.NodeAttribute("id", &value);
+      break;
+    }
+  }
+
+  if (!value.empty()) {
+#if defined(OS_TIZEN)
+    id_ = value;
+    is_valid_ =
+      SignatureValidator::Check(extracted_path) != SignatureValidator::INVALID;
+#else
+    id_ = GenerateId(value);
+    is_valid_ = true;
+#endif
+  }
+  scoped_ptr<base::ScopedFILE> file(
+      new base::ScopedFILE(base::OpenFile(path, "rb")));
+
+  file_ = file.Pass();
+}
+
+UnpackedWGTPackage::~UnpackedWGTPackage() {
+}
+
+bool UnpackedWGTPackage::ExtractToTemporaryDir(base::FilePath* result_path) {
+  if (is_extracted_) {
+    *result_path = temp_dir_.path();
+    return true;
+  }
+
+  if (!CreateTempDirectory()) {
+    LOG(ERROR) << "Can't create a temporary"
+                  "directory for extracting the package content.";
+    return false;
+  }
+
+  if (!CopyDirectoryContents(source_path_, temp_dir_.path())) {
+    LOG(ERROR) << "An error occurred during copying files.";
+    return false;
+  }
+
+  is_extracted_ = true;
+
+  *result_path = temp_dir_.path();
+
+  return true;
+}
+
+bool UnpackedWGTPackage::ExtractTo(const base::FilePath& target_path) {
+  if (!DirectoryExists(target_path)) {
+    LOG(ERROR) << "The directory " << target_path.MaybeAsASCII()
+               << "does not exist.";
+    return false;
+  }
+
+  if (!IsDirectoryEmpty(target_path)) {
+    LOG(ERROR) << "The directory " << target_path.MaybeAsASCII()
+               << "is not empty.";
+    return false;
+  }
+
+  if (!CopyDirectoryContents(source_path_, target_path)) {
+    LOG(ERROR) << "An error occurred during copying files.";
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/package/unpacked_wgt_package.h
+++ b/application/common/package/unpacked_wgt_package.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_PACKAGE_UNPACKED_WGT_PACKAGE_H_
+#define XWALK_APPLICATION_COMMON_PACKAGE_UNPACKED_WGT_PACKAGE_H_
+
+#include "base/files/file_path.h"
+#include "xwalk/application/common/package/package.h"
+
+namespace xwalk {
+namespace application {
+
+class UnpackedWGTPackage : public Package {
+ public:
+  explicit UnpackedWGTPackage(const base::FilePath& path);
+  virtual ~UnpackedWGTPackage();
+  bool ExtractToTemporaryDir(base::FilePath* result_path) override;
+  bool ExtractTo(const base::FilePath& target_path) override;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_PACKAGE_UNPACKED_WGT_PACKAGE_H_

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -46,6 +46,8 @@
         'signature_types.h',
         'package/package.h',
         'package/package.cc',
+        'package/unpacked_wgt_package.cc',
+        'package/unpacked_wgt_package.h',
         'package/wgt_package.h',
         'package/wgt_package.cc',
         'package/xpk_package.cc',

--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -66,22 +66,6 @@ const base::FilePath kDefaultIcon(
 const std::string kServicePrefix("xwalk-service.");
 const std::string kAppIdPrefix("xwalk.");
 
-bool CopyDirectoryContents(const base::FilePath& from,
-    const base::FilePath& to) {
-  base::FileEnumerator iter(from, false,
-      base::FileEnumerator::FILES | base::FileEnumerator::DIRECTORIES);
-  for (base::FilePath path = iter.Next(); !path.empty(); path = iter.Next()) {
-    if (iter.GetInfo().IsDirectory()) {
-      if (!base::CopyDirectory(path, to, true))
-        return false;
-    } else if (!base::CopyFile(path, to.Append(path.BaseName()))) {
-        return false;
-    }
-  }
-
-  return true;
-}
-
 void WriteMetaDataElement(
     XmlWriter& writer, // NOLINT
     xwalk::application::TizenMetaDataInfo* info) {
@@ -382,26 +366,16 @@ bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
       !base::CreateDirectory(install_temp_dir))
     return false;
 
-  std::string app_id;
+  scoped_ptr<Package> package = Package::Create(path);
+  if (!package || !package->IsValid())
+    return false;
+
   base::FilePath unpacked_dir;
-  scoped_ptr<Package> package;
-  FileDeleter tmp_path(install_temp_dir.Append(path.BaseName()), false);
-  if (!base::DirectoryExists(path)) {
-    if (tmp_path.path() != path &&
-        !base::CopyFile(path, tmp_path.path()))
-      return false;
-    package = Package::Create(tmp_path.path());
-    if (!package || !package->IsValid())
-      return false;
-    package->ExtractToTemporaryDir(&unpacked_dir);
-    app_id = package->Id();
-  } else {
-    unpacked_dir = path;
-  }
+  package->ExtractToTemporaryDir(&unpacked_dir);
 
   std::string error;
   scoped_refptr<ApplicationData> app_data = LoadApplication(
-      unpacked_dir, app_id, ApplicationData::LOCAL_DIRECTORY,
+      unpacked_dir, package->Id(), ApplicationData::LOCAL_DIRECTORY,
       package->manifest_type(), &error);
   if (!app_data.get()) {
     LOG(ERROR) << "Error during application installation: " << error;
@@ -428,15 +402,10 @@ bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
     if (!base::DeleteFile(app_dir, true))
       return false;
   }
-  if (!package) {
-    if (!base::CreateDirectory(app_dir))
-      return false;
-    if (!CopyDirectoryContents(unpacked_dir, app_dir))
-      return false;
-  } else {
-    if (!base::Move(unpacked_dir, app_dir))
-      return false;
-  }
+  if (!base::CreateDirectory(app_dir))
+    return false;
+  if (!xwalk::application::CopyDirectoryContents(unpacked_dir, app_dir))
+    return false;
 
   xwalk::application::TizenSettingInfo* info =
       static_cast<xwalk::application::TizenSettingInfo*>(


### PR DESCRIPTION
An uninitialized variable was used in case of installation from directory.
This patch adds a UnpackedWGTPackage class.

BUG=XWALK-2674
