### PR TITLE
ApplicationFileUtil: Stop leaking |prev_value|.

### DIFF
--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -293,8 +293,7 @@ base::DictionaryValue* LoadXMLNode(
       DCHECK(temp->IsType(base::Value::TYPE_DICTIONARY));
       base::DictionaryValue* dict;
       temp->GetAsDictionary(&dict);
-      base::DictionaryValue* prev_value(new base::DictionaryValue());
-      prev_value = dict->DeepCopy();
+      base::DictionaryValue* prev_value = dict->DeepCopy();
 
       base::ListValue* list = new base::ListValue();
       list->Append(prev_value);


### PR DESCRIPTION
Stop allocating memory for a base::DictionaryValue() that is immediately
going to be overwritten, as the initial value then leaks.

CID=194508
CID=194777
Related to: XWALK-2928
