### PR TITLE
[Tizen] Use appcore RESET event as application starting point

### DIFF
--- a/application/browser/application_system.h
+++ b/application/browser/application_system.h
@@ -72,6 +72,7 @@ class ApplicationSystem {
   XWalkBrowserContext* browser_context_;
   scoped_ptr<ApplicationService> application_service_;
 
+ private:
   DISALLOW_COPY_AND_ASSIGN(ApplicationSystem);
 };
 

--- a/application/browser/application_system_tizen.h
+++ b/application/browser/application_system_tizen.h
@@ -5,7 +5,10 @@
 #ifndef XWALK_APPLICATION_BROWSER_APPLICATION_SYSTEM_TIZEN_H_
 #define XWALK_APPLICATION_BROWSER_APPLICATION_SYSTEM_TIZEN_H_
 
+#include "base/command_line.h"
+
 #include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/browser/application_tizen.h"
 
 namespace xwalk {
 namespace application {
@@ -16,7 +19,6 @@ class ApplicationSystemTizen : public ApplicationSystem {
   virtual ~ApplicationSystemTizen();
   virtual bool LaunchFromCommandLine(const base::CommandLine& cmd_line,
                                      const GURL& url) override;
-
  private:
   DISALLOW_COPY_AND_ASSIGN(ApplicationSystemTizen);
 };


### PR DESCRIPTION
Starting application should take places in RESET event.
This change is required for futher modifications
for appcontrol implementation.

BUG=XWALK-2779