### PR TITLE
Re-factor the runtime class.

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -22,6 +22,7 @@
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/security_policy.h"
 #include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/runtime/browser/runtime_ui_strategy.h"
 
 
 namespace content {
@@ -112,13 +113,14 @@ class Application : public Runtime::Observer,
 
   void set_observer(Observer* observer) { observer_ = observer; }
 
-  // FIXME(xinchao): This method will be deprecated soon.
-  ui::WindowShowState window_show_state() const { return window_show_state_; }
-
  protected:
   Application(scoped_refptr<ApplicationData> data, RuntimeContext* context);
   virtual bool Launch(const LaunchParams& launch_params);
   virtual void InitSecurityPolicy();
+
+  // Runtime::Observer implementation.
+  virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE;
+  virtual void OnRuntimeRemoved(Runtime* runtime) OVERRIDE;
 
   // Get the path of splash screen image. Return empty path by default.
   // Sub class can override it to return a specific path.
@@ -132,6 +134,9 @@ class Application : public Runtime::Observer,
   content::WebContents* web_contents_;
   bool security_mode_enabled_;
 
+  scoped_ptr<RuntimeUIStrategy> ui_strategy_;
+  xwalk::NativeAppWindow::CreateParams window_show_params_;
+
   base::WeakPtr<Application> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
   }
@@ -141,9 +146,6 @@ class Application : public Runtime::Observer,
   friend class ApplicationService;
   static scoped_ptr<Application> Create(scoped_refptr<ApplicationData> data,
       RuntimeContext* context);
-  // Runtime::Observer implementation.
-  virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE;
-  virtual void OnRuntimeRemoved(Runtime* runtime) OVERRIDE;
 
   // content::RenderProcessHostObserver implementation.
   virtual void RenderProcessExited(content::RenderProcessHost* host,
@@ -165,8 +167,6 @@ class Application : public Runtime::Observer,
   void NotifyTermination();
 
   Observer* observer_;
-
-  ui::WindowShowState window_show_state_;
 
   std::map<std::string, std::string> name_perm_map_;
   // Application's session permissions.

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -42,11 +42,18 @@ class ApplicationTizen :  // NOLINT
 
   virtual base::FilePath GetSplashScreenPath() OVERRIDE;
 
+  // Runtime::Observer implementation.
+  virtual void OnRuntimeAdded(Runtime* runtime) OVERRIDE;
+  virtual void OnRuntimeRemoved(Runtime* runtime) OVERRIDE;
+
 #if defined(USE_OZONE)
   virtual void WillProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
   virtual void DidProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
 #endif
 
+#if defined(OS_TIZEN_MOBILE)
+  NativeAppWindow* root_window_;
+#endif
   scoped_ptr<CookieManager> cookie_manager_;
   bool is_suspended_;
 };

--- a/extensions/test/external_extension_multi_process.cc
+++ b/extensions/test/external_extension_multi_process.cc
@@ -16,6 +16,21 @@ using xwalk::NativeAppWindow;
 using xwalk::Runtime;
 using xwalk::extensions::XWalkExtensionVector;
 
