### PR TITLE
[SysApps] raw_socket: Initialize |write_buffer_size_|.

### DIFF
--- a/sysapps/raw_socket/udp_socket_object.cc
+++ b/sysapps/raw_socket/udp_socket_object.cc
@@ -28,6 +28,7 @@ UDPSocketObject::UDPSocketObject()
       is_reading_(false),
       read_buffer_(new net::IOBuffer(kBufferSize)),
       write_buffer_(new net::IOBuffer(kBufferSize)),
+      write_buffer_size_(0),
       resolver_(net::HostResolver::CreateDefaultResolver(NULL)),
       single_resolver_(new net::SingleRequestHostResolver(resolver_.get())) {
   handler_.Register("init",


### PR DESCRIPTION
The member variable was not being initialized in the constructor, so in
the worst case UDPSocketObject::OnSend() could be called with a bogus
value there.

CID=194757
Related to: XWALK-2928
