### PR TITLE
To support Cynara-based permissions checking

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -103,11 +103,11 @@ class Application : public Runtime::Observer,
   std::string GetRegisteredPermissionName(const std::string& extension_name,
                                           const std::string& api_name) const;
 
-  StoredPermission GetPermission(PermissionType type,
-                                 const std::string& permission_name) const;
-  bool SetPermission(PermissionType type,
-                     const std::string& permission_name,
-                     StoredPermission perm);
+  virtual StoredPermission GetPermission(PermissionType type,
+                                     const std::string& permission_name) const;
+  virtual bool SetPermission(PermissionType type,
+                             const std::string& permission_name,
+                             StoredPermission perm);
   bool CanRequestURL(const GURL& url) const;
   bool IsFullScreenRequired() const {
       return window_show_params_.state == ui::SHOW_STATE_FULLSCREEN; }

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -9,6 +9,9 @@
 
 #include "base/event_types.h"
 #include "xwalk/application/browser/application.h"
+#if defined(USE_CYNARA)
+#include "xwalk/application/browser/tizen/tizen_cynara_checker.h"
+#endif
 #include "xwalk/application/common/tizen/cookie_manager.h"
 
 #if defined(USE_OZONE)
@@ -33,7 +36,14 @@ class ApplicationTizen :  // NOLINT
 
   void RemoveAllCookies();
   void SetUserAgentString(const std::string& user_agent_string);
