### PR TITLE
[Tizen][Linux] Support getting thumbnail for devtools.

### DIFF
--- a/runtime/browser/devtools/xwalk_devtools_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.cc
@@ -9,21 +9,25 @@
 #include "base/base64.h"
 #include "base/memory/ref_counted_memory.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/thread_task_runner_handle.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/devtools_http_handler.h"
 #include "content/public/browser/devtools_target.h"
 #include "content/public/browser/favicon_status.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/render_view_host.h"
+#include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/url_constants.h"
 #include "grit/xwalk_resources.h"
 #include "net/socket/tcp_listen_socket.h"
 #include "ui/base/resource/resource_bundle.h"
+#include "ui/snapshot/snapshot.h"
 #include "xwalk/runtime/browser/runtime.h"
 
 using content::DevToolsAgentHost;
 using content::RenderViewHost;
+using content::RenderWidgetHostView;
 using content::WebContents;
 
 namespace {
@@ -144,6 +148,15 @@ std::string XWalkDevToolsHttpHandlerDelegate::GetDiscoveryPageHTML() {
       IDR_DEVTOOLS_FRONTEND_PAGE_HTML).as_string();
 }
 
+void XWalkDevToolsDelegate::ProcessAndSaveThumbnail(
+    const GURL& url,
+    scoped_refptr<base::RefCountedBytes> png) {
+  const std::vector<unsigned char>& png_data = png->data();
+  std::string png_string_data(reinterpret_cast<const char*>(&png_data[0]),
+                              png_data.size());
+  thumbnail_map_[url] = png_string_data;
+}
+
 bool XWalkDevToolsHttpHandlerDelegate::BundlesFrontendResources() {
   return true;
 }
@@ -160,7 +173,8 @@ XWalkDevToolsHttpHandlerDelegate::CreateSocketForTethering(
 }
 
 XWalkDevToolsDelegate::XWalkDevToolsDelegate(RuntimeContext* runtime_context)
-    : runtime_context_(runtime_context) {
+    : runtime_context_(runtime_context),
+      weak_factory_(this) {
 }
 
 XWalkDevToolsDelegate::~XWalkDevToolsDelegate() {
@@ -173,6 +187,28 @@ base::DictionaryValue* XWalkDevToolsDelegate::HandleCommand(
 }
 
 std::string XWalkDevToolsDelegate::GetPageThumbnailData(const GURL& url) {
+  if (thumbnail_map_.find(url) != thumbnail_map_.end())
+    return thumbnail_map_[url];
+  // TODO(YangangHan): Support real time thumbnail.
+  content::DevToolsAgentHost::List agents =
+      content::DevToolsAgentHost::GetOrCreateAll();
+  for (auto& it : agents) {
+    WebContents* web_contents = it.get()->GetWebContents();
+    if (web_contents && web_contents->GetURL() == url) {
+      RenderWidgetHostView* render_widget_host_view =
+          web_contents->GetRenderViewHost()->GetView();
+      gfx::Rect snapshot_bounds(
+        render_widget_host_view->GetViewBounds().size());
+      ui::GrabViewSnapshotAsync(
+        render_widget_host_view->GetNativeView(),
+        snapshot_bounds,
+        base::ThreadTaskRunnerHandle::Get(),
+        base::Bind(&XWalkDevToolsDelegate::ProcessAndSaveThumbnail,
+                   weak_factory_.GetWeakPtr(),
+                   url));
+        break;
+    }
+  }
   return std::string();
 }
 

--- a/runtime/browser/devtools/xwalk_devtools_delegate.h
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.h
@@ -5,11 +5,14 @@
 #ifndef XWALK_RUNTIME_BROWSER_DEVTOOLS_XWALK_DEVTOOLS_DELEGATE_H_
 #define XWALK_RUNTIME_BROWSER_DEVTOOLS_XWALK_DEVTOOLS_DELEGATE_H_
 
+#include <map>
 #include <string>
 #include <vector>
 
 #include "base/basictypes.h"
 #include "base/compiler_specific.h"
+#include "base/memory/ref_counted_memory.h"
+#include "base/memory/weak_ptr.h"
 #include "content/public/browser/devtools_http_handler_delegate.h"
 #include "content/public/browser/devtools_manager_delegate.h"
 #include "url/gurl.h"
@@ -58,9 +61,14 @@ class XWalkDevToolsDelegate : public content::DevToolsManagerDelegate {
       const GURL& url) OVERRIDE;
   virtual void EnumerateTargets(TargetCallback callback) OVERRIDE;
   virtual std::string GetPageThumbnailData(const GURL& url) OVERRIDE;
+  void ProcessAndSaveThumbnail(const GURL& url,
+                               scoped_refptr<base::RefCountedBytes> png);
 
  private:
+  using ThumbnailMap = std::map<GURL, std::string>;
+  ThumbnailMap thumbnail_map_;
   RuntimeContext* runtime_context_;
+  base::WeakPtrFactory<XWalkDevToolsDelegate> weak_factory_;
   DISALLOW_COPY_AND_ASSIGN(XWalkDevToolsDelegate);
 };
 

--- a/runtime/resources/devtools_discovery_page.html
+++ b/runtime/resources/devtools_discovery_page.html
@@ -39,6 +39,7 @@ body {
   border-radius: 5px;
   height: 132px;
   width: 212px;
+  -webkit-background-size: cover;
   -webkit-transition-property: background-color, border-color;
   -webkit-transition: background-color 0.15s, 0.15s;
   -webkit-transition-delay: 0, 0;
@@ -114,6 +115,8 @@ function appendItem(itemObject) {
   var thumbnail = document.createElement('div');
   thumbnail.className = itemObject.devtoolsFrontendUrl ?
                         'thumbnail' : 'thumbnail connected';
+  if (itemObject.thumbnailUrl === undefined)
+    itemObject.thumbnailUrl = "/thumb/" + itemObject.id;
   thumbnail.style.cssText = 'background-image:url(' +
                         itemObject.thumbnailUrl +
                         ')';


### PR DESCRIPTION
 Using "ui::GrabViewSnapshotAsync" to implement interface
"XWalkDevToolsDelegate::GetPageThumbnailData".

BUG=https://crosswalk-project.org/jira/browse/XWALK-2883
