### PR TITLE
[Android] Merge AndroidManifest.xml from external extension

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -25,6 +25,7 @@ from handle_xml import AddElementAttribute
 from handle_xml import AddElementAttributeAndText
 from handle_xml import EditElementAttribute
 from handle_xml import EditElementValueByNodeName
+from handle_xml import MergeNodes
 from handle_permissions import HandlePermissions
 from util import CleanDir, CreateAndCopyDir
 from xml.dom import minidom
@@ -447,6 +448,25 @@ def CustomizeExtensions(app_info, extensions):
         file_handle = open(manifest_path, 'w')
         xmldoc.writexml(file_handle, encoding='utf-8')
         file_handle.close()
+      if 'manifest' in json_output:
+        manifest_merge_path = os.path.join(source_path, json_output['manifest'])
+        if not os.path.isfile(manifest_merge_path):
+          print('Error: %s specified in the extension\'s JSON '
+                'could not be found.' % manifest_merge_path)
+          sys.exit(9)
+        xmldoc_merge = minidom.parse(manifest_merge_path)
+        manifest_nodes = xmldoc.getElementsByTagName('manifest')
+        manifest_nodes_merge = xmldoc_merge.getElementsByTagName('manifest')
+        if not manifest_nodes:
+          print('Error: %s does not have a <manifest> node.' % manifest_path)
+          sys.exit(9)
+        if not manifest_nodes_merge:
+          print('Error: %s does not have a <manifest> node.'
+                % manifest_merge_path)
+          sys.exit(9)
+        MergeNodes(manifest_nodes[0], manifest_nodes_merge[0])
+        with open(manifest_path, 'w') as file_handle:
+          xmldoc.writexml(file_handle, encoding='utf-8')
 
   # Write configuration of extensions into the target extensions-config.json.
   if extension_json_list:

--- a/app/tools/android/handle_xml.py
+++ b/app/tools/android/handle_xml.py
@@ -39,3 +39,36 @@ def AddElementAttributeAndText(doc, node, name, value, data):
   text = doc.createTextNode(data)
   item.appendChild(text)
   root.appendChild(item)
+
+
+def CompareNodes(node1, node2):
+  if node1.tagName != node2.tagName or node1.attributes is None:
+    return False
+  if node2.attributes is None:
+    return True
+
+  for item in node2.attributes.items():
+    if not item in node1.attributes.items():
+      return False
+  return True
+
+
+def MergeNodes(node1, node2):
+  tmp_node_list = []
+  for item2 in node2.childNodes:
+    if item2.nodeType != item2.ELEMENT_NODE:
+      continue
+    item1 = None
+    for tmp_item in node1.childNodes:
+      if tmp_item.nodeType != tmp_item.ELEMENT_NODE:
+        continue
+      if CompareNodes(tmp_item, item2):
+        item1 = tmp_item
+        break
+    if item1 is not None:
+      MergeNodes(item1, item2)
+    else:
+      tmp_node_list.append(item2)
+
+  for item in tmp_node_list:
+    node1.appendChild(item)

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -764,6 +764,26 @@ class TestMakeApk(unittest.TestCase):
     self.assertTrue(content.find('android.permission.READ_CONTACTS') != -1)
     self.checkApks('Example', '1.0.0')
 
+  def testExtensionWithAndroidManifest(self):
+    test_entry_root = 'test_data/entry'
+    # Add redundant separators for test.
+    extension_path = 'test_data//extensions/adextension/'
+    cmd = ['python', 'make_apk.py', '--name=Example', '--app-version=1.0.0',
+           '--package=org.xwalk.example', '--app-root=%s' % test_entry_root,
+           '--app-local-path=contactextension.html',
+           '--extensions=%s' % extension_path,
+           '--project-dir=.', self._mode]
+    RunCommand(cmd)
+    self.addCleanup(Clean, 'Example', '1.0.0')
+    self.assertTrue(os.path.exists('Example'))
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('_GOOGLE_PLAY_SERVICES_LIB_VERSION_') != -1)
+    self.checkApks('Example', '1.0.0')
+
+
   def testXPK(self):
     xpk_file = os.path.join('test_data', 'xpk', 'example.xpk')
     cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
