### PR TITLE
DEPS.xwalk: Roll ozone-wayland (597c8df -> a64feb1).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -19,7 +19,7 @@
 
 chromium_crosswalk_rev = '5557d5159b3ed591f53887db1de564d2c07725b9'
 v8_crosswalk_rev = '11bb7b400ff9e0179ecf6fe358b9d9452d297234'
-ozone_wayland_rev = '597c8dfffd6058589db481c9d3beb1120eaf2b6b'
+ozone_wayland_rev = 'a64feb172408adac51228ace3fc19c47bc0d978a'
 
 # |blink_crosswalk_rev| specifies the SHA1 hash of the blink-crosswalk commit
 # we want to point to, very much like the variables above.


### PR DESCRIPTION
a64feb1 XDG-Shell: update to 1.6.0

This change is needed to handle Weston 1.6.0 nicely.