### PR TITLE
[Runtime] Add author href attribute check in widget element handler.

### DIFF
--- a/application/common/manifest_handlers/widget_handler.cc
+++ b/application/common/manifest_handlers/widget_handler.cc
@@ -126,6 +126,10 @@ bool WidgetHandler::Parse(scoped_refptr<ApplicationData> application,
   for (KeyMapIterator iter = map.begin(); iter != map.end(); ++iter) {
     std::string string;
     bool result = manifest->GetString(iter->first, &string);
+    if (result && !string.empty() && iter->first == keys::kAuthorHrefKey &&
+        !GURL(string).is_valid())
+      // When authorhref is an invalid URI, reset it an empty string.
+      string.clear();
     widget_info->SetString(iter->second, result ? string : "");
   }
 

--- a/application/common/manifest_handlers/widget_handler_unittest.cc
+++ b/application/common/manifest_handlers/widget_handler_unittest.cc
@@ -220,5 +220,23 @@ TEST_F(WidgetHandlerTest,
   EXPECT_TRUE(widget->Equals(widget_parsed_from_manifest));
 }
 
+TEST_F(WidgetHandlerTest,
+       ParseManifestWithInvalidAuthorHrefValue) {
+  scoped_ptr<base::DictionaryValue> manifest(new base::DictionaryValue);
+  SetAllInfoToManifest(manifest.get());
+  manifest->SetString(keys::kAuthorHrefKey, "INVALID_HREF");
+
+  // Create an application use this manifest,
+  scoped_refptr<ApplicationData> application;
+  application = CreateApplication(*(manifest.get()));
+  EXPECT_TRUE(application.get());
+  EXPECT_EQ(application->manifest_type(), Manifest::TYPE_WIDGET);
+  // Get widget info from this application.
+  WidgetInfo* info = GetWidgetInfo(application);
+  EXPECT_TRUE(info);
+  std::string authorhref;
+  info->GetWidgetInfo()->GetString(keys::kAuthorHrefKey, &authorhref);
+  EXPECT_TRUE(authorhref.empty());
+}
 }  // namespace application
 }  // namespace xwalk


### PR DESCRIPTION
When parsing a widget config.xml file, runtime should make sure the author href
attribute is a valid URI, as it's required in W3C Widget spec. This patch will
fix this.

BUG=XWALK-2995
