### PR TITLE
Remove validation on uri field of app-control

### DIFF
--- a/application/common/manifest_handlers/tizen_app_control_handler.cc
+++ b/application/common/manifest_handlers/tizen_app_control_handler.cc
@@ -125,13 +125,6 @@ bool TizenAppControlHandler::Validate(
       return false;
     }
 
-    const std::string& uri = item.uri();
-    if (!uri.empty() && GURL(uri).spec().empty()) {
-      *error =
-          "The url child element of app-control element is not valid url";
-      return false;
-    }
-
     const std::string& mime = item.mime();
     if (!mime.empty() && !xdg_mime_is_valid_mime_type(mime.c_str())) {
       *error =


### PR DESCRIPTION
Following the documentation, uri could
- point a ressource without defining a sheme
- be empty

so remove the uri check
BUG=XWALK-3223
Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
