### PR TITLE
gyp: Remove dependency on the views_test_support target.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -385,10 +385,10 @@
         }],  # use_custom_freetype==1
         ['toolkit_views==1', {
           'dependencies': [
+            '../ui/events/events.gyp:events',
             '../ui/strings/ui_strings.gyp:ui_strings',
             '../ui/views/controls/webview/webview.gyp:webview',
             '../ui/views/views.gyp:views',
-            '../ui/views/views.gyp:views_test_support',
             '../ui/resources/ui_resources.gyp:ui_resources',
           ],
         }],  # toolkit_views==1


### PR DESCRIPTION
This target brings in many additional dependencies on small static
libraries and should be used only by tests, as the name says. Instead,
depend on the event target, since we just need some symbols from it to
get the xwalk binary to link.

Related to: XWALK-2571
