### PR TITLE
[Tizen] Remove xwalk backend from libs packaging

### DIFF
--- a/packaging/crosswalk-libs.spec
+++ b/packaging/crosswalk-libs.spec
@@ -225,6 +225,13 @@ DEPENDENCIES=`python %{SOURCE1002} dump.json ${NINJA_TARGETS}`
 
 ninja %{?_smp_mflags} -C src/out/Release ${DEPENDENCIES}
 
+# In '%files' section below there are added all built libraries, which satisfy
+# pattern: 'xwalk/lib/lib*.so'. During build crosswalk-bin.spec generates new
+# library - libxwalk_backend_lib.so, which should not be packaged into
+# crosswalk-libs, but then after incremental build it will also satisfy
+# pattern, which was mentioned above.
+rm -f src/out/Release/lib/libxwalk_backend_lib.so
+
 %install
 # Supporting libraries and resources.
 install -d %{buildroot}%{_libdir}/xwalk/lib


### PR DESCRIPTION
When crosswalk-libs and crosswalk-bin is build for the first time installation of rpms works fine. If next build is incremental libxwalk_backend_lib.so is not removed before next packaging, what causes packaging it into both crosswalk-libs and crosswalk-bin packages. This patch removes libxwalk_backend_lib.so before packaging of crosswalk-libs, when package is build with defined "BUILDDIR_NAME".

BUG=XWALK-3416