### PR TITLE
[Android] Don't specify compositor mode.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -97,9 +97,6 @@ void XWalkBrowserMainPartsAndroid::PreEarlyInitialization() {
   // Android. So increase the limit to 4096 explicitly.
   base::SetFdLimit(4096);
 
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      cc::switches::kCompositeToMailbox);
-
   // Initialize the Compositor.
   content::Compositor::Initialize();
 

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -116,6 +116,10 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
 #endif
 
+  // Enable experiemntal features like polymer and css animations because
+  // CrossWalk is testbed of state of art of web technology.
+  command_line->AppendSwitch(switches::kEnableExperimentalWebPlatformFeatures);
+
 #if defined(ENABLE_WEBRTC)
   // Disable HW encoding/decoding acceleration for WebRTC on Android.
   // FIXME: Remove these switches for Android when Android OS is removed from


### PR DESCRIPTION
[Android] Don't specify compositor mode.
composite to mailbox is very old legacy. Don't specify this. CrossWalk relies
on upstream Android policy in terms of compositor mode.

BUG=XWALK-322