### PR TITLE
[Application] Add the initialization for |header_|.

### DIFF
--- a/application/common/package/xpk_package.cc
+++ b/application/common/package/xpk_package.cc
@@ -26,6 +26,7 @@ XPKPackage::~XPKPackage() {
 
 XPKPackage::XPKPackage(const base::FilePath& path)
     : Package(path, Manifest::TYPE_MANIFEST),
+      header_(),
       zip_addr_(0) {
   if (!base::PathExists(path))
     return;


### PR DESCRIPTION
This patch is to add the initialization for |header_| in the
constructor.

CID=194686

Related to: XWALK-2928
