### PR TITLE
[Tizen] Parsing of app-control entry in widget manifest

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -150,6 +150,13 @@ const char kTizenAppWidgetBoxContentDropViewKey[] = "pd";
 const char kTizenAppWidgetBoxContentDropViewSrcKey[] = "@src";
 const char kTizenAppWidgetBoxContentDropViewWidthKey[] = "@width";
 const char kTizenAppWidgetBoxContentDropViewHeightKey[] = "@height";
+// App control
+const char kTizenApplicationAppControlsKey[] = "widget.app-control";
+const char kTizenApplicationAppControlSrcKey[] = "src";
+const char kTizenApplicationAppControlOperationKey[] = "operation";
+const char kTizenApplicationAppControlUriKey[] = "uri";
+const char kTizenApplicationAppControlMimeKey[] = "mime";
+const char kTizenApplicationAppControlChildNameAttrKey[] = "@name";
 #endif
 
 }  // namespace application_widget_keys

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -131,6 +131,12 @@ namespace application_widget_keys {
   extern const char kTizenAppWidgetBoxContentDropViewSrcKey[];
   extern const char kTizenAppWidgetBoxContentDropViewWidthKey[];
   extern const char kTizenAppWidgetBoxContentDropViewHeightKey[];
+  extern const char kTizenApplicationAppControlsKey[];
+  extern const char kTizenApplicationAppControlSrcKey[];
+  extern const char kTizenApplicationAppControlOperationKey[];
+  extern const char kTizenApplicationAppControlUriKey[];
+  extern const char kTizenApplicationAppControlMimeKey[];
+  extern const char kTizenApplicationAppControlChildNameAttrKey[];
 #endif
 }  // namespace application_widget_keys
 

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -9,6 +9,7 @@
 #include "base/stl_util.h"
 #include "xwalk/application/common/manifest_handlers/csp_handler.h"
 #if defined(OS_TIZEN)
