### PR TITLE
[Android] Fix devtools favicon will cause crash.

### DIFF
--- a/runtime/browser/devtools/xwalk_devtools_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.cc
@@ -95,6 +95,12 @@ Target::Target(scoped_refptr<content::DevToolsAgentHost> agent_host)
 
 GURL Target::GetFaviconDataURL(WebContents* web_contents) const {
   // Convert icon image to "data:" url.
+#if defined(OS_ANDROID)
+  // TODO(YangangHan): Add a new base parent class of WebContents
+  // for both Tizen and Android, so we can remove the current macro
+  // in the future.
+  return GURL();
+#endif
   xwalk::Runtime* runtime =
       static_cast<xwalk::Runtime*>(web_contents->GetDelegate());
   if (!runtime || runtime->app_icon().IsEmpty())


### PR DESCRIPTION
The Android has no implement set_app_icon in RuntimeUIStrategy.
So add protect to Target::GetFaviconDataURL.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2914
