### PR TITLE
Stop declaring zero-argument constructors explicit.

### DIFF
--- a/runtime/browser/runtime_file_select_helper.h
+++ b/runtime/browser/runtime_file_select_helper.h
@@ -46,7 +46,7 @@ class RuntimeFileSelectHelper
  private:
   friend class base::RefCountedThreadSafe<RuntimeFileSelectHelper>;
   FRIEND_TEST_ALL_PREFIXES(RuntimeFileSelectHelperTest, IsAcceptTypeValid);
-  explicit RuntimeFileSelectHelper();
+  RuntimeFileSelectHelper();
   virtual ~RuntimeFileSelectHelper();
 
   // Utility class which can listen for directory lister events and relay

--- a/runtime/browser/runtime_javascript_dialog_manager.h
+++ b/runtime/browser/runtime_javascript_dialog_manager.h
@@ -13,7 +13,7 @@ namespace xwalk {
 
 class RuntimeJavaScriptDialogManager : public content::JavaScriptDialogManager {
  public:
-  explicit RuntimeJavaScriptDialogManager();
+  RuntimeJavaScriptDialogManager();
   virtual ~RuntimeJavaScriptDialogManager();
 
   virtual void RunJavaScriptDialog(

--- a/sysapps/device_capabilities/device_capabilities_extension.h
+++ b/sysapps/device_capabilities/device_capabilities_extension.h
@@ -23,7 +23,7 @@ using extensions::XWalkExtensionInstance;
 
 class DeviceCapabilitiesExtension : public XWalkExtension {
  public:
-  explicit DeviceCapabilitiesExtension();
+  DeviceCapabilitiesExtension();
   virtual ~DeviceCapabilitiesExtension();
 
   // XWalkExtension implementation.

--- a/sysapps/raw_socket/raw_socket_extension.h
+++ b/sysapps/raw_socket/raw_socket_extension.h
@@ -19,7 +19,7 @@ using extensions::XWalkExtensionInstance;
 
 class RawSocketExtension : public XWalkExtension {
  public:
-  explicit RawSocketExtension();
+  RawSocketExtension();
   virtual ~RawSocketExtension();
 
   // XWalkExtension implementation.


### PR DESCRIPTION
./runtime/browser/runtime_file_select_helper.h:49:  Zero-parameter constructors should not be marked explicit.  [runtime/explicit] [5]
./runtime/browser/runtime_javascript_dialog_manager.h:16:  Zero-parameter constructors should not be marked explicit.  [runtime/explicit] [5]
./sysapps/device_capabilities/device_capabilities_extension.h:26:  Zero-parameter constructors should not be marked explicit.  [runtime/explicit] [5]
./sysapps/raw_socket/raw_socket_extension.h:22:  Zero-parameter constructors should not be marked explicit.  [runtime/explicit] [5]
