### PR TITLE
[Android] improve versionCode generation

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -211,6 +211,32 @@ def CustomizeThemeXML(name, fullscreen, manifest):
   theme_file.close()
 
 
+# Customize manifest
+def CustomizeManifest(app_info):
+  app_versionCode = app_info.app_versionCode
+  app_dir = GetBuildDir(app_info.android_name)
+  app_name = EncodingUnicodeValue(app_info.app_name)
+  if app_name.startswith('@') or app_name.startswith('?'):
+    app_name = ' ' + app_name
+
+  manifest_path = os.path.join(app_dir, 'AndroidManifest.xml')
+  if not os.path.isfile(manifest_path):
+    print('Please make sure AndroidManifest.xml'
+          ' exists under template folder.')
+    sys.exit(6)
+
+  xmldoc = minidom.parse(manifest_path)
+  if app_versionCode:
+    EditElementAttribute(xmldoc, 'manifest', 'android:versionCode',
+                         str(app_versionCode))
+  EditElementAttribute(xmldoc, 'application', 'android:label', app_name)
+  EditElementAttribute(xmldoc, 'activity', 'android:label', app_name)
+
+  file_handle = open(os.path.join(app_dir, 'AndroidManifest.xml'), 'w')
+  xmldoc.writexml(file_handle, encoding='utf-8')
+  file_handle.close()
+
+
 def CustomizeXML(app_info, description, icon_dict, manifest, permissions):
   app_version = app_info.app_version
   app_versionCode = app_info.app_versionCode

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -273,6 +273,34 @@ class TestMakeApk(unittest.TestCase):
     self.assertTrue(content.find('versionName') != -1)
     self.checkApks('Example', '1.0.0')
 
+  def testAppVersionCodeFromVersionName(self):
+    if self._mode.find('embedded') == -1:
+      return
+    if 'x86' in self.archs():
+      arch = '--arch=x86'
+      versionCode = 'versionCode="60100000"'
+    elif 'x86_64' in self.archs():
+      arch = '--arch=x86_64'
+      versionCode = 'versionCode="70100000"'
+    else:
+      arch = '--arch=arm'
+      versionCode = 'versionCode="20100000"'
+    cmd = ['python', 'make_apk.py', '--name=Example',
+           '--package=org.xwalk.example', '--app-version=1.0.0',
+           '--description=a sample application',
+           arch,
+           '--app-url=http://www.intel.com',
+           '--project-dir=.',
+           self._mode]
+    RunCommand(cmd)
+    self.addCleanup(Clean, 'Example', '1.0.0')
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find(versionCode) != -1)
+    self.checkApks('Example', '1.0.0')
+
   def testAppVersionCode(self):
     cmd = ['python', 'make_apk.py', '--name=Example',
            '--package=org.xwalk.example', '--app-version=1.0.0',
@@ -1220,6 +1248,7 @@ def SuiteWithModeOption():
   test_suite.addTest(TestMakeApk('testAppBigVersionCodeBase'))
   test_suite.addTest(TestMakeApk('testAppVersionCode'))
   test_suite.addTest(TestMakeApk('testAppVersionCodeBase'))
+  test_suite.addTest(TestMakeApk('testAppVersionCodeFromVersionName'))
   test_suite.addTest(TestMakeApk('testAppDescriptionAndVersion'))
   test_suite.addTest(TestMakeApk('testArch'))
   test_suite.addTest(TestMakeApk('testEnableRemoteDebugging'))


### PR DESCRIPTION
1. in case that no --arch specified, add correct ABI prefix for versionCode of each arch package
2. if neither --app-versionCode nor --app-versionCodeBase specified, try to parse out versionCode from versionName

BUG=XWALK-3329