### PR TITLE
[Tizen] Enable background-support attribute in settings element.

### DIFF
--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -209,8 +209,16 @@ base::FilePath ApplicationTizen::GetSplashScreenPath() {
   return base::FilePath();
 }
 
+bool ApplicationTizen::CanBeSuspended() const {
+  if (TizenSettingInfo* setting = static_cast<TizenSettingInfo*>(
+          data()->GetManifestData(widget_keys::kTizenSettingKey))) {
+    return !setting->background_support_enabled();
+  }
+  return true;
+}
+
 void ApplicationTizen::Suspend() {
-  if (is_suspended_)
+  if (is_suspended_ || !CanBeSuspended())
     return;
 
   DCHECK(render_process_host_);
@@ -226,7 +234,7 @@ void ApplicationTizen::Suspend() {
 }
 
 void ApplicationTizen::Resume() {
-  if (!is_suspended_)
+  if (!is_suspended_ || !CanBeSuspended())
     return;
 
   DCHECK(render_process_host_);

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -50,6 +50,7 @@ class ApplicationTizen :  // NOLINT
   virtual void WillProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
   virtual void DidProcessEvent(const ui::PlatformEvent& event) OVERRIDE;
 #endif
+  bool CanBeSuspended() const;
 
 #if defined(OS_TIZEN_MOBILE)
   NativeAppWindow* root_window_;

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -115,6 +115,7 @@ const char kAllowNavigationKey[] = "widget.allow-navigation.#text";
 const char kCSPReportOnlyKey[] =
     "widget.content-security-policy-report-only.#text";
 const char kTizenSettingKey[] = "widget.setting";
+const char kTizenBackgroundSupportKey[] = "widget.setting.@background-support";
 const char kTizenContextMenuKey[] = "widget.setting.@context-menu";
 const char kTizenHardwareKey[] = "widget.setting.@hwkey-event";
 const char kTizenEncryptionKey[] = "widget.setting.@encryption";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -97,6 +97,7 @@ namespace application_widget_keys {
   extern const char kAllowNavigationKey[];
   extern const char kCSPReportOnlyKey[];
   extern const char kTizenSettingKey[];
+  extern const char kTizenBackgroundSupportKey[];
   extern const char kTizenContextMenuKey[];
   extern const char kTizenHardwareKey[];
   extern const char kTizenEncryptionKey[];

--- a/application/common/manifest_handlers/tizen_setting_handler.cc
+++ b/application/common/manifest_handlers/tizen_setting_handler.cc
@@ -19,7 +19,8 @@ namespace application {
 
 TizenSettingInfo::TizenSettingInfo()
     : hwkey_enabled_(true),
-      screen_orientation_(PORTRAIT) {}
+      screen_orientation_(PORTRAIT),
+      background_support_enabled_(false) {}
 
 TizenSettingInfo::~TizenSettingInfo() {}
 
@@ -52,6 +53,10 @@ bool TizenSettingHandler::Parse(scoped_refptr<ApplicationData> application,
   std::string context_menu;
   manifest->GetString(keys::kTizenContextMenuKey, &context_menu);
   app_info->set_context_menu_enabled(context_menu != "disable");
+
+  std::string background_support;
+  manifest->GetString(keys::kTizenBackgroundSupportKey, &background_support);
+  app_info->set_background_support_enabled(background_support == "enable");
 
   application->SetManifestData(keys::kTizenSettingKey,
                                app_info.release());
@@ -97,6 +102,15 @@ bool TizenSettingHandler::Validate(
     *error = std::string("The context-menu value must be 'enable'/'disable', "
                          "or not specified in configuration file.");
     return false;
+  }
+  std::string background_support;
+  manifest->GetString(keys::kTizenBackgroundSupportKey, &background_support);
+  if (!background_support.empty() &&
+      background_support != "enable" &&
+      background_support != "disable") {
+    *error = std::string("The background-support value must be"
+                         "'enable'/'disable', or not specified in configuration"
+                         "file.");
   }
   return true;
 }

--- a/application/common/manifest_handlers/tizen_setting_handler.h
+++ b/application/common/manifest_handlers/tizen_setting_handler.h
@@ -43,11 +43,19 @@ class TizenSettingInfo : public ApplicationData::ManifestData {
   }
   bool context_menu_enabled() const { return context_menu_enabled_; }
 
+  void set_background_support_enabled(bool enabled) {
+    background_support_enabled_ = enabled;
+  }
+  bool background_support_enabled() const {
+    return background_support_enabled_;
+  }
+
  private:
   bool hwkey_enabled_;
   ScreenOrientation screen_orientation_;
   bool encryption_enabled_;
   bool context_menu_enabled_;
+  bool background_support_enabled_;
 };
 
 class TizenSettingHandler : public ManifestHandler {


### PR DESCRIPTION
When "background-support" is enabled in config.xml application will not suspend when goes background.
- enable: Web Application's execution MUST NOT be suspended when it is put into background
- disable: Web Application's execution MUST be suspended when it is put into
  background

BUG=XWALK-1148
