### PR TITLE
Remove the fullscreen command line option

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -164,11 +164,7 @@ GURL Application::GetStartURL<Manifest::TYPE_MANIFEST>() {
 
 
 template<>
-ui::WindowShowState Application::GetWindowShowState<Manifest::TYPE_WIDGET>(
-    const LaunchParams& params) {
-  if (params.force_fullscreen)
-    return ui::SHOW_STATE_FULLSCREEN;
-
+ui::WindowShowState Application::GetWindowShowState<Manifest::TYPE_WIDGET>() {
   const Manifest* manifest = data_->GetManifest();
   std::string view_modes_string;
   if (manifest->GetString(widget_keys::kViewModesKey, &view_modes_string)) {
@@ -185,11 +181,7 @@ ui::WindowShowState Application::GetWindowShowState<Manifest::TYPE_WIDGET>(
 }
 
 template<>
-ui::WindowShowState Application::GetWindowShowState<Manifest::TYPE_MANIFEST>(
-    const LaunchParams& params) {
-  if (params.force_fullscreen)
-    return ui::SHOW_STATE_FULLSCREEN;
-
+ui::WindowShowState Application::GetWindowShowState<Manifest::TYPE_MANIFEST>() {
   const Manifest* manifest = data_->GetManifest();
   std::string display_string;
   if (manifest->GetString(keys::kDisplay, &display_string)) {
@@ -232,8 +224,8 @@ bool Application::Launch(const LaunchParams& launch_params) {
   NativeAppWindow::CreateParams params;
   params.net_wm_pid = launch_params.launcher_pid;
   params.state = is_wgt ?
-      GetWindowShowState<Manifest::TYPE_WIDGET>(launch_params) :
-      GetWindowShowState<Manifest::TYPE_MANIFEST>(launch_params);
+      GetWindowShowState<Manifest::TYPE_WIDGET>() :
+      GetWindowShowState<Manifest::TYPE_MANIFEST>();
 
   window_show_params_ = params;
   // Only the first runtime can have a launch screen.

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -63,8 +63,6 @@ class Application : public Runtime::Observer,
     // Used only when running as service. Specifies the PID of the launcher
     // process.
     int32 launcher_pid;
-
-    bool force_fullscreen;
     bool remote_debugging;
   };
 
@@ -161,8 +159,7 @@ class Application : public Runtime::Observer,
   // manifest, returns it and the entry point used.
   template <Manifest::Type> GURL GetStartURL();
 
-  template <Manifest::Type>
-  ui::WindowShowState GetWindowShowState(const LaunchParams& params);
+  template <Manifest::Type> ui::WindowShowState GetWindowShowState();
 
   GURL GetAbsoluteURLFromKey(const std::string& key);
 

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -52,7 +52,6 @@ Application::LaunchParams launch_params(
     const base::CommandLine& cmd_line) {
   Application::LaunchParams params = {
       0,
-      cmd_line.HasSwitch(switches::kFullscreen),
       cmd_line.HasSwitch(switches::kRemoteDebuggingPort)};
   return params;
 }

--- a/application/browser/application_system_tizen.cc
+++ b/application/browser/application_system_tizen.cc
@@ -59,7 +59,6 @@ Application::LaunchParams launch_params(
     const base::CommandLine& cmd_line) {
   Application::LaunchParams params = {
       0,
-      cmd_line.HasSwitch(switches::kFullscreen),
       cmd_line.HasSwitch(switches::kRemoteDebuggingPort)
   };
   return params;

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -158,7 +158,6 @@ void RunningApplicationsManager::OnLaunch(
 
   Application::LaunchParams params;
   params.launcher_pid = launcher_pid;
-  params.force_fullscreen = fullscreen;
   params.remote_debugging = remote_debugging;
 
   Application* application = NULL;

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -15,9 +15,6 @@ const char kDisablePnacl[] = "disable-pnacl";
 // Enable all the experimental features in XWalk.
 const char kExperimentalFeatures[] = "enable-xwalk-experimental-features";
 
-// Specifies the window whether launched with fullscreen mode.
-const char kFullscreen[] = "fullscreen";
-
 // List the command lines feature flags.
 const char kListFeaturesFlags[] = "list-features-flags";
 

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -13,7 +13,6 @@ namespace switches {
 extern const char kAppIcon[];
 extern const char kDisablePnacl[];
 extern const char kExperimentalFeatures[];
-extern const char kFullscreen[];
 extern const char kListFeaturesFlags[];
 extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
 extern const char kXWalkDataPath[];


### PR DESCRIPTION
Fullscreen is still supported in the manifest and by the fullscreen Web API.