### PR TITLE
[Tizen] Temporarily disable -finline-functions.

### DIFF
--- a/packaging/crosswalk.spec
+++ b/packaging/crosswalk.spec
@@ -156,6 +156,12 @@ cp -a src/xwalk/LICENSE LICENSE.xwalk
 # does not expect -Wall to be passed to the compiler (see webrtc issue 3307).
 export CXXFLAGS=`echo $CXXFLAGS | sed s,-Wall,,g`
 
+# Do not use -finline-functions: it breaks the build because it causes -Wall to
+# warn about some conditions that cannot really be reached (ie. variables that
+# may be used uninitialized while in fact thay cannot be uninitialized). See
+# TC-2299.
+export CXXFLAGS=`echo $CXXFLAGS | sed s,-finline-functions,,g`
+
 # For ffmpeg on ia32. The original CFLAGS set by the gyp and config files in
 # src/third_party/ffmpeg already pass -O2 -fomit-frame-pointer, but Tizen's
 # CFLAGS end up appending -fno-omit-frame-pointer. See http://crbug.com/37246


### PR DESCRIPTION
This flag was recently introduced in Tizen's scm/meta/obs repository
commit df9ffaea0fdb71ebbe4b84afafdf9eaa9a997a15, and causes the Chromium
build to fail because it causes some spurious `maybe-uninitialized`
errors.

Disable the flag while the problem is deal with in TC-2299 so that our
Tizen Common bots do not stay red and our canary builds can resume.

BUG=TC-2299
