### PR TITLE
[Android] Fix user data dropped after upgrade from crosswalk 8

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -49,6 +49,31 @@ base::StringPiece PlatformResourceProvider(int key) {
   return base::StringPiece();
 }
 
+void MoveUserDataDirIfNecessary(const base::FilePath& user_data_dir,
+                                const base::FilePath& profile) {
+  if (base::DirectoryExists(profile))
+    return;
+
+  if (!base::CreateDirectory(profile))
+    return;
+
+  const char* possible_data_dir_names[] = {
+      "Cache",
+      "Cookies",
+      "Cookies-journal",
+      "Local Storage",
+  };
+  for (int i = 0; i < 4; i++) {
+    base::FilePath dir = user_data_dir.Append(possible_data_dir_names[i]);
+    if (base::PathExists(dir)) {
+      if (!base::Move(dir, profile.Append(possible_data_dir_names[i]))) {
+        NOTREACHED() << "Failed to import previous user data: "
+                     << possible_data_dir_names[i];
+      }
+    }
+  }
+}
+
 }  // namespace
 
 namespace xwalk {
@@ -132,9 +157,12 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopRun() {
     NOTREACHED() << "Failed to get app data directory for Crosswalk";
   }
   CommandLine* command_line = CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kXWalkProfileName))
-    user_data_dir = user_data_dir.Append(
+  if (command_line->HasSwitch(switches::kXWalkProfileName)) {
+    base::FilePath profile = user_data_dir.Append(
         command_line->GetSwitchValuePath(switches::kXWalkProfileName));
+    MoveUserDataDirIfNecessary(user_data_dir, profile);
+    user_data_dir = profile;
+  }
 
   base::FilePath cookie_store_path = user_data_dir.Append(
       FILE_PATH_LITERAL("Cookies"));


### PR DESCRIPTION
Because of multiple profile support, from crosswalk 9 user data
will be put under profile's subfolder.
We need to consider the case that crosswalk upgrades from 8 to 9.
For such case, detect the first launch and move the previous user
data to profile's subfolder.

BUG=https://crosswalk-project.org/jira/browse/XWALK-3252
