### PR TITLE
[Tizen] Enable SetVisibilityChangeAnimations by default

### DIFF
--- a/runtime/browser/ui/native_app_window_tizen.cc
+++ b/runtime/browser/ui/native_app_window_tizen.cc
@@ -121,6 +121,9 @@ void NativeAppWindowTizen::Initialize() {
     OnScreenOrientationChanged(
         SensorProvider::GetInstance()->GetScreenOrientation());
   }
+
+  // Allow CSS animations to stop/play according to VisibilityChange event.
+  GetWidget()->SetVisibilityChangedAnimationsEnabled(true);
 }
 
 NativeAppWindowTizen::~NativeAppWindowTizen() {


### PR DESCRIPTION
The IVI homescreen UI has CSS animations, but it still runs and
consume more than 35% CPU power when the UI has been hidden.

This patch allows to pause/resume CSS animations when visibilityChange
events are fired.

BUG=TC-1899