### PR TITLE
manifest_handlers: Fix some chromium-style violations.

### DIFF
--- a/application/common/manifest_handlers/tizen_application_handler.h
+++ b/application/common/manifest_handlers/tizen_application_handler.h
@@ -18,7 +18,7 @@ namespace application {
 class TizenApplicationInfo : public ApplicationData::ManifestData {
  public:
   TizenApplicationInfo();
-  virtual ~TizenApplicationInfo();
+  virtual ~TizenApplicationInfo() override;
 
   void set_id(const std::string& id) {
     id_ = id;
@@ -49,7 +49,7 @@ class TizenApplicationInfo : public ApplicationData::ManifestData {
 class TizenApplicationHandler : public ManifestHandler {
  public:
   TizenApplicationHandler();
-  virtual ~TizenApplicationHandler();
+  virtual ~TizenApplicationHandler() override;
 
   bool Parse(scoped_refptr<ApplicationData> application,
              base::string16* error) override;

--- a/application/common/manifest_handlers/widget_handler.h
+++ b/application/common/manifest_handlers/widget_handler.h
@@ -18,7 +18,7 @@ namespace application {
 class WidgetInfo : public ApplicationData::ManifestData {
  public:
   WidgetInfo();
-  virtual ~WidgetInfo();
+  virtual ~WidgetInfo() override;
   void SetString(const std::string& key, const std::string& value);
   void Set(const std::string& key, base::Value* value);
 
@@ -39,7 +39,7 @@ class WidgetInfo : public ApplicationData::ManifestData {
 class WidgetHandler : public ManifestHandler {
  public:
   WidgetHandler();
-  virtual ~WidgetHandler();
+  virtual ~WidgetHandler() override;
 
   bool Parse(scoped_refptr<ApplicationData> application,
              base::string16* error) override;


### PR DESCRIPTION
Found by the Linux clang builds in #2838.

```
../../xwalk/application/common/manifest_handlers/widget_handler.h:21:24: error: [chromium-style] Overriding method must be marked with 'override' or 'final'.
../../xwalk/application/common/manifest_handlers/widget_handler.h:42:27: error: [chromium-style] Overriding method must be marked with 'override' or 'final'.
../../xwalk/application/common/manifest_handlers/tizen_application_handler.h:21:34: error: [chromium-style] Overriding method must be marked with 'override' or 'final'.
../../xwalk/application/common/manifest_handlers/tizen_application_handler.h:52:37: error: [chromium-style] Overriding method must be marked with 'override' or 'final'.
```