### PR TITLE
[Android] Fix the file picker crash issue.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1062,7 +1062,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         Intent soundRecorder = new Intent(
                 MediaStore.Audio.Media.RECORD_SOUND_ACTION);
         ArrayList<Intent> extraIntents = new ArrayList<Intent>();
-        extraIntents.add(takePictureIntent);
+        if (takePictureIntent != null) extraIntents.add(takePictureIntent);
         extraIntents.add(camcorder);
         extraIntents.add(soundRecorder);
 
@@ -1079,8 +1079,22 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         // Create an image file name
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_";
-        File storageDir = Environment.getExternalStoragePublicDirectory(
-                Environment.DIRECTORY_PICTURES);
+        String state = Environment.getExternalStorageState();
+        File storageDir = null;
+
+        if (state.equals(Environment.MEDIA_MOUNTED)) {
+            storageDir = Environment.getExternalStoragePublicDirectory(
+                    Environment.DIRECTORY_PICTURES);
+        }
+        // FIXME: If the external storage state is not "MEDIA_MOUNTED", we need to
+        // get other volume paths by "getVolumePaths()" when it was exposed.
+        if (storageDir == null) {
+            Log.e(TAG, "Can not get the storage directory.");
+            return null;
+        } else if (!storageDir.exists()) {
+            storageDir.mkdirs();
+        }
+
         File imageFile = File.createTempFile(
                 imageFileName,  /* prefix */
                 ".jpg",         /* suffix */


### PR DESCRIPTION
This patch is to fix the special case with some ROMs.
If there is no SD card on device, getExternalStoragePublicDirectory()
returns null on these ROMs.
The ROMs changes the setting in "/system/etc/vold.fstab", external storage was
mounted on "/storage/sdcard1", but the default external storage was mounted from
"/storage/sdcard0".
If external storage state is not mounted, just return null to avoid crash instead
of get other volume paths by internal function.

BUG=XWALK-2902, XWALK-2972