### PR TITLE
Set the resource set "name" property instead of "appid" 

### DIFF
--- a/tizen/browser/media/murphy_resource.cc
+++ b/tizen/browser/media/murphy_resource.cc
@@ -53,7 +53,7 @@ MurphyResource::MurphyResource(
   if (attr)
     mrp_res_set_attribute_string(attr, app_class.c_str());
 
-  attr = mrp_res_get_attribute_by_name(resource, "resource.set.appid");
+  attr = mrp_res_get_attribute_by_name(resource, "name");
   if (attr)
     mrp_res_set_attribute_string(attr, app_id.c_str());
 


### PR DESCRIPTION
Set the resource set "name" property instead of "appid" as defined
in the Murphy.

BUG=TC-1731
