### PR TITLE
"OnSuccess" callback is still invoked when there is not camera

### DIFF
--- a/runtime/browser/media/media_capture_devices_dispatcher.cc
+++ b/runtime/browser/media/media_capture_devices_dispatcher.cc
@@ -67,7 +67,9 @@ void XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission(
     }
   }
   callback.Run(devices,
-               content::MEDIA_DEVICE_OK,
+               devices.empty() ?
+                   content::MEDIA_DEVICE_NO_HARDWARE :
+                   content::MEDIA_DEVICE_OK,
                scoped_ptr<content::MediaStreamUI>());
 }
 


### PR DESCRIPTION
When failed to request device we should inform the right status to content,
since there might have some JavaScript listening to the result,  neither success or error.

BUG=https://crosswalk-project.org/jira/browse/XWALK-3133