### PR TITLE
[Next][Tizen] Don't use scoped_ptr<T>::PassAs()

### DIFF
--- a/application/browser/linux/running_application_object.cc
+++ b/application/browser/linux/running_application_object.cc
@@ -272,7 +272,7 @@ void RunningApplicationObject::OnSetUserAgentString(
         dbus::ErrorResponse::FromMethodCall(method_call,
                                             kRunningApplicationDBusError,
                                             "Wrong user agent string");
-    response_sender.Run(error_response.PassAs<dbus::Response>());
+    response_sender.Run(error_response.Pass());
   }
 }
 #endif


### PR DESCRIPTION
This helper to upcast in return statements is no longer needed.

CL: https://codereview.chromium.org/663243003
