### PR TITLE
fixed the second issue in xwalk10 with authentication of CDT socket opened by XDK APX

### DIFF
--- a/runtime/browser/android/xwalk_dev_tools_server.h
+++ b/runtime/browser/android/xwalk_dev_tools_server.h
@@ -32,10 +32,10 @@ class XWalkDevToolsServer {
 
   void AllowConnectionFromUid(uid_t uid);
 
- private:
   bool CanUserConnectToDevTools(
     const net::UnixDomainServerSocket::Credentials& credentials);
 
+ private:
   std::string socket_name_;
   content::DevToolsHttpHandler* protocol_handler_;
   uid_t allowed_uid_;


### PR DESCRIPTION
The first issue was fixed in the class XWalkDevToolsServer a week ago and was enough for xwalk9, but not enough for xwalk10

In addition to the 1st fix there are two more places in this file where content::CanUserConnectToDevTools is registered instead of XWalkDevToolsServer::CanUserConnectToDevTools. For XDK it's enough to fix the registration of callback in the UnixDomainServerSocketFactory class.
