### PR TITLE
Removing unused (and uninitalized) remote_debugging_enabled_ (from issue 274840)

### DIFF
--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -163,7 +163,6 @@ class Runtime : public content::WebContentsDelegate,
   gfx::Image app_icon_;
 
   unsigned int fullscreen_options_;
-  bool remote_debugging_enabled_;
   RuntimeUIDelegate* ui_delegate_;
   Observer* observer_;
   base::WeakPtrFactory<Runtime> weak_ptr_factory_;


### PR DESCRIPTION
(cherry picked from commit b2e2f4b78f9f8df32db0e24b1b18b51ec8642b07)