### PR TITLE
[Tizen] Fix "Uncaught ReferenceError: tizen is not defined" error when starting an application

### DIFF
--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
@@ -9,6 +9,7 @@
 
 #include "base/files/file_path.h"
 #include "base/strings/stringprintf.h"
+#include "base/strings/utf_string_conversions.h"
 #include "net/base/filename_util.h"
 #include "net/base/net_errors.h"
 #include "url/gurl.h"
@@ -16,6 +17,8 @@
 #include "third_party/WebKit/public/platform/WebURLError.h"
 #include "third_party/WebKit/public/web/WebFrame.h"
 #include "third_party/WebKit/public/web/WebDocument.h"
+#include "third_party/WebKit/public/web/WebLocalFrame.h"
+#include "third_party/WebKit/public/web/WebScriptSource.h"
 
 namespace xwalk {
 
@@ -110,6 +113,30 @@ void XWalkContentRendererClientTizen::GetNavigationErrorStrings(
                            "<h1>NET ERROR : %s</h1></body></html>",
                            net::ErrorToString(error.reason).c_str());
   }
+}
+
+void XWalkContentRendererClientTizen::DidCreateScriptContext(
+    blink::WebFrame* frame,
+    v8::Handle<v8::Context> context,
+    int extension_group,
+    int world_id) {
+  XWalkContentRendererClient::DidCreateScriptContext(
+      frame, context, extension_group, world_id);
+  std::string code =
+      "(function() {"
+      "  window.eventListenerList = [];"
+      "  window._addEventListener = window.addEventListener;"
+      "  window.addEventListener = function(event, callback, useCapture) {"
+      "    if (event == 'storage') {"
+      "      window.eventListenerList.push(callback);"
+      "    }"
+      "    window._addEventListener(event, callback, useCapture);"
+      "  }"
+      "})();";
+
+  blink::WebScriptSource source =
+      blink::WebScriptSource(base::ASCIIToUTF16(code));
+  frame->executeScript(source);
 }
 
 std::string XWalkContentRendererClientTizen::GetOverridenUserAgent() const {

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
@@ -25,6 +25,11 @@ class XWalkContentRendererClientTizen : public XWalkContentRendererClient {
   bool HasErrorPage(int http_status_code,
                     std::string* error_domain) override;
 
+  void DidCreateScriptContext(blink::WebFrame* frame,
+                              v8::Handle<v8::Context> context,
+                              int extension_group,
+                              int world_id) override;
+
   void GetNavigationErrorStrings(
       content::RenderView* render_view,
       blink::WebFrame* frame,

--- a/runtime/renderer/tizen/xwalk_render_view_ext_tizen.cc
+++ b/runtime/renderer/tizen/xwalk_render_view_ext_tizen.cc
@@ -68,25 +68,6 @@ bool XWalkRenderViewExtTizen::OnMessageReceived(const IPC::Message& message) {
   return handled;
 }
 
-void XWalkRenderViewExtTizen::DidStartProvisionalLoad(
-    blink::WebLocalFrame* frame) {
-  std::string code =
-      "(function() {"
-      "  window.eventListenerList = [];"
-      "  window._addEventListener = window.addEventListener;"
-      "  window.addEventListener = function(event, callback, useCapture) {"
-      "    if (event == 'storage') {"
-      "      window.eventListenerList.push(callback);"
-      "    }"
-      "    window._addEventListener(event, callback, useCapture);"
-      "  }"
-      "})();";
-
-  blink::WebScriptSource source =
-      blink::WebScriptSource(base::ASCIIToUTF16(code));
-  frame->executeScript(source);
-}
-
 void XWalkRenderViewExtTizen::OnHWKeyPressed(int keycode) {
   std::string event_name;
   if (keycode == ui::VKEY_BACK) {

--- a/runtime/renderer/tizen/xwalk_render_view_ext_tizen.h
+++ b/runtime/renderer/tizen/xwalk_render_view_ext_tizen.h
@@ -8,7 +8,6 @@
 #include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "content/public/renderer/render_view_observer.h"
-#include "third_party/WebKit/public/web/WebLocalFrame.h"
 
 namespace xwalk {
 
@@ -22,7 +21,6 @@ class XWalkRenderViewExtTizen : public content::RenderViewObserver {
 
   // RenderView::Observer:
   bool OnMessageReceived(const IPC::Message& message) override;
-  void DidStartProvisionalLoad(blink::WebLocalFrame* frame) override;
 
   void OnHWKeyPressed(int keycode);
 


### PR DESCRIPTION
The issue is caused by injecting java script to enable firing widget preferences
storage event, and this will skip the initialization progress of extension
process. The patch will make sure inject this script just after the extension
has been initialized.

BUG=https://bugs.tizen.org/jira/browse/TC-2306