### PR TITLE
Drop Application::LaunchParams struct

### DIFF
--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -59,13 +59,6 @@ class Application : public Runtime::Observer,
     virtual ~Observer() {}
   };
 
-  struct LaunchParams {
-    // Used only when running as service. Specifies the PID of the launcher
-    // process.
-    int32 launcher_pid;
-    bool remote_debugging;
-  };
-
   // Closes all the application's runtimes (application pages).
   // NOTE: Application is terminated asynchronously.
   // Please use ApplicationService::Observer::WillDestroyApplication()
@@ -119,7 +112,7 @@ class Application : public Runtime::Observer,
  protected:
   Application(scoped_refptr<ApplicationData> data,
               XWalkBrowserContext* context);
-  virtual bool Launch(const LaunchParams& launch_params);
+  virtual bool Launch();
   virtual void InitSecurityPolicy();
 
   // Runtime::Observer implementation.
@@ -174,8 +167,6 @@ class Application : public Runtime::Observer,
   StoredPermissionMap permission_map_;
   // Security policy.
   scoped_ptr<ApplicationSecurityPolicy> security_policy_;
-  // Remote debugging enabled or not for this Application
-  bool remote_debugging_enabled_;
   // WeakPtrFactory should be always declared the last.
   base::WeakPtrFactory<Application> weak_factory_;
   DISALLOW_COPY_AND_ASSIGN(Application);

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -53,8 +53,7 @@ ApplicationService::~ApplicationService() {
 }
 
 Application* ApplicationService::Launch(
-    scoped_refptr<ApplicationData> application_data,
-    const Application::LaunchParams& launch_params) {
+    scoped_refptr<ApplicationData> application_data) {
   if (GetApplicationByID(application_data->ID()) != NULL) {
     LOG(INFO) << "Application with id: " << application_data->ID()
               << " is already running.";
@@ -68,7 +67,7 @@ Application* ApplicationService::Launch(
   ScopedVector<Application>::iterator app_iter =
       applications_.insert(applications_.end(), application);
 
-  if (!application->Launch(launch_params)) {
+  if (!application->Launch()) {
     applications_.erase(app_iter);
     return NULL;
   }
@@ -82,8 +81,7 @@ Application* ApplicationService::Launch(
 }
 
 Application* ApplicationService::LaunchFromManifestPath(
-    const base::FilePath& path, Manifest::Type manifest_type,
-        const Application::LaunchParams& params) {
+    const base::FilePath& path, Manifest::Type manifest_type) {
   std::string error;
   scoped_ptr<Manifest> manifest = LoadManifest(path, manifest_type, &error);
   if (!manifest) {
@@ -103,11 +101,11 @@ Application* ApplicationService::LaunchFromManifestPath(
     return NULL;
   }
 
-  return Launch(application_data, params);
+  return Launch(application_data);
 }
 
 Application* ApplicationService::LaunchFromPackagePath(
-    const base::FilePath& path, const Application::LaunchParams& params) {
+    const base::FilePath& path) {
   scoped_ptr<Package> package = Package::Create(path);
   if (!package || !package->IsValid()) {
     LOG(ERROR) << "Failed to obtain valid package from "
@@ -143,14 +141,13 @@ Application* ApplicationService::LaunchFromPackagePath(
     return NULL;
   }
 
-  return Launch(application_data, params);
+  return Launch(application_data);
 }
 
 // Launch an application created from arbitrary url.
 // FIXME: This application should have the same strict permissions
 // as common browser apps.
-Application* ApplicationService::LaunchHostedURL(
-    const GURL& url, const Application::LaunchParams& params) {
+Application* ApplicationService::LaunchHostedURL(const GURL& url) {
   const std::string& url_spec = url.spec();
   if (url_spec.empty()) {
       LOG(ERROR) << "Failed to launch application from the URL: " << url;
@@ -175,7 +172,7 @@ Application* ApplicationService::LaunchHostedURL(
         ApplicationData::EXTERNAL_URL, manifest.Pass(), &error);
   DCHECK(app_data.get());
 
-  return Launch(app_data, params);
+  return Launch(app_data);
 }
 
 namespace {

--- a/application/browser/application_service.h
+++ b/application/browser/application_service.h
@@ -41,22 +41,17 @@ class ApplicationService : public Application::Observer {
 
   // Launch an unpacked application using path to the manifest file
   // of an unpacked application.
-  Application* LaunchFromManifestPath(
-      const base::FilePath& path, Manifest::Type manifest_type,
-      const Application::LaunchParams& params = Application::LaunchParams());
+  Application* LaunchFromManifestPath(const base::FilePath& path,
+                                      Manifest::Type manifest_type);
 
   // Launch an application using path to its package file.
   // Note: the given package is unpacked to a temporary folder,
   // which is deleted after the application terminates.
-  Application* LaunchFromPackagePath(
-      const base::FilePath& path,
-      const Application::LaunchParams& params = Application::LaunchParams());
+  Application* LaunchFromPackagePath(const base::FilePath& path);
 
   // Launch an application from an arbitrary URL.
   // Creates a "dummy" application.
-  Application* LaunchHostedURL(
-      const GURL& url,
-      const Application::LaunchParams& params = Application::LaunchParams());
+  Application* LaunchHostedURL(const GURL& url);
 
   Application* GetApplicationByRenderHostID(int id) const;
   Application* GetApplicationByID(const std::string& app_id) const;
@@ -83,8 +78,7 @@ class ApplicationService : public Application::Observer {
  protected:
   explicit ApplicationService(XWalkBrowserContext* browser_context);
 
-  Application* Launch(scoped_refptr<ApplicationData> application_data,
-                      const Application::LaunchParams& launch_params);
+  Application* Launch(scoped_refptr<ApplicationData> application_data);
 
  private:
   // Implementation of Application::Observer.

--- a/application/browser/application_service_tizen.cc
+++ b/application/browser/application_service_tizen.cc
@@ -56,8 +56,7 @@ ApplicationServiceTizen::ApplicationServiceTizen(
 ApplicationServiceTizen::~ApplicationServiceTizen() {
 }
 
-Application* ApplicationServiceTizen::LaunchFromAppID(
-    const std::string& id, const Application::LaunchParams& params) {
+Application* ApplicationServiceTizen::LaunchFromAppID(const std::string& id) {
   if (!IsValidApplicationID(id)) {
      LOG(ERROR) << "The input parameter is not a valid app id: " << id;
      return NULL;
@@ -70,7 +69,7 @@ Application* ApplicationServiceTizen::LaunchFromAppID(
     return NULL;
   }
 
-  return Launch(app_data, params);
+  return Launch(app_data);
 }
 
 }  // namespace application

--- a/application/browser/application_service_tizen.h
+++ b/application/browser/application_service_tizen.h
@@ -20,9 +20,7 @@ class ApplicationServiceTizen : public ApplicationService {
  public:
   virtual ~ApplicationServiceTizen();
   // Launch an installed application using application id.
-  Application* LaunchFromAppID(
-      const std::string& id,
-      const Application::LaunchParams& params = Application::LaunchParams());
+  Application* LaunchFromAppID(const std::string& id);
 
  private:
   friend class ApplicationService;

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -46,18 +46,6 @@ scoped_ptr<ApplicationSystem> ApplicationSystem::Create(
   return app_system.Pass();
 }
 
-namespace {
-
-Application::LaunchParams launch_params(
-    const base::CommandLine& cmd_line) {
-  Application::LaunchParams params = {
-      0,
-      cmd_line.HasSwitch(switches::kRemoteDebuggingPort)};
-  return params;
-}
-
-}  // namespace
-
 bool ApplicationSystem::LaunchFromCommandLine(
     const base::CommandLine& cmd_line, const GURL& url) {
   if (!url.is_valid())
@@ -67,8 +55,7 @@ bool ApplicationSystem::LaunchFromCommandLine(
   Application* app = nullptr;
   bool is_local = url.SchemeIsFile() && net::FileURLToFilePath(url, &path);
   if (!is_local) {  // Handles external URL.
-    app = application_service_->LaunchHostedURL(
-        url, launch_params(cmd_line));
+    app = application_service_->LaunchHostedURL(url);
     return !!app;
   }
 
@@ -77,20 +64,19 @@ bool ApplicationSystem::LaunchFromCommandLine(
 
   if (path.MatchesExtension(FILE_PATH_LITERAL(".xpk")) ||
       path.MatchesExtension(FILE_PATH_LITERAL(".wgt"))) {
-    app = application_service_->LaunchFromPackagePath(
-        path, launch_params(cmd_line));
+    app = application_service_->LaunchFromPackagePath(path);
     return !!app;
   }
 
   if (path.MatchesExtension(FILE_PATH_LITERAL(".json"))) {
     app = application_service_->LaunchFromManifestPath(
-        path, Manifest::TYPE_MANIFEST, launch_params(cmd_line));
+        path, Manifest::TYPE_MANIFEST);
     return !!app;
   }
 
   if (path.MatchesExtension(FILE_PATH_LITERAL(".xml"))) {
     app = application_service_->LaunchFromManifestPath(
-        path, Manifest::TYPE_WIDGET, launch_params(cmd_line));
+        path, Manifest::TYPE_WIDGET);
     return !!app;
   }
 

--- a/application/browser/application_system_tizen.cc
+++ b/application/browser/application_system_tizen.cc
@@ -55,15 +55,6 @@ ApplicationSystemTizen::~ApplicationSystemTizen() {
 
 namespace {
 
-Application::LaunchParams launch_params(
-    const base::CommandLine& cmd_line) {
-  Application::LaunchParams params = {
-      0,
-      cmd_line.HasSwitch(switches::kRemoteDebuggingPort)
-  };
-  return params;
-}
-
 void application_event_cb(app_event event, void* data, bundle* b) {
   LOG(INFO) << "Received Tizen appcore event: " << event;
   ApplicationTizen* app = reinterpret_cast<ApplicationTizen*>(data);
@@ -107,8 +98,7 @@ bool ApplicationSystemTizen::LaunchFromCommandLine(
   ApplicationServiceTizen* app_service_tizen =
       ToApplicationServiceTizen(application_service_.get());
 
-  Application* app = app_service_tizen->LaunchFromAppID(
-      app_id, launch_params(cmd_line));
+  Application* app = app_service_tizen->LaunchFromAppID(app_id);
 
   if (!app)
     return false;

--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -178,8 +178,8 @@ void ApplicationTizen::Show() {
   }
 }
 
-bool ApplicationTizen::Launch(const LaunchParams& launch_params) {
-  if (Application::Launch(launch_params)) {
+bool ApplicationTizen::Launch() {
+  if (Application::Launch()) {
 #if defined(OS_TIZEN_MOBILE)
     if (!runtimes_.empty()) {
       root_window_ = CreateRootWindow(*(runtimes_.begin()),

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -38,7 +38,7 @@ class ApplicationTizen :  // NOLINT
   friend class Application;
   ApplicationTizen(scoped_refptr<ApplicationData> data,
                    XWalkBrowserContext* context);
-  bool Launch(const LaunchParams& launch_params) override;
+  bool Launch() override;
 
   base::FilePath GetSplashScreenPath() override;
 

--- a/application/browser/linux/running_applications_manager.cc
+++ b/application/browser/linux/running_applications_manager.cc
@@ -156,19 +156,15 @@ void RunningApplicationsManager::OnLaunch(
     return;
   }
 
-  Application::LaunchParams params;
-  params.launcher_pid = launcher_pid;
-  params.remote_debugging = remote_debugging;
-
   Application* application = NULL;
   GURL url(app_id_or_url);
   if (!url.spec().empty())
-    application = application_service_->LaunchHostedURL(url, params);
+    application = application_service_->LaunchHostedURL(url);
 
 #if defined(OS_TIZEN)
   if (!application)
     application = ToApplicationServiceTizen(
-        application_service_)->LaunchFromAppID(app_id_or_url, params);
+        application_service_)->LaunchFromAppID(app_id_or_url);
 #endif
 
   if (!application) {

--- a/runtime/browser/devtools/xwalk_devtools_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.cc
@@ -225,7 +225,6 @@ scoped_ptr<content::DevToolsTarget>
 XWalkDevToolsDelegate::CreateNewTarget(const GURL& url) {
   Runtime* runtime = CreateWithDefaultWindow(
       browser_context_, url, this);
-  runtime->set_remote_debugging_enabled(true);
   return scoped_ptr<content::DevToolsTarget>(
       new Target(DevToolsAgentHost::GetOrCreateFor(runtime->web_contents())));
 }
@@ -234,14 +233,8 @@ void XWalkDevToolsDelegate::EnumerateTargets(TargetCallback callback) {
   TargetList targets;
   content::DevToolsAgentHost::List agents =
       content::DevToolsAgentHost::GetOrCreateAll();
-  for (content::DevToolsAgentHost::List::iterator it = agents.begin();
-       it != agents.end(); ++it) {
-#if !defined(OS_ANDROID)
-    Runtime* runtime =
-        static_cast<Runtime*>((*it)->GetWebContents()->GetDelegate());
-    if (runtime && runtime->remote_debugging_enabled())
-#endif
-      targets.push_back(new Target(*it));
+  for (auto& it : agents) {
+    targets.push_back(new Target(it));
   }
   callback.Run(targets);
 }

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -60,7 +60,6 @@ Runtime::Runtime(content::WebContents* web_contents)
     : WebContentsObserver(web_contents),
       web_contents_(web_contents),
       fullscreen_options_(NO_FULLSCREEN),
-      remote_debugging_enabled_(false),
       ui_delegate_(nullptr),
       observer_(nullptr),
       weak_ptr_factory_(this) {

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -87,11 +87,6 @@ class Runtime : public content::WebContentsDelegate,
 
   content::RenderProcessHost* GetRenderProcessHost();
 
-  void set_remote_debugging_enabled(bool enable) {
-    remote_debugging_enabled_ = enable;
-  }
-  bool remote_debugging_enabled() const { return remote_debugging_enabled_; }
-
  protected:
   explicit Runtime(content::WebContents* web_contents);
 

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -97,9 +97,6 @@ Runtime* InProcessBrowserTest::CreateRuntime(
   Runtime* runtime = Runtime::Create(
       XWalkRunner::GetInstance()->browser_context());
   runtime->set_observer(this);
-  runtime->set_remote_debugging_enabled(
-      base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kRemoteDebuggingPort));
   runtimes_.push_back(runtime);
   runtime->LoadURL(url);
   content::WaitForLoadStop(runtime->web_contents());


### PR DESCRIPTION
Drop Application::LaunchParams struct (as well as all its client code) as it contains only "shared process model"-specific data.