### PR TITLE
Reenable SIMD.js support after the M40 rebase.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -111,13 +111,13 @@ void XWalkBrowserMainParts::PreMainMessageLoopStart() {
   command_line->AppendSwitch(switches::kAllowFileAccessFromFiles);
 
   // Enable SIMD.JS API by default.
-  /*std::string js_flags("--simd_object");
+  std::string js_flags("--simd_object");
   if (command_line->HasSwitch(switches::kJavaScriptFlags)) {
     js_flags += " ";
     js_flags +=
         command_line->GetSwitchValueASCII(switches::kJavaScriptFlags);
   }
-  command_line->AppendSwitchASCII(switches::kJavaScriptFlags, js_flags);*/
+  command_line->AppendSwitchASCII(switches::kJavaScriptFlags, js_flags);
 
   startup_url_ = GetURLFromCommandLine(*command_line);
 }


### PR DESCRIPTION
Commit 8c5d886 ("DEPS.xwalk: Roll v8-crosswalk (3bfc597 -> 11bb7b4)")
correctly rolled v8-crosswalk, but forgot to uncomment out the piece of
code that enables SIMD.js support by default.

BUG=XWALK-3210
