### PR TITLE
Fix build on Mac.

### DIFF
--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -6,7 +6,6 @@
       'dependencies': [
         '../../../base/base.gyp:base',
         '../../../base/base.gyp:base_i18n',
-        '../../../base/base.gyp:xdg_mime',
         '../../../content/content.gyp:content_common',
         '../../../crypto/crypto.gyp:crypto',
         '../../../net/net.gyp:net',
@@ -54,6 +53,7 @@
       'conditions': [
         ['tizen==1', {
           'dependencies': [
+            '../../../base/base.gyp:xdg_mime',
             '../../build/system.gyp:tizen',
             '../../tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
             '../../../third_party/re2/re2.gyp:re2',


### PR DESCRIPTION
Add xdg_mime dependency where it's needed. Only Tizen uses this
library in common/manifest_handlers/tizen_app_control_handler.
