### PR TITLE
[Tizen] gyp: Move xmlsec detection to system.gyp.

### DIFF
--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -55,18 +55,11 @@
         ['tizen==1', {
           'dependencies': [
             '../../build/system.gyp:tizen',
+            '../../build/system.gyp:xmlsec',
             '../../tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
             '../../../third_party/re2/re2.gyp:re2',
             '../../../net/net.gyp:net',
           ],
-          'cflags': [
-            '<!@(pkg-config --cflags xmlsec1)',
-          ],
-          'link_settings': {
-            'libraries': [
-              '<!@(pkg-config --libs-only-l xmlsec1)',
-            ],
-          },
           'sources': [
             'manifest_handlers/tizen_app_control_handler.cc',
             'manifest_handlers/tizen_app_control_handler.h',

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -193,6 +193,23 @@
             ],
           },
         },
+        {
+          'target_name': 'xmlsec',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags xmlsec1)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(pkg-config --libs-only-L --libs-only-other xmlsec1)',
+            ],
+            'libraries': [
+              '<!@(pkg-config --libs-only-l xmlsec1)',
+            ],
+          },
+        }
       ],  # targets
     }],
   ],  # conditions


### PR DESCRIPTION
This was the last remaining pkg-config call spread around random gyp
files. Move it to `build/system.gyp` with all the others and depend on the
"xmlsec" target in `xwalk_application_common.gypi`.
