### PR TITLE
[Runtime] Add the check for return value of GetDEREncoded().

### DIFF
--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -98,7 +98,9 @@ void XWalkContentsClientBridge::AllowCertificateError(
     return;
 
   std::string der_string;
-  net::X509Certificate::GetDEREncoded(cert->os_cert_handle(), &der_string);
+  if (!net::X509Certificate::GetDEREncoded(cert->os_cert_handle(),
+      &der_string))
+    return;
   ScopedJavaLocalRef<jbyteArray> jcert = base::android::ToJavaByteArray(
       env,
       reinterpret_cast<const uint8*>(der_string.data()),


### PR DESCRIPTION
This patch is to add the check for return value of GetDEREncoded() in
xwalk_contents_client_bridge.cc.

CID=220017

Related to XWALK-2928.
