### PR TITLE
[Android] Stop checking if RegisterNativesImpl() returns >= 0.

### DIFF
--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -219,7 +219,7 @@ static jlong GetOrCreateExtension(JNIEnv* env, jobject obj, jstring name,
 }
 
 bool RegisterXWalkExtensionAndroid(JNIEnv* env) {
-  return RegisterNativesImpl(env) >= 0;
+  return RegisterNativesImpl(env);
 }
 
 }  // namespace extensions

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -404,7 +404,7 @@ static jlong Init(JNIEnv* env, jobject obj, jobject web_contents_delegate,
 }
 
 bool RegisterXWalkContent(JNIEnv* env) {
-  return RegisterNativesImpl(env) >= 0;
+  return RegisterNativesImpl(env);
 }
 
 namespace {

--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -434,7 +434,7 @@ void XWalkContentsClientBridge::OnFilesNotSelected(
 }
 
 bool RegisterXWalkContentsClientBridge(JNIEnv* env) {
-  return RegisterNativesImpl(env) >= 0;
+  return RegisterNativesImpl(env);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/android/xwalk_http_auth_handler.cc
+++ b/runtime/browser/android/xwalk_http_auth_handler.cc
@@ -77,7 +77,7 @@ XWalkHttpAuthHandlerBase* XWalkHttpAuthHandlerBase::Create(
 }
 
 bool RegisterXWalkHttpAuthHandler(JNIEnv* env) {
-  return RegisterNativesImpl(env) >= 0;
+  return RegisterNativesImpl(env);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/android/xwalk_path_helper.cc
+++ b/runtime/browser/android/xwalk_path_helper.cc
@@ -38,7 +38,7 @@ static void SetDirectory(JNIEnv* env, jclass clazz,
 }
 
 bool RegisterXWalkPathHelper(JNIEnv* env) {
-  return RegisterNativesImpl(env) >= 0;
+  return RegisterNativesImpl(env);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -237,7 +237,7 @@ static jstring GetDefaultUserAgent(JNIEnv* env, jclass clazz) {
 }
 
 bool RegisterXWalkSettings(JNIEnv* env) {
-  return RegisterNativesImpl(env) >= 0;
+  return RegisterNativesImpl(env);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/android/xwalk_view_delegate.cc
+++ b/runtime/browser/android/xwalk_view_delegate.cc
@@ -19,7 +19,7 @@ jboolean IsLibraryBuiltForIA(JNIEnv* env, jclass jcaller) {
 }
 
 bool RegisterXWalkViewDelegate(JNIEnv* env) {
-  return RegisterNativesImpl(env) >= 0;
+  return RegisterNativesImpl(env);
 }
 
 }  // namespace xwalk


### PR DESCRIPTION
RegisterNativesImpl() returns a bool, so the comparison was always going
to return true.

Do the reasonable thing and just rely on the function's return value
without comparing it to anything.

(cherry picked from commit 592339ff4b176c524ba916b218bf025a51c03958)
