### PR TITLE
Add the check for return value of GetString().

### DIFF
--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -293,13 +293,14 @@ jboolean XWalkContent::SetManifest(JNIEnv* env,
 
   if (manifest.HasPath(kDisplay)) {
     std::string display_string;
-    manifest.GetString(kDisplay, &display_string);
-    // TODO(David): update the handling process of the display strings
-    // including fullscreen etc.
-    bool display_as_fullscreen = (
-        display_string.find("fullscreen") != std::string::npos);
-    Java_XWalkContent_onGetFullscreenFlagFromManifest(
-        env, obj, display_as_fullscreen ? JNI_TRUE : JNI_FALSE);
+    if (manifest.GetString(kDisplay, &display_string)) {
+      // TODO(David): update the handling process of the display strings
+      // including fullscreen etc.
+      bool display_as_fullscreen =
+          LowerCaseEqualsASCII(display_string, "fullscreen");
+      Java_XWalkContent_onGetFullscreenFlagFromManifest(
+          env, obj, display_as_fullscreen ? JNI_TRUE : JNI_FALSE);
+    }
   }
 
   // Check whether need to display launch screen. (Read from manifest.json)


### PR DESCRIPTION
This patch is to add the check for return value of GetString() in
widget_handler.cc and xwalk_content.cc.

CID=220010

Related to XWALK-2928.
(cherry picked from commit 0bc7870d527aebed3fd6b8c5108f8e931094ec4c)