### PR TITLE
gyp: Add dependency on snapshot.gyp:snapshot after 8bc6219.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -54,6 +54,7 @@
         '../ui/base/ui_base.gyp:ui_base',
         '../ui/gl/gl.gyp:gl',
         '../ui/shell_dialogs/shell_dialogs.gyp:shell_dialogs',
+        '../ui/snapshot/snapshot.gyp:snapshot',
         '../url/url.gyp:url_lib',
         '../v8/tools/gyp/v8.gyp:v8',
         'generate_upstream_blink_version',


### PR DESCRIPTION
Commit 8bc6219 ("[Tizen][Linux] Support getting thumbnail for devtools")
adds a call to ui::GrabViewSnapshotAsync but did not add a dependency on
the ui gyp target that contains the implementation of that function.

This broke the build of xwalk_browsertest on Linux when building with
component=shared_library:

  obj/xwalk/libxwalk_runtime.a(obj/xwalk/runtime/browser/devtools/xwalk_runtime.xwalk_devtools_delegate.o):xwalk_devtools_delegate.cc:function xwalk::XWalkDevToolsDelegate::GetPageThumbnailData(GURL const&):
  error: undefined reference to 'ui::GrabViewSnapshotAsync(aura::Window*, gfx::Rect const&, scoped_refptrbase::TaskRunner, base::Callback<void (scoped_refptr<base::RefCountedBytes>)> const&)'

Fix it by adding the missing dependency.
