### PR TITLE
[Tizen] Verification name of a widget entry file

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -21,6 +21,7 @@
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/constants.h"
 #include "xwalk/application/common/manifest_handlers/warp_handler.h"
+#include "xwalk/application/common/package/wgt_package.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_ui_delegate.h"
 #include "xwalk/runtime/browser/xwalk_browser_context.h"
@@ -38,12 +39,6 @@ namespace keys = application_manifest_keys;
 namespace widget_keys = application_widget_keys;
 
 namespace {
-const char* kDefaultWidgetEntryPage[] = {
-"index.htm",
-"index.html",
-"index.svg",
-"index.xhtml",
-"index.xht"};
 
 GURL GetDefaultWidgetEntryPage(
     scoped_refptr<xwalk::application::ApplicationData> data) {
@@ -52,13 +47,15 @@ GURL GetDefaultWidgetEntryPage(
       data->path(), true,
       base::FileEnumerator::FILES,
       FILE_PATH_LITERAL("index.*"));
-  size_t priority = arraysize(kDefaultWidgetEntryPage);
+  const std::vector<std::string>& defaultWidgetEntryPages =
+      application::WGTPackage::GetDefaultWidgetEntryPages();
+  size_t priority = defaultWidgetEntryPages.size();
   std::string source;
 
   for (base::FilePath file = iter.Next(); !file.empty(); file = iter.Next()) {
     for (size_t i = 0; i < priority; ++i) {
-      if (file.BaseName().MaybeAsASCII() == kDefaultWidgetEntryPage[i]) {
-        source = kDefaultWidgetEntryPage[i];
+      if (file.BaseName().MaybeAsASCII() == defaultWidgetEntryPages[i]) {
+        source = defaultWidgetEntryPages[i];
         priority = i;
         break;
       }

--- a/application/common/constants.h
+++ b/application/common/constants.h
@@ -29,7 +29,7 @@ extern const char kGeneratedMainDocumentFilename[];
 // The name of cookies database file.
 extern const base::FilePath::CharType kCookieDatabaseFilename[];
 
-// The Tizen Web API version is supported
+// The Tizen Web API version is supported.
 extern const char kTizenWebAPIVersion[];
 
 }  // namespace application

--- a/application/common/package/wgt_package.cc
+++ b/application/common/package/wgt_package.cc
@@ -1,10 +1,9 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 #include "xwalk/application/common/package/wgt_package.h"
-
-#include <string>
 
 #include "base/files/file_util.h"
 #include "base/files/scoped_file.h"
@@ -77,6 +76,20 @@ WGTPackage::WGTPackage(const base::FilePath& path)
       new base::ScopedFILE(base::OpenFile(path, "rb")));
 
   file_ = file.Pass();
+}
+
+// static
+const std::vector<std::string>& WGTPackage::GetDefaultWidgetEntryPages() {
+  static std::vector<std::string> entry_pages;
+  if (entry_pages.empty()) {
+    entry_pages.push_back("index.html");
+    entry_pages.push_back("index.htm");
+    entry_pages.push_back("index.svg");
+    entry_pages.push_back("index.xhtml");
+    entry_pages.push_back("index.xht");
+  }
+
+  return entry_pages;
 }
 
 }  // namespace application

--- a/application/common/package/wgt_package.h
+++ b/application/common/package/wgt_package.h
@@ -1,9 +1,13 @@
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Copyright (c) 2014 Samsung Electronics Co., Ltd All Rights Reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 #ifndef XWALK_APPLICATION_COMMON_PACKAGE_WGT_PACKAGE_H_
 #define XWALK_APPLICATION_COMMON_PACKAGE_WGT_PACKAGE_H_
+
+#include <string>
+#include <vector>
 
 #include "base/files/file_path.h"
 #include "xwalk/application/common/package/package.h"
@@ -15,6 +19,8 @@ class WGTPackage : public Package {
  public:
   explicit WGTPackage(const base::FilePath& path);
   virtual ~WGTPackage();
+  // Returns allowed names of default widget start file.
+  static const std::vector<std::string>& GetDefaultWidgetEntryPages();
 };
 
 }  // namespace application

--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -36,6 +36,7 @@
 #include "xwalk/application/common/tizen/application_storage.h"
 #include "xwalk/application/common/tizen/encryption.h"
 #include "xwalk/application/common/tizen/package_query.h"
+#include "xwalk/application/common/package/wgt_package.h"
 #include "xwalk/application/tools/tizen/xwalk_packageinfo_constants.h"
 #include "xwalk/application/tools/tizen/xwalk_platform_installer.h"
 #include "xwalk/application/tools/tizen/xwalk_rds_delta_parser.h"
@@ -214,6 +215,16 @@ bool CreateAppSymbolicLink(const base::FilePath& app_dir,
     return false;
   }
   return true;
+}
+
+bool ContainsWidgetStartFile(const base::FilePath& path) {
+  for (std::string fname :
+      xwalk::application::WGTPackage::GetDefaultWidgetEntryPages()) {
+    if (base::PathExists(path.AppendASCII(fname.c_str())))
+      return true;
+  }
+  LOG(ERROR) << "Default start widget file does not exist.";
+  return false;
 }
 
 }  // namespace
@@ -401,6 +412,11 @@ bool PackageInstaller::Install(const base::FilePath& path, std::string* id) {
     app_id = package->Id();
   } else {
     unpacked_dir = path;
+  }
+
+  if (package->manifest_type() == Manifest::TYPE_WIDGET &&
+      !ContainsWidgetStartFile(unpacked_dir)) {
+    return false;
   }
 
   base::FilePath app_dir = data_dir.AppendASCII(app_id);


### PR DESCRIPTION
This patch contains function which verify name
of the widget entry file during installation.
Table contains list of proper names of the files
has been moved to constans.

BUG=XWALK-2983