### PR TITLE
[Tizen] Add recognition of empty parameters in options of xwalk_backend

### DIFF
--- a/application/tools/tizen/xwalk_backend.cc
+++ b/application/tools/tizen/xwalk_backend.cc
@@ -38,13 +38,13 @@ GOptionEntry entries[] = {
   { "install", 'i', 0, G_OPTION_ARG_STRING, &install_path,
     "Path of the application to be installed/updated", "PATH" },
   { "uninstall", 'd', 0, G_OPTION_ARG_STRING, &uninstall_id,
-    "Uninstall the application with this appid/pkgid", "ID" },
+    "Uninstall the application with this pkgid", "ID" },
   { "continue", 'c' , 0, G_OPTION_ARG_NONE, &continue_tasks,
-    "Continue the previous unfinished tasks.", NULL},
+    "Continue the previous unfinished tasks", NULL},
   { "reinstall", 'r', 0, G_OPTION_ARG_STRING, &reinstall_id,
     "Reinstall the application with this pkgid "
     "(This option is ONLY for SDK to support RDS mode"
-    " (Rapid Development Support).", "ID" },
+    " (Rapid Development Support)", "ID" },
   { "key", 'k', 0, G_OPTION_ARG_STRING, &operation_key,
     "Unique operation key", "KEY" },
   { "quiet", 'q', 0, G_OPTION_ARG_NONE, &quiet,
@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) {
     const base::FilePath& path =
         base::MakeAbsoluteFilePath(base::FilePath(install_path));
     success = installer->Install(path, &app_id);
-    if (!success && storage->Contains(app_id)) {
+    if (!success && !app_id.empty() && storage->Contains(app_id)) {
       g_print("trying to update %s\n", app_id.c_str());
       success = installer->Update(app_id, path);
     }

--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -645,7 +645,7 @@ bool PackageInstaller::Uninstall(const std::string& id) {
   std::string app_id = PrepareUninstallationID(id);
 
   if (!xwalk::application::IsValidApplicationID(app_id)) {
-    LOG(ERROR) << "The given application id " << app_id << " is invalid.";
+    LOG(ERROR) << "The given application id '" << app_id << "' is invalid.";
     return false;
   }
 
@@ -673,8 +673,12 @@ bool PackageInstaller::Uninstall(const std::string& id) {
 }
 
 bool PackageInstaller::Reinstall(const std::string& pkgid) {
-  base::FilePath app_dir = xwalk::application::GetPackagePath(pkgid);
+  if (!xwalk::application::IsValidPkgID(pkgid)) {
+    LOG(ERROR) << "The given package id '" << pkgid << "' is invalid.";
+    return false;
+  }
 
+  base::FilePath app_dir = xwalk::application::GetPackagePath(pkgid);
   if (!base::DirectoryExists(app_dir)) {
     LOG(ERROR) << "Application directory " << app_dir.value()
                << " does not exist!";


### PR DESCRIPTION
Empty path in -i option and incorrect pkgid in -r option were not
recognized. These parameters were unnecessary passed further to other
functions.

BUG=XWALK-3051
