### PR TITLE
[Android] Fix the access issues from iframe.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -113,9 +113,9 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         MediaPlayerBridge.setResourceLoadingFilter(
                 new XWalkMediaPlayerResourceLoadingFilter());
 
-        XWalkPreferencesInternal.load(this);
-
         setNativeContent(nativeInit());
+
+        XWalkPreferencesInternal.load(this);
     }
 
     private void setNativeContent(long newNativeContent) {


### PR DESCRIPTION
This patch is to fix the cross origin issues when access the different
origin urls in iframe.
The instance of XWalkSettings was not initialized when the preference
value was got, so can not set the value to XWalkSettings.
Adjust the code to generate the instance of XWalkSettings before load
the preference value.

BUG=XWALK-2685, XWALK-2905
