### PR TITLE
Disable the shared process mode

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "base/command_line.h"
 #include "base/file_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_thread.h"
@@ -24,6 +25,7 @@
 #include "xwalk/application/common/id_util.h"
 #include "xwalk/runtime/browser/runtime_context.h"
 #include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 
 #if defined(OS_TIZEN)
@@ -249,12 +251,13 @@ void ApplicationService::OnApplicationTerminated(
           base::Bind(&base::DoNothing));
   }
 
-#if !defined(SHARED_PROCESS_MODE)
-  if (applications_.empty()) {
-    base::MessageLoop::current()->PostTask(
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kXWalkDisableSharedProcessMode)) {
+    if (applications_.empty()) {
+      base::MessageLoop::current()->PostTask(
             FROM_HERE, base::MessageLoop::QuitClosure());
+    }
   }
-#endif
 }
 
 void ApplicationService::CheckAPIAccessControl(const std::string& app_id,

--- a/application/browser/application_system_linux.cc
+++ b/application/browser/application_system_linux.cc
@@ -4,21 +4,24 @@
 
 #include "xwalk/application/browser/application_system_linux.h"
 
+#include "base/command_line.h"
 #include "dbus/bus.h"
 #include "xwalk/application/browser/application_service_provider_linux.h"
 #include "xwalk/dbus/dbus_manager.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 namespace xwalk {
 namespace application {
 
 ApplicationSystemLinux::ApplicationSystemLinux(RuntimeContext* runtime_context)
     : ApplicationSystem(runtime_context) {
-#if defined(SHARED_PROCESS_MODE)
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (!cmd_line->HasSwitch(switches::kXWalkDisableSharedProcessMode)) {
     service_provider_.reset(
         new ApplicationServiceProviderLinux(application_service(),
                                             dbus_manager().session_bus()));
-#endif
+  }
 }
 
 ApplicationSystemLinux::~ApplicationSystemLinux() {}

--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -153,7 +153,8 @@ void XWalkExtensionProcessHost::StartProcess() {
   CHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
   CHECK(!process_ || !channel_);
 
-#if defined(SHARED_PROCESS_MODE)
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (!cmd_line->HasSwitch(switches::kXWalkDisableSharedProcessMode)) {
 #if defined(OS_LINUX)
     std::string channel_id =
         IPC::Channel::GenerateVerifiedChannelID(std::string());
@@ -171,7 +172,7 @@ void XWalkExtensionProcessHost::StartProcess() {
 #else
     NOTIMPLEMENTED();
 #endif  // #if defined(OS_LINUX)
-#else
+  } else {
     process_.reset(content::BrowserChildProcessHost::Create(
         content::PROCESS_TYPE_CONTENT_END, this));
 
@@ -207,7 +208,7 @@ void XWalkExtensionProcessHost::StartProcess() {
     process_->Launch(
         new ExtensionSandboxedProcessLauncherDelegate(process_->GetHost()),
         cmd_line.release());
-#endif  // #if defined(SHARED_PROCESS_MODE)
+  }
 
   base::ListValue runtime_variables_lv;
   ToListValue(&const_cast<base::ValueMap&>(*runtime_variables_),

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -214,20 +214,20 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     return;
   }
 
-#if !defined(SHARED_PROCESS_MODE)
-  application::ApplicationSystem* app_system = xwalk_runner_->app_system();
-  app_system->LaunchFromCommandLine(*command_line, startup_url_,
-                                    run_default_message_loop_);
-  // If the |ui_task| is specified in main function parameter, it indicates
-  // that we will run this UI task instead of running the the default main
-  // message loop. See |content::BrowserTestBase::SetUp| for |ui_task| usage
-  // case.
-  if (parameters_.ui_task) {
-    parameters_.ui_task->Run();
-    delete parameters_.ui_task;
-    run_default_message_loop_ = false;
+  if (command_line->HasSwitch(switches::kXWalkDisableSharedProcessMode)) {
+    application::ApplicationSystem* app_system = xwalk_runner_->app_system();
+    app_system->LaunchFromCommandLine(*command_line, startup_url_,
+                                      run_default_message_loop_);
+    // If the |ui_task| is specified in main function parameter, it indicates
+    // that we will run this UI task instead of running the the default main
+    // message loop. See |content::BrowserTestBase::SetUp| for |ui_task| usage
+    // case.
+    if (parameters_.ui_task) {
+      parameters_.ui_task->Run();
+      delete parameters_.ui_task;
+      run_default_message_loop_ = false;
+    }
   }
-#endif
 }
 
 bool XWalkBrowserMainParts::MainMessageLoopRun(int* result_code) {

--- a/runtime/browser/xwalk_runner_tizen.cc
+++ b/runtime/browser/xwalk_runner_tizen.cc
@@ -4,6 +4,7 @@
 
 #include "xwalk/runtime/browser/xwalk_runner_tizen.h"
 
+#include "base/command_line.h"
 #include "content/public/browser/browser_thread.h"
 #include "crypto/nss_util.h"
 #include "xwalk/application/browser/application_service.h"
@@ -12,6 +13,7 @@
 #include "xwalk/runtime/browser/sysapps_component.h"
 #include "xwalk/runtime/browser/xwalk_component.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 namespace xwalk {
 
@@ -30,12 +32,13 @@ void XWalkRunnerTizen::PreMainMessageLoopRun() {
   // NSSInitSingleton is a costly operation (up to 100ms on VTC-1010),
   // resulting in postponing the parsing and composition steps of the render
   // process at cold start. Therefore, move the initialization logic here.
-#if defined(SHARED_PROCESS_MODE)
-  content::BrowserThread::PostTask(
-      content::BrowserThread::IO,
-      FROM_HERE,
-      base::Bind(&crypto::EnsureNSSInit));
-#endif
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (!cmd_line->HasSwitch(switches::kXWalkDisableSharedProcessMode)) {
+    content::BrowserThread::PostTask(
+        content::BrowserThread::IO,
+        FROM_HERE,
+        base::Bind(&crypto::EnsureNSSInit));
+  }
 }
 
 }  // namespace xwalk

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -4,11 +4,13 @@
 
 #include "xwalk/runtime/common/xwalk_paths.h"
 
+#include "base/command_line.h"
 #include "base/file_util.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/path_service.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 #if defined(OS_WIN)
 #include "base/base_paths_win.h"
@@ -75,11 +77,12 @@ base::FilePath GetConfigPath() {
 
 bool GetXWalkDataPath(base::FilePath* path) {
   base::FilePath::StringType xwalk_suffix;
-#if defined(SHARED_PROCESS_MODE)
-  xwalk_suffix = FILE_PATH_LITERAL("xwalk-service");
-#else
-  xwalk_suffix = FILE_PATH_LITERAL("xwalk");
-#endif
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kXWalkDisableSharedProcessMode))
+    xwalk_suffix = FILE_PATH_LITERAL("xwalk");
+  else
+    xwalk_suffix = FILE_PATH_LITERAL("xwalk-service");
+
   base::FilePath cur;
 
 #if defined(OS_WIN)

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -12,6 +12,9 @@ const char kAppIcon[] = "app-icon";
 // Disables the usage of Portable Native Client.
 const char kDisablePnacl[] = "disable-pnacl";
 
+// Disables the shared process mode
+const char kXWalkDisableSharedProcessMode[] = "disable-shared-process-mode";
+
 // Enable all the experimental features in XWalk.
 const char kExperimentalFeatures[] = "enable-xwalk-experimental-features";
 

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -17,6 +17,7 @@ extern const char kFullscreen[];
 extern const char kListFeaturesFlags[];
 extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
 extern const char kXWalkDataPath[];
+extern const char kXWalkDisableSharedProcessMode[];
 
 #if defined(OS_ANDROID)
 extern const char kXWalkProfileName[];


### PR DESCRIPTION
The shared process mode makes debugging very hard so
we need to disable it at runtime.

Bug: XWALK-2987
