### PR TITLE
[Tizen] Disable Extension process

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -227,8 +227,7 @@ bool Application::Launch() {
   // Only the first runtime can have a launch screen.
   params.splash_screen_path = GetSplashScreenPath();
   runtime->set_ui_delegate(DefaultRuntimeUIDelegate::Create(runtime, params));
-  // We call "Show" after RP is initialized to reduce
-  // the application start up time.
+  runtime->Show();
 
   return true;
 }
@@ -291,11 +290,6 @@ void Application::NotifyTermination() {
   CHECK(!render_process_host_);
   if (observer_)
     observer_->OnApplicationTerminated(this);
-}
-
-void Application::RenderChannelCreated() {
-  CHECK(!runtimes_.empty());
-  runtimes_.front()->Show();
 }
 
 bool Application::UseExtension(const std::string& extension_name) const {

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -30,7 +30,6 @@ class RenderProcessHost;
 namespace xwalk {
 
 class XWalkBrowserContext;
-class XWalkAppExtensionBridge;
 
 namespace application {
 
@@ -136,8 +135,6 @@ class Application : public Runtime::Observer,
  private:
   // We enforce ApplicationService ownership.
   friend class ApplicationService;
-  // XWalkAppExtensionBridge gives notifications.
-  friend class xwalk::XWalkAppExtensionBridge;
   static scoped_ptr<Application> Create(scoped_refptr<ApplicationData> data,
       XWalkBrowserContext* context);
 
@@ -157,8 +154,6 @@ class Application : public Runtime::Observer,
   GURL GetAbsoluteURLFromKey(const std::string& key);
 
   void NotifyTermination();
-  // Notification from XWalkAppExtensionBridge.
-  void RenderChannelCreated();
 
   Observer* observer_;
 

--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -479,10 +479,5 @@ bool XWalkExtensionService::OnRegisterPermissions(
                                         extension_name, perm_table);
 }
 
-void XWalkExtensionService::OnRenderChannelCreated(int render_process_id) {
-  CHECK(delegate_);
-  delegate_->RenderChannelCreated(render_process_id);
-}
-
 }  // namespace extensions
 }  // namespace xwalk

--- a/extensions/browser/xwalk_extension_service.h
+++ b/extensions/browser/xwalk_extension_service.h
@@ -51,7 +51,6 @@ class XWalkExtensionService : public content::NotificationObserver,
     virtual void ExtensionProcessCreated(
         int render_process_id,
         const IPC::ChannelHandle& channel_handle) {}
-    virtual void RenderChannelCreated(int render_process_id) {}
 
    protected:
     ~Delegate() {}
@@ -104,7 +103,6 @@ class XWalkExtensionService : public content::NotificationObserver,
   void OnExtensionProcessCreated(
       int render_process_id,
       const IPC::ChannelHandle handle) override;
-  void OnRenderChannelCreated(int render_process_id) override;
 
   void OnCheckAPIAccessControl(
       int render_process_id,

--- a/runtime/browser/xwalk_app_extension_bridge.cc
+++ b/runtime/browser/xwalk_app_extension_bridge.cc
@@ -60,15 +60,6 @@ bool XWalkAppExtensionBridge::RegisterPermissions(
   return service->RegisterPermissions(app->id(), extension_name, perm_table);
 }
 
-void XWalkAppExtensionBridge::RenderChannelCreated(
-    int render_process_id) {
-  Application* app = GetApplication(render_process_id);
-  if (!app)
-    return;
-  content::BrowserThread::PostTask(content::BrowserThread::UI, FROM_HERE,
-      base::Bind(&Application::RenderChannelCreated, app->GetWeakPtr()));
-}
-
 Application* XWalkAppExtensionBridge::GetApplication(int render_process_id) {
   CHECK(app_system_);
   ApplicationService* service =

--- a/runtime/browser/xwalk_app_extension_bridge.h
+++ b/runtime/browser/xwalk_app_extension_bridge.h
@@ -43,7 +43,6 @@ class XWalkAppExtensionBridge
       int render_process_id,
       const std::string& extension_name,
       const std::string& perm_table) override;
-  void RenderChannelCreated(int render_process_id) override;
 
  private:
   application::Application* GetApplication(int render_process_id);

--- a/runtime/browser/xwalk_browser_main_parts_tizen.cc
+++ b/runtime/browser/xwalk_browser_main_parts_tizen.cc
@@ -12,6 +12,7 @@
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/extensions/common/xwalk_extension.h"
+#include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "ui/gl/gl_switches.h"
@@ -44,6 +45,10 @@ void XWalkBrowserMainPartsTizen::PreMainMessageLoopStart() {
       gl_name = gfx::kGLImplementationEGLName;
     command_line->AppendSwitchASCII(switches::kUseGL, gl_name);
   }
+
+  // Disable ExtensionProcess for Tizen.
+  // External extensions will run in the BrowserProcess (in process mode).
+  command_line->AppendSwitch(switches::kXWalkDisableExtensionProcess);
 
   XWalkBrowserMainParts::PreMainMessageLoopStart();
 }


### PR DESCRIPTION
This patch disables EP on Tizen (due to the "Dual" process concept)
At the same time it fixes the issue on app start up.