### PR TITLE
Apply smack label to Crosswalk Renderer Process

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -118,6 +118,9 @@ void XWalkBrowserMainParts::PreMainMessageLoopStart() {
   command_line->AppendSwitchASCII(switches::kJavaScriptFlags, js_flags);
 
   startup_url_ = GetURLFromCommandLine(*command_line);
+
+  command_line->AppendSwitchASCII(switches::kEnableSeccompFilterSandbox,
+      startup_url_.spec());
 }
 
 void XWalkBrowserMainParts::PostMainMessageLoopStart() {

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -33,4 +33,8 @@ const char kXWalkDataPath[] = "data-path";
 const char kXWalkProfileName[] = "profile-name";
 #endif
 
+#if defined(OS_TIZEN)
+const char kIdUsedBySmack[] = "id-for-smack";
+#endif
+
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -22,6 +22,10 @@ extern const char kXWalkDataPath[];
 extern const char kXWalkProfileName[];
 #endif
 
+#if defined(OS_TIZEN)
+extern const char kIdUsedBySmack[];
+#endif
+
 }  // namespace switches
 
 #endif  // XWALK_RUNTIME_COMMON_XWALK_SWITCHES_H_


### PR DESCRIPTION
I'd like to discuss here how to aplly samck label for RP.  Below is the explanation of my patch:

(1)Add an command line option to propagate the App id to RP.
(2) Insert code to apply smack lable in "content::RendererMainPlatformDelegate::EnableSandbox", before the "Seccomp BPF" really being enabled. (refer to attached patch).
The  "content::RendererMainPlatformDelegate::EnableSandbox" is invoked in the "RedererMain", so the inserted code will be executed in RP.

So far there is no opportunity to override "content::RendererMainPlatformDelegate::EnableSandbox", so we have to patch the "content" repo.

![0001-insert-code-to-ally-smack-lable patch](https://cloud.githubusercontent.com/assets/3304318/5122503/69e312b8-70dc-11e4-8291-202ad99d6225.png)

@rakuco @kenchris @pozdnyakov @tiwanek @xuzhang, I'd like to hear your comments. Feel free to override these patches if you have a good idea. 
