### PR TITLE
[Tizen] Start using binutils-gold for linking Crosswalk again.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -39,6 +39,7 @@ Source1002:     %{name}.xml.in
 Source1003:     %{name}.png
 Patch10:        crosswalk-do-not-look-for-gtk-dependencies-on-x11.patch
 
+BuildRequires:  binutils-gold
 BuildRequires:  bison
 BuildRequires:  bzip2-devel
 BuildRequires:  elfutils
@@ -193,24 +194,18 @@ GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Duse_ozone=1"
 
 GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Ddisable_nacl=%{_disable_nacl}"
 
-# Linking fails in Tizen Common when fatal ld warnings are enabled. XWALK-1379.
-%if "%{profile}" == "common" || "%{profile}" == "generic"
+# Linking fails when fatal ld warnings are enabled. See XWALK-1379.
 GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Ddisable_fatal_linker_warnings=1"
-%endif
 
 # For building for arm in OBS, we need :
 # -> to unset sysroot value.
 # sysroot variable is automatically set for cross compilation to use arm-sysroot provided by Chromium project
-# -> to force system ld binary.
-# Indeed the build is made on Emulated / Virtualized environment that correspond
-# to the target.
-# gold ld used is avaible only for 32/64 bits Intel Arch.
 # sysroot usage is not needed, we need to use arm libraries from the virtualized environment.
 #
 # Crosswalk build fails if the fpu selected in the gcc option is different from neon in case of arm7 compilation
 # So force it.
 %ifarch %{arm}
-GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Dsysroot= -Dlinux_use_gold_binary=0"
+GYP_EXTRA_FLAGS="${GYP_EXTRA_FLAGS} -Dsysroot= "
 export CFLAGS=`echo $CFLAGS | sed s,-mfpu=vfpv3,-mfpu=neon,g`
 export CXXFLAGS=`echo $CXXFLAGS | sed s,-mfpu=vfpv3,-mfpu=neon,g`
 export FFLAGS=`echo $FFLAGS | sed s,-mfpu=vfpv3,-mfpu=neon,g`
@@ -228,6 +223,9 @@ export GYP_GENERATORS='ninja'
 ${GYP_EXTRA_FLAGS} \
 -Dchromeos=0 \
 -Dclang=0 \
+-Dlinux_use_bundled_binutils=0 \
+-Dlinux_use_bundled_gold=0 \
+-Dlinux_use_gold_flags=1 \
 -Dtizen=1 \
 -Dpython_ver=2.7 \
 -Duse_aura=1 \


### PR DESCRIPTION
Using the traditional BFD linker is causing problems with shared_library
builds on Tizen due to the way some parts of the code are built:
- The geolocation support on Tizen is implemented by making the content
  layer call NewSystemLocationProvider(), which is then implemented in
  another target in xwalk/.
  With ld.bfd, this causes issues the linker not to find the
  implementation of content::NewSystemLocationProvider() since
  libcontent.so does not depend on the Crosswalk code that implements
  that function.
- ozone-wayland adds some files to the views target, and requires
  symbols from them. However, due to circular dependency issues,
  libwayland.so does not depend on libviews.so.
  With ld.bfd, this causes linking to fail because libwayland.so cannot
  find an implementation for
  views::DesktopFactoryWayland::DesktopFactoryWayland() and
  views::DesktopFactoryWayland::~DesktopFactoryWayland().

Arguably, these can be considered actual issues with the code; on the
other hand, the gold linker seems to be smarter and finds those
implementations in separate libraries automatically without requiring us
to fiddle around with linker options (I am not even sure there is an
option to make this work with the BFD linker). Additionally, the binaries
generated by the gold linker have fewer DT_NEEDED entries so each binary
only depends on the shared libraries it actually uses.

In addition to depending on the binutils-gold package, the associated
gyp variables have all been set, so that we explicitly use the
system-wide binutils/linker instead of the ones in the Chromium
toolchain, use any additional useful gold flags. While here, we can also
stop setting the "linux_use_gold_binary" variable in the ARM case, as
that did not have any effect since M37. Last but not least, we need to
disable fatal warnings on all Tizen platforms now -- what was previously
failing only for Tizen Common because it was already using Chromium's
bundled gold is now failing everywhere.

One caveat is that this makes re-enabling NaCl support on Tizen a bit
more difficult. As explained in XWALK-1904, the way binutils is set up
on Tizen makes the ld_bfd.py not work as expected. In this respect, the
situation has not changed compared to when commit 55c37c0 ("Fix build :
Force ld.gold binary usage") was reverted. The difference here is that
NaCl support is currently disabled on all Tizen profiles and
architectures ever since we moved to Chromium M39, so we can now land
this change without having to worry about NaCl at all.

Related to: XWALK-1904
Related to: XWALK-2571
Related to: XWALK-2679
