### PR TITLE
[Tizen] SecurityPolicy classes rename and move

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -393,9 +393,9 @@ bool Application::SetPermission(PermissionType type,
 void Application::InitSecurityPolicy() {
   // CSP policy takes precedence over WARP.
   if (data_->HasCSPDefined())
-    security_policy_.reset(new SecurityPolicyCSP(this));
+    security_policy_.reset(new ApplicationSecurityPolicyCSP(this));
   else if (data_->manifest_type() == Manifest::TYPE_WIDGET)
-    security_policy_.reset(new SecurityPolicyWARP(this));
+    security_policy_.reset(new ApplicationSecurityPolicyWARP(this));
 
   if (security_policy_)
     security_policy_->Enforce();

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -19,8 +19,8 @@
 #include "base/observer_list.h"
 #include "content/public/browser/render_process_host_observer.h"
 #include "ui/base/ui_base_types.h"
+#include "xwalk/application/browser/application_security_policy.h"
 #include "xwalk/application/common/application_data.h"
-#include "xwalk/application/common/security_policy.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_ui_strategy.h"
 
@@ -37,7 +37,7 @@ namespace application {
 
 class ApplicationHost;
 class Manifest;
-class SecurityPolicy;
+class ApplicationSecurityPolicy;
 
 // The Application class is representing an active (running) application.
 // Application instances are owned by ApplicationService.
@@ -174,7 +174,7 @@ class Application : public Runtime::Observer,
   // Application's session permissions.
   StoredPermissionMap permission_map_;
   // Security policy.
-  scoped_ptr<SecurityPolicy> security_policy_;
+  scoped_ptr<ApplicationSecurityPolicy> security_policy_;
   // Remote debugging enabled or not for this Application
   bool remote_debugging_enabled_;
   // WeakPtrFactory should be always declared the last.

--- a/application/browser/application_security_policy.cc
+++ b/application/browser/application_security_policy.cc
@@ -1,8 +1,9 @@
 // Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "xwalk/application/common/security_policy.h"
+#include "xwalk/application/browser/application_security_policy.h"
 
 #include <map>
 #include <string>
@@ -57,20 +58,21 @@ CSPInfo* GetDefaultCSPInfo() {
 
 }  // namespace
 
-SecurityPolicy::WhitelistEntry::WhitelistEntry(const GURL& url, bool subdomains)
-  : url(url),
-    subdomains(subdomains) {
+ApplicationSecurityPolicy::WhitelistEntry::WhitelistEntry(
+    const GURL& url, bool subdomains)
+    : url(url),
+      subdomains(subdomains) {
 }
 
-SecurityPolicy::SecurityPolicy(Application* app)
-  : app_(app),
-    enabled_(false) {
+ApplicationSecurityPolicy::ApplicationSecurityPolicy(Application* app)
+    : app_(app),
+      enabled_(false) {
 }
 
-SecurityPolicy::~SecurityPolicy() {
+ApplicationSecurityPolicy::~ApplicationSecurityPolicy() {
 }
 
-bool SecurityPolicy::IsAccessAllowed(const GURL& url) const {
+bool ApplicationSecurityPolicy::IsAccessAllowed(const GURL& url) const {
   if (!enabled_)
     return true;
 
@@ -91,10 +93,11 @@ bool SecurityPolicy::IsAccessAllowed(const GURL& url) const {
   return false;
 }
 
-void SecurityPolicy::Enforce() {
+void ApplicationSecurityPolicy::Enforce() {
 }
 
-void SecurityPolicy::AddWhitelistEntry(const GURL& url, bool subdomains) {
+void ApplicationSecurityPolicy::AddWhitelistEntry(
+    const GURL& url, bool subdomains) {
   GURL app_url = app_->data()->URL();
   DCHECK(app_->render_process_host());
   WhitelistEntry entry = WhitelistEntry(url, subdomains);
@@ -109,14 +112,14 @@ void SecurityPolicy::AddWhitelistEntry(const GURL& url, bool subdomains) {
   whitelist_entries_.push_back(entry);
 }
 
-SecurityPolicyWARP::SecurityPolicyWARP(Application* app)
-  : SecurityPolicy(app) {
+ApplicationSecurityPolicyWARP::ApplicationSecurityPolicyWARP(Application* app)
+    : ApplicationSecurityPolicy(app) {
 }
 
-SecurityPolicyWARP::~SecurityPolicyWARP() {
+ApplicationSecurityPolicyWARP::~ApplicationSecurityPolicyWARP() {
 }
 
-void SecurityPolicyWARP::Enforce() {
+void ApplicationSecurityPolicyWARP::Enforce() {
   const WARPInfo* info = static_cast<WARPInfo*>(
       app_->data()->GetManifestData(widget_keys::kAccessKey));
   if (!info) {
@@ -125,7 +128,7 @@ void SecurityPolicyWARP::Enforce() {
     app_->render_process_host()->Send(
         new ViewMsg_EnableSecurityMode(
             ApplicationData::GetBaseURLFromApplicationId(app_->id()),
-            SecurityPolicy::WARP));
+            ApplicationSecurityPolicy::WARP));
     return;
   }
 
@@ -156,18 +159,18 @@ void SecurityPolicyWARP::Enforce() {
     app_->render_process_host()->Send(
         new ViewMsg_EnableSecurityMode(
             ApplicationData::GetBaseURLFromApplicationId(app_->id()),
-            SecurityPolicy::WARP));
+            ApplicationSecurityPolicy::WARP));
   }
 }
 
-SecurityPolicyCSP::SecurityPolicyCSP(Application* app)
-  : SecurityPolicy(app) {
+ApplicationSecurityPolicyCSP::ApplicationSecurityPolicyCSP(Application* app)
+    : ApplicationSecurityPolicy(app) {
 }
 
-SecurityPolicyCSP::~SecurityPolicyCSP() {
+ApplicationSecurityPolicyCSP::~ApplicationSecurityPolicyCSP() {
 }
 
-void SecurityPolicyCSP::Enforce() {
+void ApplicationSecurityPolicyCSP::Enforce() {
   Manifest::Type manifest_type = app_->data()->manifest_type();
   const char* scp_key = GetCSPKey(manifest_type);
   CSPInfo* csp_info =
@@ -228,7 +231,7 @@ void SecurityPolicyCSP::Enforce() {
     app_->render_process_host()->Send(
         new ViewMsg_EnableSecurityMode(
             ApplicationData::GetBaseURLFromApplicationId(app_->id()),
-            SecurityPolicy::CSP));
+            ApplicationSecurityPolicy::CSP));
   }
 }
 

--- a/application/browser/application_security_policy.h
+++ b/application/browser/application_security_policy.h
@@ -1,9 +1,10 @@
 // Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef XWALK_APPLICATION_COMMON_SECURITY_POLICY_H_
-#define XWALK_APPLICATION_COMMON_SECURITY_POLICY_H_
+#ifndef XWALK_APPLICATION_BROWSER_APPLICATION_SECURITY_POLICY_H_
+#define XWALK_APPLICATION_BROWSER_APPLICATION_SECURITY_POLICY_H_
 
 #include <vector>
 
@@ -14,9 +15,7 @@ namespace application {
 
 class Application;
 
-// FIXME(Mikhail): Move to application/browser folder.
-// Rename to ApplicationSecurityPolicy.
-class SecurityPolicy {
+class ApplicationSecurityPolicy {
  public:
   enum SecurityMode {
     NoSecurity,
@@ -24,8 +23,8 @@ class SecurityPolicy {
     WARP
   };
 
-  explicit SecurityPolicy(Application* app);
-  virtual ~SecurityPolicy();
+  explicit ApplicationSecurityPolicy(Application* app);
+  virtual ~ApplicationSecurityPolicy();
 
   bool IsAccessAllowed(const GURL& url) const;
 
@@ -49,18 +48,18 @@ class SecurityPolicy {
   bool enabled_;
 };
 
-class SecurityPolicyWARP : public SecurityPolicy {
+class ApplicationSecurityPolicyWARP : public ApplicationSecurityPolicy {
  public:
-  explicit SecurityPolicyWARP(Application* app);
-  virtual ~SecurityPolicyWARP();
+  explicit ApplicationSecurityPolicyWARP(Application* app);
+  virtual ~ApplicationSecurityPolicyWARP();
 
   virtual void Enforce() OVERRIDE;
 };
 
-class SecurityPolicyCSP : public SecurityPolicy {
+class ApplicationSecurityPolicyCSP : public ApplicationSecurityPolicy {
  public:
-  explicit SecurityPolicyCSP(Application* app);
-  virtual ~SecurityPolicyCSP();
+  explicit ApplicationSecurityPolicyCSP(Application* app);
+  virtual ~ApplicationSecurityPolicyCSP();
 
   virtual void Enforce() OVERRIDE;
 };
@@ -68,4 +67,4 @@ class SecurityPolicyCSP : public SecurityPolicy {
 }  // namespace application
 }  // namespace xwalk
 
-#endif  // XWALK_APPLICATION_COMMON_SECURITY_POLICY_H_
+#endif  // XWALK_APPLICATION_BROWSER_APPLICATION_SECURITY_POLICY_H_

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -21,13 +21,12 @@
         'browser/application.h',
         'browser/application_protocols.cc',
         'browser/application_protocols.h',
+        'browser/application_security_policy.cc',
+        'browser/application_security_policy.h',
         'browser/application_service.cc',
         'browser/application_service.h',
         'browser/application_system.cc',
         'browser/application_system.h',
-
-        'common/security_policy.cc',
-        'common/security_policy.h',
 
         'extension/application_runtime_extension.cc',
         'extension/application_runtime_extension.h',

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -11,7 +11,7 @@
 #include "ipc/ipc_message_macros.h"
 #include "ipc/ipc_platform_file.h"
 #include "url/gurl.h"
-#include "xwalk/application/common/security_policy.h"
+#include "xwalk/application/browser/application_security_policy.h"
 
 // Singly-included section for enums and custom IPC traits.
 #ifndef XWALK_RUNTIME_COMMON_XWALK_COMMON_MESSAGES_H_
@@ -27,7 +27,7 @@ namespace IPC {
 
 #define IPC_MESSAGE_START ViewMsgStart
 
-IPC_ENUM_TRAITS(xwalk::application::SecurityPolicy::SecurityMode)
+IPC_ENUM_TRAITS(xwalk::application::ApplicationSecurityPolicy::SecurityMode)
 //-----------------------------------------------------------------------------
 // RenderView messages
 // These are messages sent from the browser to the renderer process.
@@ -39,7 +39,7 @@ IPC_MESSAGE_CONTROL3(ViewMsg_SetAccessWhiteList,  // NOLINT
 
 IPC_MESSAGE_CONTROL2(ViewMsg_EnableSecurityMode,    // NOLINT
                      GURL /* application url */,
-                     xwalk::application::SecurityPolicy::SecurityMode
+                     xwalk::application::ApplicationSecurityPolicy::SecurityMode
                      /* security mode */)
 
 IPC_MESSAGE_CONTROL1(ViewMsg_SuspendJSEngine,  // NOLINT

--- a/runtime/renderer/xwalk_render_process_observer_generic.cc
+++ b/runtime/renderer/xwalk_render_process_observer_generic.cc
@@ -48,7 +48,7 @@ void AddAccessWhiteListEntry(
 XWalkRenderProcessObserver::XWalkRenderProcessObserver()
     : is_webkit_initialized_(false),
       is_suspended_(false),
-      security_mode_(application::SecurityPolicy::NoSecurity) {
+      security_mode_(application::ApplicationSecurityPolicy::NoSecurity) {
 }
 
 XWalkRenderProcessObserver::~XWalkRenderProcessObserver() {
@@ -93,7 +93,8 @@ void XWalkRenderProcessObserver::OnSetAccessWhiteList(const GURL& source,
 }
 
 void XWalkRenderProcessObserver::OnEnableSecurityMode(
-    const GURL& url, application::SecurityPolicy::SecurityMode mode) {
+    const GURL& url,
+    application::ApplicationSecurityPolicy::SecurityMode mode) {
   app_url_ = url;
   security_mode_ = mode;
 }

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -12,7 +12,7 @@
 #include "content/public/renderer/render_process_observer.h"
 #include "url/gurl.h"
 #include "v8/include/v8.h"
-#include "xwalk/application/common/security_policy.h"
+#include "xwalk/application/browser/application_security_policy.h"
 
 namespace blink {
 class WebFrame;
@@ -35,10 +35,10 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   virtual void OnRenderProcessShutdown() OVERRIDE;
 
   bool IsWarpMode() const {
-    return security_mode_ == application::SecurityPolicy::WARP;
+    return security_mode_ == application::ApplicationSecurityPolicy::WARP;
   }
   bool IsCSPMode() const {
-    return security_mode_ == application::SecurityPolicy::CSP;
+    return security_mode_ == application::ApplicationSecurityPolicy::CSP;
   }
 
   const GURL& app_url() const { return app_url_; }
@@ -50,7 +50,8 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   void OnSetAccessWhiteList(
       const GURL& source, const GURL& dest, bool allow_subdomains);
   void OnEnableSecurityMode(
-      const GURL& url, application::SecurityPolicy::SecurityMode mode);
+      const GURL& url,
+      application::ApplicationSecurityPolicy::SecurityMode mode);
   void OnSuspendJSEngine(bool is_pause);
 #if defined(OS_TIZEN)
   void OnUserAgentChanged(const std::string& userAgentString);
@@ -59,7 +60,7 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
 
   bool is_webkit_initialized_;
   bool is_suspended_;
-  application::SecurityPolicy::SecurityMode security_mode_;
+  application::ApplicationSecurityPolicy::SecurityMode security_mode_;
   GURL app_url_;
 };
 }  // namespace xwalk


### PR DESCRIPTION
This patch renames:
- SecurityPolicy to ApplicationSecurityPolicy,
- SecurityPolicyCSP to ApplicationSecurityPolicyCSP,
- SecurityPolicyWARP to ApplicationSecurityPolicyWARP,
- common/security_policy.h to browser/application_security_policy.h,
- common/security_policy.cc to browser/application_security_policy.cc.
