### PR TITLE
Fixed compilation errors on Linux

### DIFF
--- a/runtime/browser/nacl_host/nacl_browser_delegate_impl.cc
+++ b/runtime/browser/nacl_host/nacl_browser_delegate_impl.cc
@@ -5,8 +5,8 @@
 #include "xwalk/runtime/browser/nacl_host/nacl_browser_delegate_impl.h"
 
 #include "base/path_service.h"
+#include "components/nacl/renderer/ppb_nacl_private.h"
 #include "content/public/browser/browser_thread.h"
-#include "ppapi/c/private/ppb_nacl_private.h"
 #include "xwalk/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -98,7 +98,7 @@ class Runtime : public content::WebContentsDelegate,
                            bool to_different_document) override;
   void EnterFullscreenModeForTab(content::WebContents* web_contents,
                                  const GURL& origin) override;
-  virtual void ExitFullscreenModeForTab(
+  void ExitFullscreenModeForTab(
       content::WebContents* web_contents) override;
   bool IsFullscreenForTabOrPending(
       const content::WebContents* web_contents) const override;

--- a/runtime/browser/xwalk_platform_notification_service.h
+++ b/runtime/browser/xwalk_platform_notification_service.h
@@ -24,6 +24,11 @@ class XWalkPlatformNotificationService
   static XWalkPlatformNotificationService* GetInstance();
 
   // content::PlatformNotificationService implementation.
+  blink::WebNotificationPermission CheckPermissionOnUIThread(
+      content::BrowserContext* browser_context,
+      const GURL& origin,
+      int render_process_id) override;
+  // content::PlatformNotificationService implementation.
   blink::WebNotificationPermission CheckPermissionOnIOThread(
       content::ResourceContext* resource_context,
       const GURL& origin,
@@ -34,15 +39,13 @@ class XWalkPlatformNotificationService
       const SkBitmap& icon,
       const content::PlatformNotificationData& notification_data,
       scoped_ptr<content::DesktopNotificationDelegate> delegate,
-      int render_process_id,
       base::Closure* cancel_callback) override;
   void DisplayPersistentNotification(
       content::BrowserContext* browser_context,
       int64 service_worker_registration_id,
       const GURL& origin,
       const SkBitmap& icon,
-      const content::PlatformNotificationData& notification_data,
-      int render_process_id) override {}
+      const content::PlatformNotificationData& notification_data) override {}
   void ClosePersistentNotification(
       content::BrowserContext* browser_context,
       const std::string& persistent_notification_id) override {}

--- a/sysapps/raw_socket/udp_socket_object.cc
+++ b/sysapps/raw_socket/udp_socket_object.cc
@@ -214,7 +214,8 @@ void UDPSocketObject::OnRead(int status) {
       static_cast<char*>(read_buffer_->data()), status));
 
   UDPMessageEvent event;
-  event.data = std::string(read_buffer_->data(), status);
+  std::string buffer_data(read_buffer_->data(), status);
+  std::copy(buffer_data.begin(), buffer_data.end(), back_inserter(event.data));
   event.remote_port = from_.port();
   event.remote_address = from_.ToStringWithoutPort();
 


### PR DESCRIPTION
1. Changed xwalk_platform_notification_service to reflect latest api changes
introduced by this change, https://codereview.chromium.org/834263004

2. Updated ppb_nacl_private.h path in nacl_browser_delegate_impl.cc

3. Removed redundant virtual from runtime.h

4. Fixed the missing assignment operator error in udp_socket_object.cc