### PR TITLE
ApiTest: Process all events before tearing down the test suite.

### DIFF
--- a/application/test/application_browsertest.cc
+++ b/application/test/application_browsertest.cc
@@ -44,9 +44,9 @@ void ApplicationBrowserTest::SetUp() {
 void ApplicationBrowserTest::ProperMainThreadCleanup() {
   const ScopedVector<Application>& apps =
     application_sevice()->active_applications();
-
   std::for_each(apps.begin(), apps.end(),
     std::mem_fun(&Application::Terminate));
+  content::RunAllPendingInMessageLoop();
 }
 
 ApplicationService* ApplicationBrowserTest::application_sevice() const {


### PR DESCRIPTION
Call content::RunAllpendingInMessageLoop() in ProperMainThreadCleanup(),
otherwise we might end up finishing the main loop with pending events,
leading to this crash in debug mode:

```
[5879:5879:0128/012604:41680213612:FATAL:gpu_process_transport_factory.cc(92)] Check failed: per_compositor_data_.empty().
```

TEST=./out/Debug/xwalk_browsertest --gtest_filter=ApplicationTestApiTest.TestApiTest