### PR TITLE
[Android] Fix SSL Certification Error Alert

### DIFF
--- a/runtime/browser/runtime_context.cc
+++ b/runtime/browser/runtime_context.cc
@@ -192,7 +192,10 @@ content::PushMessagingService* RuntimeContext::GetPushMessagingService() {
 }
 
 content::SSLHostStateDelegate* RuntimeContext::GetSSLHostStateDelegate() {
-  return NULL;
+  if (!ssl_host_state_delegate_.get()) {
+    ssl_host_state_delegate_.reset(new XWalkSSLHostStateDelegate());
+  }
+  return ssl_host_state_delegate_.get();
 }
 
 RuntimeURLRequestContextGetter* RuntimeContext::GetURLRequestContextGetterById(

--- a/runtime/browser/runtime_context.h
+++ b/runtime/browser/runtime_context.h
@@ -20,6 +20,7 @@
 #include "components/visitedlink/browser/visitedlink_delegate.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/content_browser_client.h"
+#include "xwalk/runtime/browser/xwalk_ssl_host_state_delegate.h"
 
 namespace net {
 class URLRequestContextGetter;
@@ -118,6 +119,7 @@ class RuntimeContext
       scoped_refptr<RuntimeURLRequestContextGetter> >
       PartitionPathContextGetterMap;
   PartitionPathContextGetterMap context_getters_;
+  scoped_ptr<XWalkSSLHostStateDelegate> ssl_host_state_delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(RuntimeContext);
 };

--- a/runtime/browser/xwalk_ssl_host_state_delegate.cc
+++ b/runtime/browser/xwalk_ssl_host_state_delegate.cc
@@ -1,0 +1,89 @@
+// Copyright (c) 2014 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/xwalk_ssl_host_state_delegate.h"
+
+#include "net/base/hash_value.h"
+
+using content::SSLHostStateDelegate;
+
+namespace xwalk {
+
+namespace internal {
+
+net::SHA256HashValue getChainFingerprint256(const net::X509Certificate& cert) {
+  net::SHA256HashValue fingerprint =
+      net::X509Certificate::CalculateChainFingerprint256(
+          cert.os_cert_handle(), cert.GetIntermediateCertificates());
+  return fingerprint;
+}
+
+CertPolicy::CertPolicy() {
+}
+
+CertPolicy::~CertPolicy() {
+}
+
+// For an allowance, we consider a given |cert| to be a match to a saved
+// allowed cert if the |error| is an exact match to or subset of the errors
+// in the saved CertStatus.
+bool CertPolicy::Check(const net::X509Certificate& cert,
+                       net::CertStatus error) const {
+  net::SHA256HashValue fingerprint = getChainFingerprint256(cert);
+  CertMap::const_iterator allowed_iter = allowed_.find(fingerprint);
+  return (allowed_iter != allowed_.end()) &&
+         (allowed_iter->second & error) &&
+         ((allowed_iter->second & error) == error);
+}
+
+void CertPolicy::Allow(const net::X509Certificate& cert,
+                       net::CertStatus error) {
+  // If this same cert had already been saved with a different error status,
+  // this will replace it with the new error status.
+  net::SHA256HashValue fingerprint = getChainFingerprint256(cert);
+  allowed_[fingerprint] = error;
+}
+
+}  // namespace internal
+
+XWalkSSLHostStateDelegate::XWalkSSLHostStateDelegate() {
+}
+
+XWalkSSLHostStateDelegate::~XWalkSSLHostStateDelegate() {
+}
+
+void XWalkSSLHostStateDelegate::HostRanInsecureContent(const std::string& host,
+                                                       int pid) {
+  // Intentional no-op.
+}
+
+bool XWalkSSLHostStateDelegate::DidHostRunInsecureContent(
+    const std::string& host,
+    int pid) const {
+  // Intentional no-op.
+  return false;
+}
+
+void XWalkSSLHostStateDelegate::AllowCert(const std::string& host,
+                                          const net::X509Certificate& cert,
+                                          net::CertStatus error) {
+  cert_policy_for_host_[host].Allow(cert, error);
+}
+
+void XWalkSSLHostStateDelegate::Clear() {
+  cert_policy_for_host_.clear();
+}
+
+SSLHostStateDelegate::CertJudgment XWalkSSLHostStateDelegate::QueryPolicy(
+    const std::string& host,
+    const net::X509Certificate& cert,
+    net::CertStatus error,
+    bool* expired_previous_decision) {
+  return cert_policy_for_host_[host].Check(cert, error)
+             ? SSLHostStateDelegate::ALLOWED
+             : SSLHostStateDelegate::DENIED;
+}
+
+}  // namespace xwalk

--- a/runtime/browser/xwalk_ssl_host_state_delegate.h
+++ b/runtime/browser/xwalk_ssl_host_state_delegate.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2014 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_XWALK_SSL_HOST_STATE_DELEGATE_H_
+#define XWALK_RUNTIME_BROWSER_XWALK_SSL_HOST_STATE_DELEGATE_H_
+
+#include <map>
+#include <string>
+
+#include "content/public/browser/ssl_host_state_delegate.h"
+#include "net/base/hash_value.h"
+#include "net/cert/cert_status_flags.h"
+#include "net/cert/x509_certificate.h"
+
+namespace xwalk {
+
+namespace internal {
+
+// This class maintains the policy for storing actions on certificate errors.
+class CertPolicy {
+ public:
+  CertPolicy();
+  ~CertPolicy();
+  // Returns true if the user has decided to proceed through the ssl error
+  // before. For a certificate to be allowed, it must not have any
+  // *additional* errors from when it was allowed.
+  bool Check(const net::X509Certificate& cert, net::CertStatus error) const;
+
+  // Causes the policy to allow this certificate for a given |error|. And
+  // remember the user's choice.
+  void Allow(const net::X509Certificate& cert, net::CertStatus error);
+
+ private:
+  // The set of fingerprints of allowed certificates.
+  typedef std::map<net::SHA256HashValue, net::CertStatus,
+      net::SHA256HashValueLessThan> CertMap;
+  CertMap allowed_;
+};
+
+}  // namespace internal
+
+class XWalkSSLHostStateDelegate : public content::SSLHostStateDelegate {
+ public:
+  XWalkSSLHostStateDelegate();
+  virtual ~XWalkSSLHostStateDelegate();
+
+  // Records that |cert| is permitted to be used for |host| in the future, for
+  // a specified |error| type.
+  void AllowCert(const std::string& host,
+                 const net::X509Certificate& cert,
+                 net::CertStatus error) override;
+
+  void Clear() override;
+
+  // Queries whether |cert| is allowed or denied for |host| and |error|.
+  content::SSLHostStateDelegate::CertJudgment QueryPolicy(
+      const std::string& host,
+      const net::X509Certificate& cert,
+      net::CertStatus error,
+      bool* expired_previous_decision) override;
+
+  // Records that a host has run insecure content.
+  void HostRanInsecureContent(const std::string& host, int pid) override;
+
+  // Returns whether the specified host ran insecure content.
+  bool DidHostRunInsecureContent(const std::string& host,
+                                 int pid) const override;
+
+ private:
+  // Certificate policies for each host.
+  std::map<std::string, internal::CertPolicy> cert_policy_for_host_;
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkSSLHostStateDelegate);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_XWALK_SSL_HOST_STATE_DELEGATE_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -236,6 +236,8 @@
         'runtime/browser/xwalk_runner_android.h',
         'runtime/browser/xwalk_runner_tizen.cc',
         'runtime/browser/xwalk_runner_tizen.h',
+        'runtime/browser/xwalk_ssl_host_state_delegate.cc',
+        'runtime/browser/xwalk_ssl_host_state_delegate.h',
         'runtime/common/android/xwalk_globals_android.cc',
         'runtime/common/android/xwalk_globals_android.h',
         'runtime/common/android/xwalk_hit_test_data.cc',


### PR DESCRIPTION
Fix bug XWALK-2498, SSL Certification Error Alert popup repeatedly after click OK.
How: Implement XWalkSSLHostStateDelegate which keeps the cert after click OK.
Test page:https://kyfw.12306.cn/otn/regist/init

BUG=XWALK-2498

(cherry picked from commit bba6fc5b4b923b9af7ee3768c0be562aa809443c)