### PR TITLE
XWView{Internal}TestRunnerActivity: simplify hardware acceleration check.

### DIFF
--- a/runtime/android/core_internal_shell/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestRunnerActivity.java
+++ b/runtime/android/core_internal_shell/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestRunnerActivity.java
@@ -23,13 +23,9 @@ public class XWalkViewInternalTestRunnerActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        boolean hardwareAccelerated = true;
-
-        if (hardwareAccelerated) {
-            getWindow().setFlags(
-                    WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
-                    WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
-        }
+        getWindow().setFlags(
+                WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
+                WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
 
         mLinearLayout = new LinearLayout(this);
         mLinearLayout.setOrientation(LinearLayout.VERTICAL);

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/test/XWalkViewTestRunnerActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/test/XWalkViewTestRunnerActivity.java
@@ -23,13 +23,9 @@ public class XWalkViewTestRunnerActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        boolean hardwareAccelerated = true;
-
-        if (hardwareAccelerated) {
-            getWindow().setFlags(
-                    WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
-                    WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
-        }
+        getWindow().setFlags(
+                WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
+                WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
 
         mLinearLayout = new LinearLayout(this);
         mLinearLayout.setOrientation(LinearLayout.VERTICAL);


### PR DESCRIPTION
`hardwareAccelerated` was always true, so there is no need to check for it, or for it to exist at all.