### PR TITLE
[Tizen] Stop depending on nspr.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -81,7 +81,6 @@ BuildRequires:  pkgconfig(pkgmgr-installer)
 BuildRequires:  pkgconfig(pkgmgr-parser)
 BuildRequires:  pkgconfig(secure-storage)
 BuildRequires:  pkgconfig(sensor)
-BuildRequires:  pkgconfig(nspr)
 BuildRequires:  pkgconfig(nss)
 BuildRequires:  pkgconfig(vconf)
 BuildRequires:  pkgconfig(xmlsec1)
@@ -242,7 +241,6 @@ ${GYP_EXTRA_FLAGS} \
 -Duse_system_bzip2=1 \
 -Duse_system_libexif=1 \
 -Duse_system_libxml=1 \
--Duse_system_nspr=1 \
 -Duse_system_yasm=1 \
 -Dshared_process_mode=1 \
 -Denable_hidpi=1


### PR DESCRIPTION
The "use_system_nspr" flag has not had any effect since February 2014
when Chromium commit 74ad623 ("Remove use_system_nspr build flag")
removed it from the build system.

Additionally, Chromium now only builds a very small subset of nspr since
commit 9af1b2e0 ("Remove prtypes.h and prcpucfg*.h from
base/third_party/nspr") so building Chromium's version should not affect
performance or cause compatibility problems.
