### PR TITLE
Fix unit tests for csp handler

### DIFF
--- a/application/common/manifest_handlers/csp_handler_unittest.cc
+++ b/application/common/manifest_handlers/csp_handler_unittest.cc
@@ -1,11 +1,13 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "xwalk/application/common/manifest_handlers/csp_handler.h"
-
-#include "xwalk/application/common/application_manifest_constants.h"
+#include "base/memory/scoped_ptr.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/manifest_handlers/csp_handler.h"
+#include "xwalk/application/common/manifest_handlers/unittest_util.h"
 
 namespace xwalk {
 
@@ -14,51 +16,44 @@ namespace widget_keys = application_widget_keys;
 
 namespace application {
 
+namespace {
+
+const CSPInfo* GetCSPInfo(
+    scoped_refptr<ApplicationData> application) {
+  const CSPInfo* info = static_cast<CSPInfo*>(
+      application->GetManifestData(GetCSPKey(application->manifest_type())));
+  return info;
+}
+
+}  // namespace
+
 class CSPHandlerTest: public testing::Test {
- public:
-  scoped_refptr<ApplicationData> CreateApplication() {
-    std::string error;
-    scoped_refptr<ApplicationData> app_data = ApplicationData::Create(
-        base::FilePath(), std::string(), ApplicationData::LOCAL_DIRECTORY,
-        make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
-        &error);
-    return app_data;
-  }
-
-  const CSPInfo* GetCSPInfo(
-      scoped_refptr<ApplicationData> application) {
-    const CSPInfo* info = static_cast<CSPInfo*>(
-        application->GetManifestData(GetCSPKey(application->manifest_type())));
-    return info;
-  }
-
-  base::DictionaryValue manifest;
 };
 
 // FIXME: the default CSP policy settings in CSP manifest handler
 // are temporally removed, since they had affected some tests and legacy apps.
 TEST_F(CSPHandlerTest, DISABLED_NoCSP) {
-  manifest.SetString(keys::kNameKey, "no name");
-  manifest.SetString(keys::kXWalkVersionKey, "0");
-  scoped_refptr<ApplicationData> application = CreateApplication();
+  scoped_ptr<base::DictionaryValue> manifest = CreateDefaultManifestConfig();
+  scoped_refptr<ApplicationData> application =
+      CreateApplication(Manifest::TYPE_MANIFEST, *manifest);
   EXPECT_TRUE(application.get());
   EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 2);
 }
 
 TEST_F(CSPHandlerTest, EmptyCSP) {
-  manifest.SetString(keys::kNameKey, "no name");
-  manifest.SetString(keys::kXWalkVersionKey, "0");
-  manifest.SetString(keys::kCSPKey, "");
-  scoped_refptr<ApplicationData> application = CreateApplication();
+  scoped_ptr<base::DictionaryValue> manifest = CreateDefaultManifestConfig();
+  manifest->SetString(keys::kCSPKey, "");
+  scoped_refptr<ApplicationData> application =
+      CreateApplication(Manifest::TYPE_MANIFEST, *manifest);
   EXPECT_TRUE(application.get());
   EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 0);
 }
 
 TEST_F(CSPHandlerTest, CSP) {
-  manifest.SetString(keys::kNameKey, "no name");
-  manifest.SetString(keys::kXWalkVersionKey, "0");
-  manifest.SetString(keys::kCSPKey, "default-src    'self'   ");
-  scoped_refptr<ApplicationData> application = CreateApplication();
+  scoped_ptr<base::DictionaryValue> manifest = CreateDefaultManifestConfig();
+  manifest->SetString(keys::kCSPKey, "default-src    'self'   ");
+  scoped_refptr<ApplicationData> application =
+      CreateApplication(Manifest::TYPE_MANIFEST, *manifest);
   EXPECT_TRUE(application.get());
   const std::map<std::string, std::vector<std::string> >& policies =
       GetCSPInfo(application)->GetDirectives();
@@ -72,20 +67,20 @@ TEST_F(CSPHandlerTest, CSP) {
 
 #if defined(OS_TIZEN)
 TEST_F(CSPHandlerTest, WGTEmptyCSP) {
-  manifest.SetString(widget_keys::kNameKey, "no name");
-  manifest.SetString(widget_keys::kVersionKey, "0");
-  manifest.SetString(widget_keys::kCSPKey, "");
-  scoped_refptr<ApplicationData> application = CreateApplication();
+  scoped_ptr<base::DictionaryValue> manifest = CreateDefaultWidgetConfig();
+  manifest->SetString(widget_keys::kCSPKey, "");
+  scoped_refptr<ApplicationData> application =
+      CreateApplication(Manifest::TYPE_WIDGET, *manifest);
   EXPECT_TRUE(application.get());
   EXPECT_TRUE(GetCSPInfo(application));
   EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 0);
 }
 
 TEST_F(CSPHandlerTest, WGTCSP) {
-  manifest.SetString(widget_keys::kNameKey, "no name");
-  manifest.SetString(widget_keys::kVersionKey, "0");
-  manifest.SetString(widget_keys::kCSPKey, "default-src    'self'   ");
-  scoped_refptr<ApplicationData> application = CreateApplication();
+  scoped_ptr<base::DictionaryValue> manifest = CreateDefaultWidgetConfig();
+  manifest->SetString(widget_keys::kCSPKey, "default-src    'self'   ");
+  scoped_refptr<ApplicationData> application =
+      CreateApplication(Manifest::TYPE_WIDGET, *manifest);
   EXPECT_TRUE(application.get());
   EXPECT_TRUE(GetCSPInfo(application));
   const std::map<std::string, std::vector<std::string> >& policies =


### PR DESCRIPTION
This patch is changing the way in which manifest
and application objects are created.
All below tests now pass:
- CSPHandlerTest.WGTCSP
- CSPHandlerTest.WGTEmptyCSP
