### PR TITLE
[Android] Strip the not implemented error message.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -20,6 +20,11 @@
       ['enable_murphy==1', {
         'defines': ['ENABLE_MURPHY=1'],
       }],
+      ['OS=="android"', {
+        'defines': [
+           'NOTIMPLEMENTED_POLICY=0'
+        ],
+      }],
     ],
     'includes': [
       'xwalk_filename_rules.gypi',


### PR DESCRIPTION
This patch is to strip all of the error messages about not implemented
functions.
Add 'NOTIMPLEMENTED_POLICY=0' to common gypi file.

BUG=XWALK-3188