### PR TITLE
[Android] Enable transparent XWalkView

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -426,16 +426,25 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         return nativeGetVersion(mNativeContent);
     }
 
+    private boolean isOpaque(int color) {
+        return ((color >> 24) & 0xFF) == 0xFF;
+    }
+
     public void setBackgroundColor(final int color) {
         if (mNativeContent == 0) return;
         if (mIsLoaded == false) {
             post(new Runnable() {
                 @Override
                 public void run() {
-                    nativeSetBackgroundColor(mNativeContent, color);
+                    setBackgroundColor(color);
                 }
             });
             return;
+        }
+        if (isOpaque(color) == false) {
+            setOverlayVideoMode(true);
+            mContentViewRenderView.setSurfaceViewBackgroundColor(color);
+            mContentViewCore.setBackgroundOpaque(false);
         }
         nativeSetBackgroundColor(mNativeContent, color);
     }


### PR DESCRIPTION
Enable transparent XWalkView. Use XWalkView.setBackgroundColor(0) for transparent.

BUG=XWALK-3308

(cherry picked from commit 9ee81a73349e4da8e69d5cd3c1637ad1e5957c04)