-
+#if defined(USE_CYNARA)
+  virtual void GetPermissionAsync(PermissionType type,
+                const std::string& permission_name,
+                const TizenCynaraChecker::ResultCallback& callback) override;
+#endif
+  virtual bool SetPermission(PermissionType type,
+                             const std::string& permission_name,
+                             StoredPermission perm) override;
  private:
   friend class Application;
   ApplicationTizen(scoped_refptr<ApplicationData> data,
@@ -57,6 +67,9 @@ class ApplicationTizen :  // NOLINT
 #endif
   scoped_ptr<CookieManager> cookie_manager_;
   bool is_suspended_;
+#if defined(USE_CYNARA)
+  TizenCynaraChecker checker_;
+#endif
 };
 
 inline ApplicationTizen* ToApplicationTizen(Application* app) {

--- a/application/browser/tizen/tizen_cynara_checker.cc
+++ b/application/browser/tizen/tizen_cynara_checker.cc
@@ -1,0 +1,96 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/browser/tizen/tizen_cynara_checker.h"
+
+#include <cynara-creds-socket.h>
+
+#include "base/bind.h"
+#include "base/logging.h"
+
+namespace xwalk {
+
+TizenCynaraChecker::TizenCynaraChecker()
+    : client_id_(nullptr),
+      user_id_(nullptr),
+      cynara_handler_(nullptr),
+      thread_(new base::Thread("cynara_checking_thread")) {
+}
+
+bool TizenCynaraChecker::Init(cynara* cynara_handler, int socket_fd) {
+  LOG(ERROR) << "enter cynara check";
+
+  if (Initialized())
+    return true;
+
+  if (cynara_handler == nullptr)
+    return false;
+  else
+    cynara_handler_ = cynara_handler;
+
+  int ret;
+  ret = cynara_creds_socket_get_client(socket_fd,
+          CLIENT_METHOD_SMACK, &client_id_);
+  if (ret != CYNARA_API_SUCCESS) {
+    LOG(ERROR) << "cynara failed to get client id, error code " + ret;
+    return false;
+  }
+  ret = cynara_creds_socket_get_user(socket_fd, USER_METHOD_UID, &user_id_);
+  if (ret != CYNARA_API_SUCCESS) {
+    LOG(ERROR) << "cynara failed to get user id, error code " + ret;
+    return false;
+  }
+
+  if (!thread_.get()->Start()) {
+    LOG(ERROR) << "Failed to create Cynara checking thread";
+    return false;
+  }
+
+  return true;
+}
+
+void TizenCynaraChecker::CheckCynaraASync(const char* session,
+        const char* privilege,
+        const ResultCallback& callback) {
+  thread_.get()->task_runner()->PostTask(FROM_HERE,
+                                  base::Bind(
+                                    &TizenCynaraChecker::CheckCynaraTask,
+                                    base::Unretained(this),
+                                    session,
+                                    privilege,
+                                    callback));
+}
+
+void TizenCynaraChecker::CheckCynaraTask(const char* session,
+                       const char* privilege,
+                       const ResultCallback& callback) {
+  // If it's checked once already, the sequenced will be completed directly.
+  if (check_result_cache_[privilege].checked) {
+    callback.Run(check_result_cache_[privilege].permission);
+    return;
+  }
+
+  bool permission = cynara_check(cynara_handler_,
+                        client_id_, session, user_id_, privilege);
+  check_result_cache_[privilege].checked = true;
+  check_result_cache_[privilege].permission = permission;
+  callback.Run(permission);
+}
+
+TizenCynaraChecker::~TizenCynaraChecker() {
+  // Stop checking thread before Cynara client being invalid
+  thread_.get()->Stop();
+
+  if (client_id_)
+    free(client_id_);
+  if (user_id_)
+    free(user_id_);
+}
+
+TizenCynaraChecker::CheckResult::CheckResult()
+  : checked(false),
+    permission(false) {
+}
+
+}  // namespace xwalk

--- a/application/browser/tizen/tizen_cynara_checker.h
+++ b/application/browser/tizen/tizen_cynara_checker.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_BROWSER_TIZEN_TIZEN_CYNARA_CHECKER_H_
+#define XWALK_APPLICATION_BROWSER_TIZEN_TIZEN_CYNARA_CHECKER_H_
+
+#include <cynara-client.h>
+#include <map>
+#include <string>
+
+#include "base/threading/thread.h"
+
+namespace xwalk {
+
+// Helper class to check cynara, one Application has one instance
+class TizenCynaraChecker {
+ public:
+  TizenCynaraChecker();
+  virtual ~TizenCynaraChecker();
+
+  // Cynara needs the socket file descriptor, through which BP is communicating
+  // with RP, to indentify the correspondent RP.
+  bool Init(cynara* cynara_handler, int socket_fd);
+  bool Initialized() { return cynara_handler_ != nullptr; }
+
+  using ResultCallback = base::Callback<void(bool result)>;
+
+  // The parameter session is not used currently.
+  void CheckCynaraASync(const char* session,
+                       const char* privilege,
+                       const ResultCallback& callback);
+
+ private:
+    // The parameter session is not used currently.
+  void CheckCynaraTask(const char* session,
+                       const char* privilege,
+                       const ResultCallback& callback);
+
+  // This class is resposible to free memory
+  char* client_id_;
+  char* user_id_;
+
+  cynara* cynara_handler_;
+
+  // For the same privilege, we only check Cynara one time.
+  struct CheckResult {
+    CheckResult();
+    bool checked;
+    bool permission;
+  };
+  std::map<std::string, CheckResult> check_result_cache_;
+  scoped_ptr<base::Thread> thread_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_BROWSER_TIZEN_TIZEN_CYNARA_CHECKER_H_

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -68,6 +68,11 @@ const char kXWalkMediaAppClass[] = "xwalk_media_app_class";
 
 }  // namespace application_manifest_keys
 
+namespace application_manifest_permissions {
+const char kPermissionGeolocation[] = "geolocation";
+}  // namespace application_manifest_permissions
+
+
 // manifest keys for widget applications.
 namespace application_widget_keys {
 
@@ -164,6 +169,14 @@ const char kTizenNamespacePrefix[] = "http://tizen.org/ns/widgets";
 #endif
 
 }  // namespace application_widget_keys
+
+#if defined(OS_TIZEN)
+namespace application_tizen_privileges {
+const char kTizenAppPrivilegeLocation[] =
+    "http://tizen.org/privilege/location";
+}  // namespace application_tizen_privileges
+
+#endif
 
 namespace application_manifest_errors {
 const char kInvalidDescription[] =

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -60,6 +60,10 @@ namespace application_manifest_keys {
 #endif
 }  // namespace application_manifest_keys
 
+namespace application_manifest_permissions {
+  extern const char kPermissionGeolocation[];
+}  // namespace application_manifest_permissions
+
 namespace application_widget_keys {
   extern const char kNamespaceKey[];
   extern const char kXmlLangKey[];
@@ -143,6 +147,11 @@ namespace application_widget_keys {
 #endif
 }  // namespace application_widget_keys
 
+#if defined(OS_TIZEN)
+namespace application_tizen_privileges {
+  extern const char kTizenAppPrivilegeLocation[];
+}  // namespace application_tizen_privileges
+#endif
 
 namespace application_manifest_errors {
   extern const char kInvalidDescription[];

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -62,11 +62,23 @@
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
             '<(DEPTH)/ui/events/platform/events_platform.gyp:events_platform',
           ],
+          'cflags': [
+            '<!@(pkg-config --cflags cynara-client)',
+            '<!@(pkg-config --cflags cynara-creds-socket)',
+          ],
+          'link_settings': {
+            'libraries': [
+              '<!@(pkg-config --libs cynara-client)',
+              '<!@(pkg-config --libs cynara-creds-socket)',
+            ],
+          },
           'sources': [
             'browser/application_tizen.cc',
             'browser/application_tizen.h',
             'browser/application_service_tizen.cc',
             'browser/application_service_tizen.h',
+            'browser/tizen/tizen_cynara_checker.cc',
+            'browser/tizen/tizen_cynara_checker.h',
           ],
         }],
       ],

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -2,6 +2,8 @@
   'variables': {
     'tizen%': 0,
     'tizen_mobile%': 0,
+    'shared_process_mode%': 0,
+    'use_cynara%': 0,
     'enable_murphy%': 0,
   },
   'target_defaults': {
@@ -12,7 +14,13 @@
     },
     'conditions': [
       ['tizen==1', {
-        'defines': ['OS_TIZEN=1'],
+        'conditions': [
+          ['use_cynara==1', {
+            'defines': ['OS_TIZEN=1', 'USE_CYNARA=1']
+          },{
+            'defines': ['OS_TIZEN=1', 'USE_CYNARA=0']
+          }]
+        ]
       }],
       ['tizen_mobile==1', {
         'defines': ['OS_TIZEN_MOBILE=1', 'OS_TIZEN=1'],

--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -59,6 +59,8 @@ BuildRequires:  pkgconfig(alsa)
 BuildRequires:  pkgconfig(appcore-common)
 BuildRequires:  pkgconfig(cairo)
 BuildRequires:  pkgconfig(capi-location-manager)
+BuildRequires:  pkgconfig(cynara-client)
+BuildRequires:  pkgconfig(cynara-creds-socket)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(fontconfig)
 BuildRequires:  pkgconfig(freetype2)
@@ -237,6 +239,7 @@ ${GYP_EXTRA_FLAGS} \
 -Dpython_ver=2.7 \
 -Duse_aura=1 \
 -Duse_cups=0 \
+-Duse_cynara=1 \
 -Duse_gconf=0 \
 -Duse_gnome_keyring=0 \
 -Duse_kerberos=0 \

--- a/runtime/browser/runtime_geolocation_permission_context.h
+++ b/runtime/browser/runtime_geolocation_permission_context.h
@@ -36,13 +36,14 @@ class RuntimeGeolocationPermissionContext
 
  private:
   void RequestGeolocationPermissionOnUIThread(
-      content::WebContents* web_contents,
-      const GURL& requesting_frame,
-      base::Callback<void(bool)> result_callback);
-
-  void CancelGeolocationPermissionRequestOnUIThread(
-      content::WebContents* web_contents,
-      const GURL& requesting_frame);
+    content::WebContents* web_contents,
+    const GURL& requesting_frame,
+    base::Callback<void(bool)> result_callback,
+    base::Closure* cancel_callback);
+    // Make sure the result_callback is invoked in UI Thread
+    void ResponseGeolocationPermissionOnUIThread(
+      base::Callback<void(bool)> result_callback,
+      bool permission);
 };
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_runner_tizen.h
+++ b/runtime/browser/xwalk_runner_tizen.h
@@ -5,6 +5,9 @@
 #ifndef XWALK_RUNTIME_BROWSER_XWALK_RUNNER_TIZEN_H_
 #define XWALK_RUNTIME_BROWSER_XWALK_RUNNER_TIZEN_H_
 
+#if defined(USE_CYNARA)
+#include <cynara-client.h>
+#endif
 #include <string>
 
 #include "xwalk/runtime/browser/xwalk_runner.h"
@@ -25,9 +28,16 @@ class XWalkRunnerTizen : public XWalkRunner {
 
   void PreMainMessageLoopRun() override;
 
+  cynara* cynara_handler() { return  cynara_handler_; }
+
  private:
   friend class XWalkRunner;
   XWalkRunnerTizen();
+
+#if defined(USE_CYNARA)
+  cynara* cynara_handler_;
+  cynara_configuration* cynara_conf_;
+#endif
 
   TizenLocaleListener tizen_locale_listener_;
 };

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -323,6 +323,14 @@
             'runtime/browser/android/xwalk_web_contents_view_delegate.cc',
             'runtime/browser/android/xwalk_web_contents_view_delegate.h',
           ],
+          'cflags': [
+            '<!@(pkg-config --cflags cynara-client)',
+          ],
+          'link_settings': {
+            'libraries': [
+              '<!@(pkg-config --libs cynara-client)',
+            ],
+          },
         }],
         ['OS=="android"',{
           'dependencies':[


### PR DESCRIPTION
(1) Add class TizenCynaraChecker to deal with Cynara lib.
(2) Embbed TizenCynaraChecker into the "Application::GetPermission" to integrate with existent logic as well as possible.
(3) Add mapping between permissions name and Tizen privileges.
(4) Take Geolocation as a sample to use it.

This patch is a refactor of https://github.com/crosswalk-project/crosswalk/pull/2525 to integrate with existent code of Crosswalk, as we've resolved all the problems of invoking Cynara interfaces in that pull request.