### PR TITLE
[Android][Mini] Remove ICU datas for xwalk releases

### DIFF
--- a/build/android/clean_up_icu_data.py
+++ b/build/android/clean_up_icu_data.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+# Copyright 2011 The Chromium Authors. All rights reserved.
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import fnmatch
+import optparse
+import os
+import sys
+
+
+def FindInDirectory(directory, filename_filter):
+  files = []
+  for root, _dirnames, filenames in os.walk(directory):
+    if os.path.abspath(directory) == os.path.abspath(root):
+      continue
+    matched_files = fnmatch.filter(filenames, filename_filter)
+    files.extend((os.path.join(root, f) for f in matched_files))
+  return files
+
+
+def main():
+  parser = optparse.OptionParser()
+  info = ('product dir to clean up icu data files in')
+  parser.add_option('--product-dir', help=info)
+  options, _ = parser.parse_args()
+
+  icu_datas = FindInDirectory(options.product_dir, 'icudtl.dat')
+  for icu_data in icu_datas:
+    os.remove(icu_data)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -24,6 +24,9 @@ def AddGeneratorOptions(option_parser):
   option_parser.add_option('-t', dest='target',
                            help='Product out target directory.',
                            type='string')
+  option_parser.add_option('--no-icu-data', action='store_true',
+                           default=False,
+                           help='Exclude icudtl.dat when specified')
 
 
 def CleanLibraryProject(out_dir):
@@ -89,7 +92,7 @@ def CopyJSBindingFiles(project_source, out_dir):
     shutil.copyfile(source_file, target_file)
 
 
-def CopyBinaries(out_dir):
+def CopyBinaries(out_dir, no_icu_data):
   """cp out/Release/<pak> out/Release/xwalk_core_library/res/raw/<pak>
      cp out/Release/lib.java/<lib> out/Release/xwalk_core_library/libs/<lib>
      cp out/Release/xwalk_core_shell_apk/libs/*
@@ -108,9 +111,10 @@ def CopyBinaries(out_dir):
     os.mkdir(res_value_dir)
 
   paks_to_copy = [
-      'icudtl.dat',
       'xwalk.pak',
   ]
+  if not no_icu_data:
+    paks.append('icudtl.dat')
 
   pak_list_xml = Document()
   resources_node = pak_list_xml.createElement('resources')
@@ -223,8 +227,8 @@ def ReplaceCrunchedImage(project_source, filename, filepath):
           source_file = os.path.abspath(os.path.join(dirname, filename))
           target_file = os.path.join(filepath, filename)
           shutil.copyfile(source_file, target_file)
-          return 
-        
+          return
+
 
 def CopyResources(project_source, out_dir):
   print 'Copying resources...'
@@ -307,7 +311,7 @@ def main(argv):
   CopyProjectFiles(options.source, out_dir)
   # Copy binaries and resuorces.
   CopyResources(options.source, out_dir)
-  CopyBinaries(out_dir)
+  CopyBinaries(out_dir, options.no_icu_data)
   # Copy JS API binding files.
   CopyJSBindingFiles(options.source, out_dir)
   # Post copy library project.

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -31,6 +31,33 @@
         'runtime/app/android/xwalk_jni_registrar.cc',
         'runtime/app/android/xwalk_jni_registrar.h',
       ],
+      'conditions': [
+        ['use_icu_alternatives_on_android==1', {
+          'dependencies': [
+            'cleanup_icu_data',
+          ],
+        }],
+      ],
+    },
+    {
+      'target_name': 'cleanup_icu_data',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'cleanup_icu_data',
+          'message': 'Cleanup icu data files',
+          'inputs': [
+            'build/android/clean_up_icu_data.py',
+          ],
+          'outputs': [
+            '<(PRODUCT_DIR)/cleanup_icu_data/always_run',
+          ],
+          'action': [
+            'python', 'build/android/clean_up_icu_data.py',
+            '--product-dir', '<(PRODUCT_DIR)',
+          ],
+        },
+      ],
     },
     {
       'target_name': 'xwalk_core_strings',

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -221,6 +221,17 @@
         'xwalk_core_library_java_app_part',
         'xwalk_core_library_java_library_part',
       ],
+      'conditions': [
+        ['use_icu_alternatives_on_android==1', {
+          'variables': {
+            'icu_data_param': '--no-icu-data',
+          },
+        }, {
+          'variables': {
+            'icu_data_param': '',
+          },
+        }],
+      ],
       'actions': [
         {
           'action_name': 'generate_xwalk_core_library',
@@ -235,7 +246,8 @@
           'action': [
             'python', '<(DEPTH)/xwalk/build/android/generate_xwalk_core_library.py',
             '-s',  '<(DEPTH)',
-            '-t', '<(PRODUCT_DIR)'
+            '-t', '<(PRODUCT_DIR)',
+            '<(icu_data_param)',
           ],
         },
       ],


### PR DESCRIPTION
Exclude icudtl.dat in packages when gyp flag
use_icu_alternatives_on_android specified.

Do a pre-cleanup for existing icu data files in such
case.
