### PR TITLE
[Tizen][Desktop] Show the minimize button in the titlebar

### DIFF
--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -231,6 +231,10 @@ bool NativeAppWindowViews::CanMaximize() const {
   return resizable_ && maximum_size_.IsEmpty();
 }
 
+bool NativeAppWindowViews::CanMinimize() const {
+  return true;
+}
+
 #if defined(OS_WIN)
 views::NonClientFrameView* NativeAppWindowViews::CreateNonClientFrameView(
     views::Widget* widget) {

--- a/runtime/browser/ui/native_app_window_views.h
+++ b/runtime/browser/ui/native_app_window_views.h
@@ -78,6 +78,7 @@ class NativeAppWindowViews : public NativeAppWindow,
       gfx::Rect* bounds, ui::WindowShowState* show_state) const OVERRIDE;
   virtual bool CanResize() const OVERRIDE;
   virtual bool CanMaximize() const OVERRIDE;
+  virtual bool CanMinimize() const OVERRIDE;
 #if defined(OS_WIN)
   virtual views::NonClientFrameView* CreateNonClientFrameView(
       views::Widget* widget) OVERRIDE;


### PR DESCRIPTION
Newest implementations of Views are expecting an
implementation of the "CanMinimize()" function in the
delegate Window class ; otherwise, the "minimize" button
will not be shown in the titlebar.
