### PR TITLE
[Tizen] Transform app id to lowercase in active StoragePartitionPath

### DIFF
--- a/application/browser/application_service_tizen.cc
+++ b/application/browser/application_service_tizen.cc
@@ -4,6 +4,7 @@
 
 #include "xwalk/application/browser/application_service_tizen.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -22,7 +23,8 @@ const base::FilePath::CharType kApplicationDataDirName[] =
     FILE_PATH_LITERAL("Storage/ext");
 
 base::FilePath GetStoragePartitionPath(
-    const base::FilePath& base_path, const std::string& app_id) {
+    const base::FilePath& base_path, std::string app_id) {
+  std::transform(app_id.begin(), app_id.end(), app_id.begin(), ::tolower);
   return base_path.Append(kApplicationDataDirName).Append(app_id);
 }
 


### PR DESCRIPTION
In XWalkContentBrowserClient::GetStoragePartitionConfigForSite, we use partition_domain
equals site.host() which is lowercase. However, in CollectUnusedStoragePartitions, the
installed app id could be case-sensitive. So, it will result in deleting installed app
storage since active_paths is case-sensitive and trash path is lowercase for app id domain.