### PR TITLE
[TIZEN] Add gz compression for the source archive

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -30,7 +30,7 @@ Summary:        Chromium-based app runtime
 License:        (BSD-3-Clause and LGPL-2.1+)
 Group:          Web Framework/Web Run Time
 Url:            https://github.com/otcshare/crosswalk
-Source:         %{name}.tar
+Source:         %{name}.tar.gz
 Source1:        xwalk.in
 Source2:        org.crosswalkproject.Runtime1.service
 Source3:        xwalk.service.in

--- a/packaging/gbp-flat-tree.sh
+++ b/packaging/gbp-flat-tree.sh
@@ -28,7 +28,7 @@
 # Fail early to avoid bigger problems later in the process.
 set -e
 
-TAR_FILE="${GBP_TMP_DIR}/crosswalk.tar"
+TAR_FILE="${GBP_TMP_DIR}/crosswalk.tar.gz"
 
 if [ ! -f "${TAR_FILE}" ]; then
     echo "${TAR_FILE} does not exist. Aborting."


### PR DESCRIPTION
This permits to avoid a gbs export error on Tizen official OBS

BUG=XWALK-3222
Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
