### PR TITLE
Fix leaking file descriptor when a new app is launched

### DIFF
--- a/application/browser/linux/running_application_object.cc
+++ b/application/browser/linux/running_application_object.cc
@@ -119,6 +119,9 @@ RunningApplicationObject::~RunningApplicationObject() {
 
 void RunningApplicationObject::TerminateApplication() {
   application_->Terminate();
+
+  if (ep_bp_channel_.socket.fd != -1)
+    close(ep_bp_channel_.socket.fd);
 }
 
 void RunningApplicationObject::OnExported(const std::string& interface_name,


### PR DESCRIPTION
When establishing a communication channel between the 2 process
we create 2 sockets endpoints and one is sent to the process we
are communicating to. After sending, we need to close this fd.

BUG=TC-2361