### PR TITLE
[Tizen] packaging: Use the system's protobuf instead of Chromium's.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -79,6 +79,7 @@ BuildRequires:  pkgconfig(pkgmgr)
 BuildRequires:  pkgconfig(pkgmgr-info)
 BuildRequires:  pkgconfig(pkgmgr-installer)
 BuildRequires:  pkgconfig(pkgmgr-parser)
+BuildRequires:  pkgconfig(protobuf)
 BuildRequires:  pkgconfig(secure-storage)
 BuildRequires:  pkgconfig(sensor)
 BuildRequires:  pkgconfig(nss)
@@ -236,6 +237,7 @@ ${GYP_EXTRA_FLAGS} \
 -Duse_system_bzip2=1 \
 -Duse_system_libexif=1 \
 -Duse_system_libxml=1 \
+-Duse_system_protobuf=1 \
 -Duse_system_yasm=1 \
 -Denable_hidpi=1
 


### PR DESCRIPTION
protobuf is quite resource-heavy to compile, so using a version already
installed in the system makes the build faster and also reduces our
usage of bundled Chromium libraries.

The version in src/third_party/protobuf is similar to the one in
Tizen (which was recently updated to 2.6.1): 2.5.0 plus a lot of MIPS64
and aarch64 patches that made it into the 2.6 release series.
