### PR TITLE
[Runtime] Add the initialization for RuntimeFeature.

### DIFF
--- a/runtime/common/xwalk_runtime_features.cc
+++ b/runtime/common/xwalk_runtime_features.cc
@@ -22,8 +22,6 @@ struct MatchRuntimeFeature
   const std::string name;
 };
 
-XWalkRuntimeFeatures::RuntimeFeature::RuntimeFeature() {}
-
 // static
 XWalkRuntimeFeatures* XWalkRuntimeFeatures::GetInstance() {
   return Singleton<XWalkRuntimeFeatures>::get();

--- a/runtime/common/xwalk_runtime_features.h
+++ b/runtime/common/xwalk_runtime_features.h
@@ -41,7 +41,7 @@ class XWalkRuntimeFeatures {
     std::string command_line_switch;
     RuntimeFeatureStatus status;
     bool enabled;
-    RuntimeFeature();
+    RuntimeFeature() = default;
   };
 
  private:


### PR DESCRIPTION
The struct about RuntimeFeature was not initialized with empty constructor,
remove it to allow compiler generate one and initialize the member
variables.

CID=194651

Related to XWALK-2928
