### PR TITLE
[Android] Allow web socket connection from any uid for debugging

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -698,21 +698,15 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         mContentsClientBridge.onGeolocationPermissionsHidePrompt();
     }
 
-    public void enableRemoteDebugging(int allowedUid) {
+    public void enableRemoteDebugging() {
         // Chrome looks for "devtools_remote" pattern in the name of a unix domain socket
         // to identify a debugging page
         final String socketName = getContext().getApplicationContext().getPackageName() + "_devtools_remote";
         if (mDevToolsServer == null) {
             mDevToolsServer = new XWalkDevToolsServer(socketName);
-            mDevToolsServer.allowConnectionFromUid(allowedUid);
-            mDevToolsServer.setRemoteDebuggingEnabled(true);
+            mDevToolsServer.setRemoteDebuggingEnabled(
+                    true, XWalkDevToolsServer.Security.ALLOW_SOCKET_ACCESS);
         }
-    }
-
-    // Enables remote debugging and returns the URL at which the dev tools server is listening
-    // for commands. Only the current process is allowed to connect to the server.
-    void enableRemoteDebugging() {
-        enableRemoteDebugging(getContext().getApplicationInfo().uid);
     }
 
     void disableRemoteDebugging() {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDevToolsServer.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDevToolsServer.java
@@ -27,6 +27,9 @@ class XWalkDevToolsServer {
         // In addition to default authorization allows access to an app with android permission
         // named chromeAppPackageName + DEBUG_PERMISSION_SUFFIX.
         ALLOW_DEBUG_PERMISSION,
+
+        // Allow other apps to access the web socket url to remote debug.
+        ALLOW_SOCKET_ACCESS,
     }
 
     public XWalkDevToolsServer(String socketName) {
@@ -45,15 +48,13 @@ class XWalkDevToolsServer {
 
     public void setRemoteDebuggingEnabled(boolean enabled, Security security) {
         boolean allowDebugPermission = security == Security.ALLOW_DEBUG_PERMISSION;
-        nativeSetRemoteDebuggingEnabled(mNativeDevToolsServer, enabled, allowDebugPermission);
+        boolean allowSocketAccess = security == Security.ALLOW_SOCKET_ACCESS;
+        nativeSetRemoteDebuggingEnabled(
+                mNativeDevToolsServer, enabled, allowDebugPermission, allowSocketAccess);
     }
 
     public void setRemoteDebuggingEnabled(boolean enabled) {
         setRemoteDebuggingEnabled(enabled, Security.DEFAULT);
-    }
-
-    public void allowConnectionFromUid(int uid) {
-        nativeAllowConnectionFromUid(mNativeDevToolsServer, uid);
     }
 
     public String getSocketName() {
@@ -64,8 +65,7 @@ class XWalkDevToolsServer {
     private native void nativeDestroyRemoteDebugging(long devToolsServer);
     private native boolean nativeIsRemoteDebuggingEnabled(long devToolsServer);
     private native void nativeSetRemoteDebuggingEnabled(
-            long devToolsServer, boolean enabled, boolean allowDebugPermission);
-    private native void nativeAllowConnectionFromUid(long devToolsServer, int uid);
+            long devToolsServer, boolean enabled, boolean allowDebugPermission, boolean allowSocketAccess);
 
     @CalledByNative
     private static boolean checkDebugPermission(Context context, int pid, int uid) {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -826,13 +826,11 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * Enables remote debugging and returns the URL at which the dev tools
      * server is listening for commands.
-     * The allowedUid argument can be used to specify the uid of the process
-     * that is permitted to connect.
      */
-    public void enableRemoteDebugging(int allowedUid) {
+    public void enableRemoteDebugging() {
         if (mContent == null) return;
         checkThreadSafety();
-        mContent.enableRemoteDebugging(allowedUid);
+        mContent.enableRemoteDebugging();
     }
 
     /**
@@ -896,12 +894,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         mActivityStateListener = null;
         mContent.destroy();
         disableRemoteDebugging();
-    }
-
-    // Enables remote debugging and returns the URL at which the dev tools server is listening
-    // for commands. Only the current process is allowed to connect to the server.
-    void enableRemoteDebugging() {
-        enableRemoteDebugging(mContext.getApplicationInfo().uid);
     }
 
     void disableRemoteDebugging() {

--- a/runtime/browser/android/xwalk_dev_tools_server.h
+++ b/runtime/browser/android/xwalk_dev_tools_server.h
@@ -23,7 +23,7 @@ class XWalkDevToolsServer {
   ~XWalkDevToolsServer();
 
   // Opens linux abstract socket to be ready for remote debugging.
-  void Start(bool allow_debug_permission);
+  void Start(bool allow_debug_permission, bool allow_socket_access);
 
   // Closes debugging socket, stops debugging.
   void Stop();
@@ -38,7 +38,8 @@ class XWalkDevToolsServer {
 
   std::string socket_name_;
   content::DevToolsHttpHandler* protocol_handler_;
-  uid_t allowed_uid_;
+  bool allow_debug_permission_;
+  bool allow_socket_access_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkDevToolsServer);
 };


### PR DESCRIPTION
There is already a switch for remote debugging.
And allow uid to access is very unintuitive since:
1. uid for Android app is determined at install time, so it must be
   a dynamical setting for the allow uid.
2. There can't be "secure" rule for xwalk core to decide which
   uid to allow. So basically we need to allow any uid who requires
   if we still be using such mechanism for authentication.
So just directly allow web socket connection from any uid if
remote debugging is turned on.
