### PR TITLE
[Tizen] Remove unused variable in tizen_metadata_handler.cc

### DIFF
--- a/application/common/manifest_handlers/tizen_metadata_handler.cc
+++ b/application/common/manifest_handlers/tizen_metadata_handler.cc
@@ -11,7 +11,6 @@
 #include "base/values.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 
-
 namespace xwalk {
 
 namespace keys = application_widget_keys;
@@ -26,7 +25,6 @@ MetaDataPair ParseMetaDataItem(const base::DictionaryValue* dict,
                                base::string16* error) {
   DCHECK(dict && dict->IsType(base::Value::TYPE_DICTIONARY));
   MetaDataPair result;
-  std::string value;
   if (!dict->GetString(keys::kTizenMetaDataNameKey, &result.first) ||
       !dict->GetString(keys::kTizenMetaDataValueKey, &result.second)) {
     *error = base::ASCIIToUTF16("Invalid key/value of tizen metaData.");
@@ -58,8 +56,7 @@ void TizenMetaDataInfo::SetValue(const std::string& key,
   metadata_.insert(MetaDataPair(key, value));
 }
 
-TizenMetaDataHandler::TizenMetaDataHandler() {
-}
+TizenMetaDataHandler::TizenMetaDataHandler() {}
 
 TizenMetaDataHandler::~TizenMetaDataHandler() {}
 


### PR DESCRIPTION
Variable "value" of type std::string was declared but never used.
That's why it was removed. Besides it fixes some other nits.
