### PR TITLE
[Android] Unexpected crash when run/debug xwalkdriver unit tests

### DIFF
--- a/runtime/browser/devtools/xwalk_devtools_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.cc
@@ -98,7 +98,7 @@ GURL Target::GetFaviconDataURL(WebContents* web_contents) const {
   // Convert icon image to "data:" url.
   xwalk::Runtime* runtime =
       static_cast<xwalk::Runtime*>(web_contents->GetDelegate());
-  if (!runtime)
+  if (!runtime || runtime->app_icon().IsEmpty())
     return GURL();
   scoped_refptr<base::RefCountedMemory> icon_bytes =
       runtime->app_icon().Copy1xPNGBytes();


### PR DESCRIPTION
Add code to check the conditions of empty App icon. Since the runtime::app_icon() will
return an empty icon for Android non-host-application (the favicon is indexed by manifest.json rather than <link> in web page).

BUG=https://crosswalk-project.org/jira/browse/XWALK-2914
