### PR TITLE
[Tizen] Fix calculation for display rotation angle.

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -41,7 +41,7 @@ static gfx::Display::Rotation ToDisplayRotation(gfx::Display display,
 
   if (display.bounds().width() > display.bounds().height()) {
     // Landscape devices have landscape-primary as default.
-    rot = static_cast<gfx::Display::Rotation>((rot - 1) % 4);
+    rot = static_cast<gfx::Display::Rotation>((rot + 3) % 4);
   }
 
   return rot;


### PR DESCRIPTION
For landscape devices which have landscape-primary as default orientation, the rotation calculation " ((rot - 1) % 4) " gets invalid value that might cause unexpected result, for example when converting from portrait-primary to landscape-primary, the "rot" should be 3 (ROTATE_270) rather than -1 (invalid value).
This CL is to correct the rotation calculation.
