### PR TITLE
[Tizen] Add explicit dependencies on some targets.

### DIFF
--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -62,6 +62,7 @@
             'build/system.gyp:tizen',
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
             '../third_party/re2/re2.gyp:re2',
+            '<(DEPTH)/ui/events/platform/events_platform.gyp:events_platform',
           ],
           'sources': [
             'browser/application_tizen.cc',

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -297,6 +297,7 @@
         ['tizen==1', {
           'dependencies': [
             '../content/app/resources/content_resources.gyp:content_resources',
+            '../ui/compositor/compositor.gyp:compositor',
             'build/system.gyp:tizen_geolocation',
             'sysapps/sysapps_resources.gyp:xwalk_sysapps_resources',
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',


### PR DESCRIPTION
This fixes some issues with a component=shared_library build that just
made it evident that we were using code from some parts of Chromium
without depending on the targets:
- `application/browser/application_tizen.cc` uses `ui::PlatformEventSource`.
- `runtime/browser/ui/splash_screen_tizen.cc` uses `ui::ImplicitAnimationObserver`.
