### PR TITLE
[Tizen/Linux] Fix crash at XWalkDevToolsDelegate::ProcessAndSaveThumbnail

### DIFF
--- a/runtime/browser/devtools/xwalk_devtools_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_delegate.cc
@@ -156,6 +156,8 @@ std::string XWalkDevToolsHttpHandlerDelegate::GetDiscoveryPageHTML() {
 void XWalkDevToolsDelegate::ProcessAndSaveThumbnail(
     const GURL& url,
     scoped_refptr<base::RefCountedBytes> png) {
+  if (!png.get())
+    return;
   const std::vector<unsigned char>& png_data = png->data();
   std::string png_string_data(reinterpret_cast<const char*>(&png_data[0]),
                               png_data.size());

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -97,6 +97,9 @@ Runtime* InProcessBrowserTest::CreateRuntime(
   Runtime* runtime = Runtime::Create(
       XWalkRunner::GetInstance()->browser_context());
   runtime->set_observer(this);
+  runtime->set_remote_debugging_enabled(
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kRemoteDebuggingPort));
   runtimes_.push_back(runtime);
   runtime->LoadURL(url);
   content::WaitForLoadStop(runtime->web_contents());


### PR DESCRIPTION
The crash happened if the target page did not have thumbnail icon.