### PR TITLE
[Runtime]  Make sure that the default url request getter has been initialized

### DIFF
--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -258,6 +258,12 @@ net::URLRequestContextGetter*
 
   context_getters_.insert(
       std::make_pair(partition_path.value(), context_getter));
+  // Make sure that the default url request getter has been initialized,
+  // please refer to https://crosswalk-project.org/jira/browse/XWALK-2890
+  // for more details.
+  if (!url_request_getter_.get())
+    CreateRequestContext(protocol_handlers, request_interceptors.Pass());
+
   return context_getter.get();
 #endif
 }


### PR DESCRIPTION
When launch a web application, if the default url request getter does not been
initialized, the runtime will crash, this patch will fix this bug.

BUG=XWALK-2890
