### PR TITLE
[Tizen] Fix widget namespace value validation.

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -161,6 +161,7 @@ const char kTizenApplicationAppControlChildNameAttrKey[] = "@name";
 
 }  // namespace application_widget_keys
 
+const char kW3CNamespaceKey[] = "widget.@namespace";
 const char kW3CNamespacePrefix[] = "http://www.w3.org/ns/widgets";
 #if defined(OS_TIZEN)
 const char kTizenNamespacePrefix[] = "http://tizen.org/ns/widgets";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -140,6 +140,7 @@ namespace application_widget_keys {
 #endif
 }  // namespace application_widget_keys
 
+extern const char kW3CNamespaceKey[];
 extern const char kW3CNamespacePrefix[];
 #if defined(OS_TIZEN)
 extern const char kTizenNamespacePrefix[];

--- a/application/common/manifest_handlers/widget_handler.cc
+++ b/application/common/manifest_handlers/widget_handler.cc
@@ -159,6 +159,20 @@ bool WidgetHandler::Parse(scoped_refptr<ApplicationData> application,
   return true;
 }
 
+bool WidgetHandler::Validate(
+    scoped_refptr<const ApplicationData> application,
+    std::string* error) const {
+  const Manifest* manifest = application->GetManifest();
+  DCHECK(manifest);
+  std::string ns_value;
+  manifest->GetString(kW3CNamespaceKey, &ns_value);
+  if (base::strcasecmp(kW3CNamespacePrefix, ns_value.c_str()) != 0) {
+    *error = std::string("The widget namespace is invalid.");
+    return false;
+  }
+  return true;
+}
+
 bool WidgetHandler::AlwaysParseForType(Manifest::Type type) const {
   return true;
 }

--- a/application/common/manifest_handlers/widget_handler.h
+++ b/application/common/manifest_handlers/widget_handler.h
@@ -46,6 +46,9 @@ class WidgetHandler : public ManifestHandler {
   virtual bool AlwaysParseForType(Manifest::Type type) const OVERRIDE;
   virtual std::vector<std::string> Keys() const OVERRIDE;
 
+  virtual bool Validate(scoped_refptr<const ApplicationData> application,
+                        std::string* error) const OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(WidgetHandler);
 };

--- a/application/common/manifest_handlers/widget_handler_unittest.cc
+++ b/application/common/manifest_handlers/widget_handler_unittest.cc
@@ -93,6 +93,7 @@ class WidgetHandlerTest: public testing::Test {
   // No Preferences and full other information
   void SetAllInfoToManifest(base::DictionaryValue* manifest) {
     // Insert some key-value pairs into manifest use full key
+    manifest->SetString(kW3CNamespaceKey,      kW3CNamespacePrefix);
     manifest->SetString(keys::kAuthorKey,      author);
     manifest->SetString(keys::kDescriptionKey, decription);
     manifest->SetString(keys::kNameKey,        name);
@@ -123,6 +124,7 @@ class WidgetHandlerTest: public testing::Test {
 
 TEST_F(WidgetHandlerTest, ParseManifestWithOnlyNameAndVersion) {
   base::DictionaryValue manifest;
+  manifest.SetString(kW3CNamespaceKey, kW3CNamespacePrefix);
   manifest.SetString(keys::kNameKey, "no name");
   manifest.SetString(keys::kVersionKey, "0");
 


### PR DESCRIPTION
According to widget W3C spec (http://www.w3.org/TR/widgets/#namespace), the namespace cannot be absent or invalid.
If namespace is absent or wrong, the widget should be treated as invalid package and installation should be failed.

BUG=XWALK-2978
