### PR TITLE
[Tizen] Fix read_only can't be NULL

### DIFF
--- a/application/extension/application_widget_storage.cc
+++ b/application/extension/application_widget_storage.cc
@@ -100,11 +100,13 @@ bool AppWidgetStorage::SaveConfigInfoItem(base::DictionaryValue* dict) {
   DCHECK(dict);
   std::string key;
   std::string value;
-  bool read_only = false;
   if (dict->GetString(kPreferencesName, &key) &&
-      dict->GetString(kPreferencesValue, &value) &&
-      dict->GetBoolean(kPreferencesReadonly, &read_only))
+      dict->GetString(kPreferencesValue, &value)) {
+    bool read_only = false;
+    // read_only column can be NULL.
+    dict->GetBoolean(kPreferencesReadonly, &read_only);
     return AddEntry(key, value, read_only);
+  }
   return false;
 }
 


### PR DESCRIPTION
In config.xml, if widget.preference absents read_only attribute, the corresponding item
will fail to be inserted into the db. This change will fix it.