### PR TITLE
Add checking value of "XWALK_OS_ANDROID" during parsing xwalk deps

### DIFF
--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -36,7 +36,7 @@ def GenerateGClientXWalk(options):
   with open(os.path.join(CROSSWALK_ROOT, 'DEPS.xwalk')) as deps_file:
     deps_contents = deps_file.read()
 
-  if 'XWALK_OS_ANDROID' in os.environ:
+  if os.environ.get('XWALK_OS_ANDROID') == '1':
     deps_contents += 'target_os = [\'android\']\n'
 
   gclient_config = ParseGClientConfig()


### PR DESCRIPTION
Check effective value of "XWALK_OS_ANDROID" enviroment variable before
appending android deps_contents. Otherwise it still sync "android_tools"
even if export XWALK_OS_ANDROID=0 for non-Android gclient sync.