+namespace {
+Runtime* CreateWithDefaultWindow(
+    xwalk::RuntimeContext* runtime_context, const GURL& url,
+    Runtime::Observer* observer = NULL) {
+  Runtime* runtime = Runtime::Create(runtime_context, observer);
+  runtime->LoadURL(url);
+#if !defined(OS_ANDROID)
+  xwalk::RuntimeUIStrategy ui_strategy;
+  xwalk::NativeAppWindow::CreateParams params;
+  ui_strategy.Show(runtime, params);
+#endif
+  return runtime;
+}
+}  // namespace
+
 class ExternalExtensionMultiProcessTest : public XWalkExtensionsTestBase {
  public:
   ExternalExtensionMultiProcessTest()
@@ -124,7 +139,7 @@ IN_PROC_BROWSER_TEST_F(ExternalExtensionMultiProcessTest,
   WaitForLoadStop(runtime()->web_contents());
   EXPECT_EQ(1, CountRegisterExtensions());
 
-  Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
+  Runtime* new_runtime = CreateWithDefaultWindow(
       GetRuntimeContext(), url, runtime_registry());
   EXPECT_EQ(new_runtime, WaitForSingleNewRuntime());
   EXPECT_NE(runtime(), new_runtime);

--- a/runtime/browser/devtools/xwalk_devtools_browsertest.cc
+++ b/runtime/browser/devtools/xwalk_devtools_browsertest.cc
@@ -16,6 +16,20 @@
 #include "testing/gmock/include/gmock/gmock.h"
 
 using xwalk::Runtime;
+namespace {
+Runtime* CreateWithDefaultWindow(
+    xwalk::RuntimeContext* runtime_context, const GURL& url,
+    Runtime::Observer* observer = NULL) {
+  Runtime* runtime = Runtime::Create(runtime_context, observer);
+  runtime->LoadURL(url);
+#if !defined(OS_ANDROID)
+  xwalk::RuntimeUIStrategy ui_strategy;
+  xwalk::NativeAppWindow::CreateParams params;
+  ui_strategy.Show(runtime, params);
+#endif
+  return runtime;
+}
+}  // namespace
 
 class XWalkDevToolsTest : public InProcessBrowserTest {
  public:
@@ -30,7 +44,7 @@ class XWalkDevToolsTest : public InProcessBrowserTest {
 
 IN_PROC_BROWSER_TEST_F(XWalkDevToolsTest, RemoteDebugging) {
   GURL localhost_url("http://127.0.0.1:9222");
-  Runtime* debugging_host = Runtime::CreateWithDefaultWindow(
+  Runtime* debugging_host = CreateWithDefaultWindow(
       GetRuntimeContext(), localhost_url, runtime_registry());
   content::WaitForLoadStop(debugging_host->web_contents());
   base::string16 real_title = debugging_host->web_contents()->GetTitle();

--- a/runtime/browser/devtools/xwalk_devtools_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.cc
@@ -118,6 +118,21 @@ bool Target::Close() const {
 
 namespace xwalk {
 
+namespace {
+Runtime* CreateWithDefaultWindow(
+    RuntimeContext* runtime_context, const GURL& url,
+    Runtime::Observer* observer = NULL) {
+  Runtime* runtime = Runtime::Create(runtime_context, observer);
+  runtime->LoadURL(url);
+#if !defined(OS_ANDROID)
+  RuntimeUIStrategy ui_strategy;
+  NativeAppWindow::CreateParams params;
+  ui_strategy.Show(runtime, params);
+#endif
+  return runtime;
+}
+}  // namespace
+
 XWalkDevToolsHttpHandlerDelegate::XWalkDevToolsHttpHandlerDelegate() {
 }
 
@@ -163,7 +178,7 @@ std::string XWalkDevToolsDelegate::GetPageThumbnailData(const GURL& url) {
 
 scoped_ptr<content::DevToolsTarget>
 XWalkDevToolsDelegate::CreateNewTarget(const GURL& url) {
-  Runtime* runtime = Runtime::CreateWithDefaultWindow(
+  Runtime* runtime = CreateWithDefaultWindow(
       runtime_context_, GURL(url::kAboutBlankURL));
   return scoped_ptr<content::DevToolsTarget>(
       new Target(DevToolsAgentHost::GetOrCreateFor(runtime->web_contents())));

--- a/runtime/browser/runtime_ui_strategy.cc
+++ b/runtime/browser/runtime_ui_strategy.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/runtime_ui_strategy.h"
+
+#include "base/command_line.h"
+#include "grit/xwalk_resources.h"
+#include "ui/base/resource/resource_bundle.h"
+#include "ui/gfx/image/image.h"
+#include "xwalk/runtime/browser/image_util.h"
+#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
+
+namespace xwalk {
+namespace {
+#if !defined(OS_ANDROID)
+// The default size for web content area size.
+const int kDefaultWidth = 840;
+const int kDefaultHeight = 600;
+
+void ApplyWindowDefaultParams(Runtime* runtime,
+                              NativeAppWindow::CreateParams* params) {
+  if (!params->delegate)
+    params->delegate = runtime;
+  if (!params->web_contents)
+    params->web_contents = runtime->web_contents();
+  if (params->bounds.IsEmpty())
+    params->bounds = gfx::Rect(0, 0, kDefaultWidth, kDefaultHeight);
+
+  unsigned int fullscreen_options = runtime->fullscreen_options();
+  if (params->state == ui::SHOW_STATE_FULLSCREEN)
+    fullscreen_options |= Runtime::FULLSCREEN_FOR_LAUNCH;
+  else
+    fullscreen_options &= ~Runtime::FULLSCREEN_FOR_LAUNCH;
+  runtime->set_fullscreen_options(fullscreen_options);
+}
+#endif
+}  // namespace
+
+RuntimeUIStrategy::RuntimeUIStrategy() {}
+
+RuntimeUIStrategy::~RuntimeUIStrategy() {}
+
+void RuntimeUIStrategy::Show(
+    Runtime* runtime, const NativeAppWindow::CreateParams& params) {
+#if defined(OS_ANDROID)
+  NOTIMPLEMENTED();
+#else
+  NativeAppWindow::CreateParams effective_params(params);
+  ApplyWindowDefaultParams(runtime, &effective_params);
+
+  // Set the app icon if it is passed from command line.
+  CommandLine* command_line = CommandLine::ForCurrentProcess();
+  gfx::Image app_icon;
+  if (command_line->HasSwitch(switches::kAppIcon)) {
+    base::FilePath icon_file =
+        command_line->GetSwitchValuePath(switches::kAppIcon);
+    app_icon = xwalk_utils::LoadImageFromFilePath(icon_file);
+  } else {
+    // Otherwise, use the default icon for Crosswalk app.
+    ui::ResourceBundle& rb = ui::ResourceBundle::GetSharedInstance();
+    app_icon = rb.GetNativeImageNamed(IDR_XWALK_ICON_48);
+  }
+
+  runtime->EnableTitleUpdatedNotification();
+
+  NativeAppWindow* window = NativeAppWindow::Create(effective_params);
+  runtime->set_window(window);
+
+  runtime->set_app_icon(app_icon);
+  window->Show();
+#endif
+}
+}  // namespace xwalk

--- a/runtime/browser/runtime_ui_strategy.h
+++ b/runtime/browser/runtime_ui_strategy.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_RUNTIME_UI_STRATEGY_H_
+#define XWALK_RUNTIME_BROWSER_RUNTIME_UI_STRATEGY_H_
+
+#include "xwalk/runtime/browser/ui/native_app_window.h"
+
+namespace xwalk {
+class Runtime;
+
+class RuntimeUIStrategy {
+ public:
+  RuntimeUIStrategy();
+  virtual ~RuntimeUIStrategy();
+  virtual void Show(Runtime* runtime,
+                    const NativeAppWindow::CreateParams& params);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_RUNTIME_UI_STRATEGY_H_

--- a/runtime/browser/xwalk_runtime_browsertest.cc
+++ b/runtime/browser/xwalk_runtime_browsertest.cc
@@ -12,6 +12,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "xwalk/runtime/browser/image_util.h"
 #include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/runtime/browser/runtime_ui_strategy.h"
 #include "xwalk/runtime/common/xwalk_notification_types.h"
 #include "xwalk/test/base/in_process_browser_test.h"
 #include "xwalk/test/base/xwalk_test_utils.h"
@@ -37,6 +38,21 @@ using xwalk::NativeAppWindow;
 using xwalk::Runtime;
 using content::WebContents;
 using testing::_;
+
+namespace {
+Runtime* CreateWithDefaultWindow(
+    xwalk::RuntimeContext* runtime_context, const GURL& url,
+    Runtime::Observer* observer = NULL) {
+  Runtime* runtime = Runtime::Create(runtime_context, observer);
+  runtime->LoadURL(url);
+#if !defined(OS_ANDROID)
+  xwalk::RuntimeUIStrategy ui_strategy;
+  xwalk::NativeAppWindow::CreateParams params;
+  ui_strategy.Show(runtime, params);
+#endif
+  return runtime;
+}
+}  // namespace
 
 // Observer for NOTIFICATION_FULLSCREEN_CHANGED notifications.
 class FullscreenNotificationObserver
@@ -109,7 +125,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CreateAndCloseRuntime) {
 
   // Create a new Runtime instance.
   GURL url(test_server()->GetURL("test.html"));
-  Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
+  Runtime* new_runtime = CreateWithDefaultWindow(
       GetRuntimeContext(), url, runtime_registry());
   EXPECT_TRUE(url == new_runtime->web_contents()->GetURL());
   EXPECT_EQ(new_runtime, WaitForSingleNewRuntime());
@@ -135,7 +151,7 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LoadURLAndClose) {
 
 IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, CloseNativeWindow) {
   GURL url(test_server()->GetURL("test.html"));
-  Runtime* new_runtime = Runtime::CreateWithDefaultWindow(
+  Runtime* new_runtime = CreateWithDefaultWindow(
       GetRuntimeContext(), url, runtime_registry());
   size_t len = runtimes().size();
   new_runtime->window()->Close();
@@ -151,7 +167,9 @@ IN_PROC_BROWSER_TEST_F(XWalkRuntimeTest, LaunchWithFullscreenWindow) {
 
   NativeAppWindow::CreateParams params;
   params.state = ui::SHOW_STATE_FULLSCREEN;
-  new_runtime->AttachWindow(params);
+  scoped_ptr<xwalk::RuntimeUIStrategy> ui_strategy(
+      new xwalk::RuntimeUIStrategy);
+  ui_strategy->Show(new_runtime, params);
   xwalk_test_utils::NavigateToURL(new_runtime, url);
 
   EXPECT_TRUE(new_runtime->window()->IsFullscreen());

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -50,6 +50,19 @@ base::LazyInstance<XWalkContentRendererClient>::Leaky
         g_xwalk_content_renderer_client = LAZY_INSTANCE_INITIALIZER;
 #endif
 
+Runtime* CreateWithDefaultWindow(
+    xwalk::RuntimeContext* runtime_context, const GURL& url,
+    Runtime::Observer* observer = NULL) {
+  Runtime* runtime = Runtime::Create(runtime_context, observer);
+  runtime->LoadURL(url);
+#if !defined(OS_ANDROID)
+  xwalk::RuntimeUIStrategy ui_strategy;
+  xwalk::NativeAppWindow::CreateParams params;
+  ui_strategy.Show(runtime, params);
+#endif
+  return runtime;
+}
+
 }  // namespace
 
 RuntimeRegistry::RuntimeRegistry() {
@@ -148,7 +161,7 @@ void InProcessBrowserTest::RunTestOnMainThreadLoop() {
   // method, instead they should just create runtimes themselves
   // when needed and thus the 'runtime()' method should be removed
   // as well as 'runtime_' initialization below.
-  runtime_ = Runtime::CreateWithDefaultWindow(
+  runtime_ = CreateWithDefaultWindow(
           GetRuntimeContext(),
           GURL(), runtime_registry_.get());
   content::WaitForLoadStop(runtime_->web_contents());

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -183,6 +183,8 @@
         'runtime/browser/runtime_resource_dispatcher_host_delegate_android.h',
         'runtime/browser/runtime_select_file_policy.cc',
         'runtime/browser/runtime_select_file_policy.h',
+        'runtime/browser/runtime_ui_strategy.cc',
+        'runtime/browser/runtime_ui_strategy.h',
         'runtime/browser/runtime_url_request_context_getter.cc',
         'runtime/browser/runtime_url_request_context_getter.h',
         'runtime/browser/speech/speech_recognition_manager_delegate.cc',


### PR DESCRIPTION
Add RuntimeUIStrategy for creating and showing the runtime window by provided params. This will separate the UI related implementations into the new strategy object.
