### PR TITLE
[Runtime] Add the initialization for |app_component_|.

### DIFF
--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -41,7 +41,8 @@ XWalkRunner* g_xwalk_runner = NULL;
 }  // namespace
 
 XWalkRunner::XWalkRunner()
-    : shared_process_mode_enabled_(false) {
+    : shared_process_mode_enabled_(false),
+      app_component_(nullptr) {
   VLOG(1) << "Creating XWalkRunner object.";
   DCHECK(!g_xwalk_runner);
   g_xwalk_runner = this;


### PR DESCRIPTION
This patch is to add the initialization in the constructor.

CID=220054

Related to XWALK-2928.
