### PR TITLE
gyp: Cleanup dependency on re2.

### DIFF
--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -13,7 +13,6 @@
         '../../../sql/sql.gyp:sql',
         '../../../url/url.gyp:url_lib',
         '../../../third_party/libxml/libxml.gyp:libxml',
-        '../../../third_party/re2/re2.gyp:re2',
         '../../../third_party/zlib/google/zip.gyp:zip',
       ],
       'sources': [

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -60,7 +60,6 @@
           'dependencies': [
             'build/system.gyp:tizen',
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
-            '../third_party/re2/re2.gyp:re2',
             '<(DEPTH)/ui/events/platform/events_platform.gyp:events_platform',
           ],
           'sources': [


### PR DESCRIPTION
- Stop always depending on it in `xwalk_application_common.gypi`, as it
  is only needed for Tizen.
- Remove dependency in `xwalk_application.gypi` now that the manifest
  handling files are in `application/common/` and thus covered by
  `xwalk_application_common.gypi`.
