### PR TITLE
[Tizen] packaging: Regroup conditional dependencies.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -85,7 +85,18 @@ BuildRequires:  pkgconfig(nspr)
 BuildRequires:  pkgconfig(nss)
 BuildRequires:  pkgconfig(vconf)
 BuildRequires:  pkgconfig(xmlsec1)
+Requires:  ca-certificates-tizen
+Requires:  ss-server
+
+%if %{with wayland}
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-cursor)
+BuildRequires:  pkgconfig(wayland-egl)
+BuildRequires:  pkgconfig(xkbcommon)
+%endif
+
 %if %{with x}
+BuildRequires:  pkgconfig(scim)
 BuildRequires:  pkgconfig(x11)
 BuildRequires:  pkgconfig(xcomposite)
 BuildRequires:  pkgconfig(xcursor)
@@ -104,17 +115,6 @@ BuildRequires:  pkgconfig(xtst)
 BuildRequires:  pkgconfig(murphy-common)
 BuildRequires:  pkgconfig(murphy-resource)
 %endif
-
-%if %{with wayland}
-BuildRequires:  pkgconfig(wayland-client)
-BuildRequires:  pkgconfig(wayland-cursor)
-BuildRequires:  pkgconfig(wayland-egl)
-BuildRequires:  pkgconfig(xkbcommon)
-%else
-BuildRequires:  pkgconfig(scim)
-%endif
-Requires:  ca-certificates-tizen
-Requires:  ss-server
 
 %description
 Crosswalk is an app runtime based on Chromium. It is an open source project started by the Intel Open Source Technology Center (http://www.01.org).


### PR DESCRIPTION
Make the list of BuildRequires and Requires easier to follow:
dependencies needed by all profiles under all configurations come first,
then the conditional dependencies are listed each in a separate block
without repeated checks.
