### PR TITLE
[Tizen] Fix memory leaks found in xwalk_tizen_user.cc

### DIFF
--- a/application/tools/tizen/xwalk_tizen_user.cc
+++ b/application/tools/tizen/xwalk_tizen_user.cc
@@ -16,64 +16,56 @@
 
 #include <tzplatform_config.h>
 
+#include "base/memory/scoped_ptr.h"
+
 int xwalk_tizen_check_group_users(void) {
-  char* buffer = NULL;
   int err = 0;
   struct group grp;
   struct group* current_g;
   int64_t len = sysconf(_SC_GETGR_R_SIZE_MAX);
   if (len == -1)
     len = 1024;
-  buffer = reinterpret_cast<char*>(malloc((size_t)len));
-  if (!buffer)
-    return -EINVAL;
 
-  err = getgrgid_r(getgid(), &grp, buffer, len, &current_g);
+  scoped_ptr<char[]> buffer(new char[len]);
+  err = getgrgid_r(getgid(), &grp, buffer.get(), len, &current_g);
   if (err) {
     fprintf(stderr, "group can't be determined");
     fprintf(stderr, "launching an application will not work\n");
-    free(buffer);
     return -EINVAL;
   }
 
   if ((!current_g) ||
       strcmp(current_g->gr_name, "users")) {
-      fprintf(stderr, "group '%s' is not allowed :",
+      fprintf(stderr, "group '%s' is not allowed: ",
               current_g ? current_g->gr_name : "<NULL>");
       fprintf(stderr, "launching an application will not work\n");
-      free(buffer);
       return -EINVAL;
   }
   return 0;
 }
 
 int xwalk_tizen_check_user_for_xwalk_backend(void) {
-  char* buffer = NULL;
   int err = 0;
   struct group grp;
   struct group* current_g;
   int64_t len = sysconf(_SC_GETGR_R_SIZE_MAX);
   if (len == -1)
     len = 1024;
-  buffer = reinterpret_cast<char*>(malloc((size_t)len));
-  if (!buffer)
-    return -EINVAL;
 
-  err = getgrgid_r(getgid(), &grp, buffer, len, &current_g);
+  scoped_ptr<char[]> buffer(new char[len]);
+  err = getgrgid_r(getgid(), &grp, buffer.get(), len, &current_g);
   if (err) {
     fprintf(stderr, "group can't be determined");
     fprintf(stderr, "launching an application will not work\n");
-    free(buffer);
     return -EINVAL;
   }
 
   if ((!current_g) || (
       strcmp(current_g->gr_name, "users") &&
       getuid() != tzplatform_getuid(TZ_SYS_GLOBALAPP_USER))) {
-    fprintf(stderr, "group '%s' is not allowed :",
+    fprintf(stderr, "group '%s' is not allowed: ",
             current_g ? current_g->gr_name : "<NULL>");
     fprintf(stderr, "launching an application will not work\n");
-    free(buffer);
     return -EINVAL;
   }
   return 0;


### PR DESCRIPTION
Memory leaks appear when xwalk_backend runs correctly.
This patch adds freeing buffer after usage.

BUG=XWALK-3206
