### PR TITLE
gyp: Stop using Chromium's bundled freetype2.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -4,11 +4,6 @@
     'xwalk_version': '<!(python ../build/util/version.py -f VERSION -t "@MAJOR@.@MINOR@.@BUILD@.@PATCH@")',
     'chrome_version': '<!(python ../build/util/version.py -f ../chrome/VERSION -t "@MAJOR@.@MINOR@.@BUILD@.@PATCH@")',
     'conditions': [
-      ['OS=="linux"', {
-       'use_custom_freetype%': 1,
-      }, {
-       'use_custom_freetype%': 0,
-      }],
       ['OS=="win" or OS=="mac"', {
         'disable_nacl': 1,
       }],
@@ -378,11 +373,6 @@
             '../base/allocator/allocator.gyp:allocator',
           ],
         }],  # os_posix==1 and OS != "mac" and use_allocator=="tcmalloc"
-        ['use_custom_freetype==1', {
-          'dependencies': [
-             '../third_party/freetype2/freetype2.gyp:freetype2',
-          ],
-        }],  # use_custom_freetype==1
         ['toolkit_views==1', {
           'dependencies': [
             '../ui/strings/ui_strings.gyp:ui_strings',


### PR DESCRIPTION
Remove the |use_custom_freetype| variable from xwalk.gyp and use the
system's Freetype instead.

The use_custom_freetype code came in from content_shell's gyp code when
we started the project. It is only used there for DumpRenderTree,
requires additional code to be built and is not used by the Chromium
browser at all.

Related to: XWALK-1985
Related to: XWALK-2571
