### PR TITLE
DEPS.xwalk: Roll chromium-crosswalk (5557d51 -> ed58c20).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '5557d5159b3ed591f53887db1de564d2c07725b9'
+chromium_crosswalk_rev = 'ed58c20d0fa26a6767fba172e19f09d797b97bef'
 v8_crosswalk_rev = '11bb7b400ff9e0179ecf6fe358b9d9452d297234'
 ozone_wayland_rev = 'a64feb172408adac51228ace3fc19c47bc0d978a'
 


### PR DESCRIPTION
ed58c20 Merge pull request #227 from wuhengzhi/crosswalk-11/40.0.2214.28
1a2e3d3 [Temp] Make unix socket Get{Peer|Local}Address return more
rational errors.

This pulls a commit that fix the endless error logs in remote
debugging.

Related to XWALK-3188.