### PR TITLE
[Tizen] xwalk crashed when requests "json/new" in devtools

### DIFF
--- a/runtime/browser/devtools/xwalk_devtools_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.cc
@@ -222,7 +222,8 @@ std::string XWalkDevToolsDelegate::GetPageThumbnailData(const GURL& url) {
 scoped_ptr<content::DevToolsTarget>
 XWalkDevToolsDelegate::CreateNewTarget(const GURL& url) {
   Runtime* runtime = CreateWithDefaultWindow(
-      browser_context_, GURL(url::kAboutBlankURL), this);
+      browser_context_, url, this);
+  runtime->set_remote_debugging_enabled(true);
   return scoped_ptr<content::DevToolsTarget>(
       new Target(DevToolsAgentHost::GetOrCreateFor(runtime->web_contents())));
 }

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -79,7 +79,7 @@ namespace xwalk {
 namespace {
 
 // The application-wide singleton of ContentBrowserClient impl.
-XWalkContentBrowserClient* g_browser_client = NULL;
+XWalkContentBrowserClient* g_browser_client = nullptr;
 
 }  // namespace
 
@@ -91,16 +91,16 @@ XWalkContentBrowserClient* XWalkContentBrowserClient::Get() {
 
 XWalkContentBrowserClient::XWalkContentBrowserClient(XWalkRunner* xwalk_runner)
     : xwalk_runner_(xwalk_runner),
-      url_request_context_getter_(NULL),
-      main_parts_(NULL),
-      browser_context_(NULL) {
+      url_request_context_getter_(nullptr),
+      main_parts_(nullptr),
+      browser_context_(xwalk_runner->browser_context()) {
   DCHECK(!g_browser_client);
   g_browser_client = this;
 }
 
 XWalkContentBrowserClient::~XWalkContentBrowserClient() {
   DCHECK(g_browser_client);
-  g_browser_client = NULL;
+  g_browser_client = nullptr;
 }
 
 content::BrowserMainParts* XWalkContentBrowserClient::CreateBrowserMainParts(
@@ -122,10 +122,8 @@ net::URLRequestContextGetter* XWalkContentBrowserClient::CreateRequestContext(
     content::BrowserContext* browser_context,
     content::ProtocolHandlerMap* protocol_handlers,
     content::URLRequestInterceptorScopedVector request_interceptors) {
-  browser_context_ = static_cast<XWalkBrowserContext*>(browser_context);
-  url_request_context_getter_ = browser_context_->
+  return static_cast<XWalkBrowserContext*>(browser_context)->
       CreateRequestContext(protocol_handlers, request_interceptors.Pass());
-  return url_request_context_getter_;
 }
 
 net::URLRequestContextGetter*
@@ -175,7 +173,7 @@ XWalkContentBrowserClient::GetWebContentsViewDelegate(
   return new XWalkWebContentsViewDelegate(
       web_contents, xwalk_runner_->app_system()->application_service());
 #else
-  return NULL;
+  return nullptr;
 #endif
 }
 
@@ -381,7 +379,7 @@ content::BrowserPpapiHost*
     ++iter;
   }
 #endif
-  return NULL;
+  return nullptr;
 }
 
 #if defined(OS_ANDROID) || defined(OS_TIZEN)  || defined(OS_LINUX)


### PR DESCRIPTION
The main reason is: 
The intialization of "XWalkContentBrowserClient::browser_context_"
depends on invoking "XWalkContentBrowserClient::CreateRequestContext",
so in this case when "GetDevToolsManagerDelegate" is creating, the 
"browser_context_" is still NULL. And we can init "browser_context_"
through "xwalk_runner_" in constructor function to make sure it's valid
at least anytime.

BUG=https://crosswalk-project.org/jira/browse/XWALK-3178

@pozdnyakov @wang16 @takethathe please help to review it, thanks :)
