### PR TITLE
Stop running gyp_chromium in our sync process.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -76,6 +76,15 @@ solutions = [
       'commit-queue': None,
       'depot_tools': None,
     },
+
+    'custom_hooks': [
+      # Disable Chromium's "gyp" hooks, which runs the gyp_chromium script. We
+      # are not interested in running it as we use gyp_xwalk instead (and it is
+      # run at a later stage as a hook in Crosswalk's own DEPS).
+      {
+        'name': 'gyp',
+      },
+    ],
   },
 
   # ozone-wayland is set as a separate solution because we gclient _not_ to read


### PR DESCRIPTION
Add a custom hook to DEPS.xwalk called "gyp", which is the name of the
hook in Chromium's DEPS that runs the gyp_chromium script.

Calling gyp_chromium is bad for several reasons:
- It is slow and adds several seconds to a "gclient sync" call.
- It is not necessary since we use our own gyp_xwalk script.
- It is actively harmful when one is building Crosswalk for Tizen, since
  it is unconditionally run on the host side. In practice, this means
  several additional Linux dependencies are required even though they
  will not be used in the build.
  This used to be the case for Android as well, but since a few
  milestones ago upstream improved the situation there so that just
  passing OS=android in gyp is enough.

Related to XWALK-81 (it might even completely fix it, but I need to verify).
