### PR TITLE
Properly initialize all RuntimeFeature members.

### DIFF
--- a/runtime/common/xwalk_runtime_features.cc
+++ b/runtime/common/xwalk_runtime_features.cc
@@ -22,6 +22,11 @@ struct MatchRuntimeFeature
   const std::string name;
 };
 
+XWalkRuntimeFeatures::RuntimeFeature::RuntimeFeature()
+    : status(Experimental),
+      enabled(false) {
+}
+
 // static
 XWalkRuntimeFeatures* XWalkRuntimeFeatures::GetInstance() {
   return Singleton<XWalkRuntimeFeatures>::get();

--- a/runtime/common/xwalk_runtime_features.h
+++ b/runtime/common/xwalk_runtime_features.h
@@ -34,14 +34,14 @@ class XWalkRuntimeFeatures {
     Experimental
   };
 
-
   struct RuntimeFeature {
     std::string name;
     std::string description;
     std::string command_line_switch;
     RuntimeFeatureStatus status;
     bool enabled;
-    RuntimeFeature() = default;
+
+    RuntimeFeature();
   };
 
  private:


### PR DESCRIPTION
Just having a default constructor will not initialize |status| and
|enabled|. Instead, implement a proper constructor that initializes them
as expected.

CID=194651