+#include "xwalk/application/common/manifest_handlers/tizen_app_control_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_application_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_appwidget_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_metadata_handler.h"
@@ -77,6 +78,7 @@ ManifestHandlerRegistry::GetInstanceForWGT() {
   handlers.push_back(new WARPHandler);
 #if defined(OS_TIZEN)
   handlers.push_back(new CSPHandler(Manifest::TYPE_WIDGET));
+  handlers.push_back(new TizenAppControlHandler);
   handlers.push_back(new TizenApplicationHandler);
   handlers.push_back(new TizenAppWidgetHandler);
   handlers.push_back(new TizenMetaDataHandler);

--- a/application/common/manifest_handlers/tizen_app_control_handler.cc
+++ b/application/common/manifest_handlers/tizen_app_control_handler.cc
@@ -1,0 +1,151 @@
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/manifest_handlers/tizen_app_control_handler.h"
+
+#include "base/memory/scoped_ptr.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/third_party/xdg_mime/xdgmime.h"
+#include "base/values.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_widget_keys;
+
+namespace application {
+
+namespace {
+
+void ParseAppControlEntryAndStore(const base::DictionaryValue& control_dict,
+    AppControlInfoList* aplist) {
+  std::string src;
+  const base::DictionaryValue* src_dict;
+  if (control_dict.GetDictionary(keys::kTizenApplicationAppControlSrcKey,
+      &src_dict)) {
+    src_dict->GetString(
+        keys::kTizenApplicationAppControlChildNameAttrKey, &src);
+  }
+
+  std::string operation;
+  const base::DictionaryValue* operation_dict;
+  if (control_dict.GetDictionary(
+      keys::kTizenApplicationAppControlOperationKey,
+      &operation_dict)) {
+    operation_dict->GetString(
+        keys::kTizenApplicationAppControlChildNameAttrKey, &operation);
+  }
+
+  std::string uri;
+  const base::DictionaryValue* uri_dict;
+  if (control_dict.GetDictionary(keys::kTizenApplicationAppControlUriKey,
+      &uri_dict)) {
+    uri_dict->GetString(
+        keys::kTizenApplicationAppControlChildNameAttrKey, &uri);
+  }
+
+  std::string mime;
+  const base::DictionaryValue* mime_dict;
+  if (control_dict.GetDictionary(keys::kTizenApplicationAppControlMimeKey,
+      &mime_dict)) {
+    mime_dict->GetString(
+        keys::kTizenApplicationAppControlChildNameAttrKey, &mime);
+  }
+
+  aplist->controls.emplace_back(src, operation, uri, mime);
+}
+
+}  // namespace
+
+TizenAppControlHandler::TizenAppControlHandler() {
+}
+
+TizenAppControlHandler::~TizenAppControlHandler() {
+}
+
+bool TizenAppControlHandler::Parse(scoped_refptr<ApplicationData> application,
+    base::string16* error) {
+  const Manifest* manifest = application->GetManifest();
+  scoped_ptr<AppControlInfoList> aplist(new AppControlInfoList());
+  base::Value* value;
+  manifest->Get(keys::kTizenApplicationAppControlsKey, &value);
+
+  if (value->GetType() == base::Value::TYPE_LIST) {
+    // multiple entries
+    const base::ListValue* list;
+    value->GetAsList(&list);
+    for (const auto& item : *list) {
+      const base::DictionaryValue* control_dict;
+      if (!item->GetAsDictionary(&control_dict)) {
+        *error = base::ASCIIToUTF16("Parsing app-control element failed");
+        return false;
+      }
+
+      ParseAppControlEntryAndStore(*control_dict, aplist.get());
+    }
+  } else if (value->GetType() == base::Value::TYPE_DICTIONARY) {
+    // single entry
+    const base::DictionaryValue* dict;
+    value->GetAsDictionary(&dict);
+    ParseAppControlEntryAndStore(*dict, aplist.get());
+  } else {
+    *error = base::ASCIIToUTF16("Cannot parsing app-control element");
+    return false;
+  }
+
+  application->SetManifestData(
+      keys::kTizenApplicationAppControlsKey,
+      aplist.release());
+  return true;
+}
+
+bool TizenAppControlHandler::Validate(
+    scoped_refptr<const ApplicationData> application,
+    std::string* error) const {
+  const AppControlInfoList* app_controls =
+      static_cast<const AppControlInfoList*>(
+          application->GetManifestData(keys::kTizenApplicationAppControlsKey));
+
+  for (const auto& item : app_controls->controls) {
+    if (item.src().empty()) {
+      *error = "The src child element of app-control element is obligatory";
+      return false;
+    }
+
+    const std::string& operation = item.operation();
+    if (operation.empty()) {
+      *error =
+          "The operation child element of app-control element is obligatory";
+      return false;
+    }
+    if (GURL(operation).spec().empty()) {
+      *error =
+          "The operation child element of app-control element is not valid url";
+      return false;
+    }
+
+    const std::string& uri = item.uri();
+    if (!uri.empty() && GURL(uri).spec().empty()) {
+      *error =
+          "The url child element of app-control element is not valid url";
+      return false;
+    }
+
+    const std::string& mime = item.mime();
+    if (!mime.empty() && !xdg_mime_is_valid_mime_type(mime.c_str())) {
+      *error =
+          "The mime child element of app-control "
+          "element is not valid mime type";
+      return false;
+    }
+  }
+  return true;
+}
+
+std::vector<std::string> TizenAppControlHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kTizenApplicationAppControlsKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/tizen_app_control_handler.h
+++ b/application/common/manifest_handlers/tizen_app_control_handler.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_APP_CONTROL_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_APP_CONTROL_HANDLER_H_
+
+#include <string>
+#include <vector>
+
+#include "base/macros.h"
+#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest_handler.h"
+
+namespace xwalk {
+namespace application {
+
+class AppControlInfo {
+ public:
+  AppControlInfo(const std::string& src, const std::string& operation,
+      const std::string& uri, const std::string& mime)
+      : src_(src),
+        operation_(operation),
+        uri_(uri),
+        mime_(mime) { }
+  const std::string& src() const {
+    return src_;
+  }
+  const std::string& operation() const {
+    return operation_;
+  }
+  const std::string& uri() const {
+    return uri_;
+  }
+  const std::string& mime() const {
+    return mime_;
+  }
+
+ private:
+  std::string src_;
+  std::string operation_;
+  std::string uri_;
+  std::string mime_;
+};
+
+struct AppControlInfoList : public ApplicationData::ManifestData {
+  std::vector<AppControlInfo> controls;
+};
+
+class TizenAppControlHandler : public ManifestHandler {
+ public:
+  TizenAppControlHandler();
+  virtual ~TizenAppControlHandler();
+  bool Parse(scoped_refptr<ApplicationData> application,
+      base::string16* error) override;
+  bool Validate(scoped_refptr<const ApplicationData> application,
+      std::string* error) const override;
+  std::vector<std::string> Keys() const override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(TizenAppControlHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_TIZEN_APP_CONTROL_HANDLER_H_

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -6,6 +6,7 @@
       'dependencies': [
         '../../../base/base.gyp:base',
         '../../../base/base.gyp:base_i18n',
+        '../../../base/base.gyp:xdg_mime',
         '../../../content/content.gyp:content_common',
         '../../../crypto/crypto.gyp:crypto',
         '../../../net/net.gyp:net',
@@ -68,6 +69,8 @@
             ],
           },
           'sources': [
+            'manifest_handlers/tizen_app_control_handler.cc',
+            'manifest_handlers/tizen_app_control_handler.h',
             'manifest_handlers/tizen_application_handler.cc',
             'manifest_handlers/tizen_application_handler.h',
             'manifest_handlers/tizen_appwidget_handler.cc',

--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -28,6 +28,7 @@
 #include "xwalk/application/common/application_file_util.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/id_util.h"
+#include "xwalk/application/common/manifest_handlers/tizen_app_control_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_application_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_metadata_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
@@ -135,6 +136,39 @@ bool GeneratePkgInfoXml(xwalk::application::ApplicationData* application,
   xml_writer.AddAttribute("exec", execute_path.MaybeAsASCII());
   xml_writer.AddAttribute("type", "webapp");
   xml_writer.AddAttribute("taskmanage", "true");
+
+  const xwalk::application::AppControlInfoList* aplist =
+      static_cast<const xwalk::application::AppControlInfoList*>(
+          application->GetManifestData(
+              widget_keys::kTizenApplicationAppControlsKey));
+  if (aplist) {
+    for (const auto& item : aplist->controls) {
+      xml_writer.StartElement("app-control");
+
+      xml_writer.StartElement("operation");
+      xml_writer.AddAttribute("name", item.operation());
+      xml_writer.EndElement();
+
+      xml_writer.StartElement("uri");
+      if (!item.uri().empty()) {
+        xml_writer.AddAttribute("name", item.uri());
+      } else {
+        xml_writer.AddAttribute("name", "*/*");
+      }
+      xml_writer.EndElement();
+
+      xml_writer.StartElement("mime");
+      if (!item.mime().empty()) {
+        xml_writer.AddAttribute("name", item.mime());
+      } else {
+        xml_writer.AddAttribute("name", "*/*");
+      }
+      xml_writer.EndElement();
+
+      xml_writer.EndElement();
+    }
+  }
+
   xml_writer.WriteElement("label", application->Name());
 
   xwalk::application::TizenMetaDataInfo* info =


### PR DESCRIPTION
In xml manifest, we have following structure of app-control entry:

``` xml
 <tizen:app-control>
    <tizen:src name="edit.html"/>
    <tizen:operation name="http://tizen.org/appcontrol/operation/edit"/>
    <tizen:mime name="image/jpg" />
    <tizen:uri name=""/>
 </tizen:app-control>
```

Information about app-control should be passed to platform's manifest.xml
during installation of widget.

This information enables launching applications based on app control as
handler for given URI or MIME type.

Refers to feature: XWALK-1490 [Installer part]
This is first of 3 commits (or more).
