### PR TITLE
[Tizen] Remove method set_path from ApplicationData class

### DIFF
--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -93,9 +93,6 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   // Accessors:
   const base::FilePath& path() const { return path_; }
-#if defined(OS_TIZEN)  // FIXME : This method should be removed.
-  void set_path(const base::FilePath& path) { path_ = path; }
-#endif
   const GURL& URL() const { return application_url_; }
   SourceType source_type() const { return source_type_; }
   Manifest::Type manifest_type() const { return manifest_->type(); }

--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -362,9 +362,22 @@ bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
     unpacked_dir = path;
   }
 
+  base::FilePath app_dir = data_dir.AppendASCII(app_id);
+  base::FilePath manifest_path =
+      xwalk::application::GetManifestPath(app_dir, package->manifest_type());
+  if (!base::PathExists(manifest_path)) {
+    if (!base::DirectoryExists(app_dir))
+      if (!base::CreateDirectory(app_dir))
+        return false;
+    if (!base::CopyFile(
+        xwalk::application::GetManifestPath(
+            unpacked_dir, package->manifest_type()), manifest_path))
+      return false;
+  }
+
   std::string error;
   scoped_refptr<ApplicationData> app_data = LoadApplication(
-      unpacked_dir, app_id, ApplicationData::LOCAL_DIRECTORY,
+      app_dir, app_id, ApplicationData::LOCAL_DIRECTORY,
       package->manifest_type(), &error);
   if (!app_data.get()) {
     LOG(ERROR) << "Error during application installation: " << error;
@@ -386,7 +399,6 @@ bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
     return false;
   }
 
-  base::FilePath app_dir = data_dir.AppendASCII(app_data->ID());
   if (base::DirectoryExists(app_dir)) {
     if (!base::DeleteFile(app_dir, true))
       return false;
@@ -449,8 +461,6 @@ bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
       }
     }
   }
-
-  app_data->set_path(app_dir);
 
   if (!storage_->AddApplication(app_data)) {
     LOG(ERROR) << "Application with id " << app_data->ID()


### PR DESCRIPTION
Method set_path from ApplicationData class is deleted.
Function in which it was called has been refactored.

BUG=XWALK-2926
