### PR TITLE
[Tizen] Fix multiple occurrences of author in widget setting.

### DIFF
--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -62,6 +62,7 @@ const char kDirRLOKey[] = "rlo";
 
 const char* kSingletonElements[] = {
   "allow-navigation",
+  "author",
   "content-security-policy-report-only",
   "content-security-policy",
   "content"


### PR DESCRIPTION
According to widget spec(http://www.w3.org/TR/widgets/#the-author-element-and-its-attributes), the author element's occurrences should be zero or one.
If there are more than single occurrences, just read the first one and ignore others.

BUG=XWALK-2986
