### PR TITLE
[Tizen]Move global constant values into proper namespace.

### DIFF
--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -108,7 +108,7 @@ bool ApplicationData::IsHostedApp() const {
   if (manifest_->HasPath(widget_keys::kContentNamespace)) {
     std::string ns;
     if (manifest_->GetString(widget_keys::kContentNamespace, &ns) &&
-        ns == kTizenNamespacePrefix)
+        ns == widget_keys::kTizenNamespacePrefix)
       hosted = true;
   }
 #endif

--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -276,7 +276,7 @@ base::DictionaryValue* LoadXMLNode(
       current_value->GetString(kNamespaceKey, &current_namespace);
       sub_value->GetString(kNamespaceKey, &new_namespace);
       if (current_namespace != new_namespace &&
-          new_namespace == kTizenNamespacePrefix)
+          new_namespace == widget_keys::kTizenNamespacePrefix)
         value->Set(sub_node_name, sub_value);
       continue;
 #endif

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -97,6 +97,9 @@ const char kPreferencesNameKey[] = "@name";
 const char kPreferencesValueKey[] = "@value";
 const char kPreferencesReadonlyKey[] = "@readonly";
 
+const char kWidgetNamespaceKey[] = "widget.@namespace";
+const char kWidgetNamespacePrefix[] = "http://www.w3.org/ns/widgets";
+
 // Child keys inside 'kAccessKey'.
 const char kAccessOriginKey[] = "@origin";
 const char kAccessSubdomainsKey[] = "@subdomains";
@@ -157,15 +160,10 @@ const char kTizenApplicationAppControlOperationKey[] = "operation";
 const char kTizenApplicationAppControlUriKey[] = "uri";
 const char kTizenApplicationAppControlMimeKey[] = "mime";
 const char kTizenApplicationAppControlChildNameAttrKey[] = "@name";
+const char kTizenNamespacePrefix[] = "http://tizen.org/ns/widgets";
 #endif
 
 }  // namespace application_widget_keys
