### PR TITLE
[Tizen][Runtime] Fix can not open blocked http/https pages in external web browser

### DIFF
--- a/runtime/browser/runtime_platform_util_tizen.cc
+++ b/runtime/browser/runtime_platform_util_tizen.cc
@@ -102,13 +102,10 @@ bool HandleExternalProtocol(const GURL& url) {
       return CallDbusService(info, url);
     }
   }
-  return true;
+  return false;
 }
 
 void OpenExternal(const GURL& url) {
-  if (HandleExternalProtocol(url))
-    return;
-
   if (url.SchemeIsHTTPOrHTTPS()) {
     LOG(INFO) << "Open in WebBrowser.";
     std::vector<std::string> argv;
@@ -121,6 +118,8 @@ void OpenExternal(const GURL& url) {
 
     if (base::LaunchProcess(argv, base::LaunchOptions(), &handle))
       base::EnsureProcessGetsReaped(handle);
+  } else if (!HandleExternalProtocol(url)) {
+    LOG(ERROR) << "Can not handle url: " << url.spec();
   }
 }
 


### PR DESCRIPTION
There's a bug in the logic of open external url, all http/https pages will not
be opend in external web browser. This patch will fix it.

BUG=XWALK-1605
