### PR TITLE
crosswalk-10: Backport "Properly initialize all RuntimeFeature members".

### DIFF
--- a/runtime/common/xwalk_runtime_features.cc
+++ b/runtime/common/xwalk_runtime_features.cc
@@ -22,6 +22,11 @@ struct MatchRuntimeFeature
   const std::string name;
 };
 
+XWalkRuntimeFeatures::RuntimeFeature::RuntimeFeature()
+    : status(Experimental),
+      enabled(false) {
+}
+
 // static
 XWalkRuntimeFeatures* XWalkRuntimeFeatures::GetInstance() {
   return Singleton<XWalkRuntimeFeatures>::get();

--- a/runtime/common/xwalk_runtime_features.h
+++ b/runtime/common/xwalk_runtime_features.h
@@ -34,14 +34,14 @@ class XWalkRuntimeFeatures {
     Experimental
   };
 
-
   struct RuntimeFeature {
     std::string name;
     std::string description;
     std::string command_line_switch;
     RuntimeFeatureStatus status;
     bool enabled;
-    RuntimeFeature() = default;
+
+    RuntimeFeature();
   };
 
  private:


### PR DESCRIPTION
This patch series contains both the first commit that made `RuntimeFeature`'s constructor a default one and my follow-up commit that initializes both members.

I could have cherry-picked only the latter and handled the conflicts, but I think it makes sense to try to use commits from master with as few changes as possible.
