### PR TITLE
[Android] Fix file://*/*.xhtml will be opened in default browser.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationHandlerImpl.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationHandlerImpl.java
@@ -147,6 +147,9 @@ public class XWalkNavigationHandlerImpl implements XWalkNavigationHandler {
         // Other types (text/*, video/*, image/*, audio/*) are not handled
         // by intent actions.
         if (mimeType != null && mimeType.startsWith("application/")) {
+            // "application/xhtml+xml" should not be handled by intent actions. See XWALK-2912.
+            if (mimeType == "application/xhtml+xml" || mimeType == "application/xml")
+                return false;
             return true;
         }
         return false;


### PR DESCRIPTION
Because the mime type of xhtml file is "application/xhtml+xml".
It's intercepted by XWalkNavigationHandler to not handle in Crosswalk.
The default behavior for xhtml should be the same as html file, that
is loaded in the Crosswalk no matter with file schema or http schema.

This commit is backported from 6056a6f27

BUG=XWALK-2912