### PR TITLE
[Tizen] gyp: Centralize the dependency on libtzplatform-config.

### DIFF
--- a/application/tools/tizen/xwalk_tizen_tools.gyp
+++ b/application/tools/tizen/xwalk_tizen_tools.gyp
@@ -8,6 +8,7 @@
         '../../../application/common/xwalk_application_common.gypi:xwalk_application_common_lib',
         '../../../build/system.gyp:gio',
         '../../../build/system.gyp:tizen',
+        '../../../build/system.gyp:tizen_tzplatform_config',
       ],
       'include_dirs': [
         '../../../..',

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -29,6 +29,28 @@
     ['tizen==1', {
       'targets': [
         {
+          'target_name': 'tizen_tzplatform_config',
+          'type': 'none',
+          'variables': {
+            'packages': [
+              'libtzplatform-config',
+            ],
+          },
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags <@(packages))',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(pkg-config --libs-only-L --libs-only-other <@(packages))',
+            ],
+            'libraries': [
+              '<!@(pkg-config --libs-only-l <@(packages))',
+            ],
+          },
+        },
+        {
           'target_name': 'tizen_geolocation',
           'type': 'none',
           'variables': {
@@ -56,7 +78,6 @@
           'type': 'none',
           'variables': {
             'packages': [
-              'libtzplatform-config',
               'ail',
               'dlog',
               'nss',

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -299,20 +299,13 @@
             '../content/app/resources/content_resources.gyp:content_resources',
             '../ui/compositor/compositor.gyp:compositor',
             'build/system.gyp:tizen_geolocation',
+            'build/system.gyp:tizen_tzplatform_config',
             'sysapps/sysapps_resources.gyp:xwalk_sysapps_resources',
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
             '<(DEPTH)/third_party/jsoncpp/jsoncpp.gyp:jsoncpp',
             '../components/components.gyp:web_modal',
             '../components/components.gyp:renderer_context_menu',
           ],
-          'cflags': [
-            '<!@(pkg-config --cflags libtzplatform-config)',
-          ],
-          'link_settings': {
-            'libraries': [
-              '<!@(pkg-config --libs libtzplatform-config)',
-            ],
-          },
           'sources': [
             'experimental/native_file_system/virtual_root_provider_tizen.cc',
             'runtime/browser/tizen/tizen_locale_listener.cc',


### PR DESCRIPTION
pkg-config was being used to get libtzplatform-config's flags in both
build/system.gyp and xwalk.gyp. Do that in a single place,
build/system.gyp, instead, to reduce this needless duplication.

Since libtzplatform-config was part of the catch-all "tizen" target in
system.gyp, it has been split into its own separate target so that code
that only needs libtzplatform-config does not end up depending on
several other Tizen libraries as well.
