### PR TITLE
[Android] Add bridge code for test and get rid of loadJavascriptUrl.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -279,6 +279,10 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         mContentViewCore.evaluateJavaScript(script, coreCallback);
     }
 
+    public void evaluateJavascriptForTests(String script) {
+        mWebContents.evaluateJavaScriptForTests(script);
+    }
+
     public void setUIClient(XWalkUIClientInternal client) {
         mContentsClientBridge.setUIClient(client);
     }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -529,6 +529,17 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     }
 
     /**
+     * Evaluate a fragment of JavaScript code.
+     * @param script the JavaScript string.
+     */
+    @XWalkAPI
+    public void evaluateJavascriptForTests(String script) {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.evaluateJavascriptForTests(script);
+    }
+
+    /**
      * Clear the resource cache. Note that the cache is per-application, so this
      * will clear the cache for all XWalkViews used.
      * @param includeDiskFiles indicate whether to clear disk files for cache.

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
@@ -107,13 +107,13 @@ public class CookieManagerTest extends XWalkViewTestBase {
     }
 
     private void setCookie(final String name, final String value) throws Exception {
-        String jsCommand = "javascript:void((function(){" +
+        String jsCommand = "void((function(){" +
                 "var expirationDate = new Date();" +
                 "expirationDate.setDate(expirationDate.getDate() + 5);" +
                 "document.cookie='" + name + "=" + value +
                         "; expires=' + expirationDate.toUTCString();" +
                 "})())";
-        loadJavaScriptUrl(jsCommand);
+        executeJavaScript(jsCommand);
     }
 
     private void waitForCookie(final String url) throws InterruptedException {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
@@ -118,7 +118,7 @@ public class OnPageFinishedTest extends XWalkViewTestBase {
         assertEquals(0, currentCallCount);
 
         loadDataAsync(null, html, "text/html", false);
-        loadJavaScriptUrl("javascript: try { console.log('foo'); } catch(e) {};");
+        executeJavaScript("try { console.log('foo'); } catch(e) {};");
 
         onPageFinishedHelper.waitForCallback(currentCallCount);
         assertEquals("about:blank", onPageFinishedHelper.getUrl());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldOverrideUrlLoadingTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldOverrideUrlLoadingTest.java
@@ -561,13 +561,13 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     @SmallTest
     @Feature({"XWalkView", "Navigation"})
     public void testDoubleNavigateDoesNotSuppressInitialNavigate() throws Throwable {
-        final String jsUrl = "javascript:try{console.log('processed js loadUrl');}catch(e){};";
+        final String jsUrl = "try{console.log('processed js loadUrl');}catch(e){};";
 
         // Do a double navigagtion, the second being an effective no-op, in quick succession (i.e.
         // without yielding the main thread inbetween).
         loadDataSync(null,
                 CommonResources.makeHtmlPageWithSimpleLinkTo(DATA_URL), "text/html", false);
-        loadJavaScriptUrl(jsUrl);
+        executeJavaScript(jsUrl);
         assertEquals(0, mShouldOverrideUrlLoadingHelper.getCallCount());
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -482,6 +482,15 @@ public class XWalkViewTestBase
         return helper.getJsonResultAndClear();
     }
 
+    protected void executeJavaScript(final String code) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.evaluateJavascriptForTests(code);
+            }
+        });
+    }
+
     protected String getUrlOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -204,14 +204,6 @@ public class XWalkViewTestBase
         });
     }
 
-    protected void loadJavaScriptUrl(final String url) throws Exception {
-        if (!url.startsWith("javascript:")) {
-            Log.w(TAG, "loadJavascriptUrl only accepts javascript: url");
-            return;
-        }
-        loadUrlAsync(url);
-    }
-
     protected void loadUrlSync(final String url) throws Exception {
         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();
@@ -551,7 +543,7 @@ public class XWalkViewTestBase
         }, WAIT_TIMEOUT_MS, CHECK_INTERVAL));
 
         try {
-            loadJavaScriptUrl("javascript:var evObj = document.createEvent('Events'); " +
+            executeJavaScript("var evObj = document.createEvent('Events'); " +
                 "evObj.initEvent('click', true, false); " +
                 script2 +
                 "console.log('element with id [" + id + "] clicked');");

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
@@ -181,14 +181,6 @@ public class XWalkViewInternalTestBase
         });
     }
 
-    protected void loadJavaScriptUrl(final String url) throws Exception {
-        if (!url.startsWith("javascript:")) {
-            Log.w(TAG, "loadJavascriptUrl only accepts javascript: url");
-            return;
-        }
-        loadUrlAsync(url);
-    }
-
     protected void loadUrlSync(final String url) throws Exception {
         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();


### PR DESCRIPTION
1. Add bridge code to evaluate javascript for test.
2. Get rid of loadJavascriptUrl in test project.
This patch should be merged after https://github.com/crosswalk-project/chromium-crosswalk/pull/201.