### PR TITLE
[Android] Fix the error when run make_apk.py with python 3.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -459,7 +459,7 @@ def MakeApk(options, app_info, manifest):
             options.arch = 'arm'
           else:
             options.arch = arch
-          print "options.arch:", options.arch
+          print("options.arch:", options.arch)
           Execution(options, name)
           packaged_archs.append(options.arch)
         else:


### PR DESCRIPTION
This patch is to fix the error about missing parentheses with python 3.
In Python 3, the printed value should be surrounded with parentheses.

BUG=XWALK-3240
