### PR TITLE
[TIZEN] Runtime has no chance to get remote debug flag

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -222,6 +222,7 @@ bool Application::Launch(const LaunchParams& launch_params) {
   auto site = content::SiteInstance::CreateForURL(browser_context_, url);
   Runtime* runtime = Runtime::Create(browser_context_, site);
   runtime->set_observer(this);
+  runtime->set_remote_debugging_enabled(remote_debugging_enabled_);
   runtimes_.push_back(runtime);
   render_process_host_ = runtime->GetRenderProcessHost();
   render_process_host_->AddObserver(this);


### PR DESCRIPTION
Since the first-created Runtime cannot trigger "Application::OnNewRuntimeAdded" now, the first-created Runtime has no chance to notify its application (observer) to update its remote debug flag.

BUG=https://crosswalk-project.org/jira/browse/XWALK-3080
