### PR TITLE
gyp: Cleanup Aura-related files and dependencies.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -383,7 +383,6 @@
           ],
         }, { # toolkit_views==0
           'sources/': [
-            ['exclude', 'runtime/browser/ui/native_app_window_views.cc'],
             ['exclude', 'runtime/browser/ui/xwalk_views_delegate.cc'],
             ['exclude', 'runtime/browser/ui/color_chooser_aura.cc'],
           ],
@@ -391,12 +390,6 @@
         ['use_aura==1', {
           'dependencies': [
             '../ui/aura/aura.gyp:aura',
-            '../ui/aura/aura.gyp:aura_test_support',
-            '../ui/wm/wm.gyp:wm'
-          ],
-        }, {  # use_aura==0
-          'sources/': [
-            ['exclude', '_aura\\.cc$'],
           ],
         }],
         ['disable_nacl==0', {


### PR DESCRIPTION
- Stop manually excluding `_aura.cc` files from the build, this is done
  automatically by Chromium's `filename_rules.gypi`. Ditto for files
  ending in `_views.cc`.
- Remove the dependency on the `aura_test_support` and `wm` targets. Not
  only does depending on a test target even when no tests are being
  bring a ton of additional dependencies, but neither targets seem to be
  needed at all, and were probably only needed in an earlier version of
  commit 336c03a ("runtime: Add aura-only native support").
