### PR TITLE
[Android] Fix three failed test cases in core test.

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnFullscreenToggledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnFullscreenToggledTest.java
@@ -6,7 +6,6 @@ package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
 
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 
 /**
@@ -21,12 +20,8 @@ public class OnFullscreenToggledTest extends XWalkViewTestBase {
         mOnFullscreenToggledHelper = mTestHelperBridge.getOnFullscreenToggledHelper();
     }
 
-    /*
     @SmallTest
     @Feature({"OnFullscreenToggled"})
-    See XWALK-2755.
-    */
-    @DisabledTest
     public void testOnFullscreenToggled() throws Throwable {
         final String name = "fullscreen_togged.html";
         String fileContent = getFileContent(name);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnRequestFocusTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnRequestFocusTest.java
@@ -6,7 +6,6 @@ package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
 
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 
 /**
@@ -21,12 +20,8 @@ public class OnRequestFocusTest extends XWalkViewTestBase {
         mOnRequestFocusHelper = mTestHelperBridge.getOnRequestFocusHelper();
     }
 
-    /*
     @SmallTest
     @Feature({"OnRequestFocus"})
-    See XWALK-2755.
-    */
-    @DisabledTest
     public void testOnRequestFocus() throws Throwable {
         final String url = "file:///android_asset/www/request_focus_main.html";
         int count = mOnRequestFocusHelper.getCallCount();

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OpenFileChooserTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OpenFileChooserTest.java
@@ -6,7 +6,6 @@ package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
 
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 
 /**
@@ -21,12 +20,8 @@ public class OpenFileChooserTest extends XWalkViewTestBase {
         mOpenFileChooserHelper = mTestHelperBridge.getOpenFileChooserHelper();
     }
 
-    /*
     @SmallTest
     @Feature({"OpenFileChooser"})
-    See XWALK-2755.
-    */
-    @DisabledTest
     public void testOpenFileChooser() throws Throwable {
         final String name = "file_chooser.html";
         String fileContent = getFileContent(name);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -521,7 +521,7 @@ public class XWalkViewTestBase
     public void clickOnElementId(final String id, String frameName) throws Exception {
         String str;
         if (frameName != null) {
-            str = "top.window." + "LeftFrame" + ".document.getElementById('" + id + "')";
+            str = "top.window." + frameName + ".document.getElementById('" + id + "')";
         } else {
             str = "document.getElementById('" + id + "')";
         }
@@ -542,8 +542,7 @@ public class XWalkViewTestBase
         }, WAIT_TIMEOUT_MS, CHECK_INTERVAL));
 
         try {
-            String result = executeJavaScriptAndWaitForResult(
-                "var evObj = document.createEvent('Events'); " +
+            loadJavaScriptUrl("javascript:var evObj = document.createEvent('Events'); " +
                 "evObj.initEvent('click', true, false); " +
                 script2 +
                 "console.log('element with id [" + id + "] clicked');");


### PR DESCRIPTION
This patch is to fix three failed test cases about full screen, request
focus and file chooser.
This issue was caused by CL:https://codereview.chromium.org/518633002/
Fix it by loading javascript url, it will fake UserGestureIndicator from
WebLocalFrameImpl.

BUG=XWALK-2755
