### PR TITLE
[Android] Disable the use of external startup data for V8.

### DIFF
--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -219,8 +219,11 @@ class TestMakeApk(unittest.TestCase):
     if self._mode.find('embedded') != -1:
       embedded_related_files = ['icudtl.dat',
                                 'xwalk.pak',
-                                'natives_blob.bin',
-                                'snapshot_blob.bin',
+                                # Please refer to XWALK-3516, disable v8 use
+                                # external startup data, reopen it if needed
+                                # later.
+                                # 'natives_blob.bin',
+                                # 'snapshot_blob.bin',
                                 'device_capabilities_api.js',
                                 'launch_screen_api.js',
                                 'presentation_api.js']

--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -105,8 +105,10 @@ def CopyBinaries(out_dir, out_project_dir, src_package):
 
   paks_to_copy = [
       'icudtl.dat',
-      'natives_blob.bin',
-      'snapshot_blob.bin',
+      # Please refer to XWALK-3516, disable v8 use external startup data,
+      # reopen it if needed later.
+      # 'natives_blob.bin',
+      # 'snapshot_blob.bin',
       'xwalk.pak',
   ]
 

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -7,6 +7,7 @@
       ['OS=="android"', {
         # Enable WebCL by default on android.
         'enable_webcl%': 1,
+        'v8_use_external_startup_data%': 0,
       }, {
         'enable_webcl%': 0,
       }],

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -41,8 +41,10 @@ class XWalkViewDelegate {
             "xwalk.pak",
             "en-US.pak",
             "icudtl.dat",
-            "natives_blob.bin",
-            "snapshot_blob.bin"
+            // Please refer to XWALK-3516, disable v8 use external startup data,
+            // reopen it if needed later.
+            // "natives_blob.bin",
+            // "snapshot_blob.bin"
     };
     private static final String[] MANDATORY_LIBRARIES = {
             "libxwalkcore.so"


### PR DESCRIPTION
This patch is to disable the use of external startup data for V8
for android platform.
We just disable this feature to unblock the release at present.
Next step we will evaluate the tricky then decide to ship blobs
(for x86, arm, x86-64) or not.

BUG=XWALK-3516

(cherry picked from commit bcbad4e1ede1615b6688357aec59148b83b60ac8)