### PR TITLE
[Android] Optimize the process for file picker.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -155,6 +155,13 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     static final String PLAYSTORE_DETAIL_URI = "market://details?id=";
     public static final int INPUT_FILE_REQUEST_CODE = 1;
     private static final String TAG = XWalkViewInternal.class.getSimpleName();
+    private static final String IMAGE_TYPE = "image/";
+    private static final String VIDEO_TYPE = "video/";
+    private static final String AUDIO_TYPE = "audio/";
+    private static final String ALL_IMAGE_TYPES = IMAGE_TYPE + "*";
+    private static final String ALL_VIDEO_TYPES = VIDEO_TYPE + "*";
+    private static final String ALL_AUDIO_TYPES = AUDIO_TYPE + "*";
+    private static final String ANY_TYPES = "*/*";
 
     private XWalkContent mContent;
     private Activity mActivity;
@@ -163,6 +170,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     private XWalkActivityStateListener mActivityStateListener;
     private ValueCallback<Uri> mFilePathCallback;
     private String mCameraPhotoPath;
+    private String mFileType;
 
     /**
      * Normal reload mode as default.
@@ -1031,6 +1039,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     public boolean showFileChooser(ValueCallback<Uri> uploadFile, String acceptType,
             String capture) {
         mFilePathCallback = uploadFile;
+        mFileType = acceptType;
 
         Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         if (takePictureIntent.resolveActivity(getActivity().getPackageManager()) != null) {
@@ -1054,18 +1063,47 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
             }
         }
 
-        Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
-        contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
-        contentSelectionIntent.setType("*/*");
-
         Intent camcorder = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
         Intent soundRecorder = new Intent(
                 MediaStore.Audio.Media.RECORD_SOUND_ACTION);
-        ArrayList<Intent> extraIntents = new ArrayList<Intent>();
-        extraIntents.add(takePictureIntent);
-        extraIntents.add(camcorder);
-        extraIntents.add(soundRecorder);
+        if (capture.equals("true")) {
+            if (mFileType.equals(ALL_IMAGE_TYPES)) {
+                getActivity().startActivityForResult(takePictureIntent,
+                        INPUT_FILE_REQUEST_CODE);
+                return true;
+            } else if (mFileType.equals(ALL_VIDEO_TYPES)) {
+                getActivity().startActivityForResult(camcorder,
+                        INPUT_FILE_REQUEST_CODE);
+                return true;
+            } else if (mFileType.equals(ALL_AUDIO_TYPES)) {
+                getActivity().startActivityForResult(soundRecorder,
+                        INPUT_FILE_REQUEST_CODE);
+                return true;
+            }
+        }
 
+        Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
+        contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
+        ArrayList<Intent> extraIntents = new ArrayList<Intent>();
+        if (!noSpecificType()) {
+            if (shouldShowImageTypes()) {
+                extraIntents.add(takePictureIntent);
+                contentSelectionIntent.setType(ALL_IMAGE_TYPES);
+            } else if (shouldShowVideoTypes()) {
+                extraIntents.add(camcorder);
+                contentSelectionIntent.setType(ALL_VIDEO_TYPES);
+            } else if (shouldShowAudioTypes()) {
+                extraIntents.add(soundRecorder);
+                contentSelectionIntent.setType(ALL_AUDIO_TYPES);
+            }
+        }
+
+        if (extraIntents.isEmpty()) {
+            contentSelectionIntent.setType(ANY_TYPES);
+            extraIntents.add(takePictureIntent);
+            extraIntents.add(camcorder);
+            extraIntents.add(soundRecorder);
+        }
         Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
         chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
         chooserIntent.putExtra(Intent.EXTRA_TITLE, "Choose an action");
@@ -1087,6 +1125,32 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
                 storageDir      /* directory */
         );
         return imageFile;
+    }
+
+    private boolean noSpecificType() {
+        return mFileType.isEmpty() != false || mFileType.contains(ANY_TYPES);
+    }
+
+    private boolean shouldShowTypes(String allTypes, String specificType) {
+        if (noSpecificType() || mFileType.contains(allTypes)) return true;
+        return acceptSpecificType(specificType);
+    }
+
+    private boolean acceptSpecificType(String accept) {
+        if (mFileType.startsWith(accept))  return true;
+        return false;
+    }
+
+    private boolean shouldShowImageTypes() {
+        return shouldShowTypes(ALL_IMAGE_TYPES, IMAGE_TYPE);
+    }
+
+    private boolean shouldShowVideoTypes() {
+        return shouldShowTypes(ALL_VIDEO_TYPES, VIDEO_TYPE);
+    }
+
+    private boolean shouldShowAudioTypes() {
+        return shouldShowTypes(ALL_AUDIO_TYPES, AUDIO_TYPE);
     }
 
     // For instrumentation test.


### PR DESCRIPTION
This patch is to optimize the process with accept type.
Optimize the process to run related apps when file picker's accept type
was specified. E.g. the accept type is "video/*", click the file picker,
the camera goes into video status directly.