-
-const char kW3CNamespaceKey[] = "widget.@namespace";
-const char kW3CNamespacePrefix[] = "http://www.w3.org/ns/widgets";
-#if defined(OS_TIZEN)
-const char kTizenNamespacePrefix[] = "http://tizen.org/ns/widgets";
-#endif
 
 namespace application_manifest_errors {
 const char kInvalidDescription[] =

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -86,6 +86,8 @@ namespace application_widget_keys {
   extern const char kPreferencesNameKey[];
   extern const char kPreferencesValueKey[];
   extern const char kPreferencesReadonlyKey[];
+  extern const char kWidgetNamespaceKey[];
+  extern const char kWidgetNamespacePrefix[];
 #if defined(OS_TIZEN)
   extern const char kTizenWidgetKey[];
   extern const char kTizenApplicationKey[];
@@ -137,14 +139,10 @@ namespace application_widget_keys {
   extern const char kTizenApplicationAppControlUriKey[];
   extern const char kTizenApplicationAppControlMimeKey[];
   extern const char kTizenApplicationAppControlChildNameAttrKey[];
+  extern const char kTizenNamespacePrefix[];
 #endif
 }  // namespace application_widget_keys
 
-extern const char kW3CNamespaceKey[];
-extern const char kW3CNamespacePrefix[];
-#if defined(OS_TIZEN)
-extern const char kTizenNamespacePrefix[];
-#endif
 
 namespace application_manifest_errors {
   extern const char kInvalidDescription[];

--- a/application/common/manifest_handlers/tizen_application_handler.cc
+++ b/application/common/manifest_handlers/tizen_application_handler.cc
@@ -46,7 +46,7 @@ bool TizenApplicationHandler::Parse(scoped_refptr<ApplicationData> application,
   if (app_value && app_value->IsType(base::Value::TYPE_DICTIONARY)) {
     app_value->GetAsDictionary(&app_dict);
     find = app_dict->GetString(keys::kNamespaceKey, &value);
-    find = find && (value == kTizenNamespacePrefix);
+    find = find && (value == keys::kTizenNamespacePrefix);
   } else if (app_value && app_value->IsType(base::Value::TYPE_LIST)) {
     base::ListValue* list;
     app_value->GetAsList(&list);
@@ -54,7 +54,7 @@ bool TizenApplicationHandler::Parse(scoped_refptr<ApplicationData> application,
          it != list->end(); ++it) {
       (*it)->GetAsDictionary(&app_dict);
       find = app_dict->GetString(keys::kNamespaceKey, &value);
-      find = find && (value == kTizenNamespacePrefix);
+      find = find && (value == keys::kTizenNamespacePrefix);
       if (find)
         break;
     }

--- a/application/common/manifest_handlers/tizen_appwidget_handler.cc
+++ b/application/common/manifest_handlers/tizen_appwidget_handler.cc
@@ -291,7 +291,7 @@ bool ParseLabel(const base::DictionaryValue& dict,
     const std::string& key, TizenAppWidget* app_widget, base::string16* error) {
   DCHECK(app_widget);
 
-  if (!VerifyElementNamespace(dict, key, kTizenNamespacePrefix, error))
+  if (!VerifyElementNamespace(dict, key, keys::kTizenNamespacePrefix, error))
     return false;
 
   std::string lang;
@@ -322,7 +322,7 @@ bool ParseIcon(const base::DictionaryValue& dict,
     const std::string& key, TizenAppWidget* app_widget, base::string16* error) {
   DCHECK(app_widget);
 
-  if (!VerifyElementNamespace(dict, key, kTizenNamespacePrefix, error))
+  if (!VerifyElementNamespace(dict, key, keys::kTizenNamespacePrefix, error))
     return false;
 
   if (!app_widget->icon_src.empty()) {
@@ -360,7 +360,7 @@ bool ParseContentSizes(const base::DictionaryValue& dict,
     const std::string& key, TizenAppWidget* app_widget, base::string16* error) {
   DCHECK(app_widget);
 
-  if (!VerifyElementNamespace(dict, key, kTizenNamespacePrefix, error))
+  if (!VerifyElementNamespace(dict, key, keys::kTizenNamespacePrefix, error))
     return false;
 
   TizenAppWidgetSize size;
@@ -397,7 +397,7 @@ bool ParseContentDropView(const base::DictionaryValue& dict,
     const std::string& key, TizenAppWidget* app_widget, base::string16* error) {
   DCHECK(app_widget);
 
-  if (!VerifyElementNamespace(dict, key, kTizenNamespacePrefix, error))
+  if (!VerifyElementNamespace(dict, key, keys::kTizenNamespacePrefix, error))
     return false;
 
   if (!app_widget->content_drop_view.empty()) {
@@ -431,7 +431,7 @@ bool ParseContent(const base::DictionaryValue& dict,
     const std::string& key, TizenAppWidget* app_widget, base::string16* error) {
   DCHECK(app_widget);
 
-  if (!VerifyElementNamespace(dict, key, kTizenNamespacePrefix, error))
+  if (!VerifyElementNamespace(dict, key, keys::kTizenNamespacePrefix, error))
     return false;
 
   if (!app_widget->content_src.empty()) {
@@ -467,7 +467,7 @@ bool ParseAppWidget(const base::DictionaryValue& dict,
     base::string16* error) {
   DCHECK(app_widgets);
 
-  if (!VerifyElementNamespace(dict, key, kTizenNamespacePrefix, error))
+  if (!VerifyElementNamespace(dict, key, keys::kTizenNamespacePrefix, error))
     return false;
 
   TizenAppWidget app_widget;

--- a/application/common/manifest_handlers/unittest_util.cc
+++ b/application/common/manifest_handlers/unittest_util.cc
@@ -49,7 +49,7 @@ scoped_ptr<base::DictionaryValue> CreateDefaultWidgetConfig() {
 
   manifest->SetString(
       DotConnect(widget_keys::kWidgetKey, widget_keys::kNamespaceKey),
-      kW3CNamespacePrefix);
+      widget_keys::kWidgetNamespacePrefix);
   manifest->SetString(widget_keys::kVersionKey, kDefaultVersion);
   manifest->SetString(widget_keys::kNameKey, kDefaultName);
 
@@ -60,7 +60,7 @@ scoped_ptr<base::DictionaryValue> CreateDefaultWidgetConfig() {
   manifest->SetString(
       DotConnect(widget_keys::kTizenApplicationKey,
                  widget_keys::kNamespaceKey),
-      kTizenNamespacePrefix);
+      widget_keys::kTizenNamespacePrefix);
   manifest->SetString(
       DotConnect(widget_keys::kTizenApplicationKey,
                  widget_keys::kTizenApplicationIdKey),

--- a/application/common/manifest_handlers/widget_handler.cc
+++ b/application/common/manifest_handlers/widget_handler.cc
@@ -165,8 +165,8 @@ bool WidgetHandler::Validate(
   const Manifest* manifest = application->GetManifest();
   DCHECK(manifest);
   std::string ns_value;
-  manifest->GetString(kW3CNamespaceKey, &ns_value);
-  if (base::strcasecmp(kW3CNamespacePrefix, ns_value.c_str()) != 0) {
+  manifest->GetString(keys::kWidgetNamespaceKey, &ns_value);
+  if (base::strcasecmp(keys::kWidgetNamespacePrefix, ns_value.c_str()) != 0) {
     *error = std::string("The widget namespace is invalid.");
     return false;
   }

--- a/application/common/manifest_handlers/widget_handler_unittest.cc
+++ b/application/common/manifest_handlers/widget_handler_unittest.cc
@@ -93,7 +93,8 @@ class WidgetHandlerTest: public testing::Test {
   // No Preferences and full other information
   void SetAllInfoToManifest(base::DictionaryValue* manifest) {
     // Insert some key-value pairs into manifest use full key
-    manifest->SetString(kW3CNamespaceKey,      kW3CNamespacePrefix);
+    manifest->SetString(keys::kWidgetNamespaceKey,
+                        keys::kWidgetNamespacePrefix);
     manifest->SetString(keys::kAuthorKey,      author);
     manifest->SetString(keys::kDescriptionKey, decription);
     manifest->SetString(keys::kNameKey,        name);
@@ -124,7 +125,7 @@ class WidgetHandlerTest: public testing::Test {
 
 TEST_F(WidgetHandlerTest, ParseManifestWithOnlyNameAndVersion) {
   base::DictionaryValue manifest;
-  manifest.SetString(kW3CNamespaceKey, kW3CNamespacePrefix);
+  manifest.SetString(keys::kWidgetNamespaceKey, keys::kWidgetNamespacePrefix);
   manifest.SetString(keys::kNameKey, "no name");
   manifest.SetString(keys::kVersionKey, "0");
 


### PR DESCRIPTION
The widget configuration keys and preset values should be included inside the namespace "application_widget_keys".
