### PR TITLE
[Tizen] Implementation of reinstallation option to support RDS mode in SDK

### DIFF
--- a/application/tools/tizen/xwalk_backend.cc
+++ b/application/tools/tizen/xwalk_backend.cc
@@ -29,7 +29,7 @@ namespace {
 
 char* install_path = NULL;
 char* uninstall_id = NULL;
-char* reinstall_path = NULL;
+char* reinstall_id = NULL;
 char* operation_key = NULL;
 int quiet = 0;
 
@@ -42,8 +42,10 @@ GOptionEntry entries[] = {
     "Uninstall the application with this appid/pkgid", "ID" },
   { "continue", 'c' , 0, G_OPTION_ARG_NONE, &continue_tasks,
     "Continue the previous unfinished tasks.", NULL},
-  { "reinstall", 'r', 0, G_OPTION_ARG_STRING, &reinstall_path,
-    "Reinstall the application with path", "PATH" },
+  { "reinstall", 'r', 0, G_OPTION_ARG_STRING, &reinstall_id,
+    "Reinstall the application with this pkgid "
+    "(This option is ONLY for SDK to support RDS mode"
+    " (Rapid Development Support).", "ID" },
   { "key", 'k', 0, G_OPTION_ARG_STRING, &operation_key,
     "Unique operation key", "KEY" },
   { "quiet", 'q', 0, G_OPTION_ARG_NONE, &quiet,
@@ -110,9 +112,8 @@ int main(int argc, char* argv[]) {
     }
   } else if (uninstall_id) {
     success = installer->Uninstall(uninstall_id);
-  } else if (reinstall_path) {
-    success = installer->Reinstall(
-        base::MakeAbsoluteFilePath(base::FilePath(reinstall_path)));
+  } else if (reinstall_id) {
+    success = installer->Reinstall(reinstall_id);
   }
   return success ? 0 : 1;
 }

