### PR TITLE
[Runtime] Add the initialization for |app_component_|.

### DIFF
--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -40,7 +40,8 @@ XWalkRunner* g_xwalk_runner = NULL;
 
 }  // namespace
 
-XWalkRunner::XWalkRunner() {
+XWalkRunner::XWalkRunner()
+    : app_component_(nullptr) {
   VLOG(1) << "Creating XWalkRunner object.";
   DCHECK(!g_xwalk_runner);
   g_xwalk_runner = this;


### PR DESCRIPTION
This patch is to add the initialization in the constructor.

CID=220054

Related to XWALK-2928.
(cherry picked from commit cff0b9f73256395fdd6055d97e151df318838d9b)

Conflicts:

```
runtime/browser/xwalk_runner.cc
```
