### PR TITLE
 [TIZEN] Add media class property in manifest for audio streams

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '88fc58a654d73e2df3dffc946077486c450f3bdb'
+chromium_crosswalk_rev = '52d4347d95a66afe54be98677b077fce0b7fd846'
 v8_crosswalk_rev = '03d8b6ce957064a8f80e7c6f9555e508d4c00844'
 ozone_wayland_rev = '8f3a1b59dd183087269400208947031cac5fcfcd'
 

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -63,6 +63,7 @@ const char kXWalkLaunchScreenReadyWhen[] =
 #if defined(OS_TIZEN)
 const char kTizenAppIdKey[] = "tizen_app_id";
 const char kIcon128Key[] = "icons.128";
+const char kXWalkMediaAppClass[] = "xwalk_media_app_class";
 #endif
 
 }  // namespace application_manifest_keys

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -56,6 +56,7 @@ namespace application_manifest_keys {
 #if defined(OS_TIZEN)
   extern const char kTizenAppIdKey[];
   extern const char kIcon128Key[];
+  extern const char kXWalkMediaAppClass[];
 #endif
 }  // namespace application_manifest_keys
 

--- a/tizen/browser/media/browser_mediaplayer_manager.cc
+++ b/tizen/browser/media/browser_mediaplayer_manager.cc
@@ -5,6 +5,8 @@
 
 #include "xwalk/tizen/browser/media/browser_mediaplayer_manager.h"
 
+#include "content/browser/renderer_host/media/audio_renderer_host.h"
+#include "content/browser/renderer_host/render_process_host_impl.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "xwalk/tizen/common/media/media_player_messages.h"
@@ -80,10 +82,15 @@ void BrowserMediaPlayerManager::OnInitialize(
     MediaPlayerID player_id,
     int process_id,
     const GURL& url) {
+  scoped_refptr<content::AudioRendererHost> audio_host =
+      static_cast<content::RenderProcessHostImpl*>(
+          render_frame_host_->GetProcess())->audio_renderer_host();
+
   // Create murphy resource for the given player id.
   if (resource_manager_ && resource_manager_->IsConnected()) {
-    MurphyResource* resource = new MurphyResource(this,
-        player_id, resource_manager_);
+    MurphyResource* resource = new MurphyResource(
+        this, player_id, audio_host->app_id(),
+        audio_host->app_class(), resource_manager_);
     RemoveMurphyResource(player_id);
     AddMurphyResource(resource);
   }

--- a/tizen/browser/media/murphy_resource.cc
+++ b/tizen/browser/media/murphy_resource.cc
@@ -8,9 +8,7 @@
 
 namespace {
 
-const char kMediaApplicationClass[] = "player";
 const char kMediaStreamName[] = "audio_playback";
-const char kMediaRole[] = "browser";
 
 static void NotifyCallback(mrp_res_context_t* context,
     const mrp_res_resource_set_t* resource_set,
@@ -32,6 +30,8 @@ namespace tizen {
 MurphyResource::MurphyResource(
     BrowserMediaPlayerManager* manager,
     MediaPlayerID player_id,
+    const std::string& app_id,
+    const std::string& app_class,
     MurphyResourceManager* resource_manager)
     : manager_(manager),
       player_id_(player_id),
@@ -42,17 +42,20 @@ MurphyResource::MurphyResource(
     return;
 
   resource_set_ = mrp_res_create_resource_set(context,
-      kMediaApplicationClass, NotifyCallback, this);
+      app_class.c_str(), NotifyCallback, this);
   if (!resource_set_)
     return;
 
   mrp_res_resource_t* resource = mrp_res_create_resource(
       resource_set_, kMediaStreamName, true, true);
 
-  mrp_res_attribute_t* attr = mrp_res_get_attribute_by_name(
-      resource, "role");
+  mrp_res_attribute_t* attr = mrp_res_get_attribute_by_name(resource, "role");
   if (attr)
-    mrp_res_set_attribute_string(attr, kMediaRole);
+    mrp_res_set_attribute_string(attr, app_class.c_str());
+
+  attr = mrp_res_get_attribute_by_name(resource, "resource.set.appid");
+  if (attr)
+    mrp_res_set_attribute_string(attr, app_id.c_str());
 
   mrp_res_release_resource_set(resource_set_);
 }

--- a/tizen/browser/media/murphy_resource.h
+++ b/tizen/browser/media/murphy_resource.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_TIZEN_BROWSER_MEDIA_MURPHY_RESOURCE_H_
 #define XWALK_TIZEN_BROWSER_MEDIA_MURPHY_RESOURCE_H_
 
+#include <string>
+
 #include "xwalk/tizen/browser/media/murphy_resource_manager.h"
 
 namespace tizen {
@@ -15,6 +17,8 @@ class MurphyResource {
  public:
   MurphyResource(BrowserMediaPlayerManager* manager,
       MediaPlayerID player_id,
+      const std::string& app_id,
+      const std::string& app_calss,
       MurphyResourceManager* resource_manager);
   ~MurphyResource();
 


### PR DESCRIPTION
This change extends the manifest with 'xwalk_media_app_class' property that can be used to tag audio streams in pulseaudio and Murphy, so that the Murphy resource policy daemon can dictate when the audio will be paused and resumed in response to other audio playing.

BUG=XWALK-2788