--- a/application/tools/tizen/xwalk_package_installer.h
+++ b/application/tools/tizen/xwalk_package_installer.h
@@ -31,7 +31,7 @@ class PackageInstaller {
   bool Install(const base::FilePath& path, std::string* id);
   bool Uninstall(const std::string& id);
   bool Update(const std::string& id, const base::FilePath& path);
-  bool Reinstall(const base::FilePath& path);
+  bool Reinstall(const std::string& pkgid);
 
   void ContinueUnfinishedTasks();
 
@@ -46,7 +46,7 @@ class PackageInstaller {
   bool PlatformInstall(xwalk::application::ApplicationData* data);
   bool PlatformUninstall(const std::string& app_id);
   bool PlatformUpdate(xwalk::application::ApplicationData* updated_data);
-  bool PlatformReinstall(const base::FilePath& path);
+  bool PlatformReinstall(const std::string& pkgid);
 
   xwalk::application::ApplicationStorage* storage_;
   bool quiet_;

--- a/application/tools/tizen/xwalk_platform_installer.cc
+++ b/application/tools/tizen/xwalk_platform_installer.cc
@@ -164,11 +164,11 @@ bool PlatformInstaller::UpdateApplication(const base::FilePath& xmlpath,
   return ret;
 }
 
-bool PlatformInstaller::ReinstallApplication() {
+bool PlatformInstaller::ReinstallApplication(const std::string& pkgid) {
   SendSignal(PKGMGR_START_KEY, PKGMGR_START_REINSTALL);
-  // FIXME not implemented, just send signal abotu failure
-  SendSignal(PKGMGR_END_KEY, ToEndStatus(false));
-  return false;
+  bool ret = ReinstallApplicationInternal(pkgid);
+  SendSignal(PKGMGR_END_KEY, ToEndStatus(ret));
+  return ret;
 }
 
 bool PlatformInstaller::InstallApplicationInternal(
@@ -315,6 +315,15 @@ bool PlatformInstaller::UpdateApplicationInternal(
 
   xml_cleaner.Dismiss();
   icon_cleaner.Dismiss();
+
+  return true;
+}
+
+bool PlatformInstaller::ReinstallApplicationInternal(const std::string& pkgid) {
+  if (pkgid.empty()) {
+    LOG(ERROR) << "Invalid package ID for reinstallation!";
+    return false;
+  }
 
   return true;
 }

--- a/application/tools/tizen/xwalk_platform_installer.h
+++ b/application/tools/tizen/xwalk_platform_installer.h
@@ -23,7 +23,7 @@ class PlatformInstaller {
   bool UninstallApplication();
   bool UpdateApplication(const base::FilePath& xmlpath,
                          const base::FilePath& iconpath);
-  bool ReinstallApplication();
+  bool ReinstallApplication(const std::string& pkgid);
 
  private:
   bool InstallApplicationInternal(const base::FilePath& xmlpath,
@@ -31,6 +31,7 @@ class PlatformInstaller {
   bool UninstallApplicationInternal();
   bool UpdateApplicationInternal(const base::FilePath& xmlpath,
                                  const base::FilePath& iconpath);
+  bool ReinstallApplicationInternal(const std::string& pkgid);
 
   bool SendSignal(const std::string& key, const std::string& value);
 

--- a/application/tools/tizen/xwalk_rds_delta_parser.cc
+++ b/application/tools/tizen/xwalk_rds_delta_parser.cc
@@ -1,0 +1,134 @@
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/tools/tizen/xwalk_rds_delta_parser.h"
+
+#include <list>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/file_util.h"
+#include "base/logging.h"
+#include "base/strings/string_split.h"
+
+namespace {
+
+const char kRDSDeltaFile[] = ".rds_delta";
+const std::string kRDSWidgetPath = "res/wgt/";
+const std::string kKeyAdd = "#add";
+const std::string kKeyDelete = "#delete";
+const std::string kKeyModify = "#modify";
+const base::FilePath kRDSTempDir = base::FilePath("/opt/usr/apps/tmp/");
+const std::list<std::string> key_list = {kKeyDelete, kKeyAdd, kKeyModify};
+
+}  // namespace
+
+RDSDeltaParser::RDSDeltaParser(const base::FilePath& app_path,
+    const std::string& pkgid) : app_dir_(app_path) {
+  rds_dir_ = kRDSTempDir.Append(pkgid);
+}
+
+bool RDSDeltaParser::Parse() {
+  base::FilePath rds_file = rds_dir_.AppendASCII(kRDSDeltaFile);
+
+  if (!base::PathExists(rds_file)) {
+    LOG(ERROR) << "RDS delta file " << rds_file.value()
+               << " does not exists!";
+    return false;
+  }
+
+  std::string file_buffer;
+  if (!base::ReadFileToString(rds_file, &file_buffer)) {
+    LOG(ERROR) << "RDS delta file " << rds_file.value()
+               << " cannot be read!";
+    return false;
+  }
+
+  std::vector<std::string> lines;
+  base::SplitString(file_buffer, '\n', &lines);
+
+  if (lines.empty()) {
+    LOG(ERROR) << "RDS delta file " << rds_file.value() << " is empty!";
+    return false;
+  }
+
+  std::string key;
+  parsed_data_.clear();
+  for (const auto& line : lines) {
+    for (const auto& it : key_list) {
+      if (line == it) {
+        key = line;
+        break;
+      }
+    }
+    if (key == line || line.empty() || line == "\n") {
+      continue;
+    }
+    parsed_data_.insert(std::pair<std::string, std::string>(key,
+        line.substr(kRDSWidgetPath.length())));
+  }
+  return true;
+}
+
+bool RDSDeltaParser::ApplyParsedData() {
+  for (const auto& it : parsed_data_) {
+    if (it.first == kKeyDelete)
+      return DeleteFile(it.second);
+    if (it.first == kKeyAdd)
+      return AddFile(it.second);
+    if (it.first == kKeyModify)
+      return ModifyFile(it.second);
+  }
+  return true;
+}
+
+bool RDSDeltaParser::AddFile(const std::string& file_name) {
+  base::FilePath src_path = rds_dir_.Append(kRDSWidgetPath).Append(file_name);
+
+  if (!base::PathExists(src_path)) {
+    LOG(ERROR) << "File " << src_path.value() << " does not exists!";
+    return false;
+  }
+  base::FilePath dst_file = app_dir_.Append(file_name);
+  if (!base::DirectoryExists(dst_file.DirName()) &&
+      !base::CreateDirectory(dst_file.DirName())) {
+    LOG(ERROR) << "Can't create directory " << dst_file.DirName().value();
+    return false;
+  }
+  if (!base::CopyFile(src_path, dst_file)) {
+    LOG(ERROR) << "Error when adding a file " << src_path.BaseName().value()
+               << " to " << dst_file.DirName().value();
+    return false;
+  }
+  return true;
+}
+
+bool RDSDeltaParser::DeleteFile(const std::string& file_name) {
+  base::FilePath dst_file = app_dir_.Append(file_name);
+
+  if (!base::DeleteFile(dst_file, true)) {
+    LOG(ERROR) << "Error when deleting a file " << dst_file.value();
+    return false;
+  }
+  return true;
+}
+
+bool RDSDeltaParser::ModifyFile(const std::string& file_name) {
+  base::FilePath src_file = rds_dir_.Append(kRDSWidgetPath).Append(file_name);
+
+  if (!base::PathExists(src_file)) {
+    LOG(ERROR) << "File " << src_file.value() << " does not exists!";
+    return false;
+  }
+
+  base::FilePath dst_file = app_dir_.Append(file_name);
+  if (!base::CopyFile(src_file, dst_file)) {
+    LOG(ERROR) << "Error when copying a file " << src_file.value()
+               << " to " << dst_file.DirName().value();
+    return false;
+  }
+  return true;
+}

--- a/application/tools/tizen/xwalk_rds_delta_parser.h
+++ b/application/tools/tizen/xwalk_rds_delta_parser.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_TOOLS_TIZEN_XWALK_RDS_DELTA_PARSER_H_
+#define XWALK_APPLICATION_TOOLS_TIZEN_XWALK_RDS_DELTA_PARSER_H_
+
+#include <map>
+#include <string>
+
+#include "base/files/file_path.h"
+
+class RDSDeltaParser {
+ public:
+  RDSDeltaParser(const base::FilePath& app_path, const std::string& pkgid);
+  bool Parse();
+  bool ApplyParsedData();
+
+ private:
+  base::FilePath app_dir_;
+  base::FilePath rds_dir_;
+  std::multimap<std::string, std::string> parsed_data_;
+
+  bool AddFile(const std::string& file_name);
+  bool DeleteFile(const std::string& file_name);
+  bool ModifyFile(const std::string& file_name);
+};
+
+#endif  // XWALK_APPLICATION_TOOLS_TIZEN_XWALK_RDS_DELTA_PARSER_H_

--- a/application/tools/tizen/xwalk_tizen_tools.gyp
+++ b/application/tools/tizen/xwalk_tizen_tools.gyp
@@ -20,6 +20,8 @@
         'xwalk_packageinfo_constants.h',
         'xwalk_platform_installer.cc',
         'xwalk_platform_installer.h',
+        'xwalk_rds_delta_parser.cc',
+        'xwalk_rds_delta_parser.h',
         'xwalk_tizen_user.cc',
         'xwalk_tizen_user.h',
         # TODO(t.iwanek) fix me - this duplicates compilation of those files


### PR DESCRIPTION
This commit enables a possibility to reinstall a widget by SDK
in RDS mode. In this mode SDK copy only modified files to the device and
also a file named rds_delta which stores what must be changed
in the application directory. The rds_delta file is parsed by RDSDeltaParser
class and then all changes are applied into the application directory.

BUG=XWALK-2687
