### PR TITLE
[Tizen] XWalkExtension class refactoring

### DIFF
--- a/extensions/common/xwalk_extension.cc
+++ b/extensions/common/xwalk_extension.cc
@@ -4,8 +4,6 @@
 
 #include "xwalk/extensions/common/xwalk_extension.h"
 
-#include <string.h>
-
 #include "base/logging.h"
 
 namespace xwalk {
@@ -25,7 +23,7 @@ XWalkExtension::XWalkExtension() : permissions_delegate_(NULL) {}
 
 XWalkExtension::~XWalkExtension() {}
 
-const base::ListValue& XWalkExtension::entry_points() const {
+const std::vector<std::string>& XWalkExtension::entry_points() const {
   return entry_points_;
 }
 

--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -54,7 +54,7 @@ class XWalkExtension {
   // Returns a list of entry points for which the extension should be loaded
   // when accessed. Entry points are used when the extension needs to have
   // objects outside the namespace that is implicitly created using its name.
-  virtual const base::ListValue& entry_points() const;
+  virtual const std::vector<std::string>& entry_points() const;
 
   void set_permissions_delegate(XWalkExtension::PermissionsDelegate* delegate) {
     permissions_delegate_ = delegate;
@@ -70,7 +70,8 @@ class XWalkExtension {
     javascript_api_ = javascript_api;
   }
   void set_entry_points(const std::vector<std::string>& entry_points) {
-    entry_points_.AppendStrings(entry_points);
+    entry_points_.insert(entry_points_.end(), entry_points.begin(),
+                         entry_points.end());
   }
 
  private:
@@ -82,9 +83,7 @@ class XWalkExtension {
   // message passing.
   std::string javascript_api_;
 
-  // FIXME(jeez): convert this to std::vector<std::string> to avoid
-  // extra conversions later on.
-  base::ListValue entry_points_;
+  std::vector<std::string> entry_points_;
 
   // Permission check delegate for both in and out of process extensions.
   PermissionsDelegate* permissions_delegate_;

--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -177,12 +177,9 @@ bool XWalkExtensionServer::RegisterExtension(
     return false;
   }
 
-  const base::ListValue& entry_points = extension->entry_points();
-  base::ListValue::const_iterator it = entry_points.begin();
+  const std::vector<std::string>& entry_points = extension->entry_points();
 
-  for (; it != entry_points.end(); ++it) {
-    std::string entry_point;
-    (*it)->GetAsString(&entry_point);
+  for (const std::string& entry_point : entry_points) {
     extension_symbols_.insert(entry_point);
   }
 
@@ -280,14 +277,8 @@ void XWalkExtensionServer::DeleteInstanceMap() {
 }
 
 bool XWalkExtensionServer::ValidateExtensionEntryPoints(
-    const base::ListValue& entry_points) {
-  base::ListValue::const_iterator it = entry_points.begin();
-
-  for (; it != entry_points.end(); ++it) {
-    std::string entry_point;
-
-    (*it)->GetAsString(&entry_point);
-
+    const std::vector<std::string>& entry_points) {
+  for (const std::string& entry_point : entry_points) {
     if (!ValidateExtensionIdentifier(entry_point))
       return false;
 
@@ -357,11 +348,8 @@ void XWalkExtensionServer::OnGetExtensions(
     extension_parameters.name = extension->name();
     extension_parameters.js_api = extension->javascript_api();
 
-    const base::ListValue& entry_points = extension->entry_points();
-    base::ListValue::const_iterator entry_it = entry_points.begin();
-    for (; entry_it != entry_points.end(); ++entry_it) {
-      std::string entry_point;
-      (*entry_it)->GetAsString(&entry_point);
+    const std::vector<std::string>& entry_points = extension->entry_points();
+    for (const std::string& entry_point : entry_points) {
       extension_parameters.entry_points.push_back(entry_point);
     }
 

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -101,7 +101,8 @@ class XWalkExtensionServer : public IPC::Listener,
 
   void DeleteInstanceMap();
 
-  bool ValidateExtensionEntryPoints(const base::ListValue& entry_points);
+  bool ValidateExtensionEntryPoints(
+      const std::vector<std::string>& entry_points);
 
   base::Lock sender_lock_;
   IPC::Sender* sender_;


### PR DESCRIPTION
A type of a field in XWalkExtension class was changed
from base::ListValue to std::vectorstd::string
to avoid unnecessary conversions.
