### PR TITLE
[Tizen] Backendlib should differ between xpk and wgt extensions

### DIFF
--- a/application/common/tizen/package_query.h
+++ b/application/common/tizen/package_query.h
@@ -17,9 +17,11 @@ namespace application {
 base::FilePath GetApplicationPath(const std::string& app_id);
 base::FilePath GetPackagePath(const std::string& pkg_id);
 
+std::string GetPackageType(const std::string& pkg_id);
+
 base::Time GetApplicationInstallationTime(const std::string& app_id);
 
-}  // application
-}  // xwalk
+}  // namespace application
+}  // namespace xwalk
 
 #endif  // XWALK_APPLICATION_COMMON_TIZEN_PACKAGE_QUERY_H_

--- a/application/tools/tizen/xwalk_backend_plugin.h
+++ b/application/tools/tizen/xwalk_backend_plugin.h
@@ -33,20 +33,27 @@ class PkgmgrBackendPlugin {
   int IsAppInstalled(const std::string& pkgid);
   int AppsList(package_manager_pkg_info_t** list, int* count);
 
+  void SetLoadSet(pkg_plugin_set* set);
+
+  std::string type() const;
+
  private:
   PkgmgrBackendPlugin();
 
   void SaveInfo(scoped_refptr<xwalk::application::ApplicationData> app_data,
-                package_manager_pkg_info_t* pkg_detail_info);
+                package_manager_pkg_info_t* pkg_detail_info,
+                const std::string& force_type = std::string());
   void SaveDetailInfo(
       scoped_refptr<xwalk::application::ApplicationData> app_data,
-      package_manager_pkg_detail_info_t* pkg_detail_info);
+      package_manager_pkg_detail_info_t* pkg_detail_info,
+      const std::string& force_type = std::string());
   scoped_refptr<xwalk::application::ApplicationData> GetApplicationDataFromPkg(
       const std::string& pkg_path, base::ScopedTempDir* dir);
 
   friend struct DefaultSingletonTraits<PkgmgrBackendPlugin>;
 
   scoped_ptr<xwalk::application::ApplicationStorage> storage_;
+  pkg_plugin_set* set_;
 
   DISALLOW_COPY_AND_ASSIGN(PkgmgrBackendPlugin);
 };

--- a/application/tools/tizen/xwalk_backendlib.cc
+++ b/application/tools/tizen/xwalk_backendlib.cc
@@ -42,16 +42,26 @@ int pkg_plugin_on_load(pkg_plugin_set* set) {
   set->get_pkg_detail_info_from_package =
       pkg_plugin_get_app_detail_info_from_package;
 
+  // FIXME: store load set which contains
+  // pkgmgr sets pkg_type after calling 'pkg_plugin_on_load'
+  // we need to store load set to recover type of package
+  // for which backendlib was loaded - wgt or xpk
+  PkgmgrBackendPlugin::GetInstance()->SetLoadSet(set);
+
   return 0;
 }
 
 void pkg_plugin_on_unload() {
-  LOG(INFO) << "Crosswalk backend plugin - unload";
+  LOG(INFO) << "Crosswalk backend plugin ("
+            << PkgmgrBackendPlugin::GetInstance()->type()
+            << ") - unload";
 }
 
 int pkg_plugin_get_app_detail_info(
     const char *pkg_name, package_manager_pkg_detail_info_t *pkg_detail_info) {
-  LOG(INFO) << "Crosswalk backend plugin - pkg_plugin_get_app_detail_info";
+  LOG(INFO) << "Crosswalk backend plugin ("
+            << PkgmgrBackendPlugin::GetInstance()->type()
+            << ") - pkg_plugin_get_app_detail_info";
 
   return PkgmgrBackendPlugin::GetInstance()->DetailedInfo(pkg_name,
                                                           pkg_detail_info);
@@ -59,15 +69,18 @@ int pkg_plugin_get_app_detail_info(
 
 int pkg_plugin_get_app_detail_info_from_package(
     const char *pkg_path, package_manager_pkg_detail_info_t *pkg_detail_info) {
-  LOG(INFO)
-    << "Crosswalk backend plugin - pkg_plugin_get_app_detail_info_from_package";
+  LOG(INFO) << "Crosswalk backend plugin ("
+            << PkgmgrBackendPlugin::GetInstance()->type()
+            << ") - pkg_plugin_get_app_detail_info_from_package";
 
   return PkgmgrBackendPlugin::GetInstance()->DetailedInfoPkg(pkg_path,
                                                              pkg_detail_info);
 }
 
 int pkg_plugin_app_is_installed(const char *pkg_name) {
-  LOG(INFO) << "Crosswalk backend plugin - pkg_plugin_app_is_installed";
+  LOG(INFO) << "Crosswalk backend plugin ("
+            << PkgmgrBackendPlugin::GetInstance()->type()
+            << ") - pkg_plugin_app_is_installed";
 
   return PkgmgrBackendPlugin::GetInstance()->IsAppInstalled(pkg_name);
 }
@@ -76,7 +89,9 @@ int pkg_plugin_get_installed_apps_list(const char* category,
                                        const char* option,
                                        package_manager_pkg_info_t** list,
                                        int* count) {
-  LOG(INFO) << "Crosswalk backend plugin - pkg_plugin_get_installed_apps_list";
+  LOG(INFO) << "Crosswalk backend plugin ("
+            << PkgmgrBackendPlugin::GetInstance()->type()
+            << ") - pkg_plugin_get_installed_apps_list";
 
   return PkgmgrBackendPlugin::GetInstance()->AppsList(list, count);
 }

--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -120,7 +120,9 @@ bool GeneratePkgInfoXml(xwalk::application::ApplicationData* application,
   xml_writer.StartElement("manifest");
   xml_writer.AddAttribute("xmlns", "http://tizen.org/ns/packages");
   xml_writer.AddAttribute("package", package_id);
-  xml_writer.AddAttribute("type", "wgt");
+  xml_writer.AddAttribute("type",
+      application->GetManifest()->type() == Manifest::TYPE_MANIFEST
+      ? "xpk" : "wgt");
   xml_writer.AddAttribute("version", application->VersionString());
   xml_writer.WriteElement("label", application->Name());
   xml_writer.WriteElement("description", application->Description());


### PR DESCRIPTION
This commit fixes the way backend library pkgmgr's plugin will display type of application.
Extra query to pkgmgr is added to check for type of package - xpk or wgt.

Verify:
- install xpk package,
- install wgt package,
- run: pkgcmd -l -q                           #xpk and wgt is listed
- run: pkgcmd -l -q -t wgt                    #wgt is listed
- run: pkgcmd -l -q -t xpk                    #xpk is listed
- run: pkgcmd -q -s -n ${wgt_pkg_id} -t wgt   #wgt package is shown with wgt type in data
- run: pkgcmd -q -s -n ${wgt_pkg_id} -t xpk   #no package should be found
- run: pkgcmd -q -s -n ${xpk_pkg_id} -t wgt   #no package should be found
- run: pkgcmd -q -s -n ${xpk_pkg_id} -t xpk   #xpk package is shown with xpk type in data
- run: pkgcmd -q -s -p ${xpk_pkg_path} -t xpk #details should be listed
- run: pkgcmd -q -s -p ${wgt_pkg_path} -t wgt #details should be listed

BUG=XWALK-2771
