### PR TITLE
Fix the issue about placeholder was not cleared in textarea.

### DIFF
--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -6,6 +6,8 @@
 
 #include "base/command_line.h"
 #include "base/strings/utf_string_conversions.h"
+#include "components/autofill/content/renderer/autofill_agent.h"
+#include "components/autofill/content/renderer/password_autofill_agent.h"
 #include "components/nacl/renderer/ppb_nacl_private_impl.h"
 #include "components/visitedlink/renderer/visitedlink_slave.h"
 #include "content/public/renderer/render_frame.h"
@@ -156,6 +158,13 @@ void XWalkContentRendererClient::RenderViewCreated(
 #elif defined(OS_TIZEN)
   XWalkRenderViewExtTizen::RenderViewCreated(render_view);
 #endif
+  // The following code was copied from
+  // android_webview/renderer/aw_content_renderer_client.cc
+  // TODO(sgurun) do not create a password autofill agent (change
+  // autofill agent to store a weakptr).
+  autofill::PasswordAutofillAgent* password_autofill_agent =
+      new autofill::PasswordAutofillAgent(render_view);
+  new autofill::AutofillAgent(render_view, password_autofill_agent, nullptr);
 }
 
 void XWalkContentRendererClient::DidCreateScriptContext(

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -30,6 +30,7 @@
         '../base/base.gyp:base_i18n',
         '../base/third_party/dynamic_annotations/dynamic_annotations.gyp:dynamic_annotations',
         '../cc/cc.gyp:cc',
+        '../components/components.gyp:autofill_content_renderer',
         '../components/components.gyp:visitedlink_browser',
         '../components/components.gyp:visitedlink_renderer',
         '../content/content.gyp:content',


### PR DESCRIPTION
This patch is to fix the issue about placeholder was not cleared in
textarea when enter first character.
Invoke the construction for AutofillAgent(), it will set auto fill
client which will be used when the text was changed in textarea.

BUG=XWALK-3334