### PR TITLE
[Android] Remove XWalkRenderViewExt::capture_picture_enabled_.

### DIFF
--- a/runtime/renderer/android/xwalk_render_view_ext.h
+++ b/runtime/renderer/android/xwalk_render_view_ext.h
@@ -52,8 +52,6 @@ class XWalkRenderViewExt : public content::RenderViewObserver {
 
   void OnSetBackgroundColor(SkColor c);
 
-  bool capture_picture_enabled_;
-
   float page_scale_factor_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRenderViewExt);


### PR DESCRIPTION
This variable was never used anywhere ever since it was introduced, and
was not being initialized in the constructor.

CID=194717
Related to: XWALK-2928