@@ -1164,6 +1184,7 @@ def SuiteWithModeOption():
   test_suite.addTest(TestMakeApk('testEntryWithErrors'))
   test_suite.addTest(TestMakeApk('testExtensionsWithOneExtension'))
   test_suite.addTest(TestMakeApk('testExtensionsWithNonExtension'))
+  test_suite.addTest(TestMakeApk('testExtensionWithAndroidManifest'))
   test_suite.addTest(TestMakeApk('testExtensionWithPermissions'))
   test_suite.addTest(TestMakeApk('testFullscreen'))
   test_suite.addTest(TestMakeApk('testIconByOption'))

--- a/app/tools/android/test_data/extensions/adextension/AndroidManifest.xml
+++ b/app/tools/android/test_data/extensions/adextension/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:name="org.xwalk.core.XWalkApplication">
+        <meta-data android:name="com.google.android.gms.version" android:value="_GOOGLE_PLAY_SERVICES_LIB_VERSION_"/>
+    </application>
+</manifest>

--- a/app/tools/android/test_data/extensions/adextension/adextension.js
+++ b/app/tools/android/test_data/extensions/adextension/adextension.js
@@ -1,0 +1,5 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//This is a dummy file

--- a/app/tools/android/test_data/extensions/adextension/adextension.json
+++ b/app/tools/android/test_data/extensions/adextension/adextension.json
@@ -1,0 +1,6 @@
+{
+  "name":  "Ad",
+  "class": "com.example.extension.AdExtension",
+  "jsapi": "adextension.js",
+  "manifest": "AndroidManifest.xml"
+}

--- a/app/tools/android/test_data/extensions/adextension/src/com/example/extension/AdExtension.java
+++ b/app/tools/android/test_data/extensions/adextension/src/com/example/extension/AdExtension.java
@@ -1,0 +1,11 @@
+package com.example.extension;
+
+import org.xwalk.app.runtime.extension.XWalkExtensionClient;
+import org.xwalk.app.runtime.extension.XWalkExtensionContextClient;
+
+public class AdExtension extends XWalkExtensionClient {
+    // Don't change the parameters in Constructor because XWalk needs to call this constructor.
+    public AdExtension(String name, String JsApi, XWalkExtensionContextClient context) {
+        super(name, JsApi, context);
+    }
+}

--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -153,6 +153,17 @@
       ],
     },
     {
+      'target_name': 'adextension',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_app_runtime_java',
+      ],
+      'variables': {
+        'java_in_dir': 'app/tools/android/test_data/extensions/adextension/',
+      },
+      'includes': ['../build/java.gypi'],
+    },
+    {
       'target_name': 'contactextension',
       'type': 'none',
       'dependencies': [
@@ -178,6 +189,7 @@
       'target_name': 'xwalk_packaging_tool_test',
       'type': 'none',
       'dependencies': [
+        'adextension',
         'contactextension',
         'myextension',
       ],


### PR DESCRIPTION
Add new parameter "manifest" to external extension manifest json file.
This parameter points to an AndroidManifest.xml file, which contains
the config items. These items will be merged to real AndroidManifest.xml,
when packets apk. Please look into the following example.

```
before:
<manifest>
  <application>
    <activity android:name="org.xwalk.app.template.AppTemplateActivity">
    <intent-filter>
    ...
    </intent-filter>
    </activity>
  </application>
</manifest>
```

```
AndroidManifest.xml from exteranl extension:
<manifest>
  <application>
    <activity android:name="org.xwalk.app.template.AppTemplateActivity">
    <meta-data ... />
    </activity>
    <activity android:name="com.google.android.gms.ads.AdActivity" ...  />
  </application>
</manifest>
```

```
after:
<manifest>
  <application>
    <activity android:name="org.xwalk.app.template.AppTemplateActivity">
    <intent-filter>
    ...
    </intent-filter>
    <meta-data ... />
    <activity android:name="com.google.android.gms.ads.AdActivity" ...  />
    </activity>
  </application>
</manifest>
```

Refer to, https://github.com/crosswalk-project/crosswalk-android-extensions/pull/25
In this PR, the AndroidManifest in the extension include other data that we will need in the final manifest.
