### PR TITLE
[Android] Fixed error that file not found in CrosswalkSample

### DIFF
--- a/runtime/android/sample/src/org/xwalk/core/sample/OnCreateWindowRequestedActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/OnCreateWindowRequestedActivity.java
@@ -34,7 +34,7 @@ public class OnCreateWindowRequestedActivity extends XWalkBaseActivity {
         mParent.addView(mXWalkView);
         mXWalkViewHistory.add(mXWalkView);
 
-        mXWalkView.load("file:///android_asset/create_window_by_script.html", null);
+        mXWalkView.load("file:///android_asset/create_window_1.html", null);
     }
 
     private void setClient(XWalkView view) {


### PR DESCRIPTION
The url of initial page in sample of onCreateWindowRequested is the
old one which already not present in the assets folder.
