### PR TITLE
[Tizen] Move application binary path from .config to  TZ_USER_APP / TZ_SYS_RW_APP

### DIFF
--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -12,6 +12,8 @@
 
 #if defined(OS_WIN)
 #include "base/base_paths_win.h"
+#elif defined(OS_TIZEN)
+#include <tzplatform_config.h>
 #elif defined(OS_LINUX)
 #include "base/environment.h"
 #include "base/nix/xdg_util.h"
@@ -65,7 +67,15 @@ base::FilePath GetFrameworkBundlePath() {
 const base::FilePath::CharType kInternalNaClPluginFileName[] =
     FILE_PATH_LITERAL("internal-nacl-plugin");
 
-#if defined(OS_LINUX)
+#if defined(OS_TIZEN)
+base::FilePath GetAppPath() {
+  const char* app_path = getuid() != tzplatform_getuid(TZ_SYS_GLOBALAPP_USER) ?
+                         tzplatform_getenv(TZ_USER_APP) :
+                         tzplatform_getenv(TZ_SYS_RW_APP);
+  return base::FilePath(app_path);
+}
+
+#elif defined(OS_LINUX)
 base::FilePath GetConfigPath() {
   scoped_ptr<base::Environment> env(base::Environment::Create());
   return base::nix::GetXDGDirectory(
@@ -86,7 +96,10 @@ bool GetXWalkDataPath(base::FilePath* path) {
   CHECK(PathService::Get(base::DIR_LOCAL_APP_DATA, &cur));
   cur = cur.Append(xwalk_suffix);
 
-#elif defined(OS_TIZEN) || defined(OS_LINUX)
+#elif defined(OS_TIZEN)
+  cur = GetAppPath().Append(xwalk_suffix);
+
+#elif defined(OS_LINUX)
   cur = GetConfigPath().Append(xwalk_suffix);
 
 #elif defined(OS_MACOSX)


### PR DESCRIPTION
user application binary is now located in TZ_USER_APP instead of /$HOME/.config
global application binary in TZ_SYS_RW_APP instead of /usr/apps/.config

BUG=XWALK-2672

Signed-off-by: Sabera Djelti (sdi2) sabera.djelti@open.eurogiciel.org
