### PR TITLE
[Android] Fix app crash when two pages load each other for more than 512...

### DIFF
--- a/runtime/browser/android/net/android_stream_reader_url_request_job.cc
+++ b/runtime/browser/android/net/android_stream_reader_url_request_job.cc
@@ -34,6 +34,7 @@
 #include "xwalk/runtime/browser/android/net/url_constants.h"
 
 using base::android::AttachCurrentThread;
+using base::android::DetachFromVM;
 using base::PostTaskAndReplyWithResult;
 using content::BrowserThread;
 using xwalk::InputStream;
@@ -129,6 +130,8 @@ void OpenInputStreamOnWorkerThread(
                              base::Bind(callback,
                                         base::Passed(delegate.Pass()),
                                         base::Passed(input_stream.Pass())));
+
+  DetachFromVM();
 }
 
 }  // namespace


### PR DESCRIPTION
... times

The crash is caused by local reference table overflow, there is a thread hold the
input stream reference by analysing MAT.
Threads attached through JNI must call DetachCurrentThread before they exit. So
call DetachFromVM after AttachCurrentThread which wraps the DetachCurrentThread
function.

BUG=XWALK-3351

(cherry picked from commit 8fbf5a4cfe89c52e109a3e1c119a3de69a78933c)