### PR TITLE
[Next][Tizen] Build fix: cancel_callback should be removed

### DIFF
--- a/runtime/browser/runtime_geolocation_permission_context.cc
+++ b/runtime/browser/runtime_geolocation_permission_context.cc
@@ -61,14 +61,13 @@ void
 RuntimeGeolocationPermissionContext::RequestGeolocationPermissionOnUIThread(
     content::WebContents* web_contents,
     const GURL& requesting_frame,
-    base::Callback<void(bool)> result_callback,
-    base::Closure* cancel_callback) {
+    base::Callback<void(bool)> result_callback) {
   DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
 
-  int render_process_id = web_contents->GetRenderProcessHost()->GetID();
   int render_view_id = web_contents->GetRenderViewHost()->GetRoutingID();
 
 #if defined(OS_ANDROID)
+  int render_process_id = web_contents->GetRenderProcessHost()->GetID();
   XWalkContent* xwalk_content =
       XWalkContent::FromID(render_process_id, render_view_id);
   if (!xwalk_content) {
@@ -104,14 +103,6 @@ RuntimeGeolocationPermissionContext::RequestGeolocationPermissionOnUIThread(
   result_callback.Run(has_geolocation_permission);
 #endif
 
-  if (cancel_callback) {
-     *cancel_callback = base::Bind(
-         CancelGeolocationPermissionRequest,
-         render_process_id,
-         render_view_id,
-         requesting_frame);
-  }
-
   // TODO(yongsheng): Handle this for other platforms.
 }
 
@@ -119,8 +110,7 @@ void
 RuntimeGeolocationPermissionContext::RequestGeolocationPermission(
     content::WebContents* web_contents,
     const GURL& requesting_frame,
-    base::Callback<void(bool)> result_callback,
-    base::Closure* cancel_callback) {
+    base::Callback<void(bool)> result_callback) {
   content::BrowserThread::PostTask(
       content::BrowserThread::UI, FROM_HERE,
       base::Bind(
@@ -129,8 +119,7 @@ RuntimeGeolocationPermissionContext::RequestGeolocationPermission(
           this,
           web_contents,
           requesting_frame,
-          result_callback,
-          cancel_callback));
+          result_callback));
 }
 
 }  // namespace xwalk

--- a/runtime/browser/runtime_geolocation_permission_context.h
+++ b/runtime/browser/runtime_geolocation_permission_context.h
@@ -25,8 +25,7 @@ class RuntimeGeolocationPermissionContext
   virtual void RequestGeolocationPermission(
     content::WebContents* web_contents,
     const GURL& requesting_frame,
-    base::Callback<void(bool)> result_callback,
-    base::Closure* cancel_callback);
+    base::Callback<void(bool)> result_callback);
 
  protected:
   virtual ~RuntimeGeolocationPermissionContext();
@@ -36,8 +35,7 @@ class RuntimeGeolocationPermissionContext
   void RequestGeolocationPermissionOnUIThread(
     content::WebContents* web_contents,
     const GURL& requesting_frame,
-    base::Callback<void(bool)> result_callback,
-    base::Closure* cancel_callback);
+    base::Callback<void(bool)> result_callback);
 };
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -314,8 +314,7 @@ void XWalkContentBrowserClient::RequestPermission(
     geolocation_permission_context_->RequestGeolocationPermission(
       web_contents,
       requesting_frame,
-      result_callback,
-      cancel_callback);
+      result_callback);
 #else
     result_callback.Run(false);
 #endif


### PR DESCRIPTION
API changes in content_browser_client that cancel_callback is removed.
The build error is introduced by a previous fix (a52a0530).
