### PR TITLE
[Android] Fix the issue about control bar disappeared in fullscreen of

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
@@ -90,8 +90,9 @@ public class XWalkWebChromeClient {
             mContentsClient.onToggleFullscreen(true);
         }
 
-        // Add the video view to the activity's ContentView.
-        activity.getWindow().addContentView(view,
+        // Add the video view to the activity's DecorView.
+        FrameLayout decor = (FrameLayout) activity.getWindow().getDecorView();
+        decor.addView(mCustomXWalkView, 0,
                 new FrameLayout.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT,


### PR DESCRIPTION
landscape.

This patch is to fix the issue that control bar disappeared in
fullscreen when screen's orientation changed to landscape.
Add the XWalkView to activity's Decor view.

BUG=XWALK-3048
