### PR TITLE
[Tizen] Fix the crash of RemoteDebuggingServer when repeatedly resetting

### DIFF
--- a/runtime/browser/devtools/remote_debugging_server.cc
+++ b/runtime/browser/devtools/remote_debugging_server.cc
@@ -41,6 +41,7 @@ RemoteDebuggingServer::RemoteDebuggingServer(
       frontend_url,
       new XWalkDevToolsHttpHandlerDelegate(),
       output_dir));
+  port_ = port;
 }
 
 RemoteDebuggingServer::~RemoteDebuggingServer() {

--- a/runtime/browser/devtools/remote_debugging_server.h
+++ b/runtime/browser/devtools/remote_debugging_server.h
@@ -26,9 +26,11 @@ class RemoteDebuggingServer {
                         const std::string& frontend_url);
 
   virtual ~RemoteDebuggingServer();
+  int port() { return port_; }
 
  private:
   scoped_ptr<content::DevToolsHttpHandler> devtools_http_handler_;
+  int port_;
   DISALLOW_COPY_AND_ASSIGN(RemoteDebuggingServer);
 };
 

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -176,6 +176,9 @@ void XWalkRunner::OnRenderProcessHostGone(content::RenderProcessHost* host) {
 void XWalkRunner::EnableRemoteDebugging(int port) {
   const char* local_ip = "0.0.0.0";
   if (port > 0 && port < 65535) {
+    if (remote_debugging_server_.get() &&
+        remote_debugging_server_.get()->port() == port)
+      remote_debugging_server_.reset();
     remote_debugging_server_.reset(
         new RemoteDebuggingServer(browser_context(),
             local_ip, port, std::string()));


### PR DESCRIPTION
Guarantee the right time sequence of resetting TCPServerSocket inside
RemoteDebuggingServer in case of repeatedly invoke it with same tcp port
parameter which leads to the crash.

@pozdnyakov @halton 
Please spare time to help review, thank you very much.