### PR TITLE
Remove trailing semicolons at the end of functions.

### DIFF
--- a/dbus/object_manager_adaptor.cc
+++ b/dbus/object_manager_adaptor.cc
@@ -168,7 +168,7 @@ ManagedObject::~ManagedObject() {}
 
 ObjectPath ManagedObject::path() const {
   return path_;
-};
+}
 
 void ManagedObject::AppendAllPropertiesToWriter(MessageWriter* writer) const {
   MessageWriter interfaces_writer(NULL);

--- a/extensions/browser/xwalk_extension_function_handler.h
+++ b/extensions/browser/xwalk_extension_function_handler.h
@@ -37,7 +37,7 @@ class XWalkExtensionFunctionInfo {
   // be called from any thread.
   void PostResult(scoped_ptr<base::ListValue> result) const {
     post_result_cb_.Run(result.Pass());
-  };
+  }
 
   std::string name() const {
     return name_;


### PR DESCRIPTION
> ./dbus/object_manager_adaptor.cc:171:  You don't need a ; after a }  [readability/braces] [4]
> ./extensions/browser/xwalk_extension_function_handler.h:40:  You don't need a ; after a }  [readability/braces] [4]
