### PR TITLE
[Runtime] Change the default start files priority

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -39,8 +39,8 @@ namespace widget_keys = application_widget_keys;
 
 namespace {
 const char* kDefaultWidgetEntryPage[] = {
-"index.html",
 "index.htm",
+"index.html",
 "index.svg",
 "index.xhtml",
 "index.xht"};


### PR DESCRIPTION
According to W3C Widget specific (http://www.w3.org/TR/widgets/), when a start
page is not given by config.xml, the UA should locate default start file by a
fixing order instead, which is given by "default start files
table" (http://www.w3.org/TR/widgets/#default-start-files-table) from top to
bottom. This patch will solve a mismatch with the spec.

BUG=XWALK-3264