### PR TITLE
DEPS.xwalk: Roll ozone-wayland (b002e06 -> a4ca316).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -19,7 +19,7 @@
 
 chromium_crosswalk_rev = '0bbff352135bacf2e6a17b5ffebd387f3c2d085f'
 v8_crosswalk_rev = '05d1cf41ef1b6e73079f69492d9e942ec19cc61a'
-ozone_wayland_rev = 'b002e0692f397a02264cc99208081f54a90d0973'
+ozone_wayland_rev = 'a4ca3163fc5faaa32c01e23b5ec621c360254326'
 
 # |blink_crosswalk_rev| specifies the SHA1 hash of the blink-crosswalk commit
 # we want to point to, very much like the variables above.


### PR DESCRIPTION
- a4ca316 Make vkb work on Tizen emulator
- 1bc6d86 Do not uninitialize input devices when disconnecting the devices.

BUG=TC-1373
BUG=TC-2202
