### PR TITLE
[Tizen] Enable/Disable the shared process mode at runtime.

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -24,6 +24,7 @@
 #include "xwalk/application/common/id_util.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/xwalk_browser_context.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 
 #if defined(OS_TIZEN)
@@ -249,12 +250,12 @@ void ApplicationService::OnApplicationTerminated(
           base::Bind(&base::DoNothing));
   }
 
-#if !defined(SHARED_PROCESS_MODE)
-  if (applications_.empty()) {
-    base::MessageLoop::current()->PostTask(
+  if (!XWalkRunner::GetInstance()->shared_process_mode_enabled()) {
+    if (applications_.empty()) {
+      base::MessageLoop::current()->PostTask(
             FROM_HERE, base::MessageLoop::QuitClosure());
+    }
   }
-#endif
 }
 
 void ApplicationService::CheckAPIAccessControl(const std::string& app_id,

--- a/application/browser/application_system_linux.cc
+++ b/application/browser/application_system_linux.cc
@@ -14,11 +14,11 @@ namespace application {
 
 ApplicationSystemLinux::ApplicationSystemLinux(XWalkBrowserContext* context)
     : ApplicationSystem(context) {
-#if defined(SHARED_PROCESS_MODE)
+  if (XWalkRunner::GetInstance()->shared_process_mode_enabled()) {
     service_provider_.reset(
         new ApplicationServiceProviderLinux(application_service(),
                                             dbus_manager().session_bus()));
-#endif
+  }
 }
 
 ApplicationSystemLinux::~ApplicationSystemLinux() {}

--- a/application/tools/linux/xwalk_application_tools.gyp
+++ b/application/tools/linux/xwalk_application_tools.gyp
@@ -61,6 +61,8 @@
             '../tizen/xwalk_tizen_user.h',
             '../../../runtime/common/xwalk_paths.cc',
             '../../../runtime/common/xwalk_paths.h',
+            '../../../runtime/common/xwalk_switches.cc',
+            '../../../runtime/common/xwalk_switches.h',
             '../../../runtime/common/xwalk_system_locale.cc',
             '../../../runtime/common/xwalk_system_locale.h',
           ],

--- a/application/tools/tizen/xwalk_tizen_tools.gyp
+++ b/application/tools/tizen/xwalk_tizen_tools.gyp
@@ -28,6 +28,8 @@
         # TODO(t.iwanek) fix me - this duplicates compilation of those files
         '../../../runtime/common/xwalk_paths.cc',
         '../../../runtime/common/xwalk_paths.h',
+        '../../../runtime/common/xwalk_switches.cc',
+        '../../../runtime/common/xwalk_switches.h',
         '../../../runtime/common/xwalk_system_locale.cc',
         '../../../runtime/common/xwalk_system_locale.h',
       ],
@@ -51,6 +53,8 @@
         # TODO(t.iwanek) fix me - this duplicates compilation of those files
         '../../../runtime/common/xwalk_paths.cc',
         '../../../runtime/common/xwalk_paths.h',
+        '../../../runtime/common/xwalk_switches.cc',
+        '../../../runtime/common/xwalk_switches.h',
         '../../../runtime/common/xwalk_system_locale.cc',
         '../../../runtime/common/xwalk_system_locale.h',
       ],

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -2,7 +2,6 @@
   'variables': {
     'tizen%': 0,
     'tizen_mobile%': 0,
-    'shared_process_mode%': 0,
     'enable_murphy%': 0,
   },
   'target_defaults': {
@@ -17,9 +16,6 @@
       }],
       ['tizen_mobile==1', {
         'defines': ['OS_TIZEN_MOBILE=1', 'OS_TIZEN=1'],
-      }],
-      ['shared_process_mode==1', {
-        'defines': ['SHARED_PROCESS_MODE=1'],
       }],
       ['enable_murphy==1', {
         'defines': ['ENABLE_MURPHY=1'],

--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -21,6 +21,7 @@
 #include "ipc/message_filter.h"
 #include "xwalk/extensions/common/xwalk_extension_messages.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
+#include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 
 using content::BrowserThread;
@@ -153,7 +154,7 @@ void XWalkExtensionProcessHost::StartProcess() {
   CHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
   CHECK(!process_ || !channel_);
 
-#if defined(SHARED_PROCESS_MODE)
+  if (XWalkRunner::GetInstance()->shared_process_mode_enabled()) {
 #if defined(OS_LINUX)
     std::string channel_id =
         IPC::Channel::GenerateVerifiedChannelID(std::string());
@@ -171,7 +172,7 @@ void XWalkExtensionProcessHost::StartProcess() {
 #else
     NOTIMPLEMENTED();
 #endif  // #if defined(OS_LINUX)
-#else
+  } else {
     process_.reset(content::BrowserChildProcessHost::Create(
         content::PROCESS_TYPE_CONTENT_END, this));
 
@@ -207,7 +208,7 @@ void XWalkExtensionProcessHost::StartProcess() {
     process_->Launch(
         new ExtensionSandboxedProcessLauncherDelegate(process_->GetHost()),
         cmd_line.release());
-#endif  // #if defined(SHARED_PROCESS_MODE)
+  }
 
   base::ListValue runtime_variables_lv;
   ToListValue(&const_cast<base::ValueMap&>(*runtime_variables_),

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -237,7 +237,6 @@ ${GYP_EXTRA_FLAGS} \
 -Duse_system_libexif=1 \
 -Duse_system_libxml=1 \
 -Duse_system_yasm=1 \
--Dshared_process_mode=1 \
 -Denable_hidpi=1
 
 ninja %{?_smp_mflags} -C src/out/Release xwalk xwalk_launcher xwalk_application_tools

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -216,20 +216,20 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
     return;
   }
 
-#if !defined(SHARED_PROCESS_MODE)
-  application::ApplicationSystem* app_system = xwalk_runner_->app_system();
-  app_system->LaunchFromCommandLine(*command_line, startup_url_,
-                                    run_default_message_loop_);
-  // If the |ui_task| is specified in main function parameter, it indicates
-  // that we will run this UI task instead of running the the default main
-  // message loop. See |content::BrowserTestBase::SetUp| for |ui_task| usage
-  // case.
-  if (parameters_.ui_task) {
-    parameters_.ui_task->Run();
-    delete parameters_.ui_task;
-    run_default_message_loop_ = false;
+  if (!xwalk_runner_->shared_process_mode_enabled()) {
+    application::ApplicationSystem* app_system = xwalk_runner_->app_system();
+    app_system->LaunchFromCommandLine(*command_line, startup_url_,
+                                      run_default_message_loop_);
+    // If the |ui_task| is specified in main function parameter, it indicates
+    // that we will run this UI task instead of running the the default main
+    // message loop. See |content::BrowserTestBase::SetUp| for |ui_task| usage
+    // case.
+    if (parameters_.ui_task) {
+      parameters_.ui_task->Run();
+      delete parameters_.ui_task;
+      run_default_message_loop_ = false;
+    }
   }
-#endif
 }
 
 bool XWalkBrowserMainParts::MainMessageLoopRun(int* result_code) {

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -40,7 +40,8 @@ XWalkRunner* g_xwalk_runner = NULL;
 
 }  // namespace
 
-XWalkRunner::XWalkRunner() {
+XWalkRunner::XWalkRunner()
+    : shared_process_mode_enabled_(false) {
   VLOG(1) << "Creating XWalkRunner object.";
   DCHECK(!g_xwalk_runner);
   g_xwalk_runner = this;

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -81,6 +81,9 @@ class XWalkRunner {
   void EnableRemoteDebugging(int port);
   void DisableRemoteDebugging();
 
+  bool shared_process_mode_enabled() const
+      { return shared_process_mode_enabled_; }
+
  protected:
   XWalkRunner();
 
@@ -97,6 +100,8 @@ class XWalkRunner {
   virtual scoped_ptr<ApplicationComponent> CreateAppComponent();
   virtual scoped_ptr<SysAppsComponent> CreateSysAppsComponent();
   virtual scoped_ptr<StorageComponent> CreateStorageComponent();
+
+  bool shared_process_mode_enabled_;
 
  private:
   friend class XWalkMainDelegate;

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -4,11 +4,13 @@
 
 #include "xwalk/runtime/common/xwalk_paths.h"
 
+#include "base/command_line.h"
 #include "base/file_util.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/path_service.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 #if defined(OS_WIN)
 #include "base/base_paths_win.h"
@@ -85,11 +87,11 @@ base::FilePath GetConfigPath() {
 
 bool GetXWalkDataPath(base::FilePath* path) {
   base::FilePath::StringType xwalk_suffix;
-#if defined(SHARED_PROCESS_MODE)
-  xwalk_suffix = FILE_PATH_LITERAL("xwalk-service");
-#else
-  xwalk_suffix = FILE_PATH_LITERAL("xwalk");
-#endif
+  CommandLine* cmd_line = CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kXWalkDisableSharedProcessMode))
+    xwalk_suffix = FILE_PATH_LITERAL("xwalk");
+  else
+    xwalk_suffix = FILE_PATH_LITERAL("xwalk-service");
   base::FilePath cur;
 
 #if defined(OS_WIN)

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -12,6 +12,9 @@ const char kAppIcon[] = "app-icon";
 // Disables the usage of Portable Native Client.
 const char kDisablePnacl[] = "disable-pnacl";
 
+// Disables the shared process mode
+const char kXWalkDisableSharedProcessMode[] = "disable-shared-process-mode";
+
 // Enable all the experimental features in XWalk.
 const char kExperimentalFeatures[] = "enable-xwalk-experimental-features";
 

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -17,6 +17,7 @@ extern const char kFullscreen[];
 extern const char kListFeaturesFlags[];
 extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
 extern const char kXWalkDataPath[];
+extern const char kXWalkDisableSharedProcessMode[];
 
 #if defined(OS_ANDROID)
 extern const char kXWalkProfileName[];


### PR DESCRIPTION
The shared process mode has been enabled by default, which makes
debugging very hard so we need to enable/disable it at runtime.

This patch allows to add a new command line option
(--disable-shared-process-mode) for disabling the shared process
mode at runtime.

Bug=XWALK-2987
