### PR TITLE
[Android] Fix the issue about status bar was not shown.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -40,6 +40,7 @@ public class XWalkUIClientInternal {
     private XWalkViewInternal mXWalkView;
     private boolean mOriginalFullscreen;
     private boolean mOriginalForceNotFullscreen;
+    private boolean mIsFullscreen = false;
 
     /**
      * Initiator
@@ -199,23 +200,26 @@ public class XWalkUIClientInternal {
             } else {
                 mOriginalForceNotFullscreen = false;
             }
-            if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-                mSystemUiFlag = mDecorView.getSystemUiVisibility();
-                mDecorView.setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
-                        View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
-                        View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-                        View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                        View.SYSTEM_UI_FLAG_FULLSCREEN |
-                        View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-            } else {
-                if ((activity.getWindow().getAttributes().flags &
-                        WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
-                    mOriginalFullscreen = true;
+            if (!mIsFullscreen) {
+                if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
+                    mSystemUiFlag = mDecorView.getSystemUiVisibility();
+                    mDecorView.setSystemUiVisibility(
+                            View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+                            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+                            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+                            View.SYSTEM_UI_FLAG_FULLSCREEN |
+                            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
                 } else {
-                    mOriginalFullscreen = false;
-                    activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                    if ((activity.getWindow().getAttributes().flags &
+                            WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
+                        mOriginalFullscreen = true;
+                    } else {
+                        mOriginalFullscreen = false;
+                        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                    }
                 }
+                mIsFullscreen = true;
             }
         } else {
             if (mOriginalForceNotFullscreen) {
@@ -230,6 +234,7 @@ public class XWalkUIClientInternal {
                     activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
             }
+            mIsFullscreen = false;
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
@@ -125,7 +125,7 @@ public class XWalkWebChromeClient {
         if (mCustomXWalkView == null || activity == null) return;
 
         if (mContentsClient != null) {
-            mContentsClient.onToggleFullscreen(true);
+            mContentsClient.onToggleFullscreen(false);
         }
 
         // Remove video view from activity's ContentView.


### PR DESCRIPTION
This patch is to fix the issue about status bar was not shown when exit
the fullscreen mode.
Add flag to avoid the second setting from video view.

BUG=XWALK-3023
(cherry picked from commit 9de6a7597178774a63453d55f009226f65365b82)
