### PR TITLE
[Tizen] Load application according to bundle values

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -8,6 +8,7 @@
 
 #include "base/files/file_enumerator.h"
 #include "base/json/json_reader.h"
+#include "base/logging.h"
 #include "base/macros.h"
 #include "base/message_loop/message_loop.h"
 #include "base/stl_util.h"
@@ -102,7 +103,7 @@ Application::~Application() {
 }
 
 template<>
-GURL Application::GetStartURL<Manifest::TYPE_WIDGET>() {
+GURL Application::GetStartURL<Manifest::TYPE_WIDGET>() const {
 #if defined(OS_TIZEN)
   if (data_->IsHostedApp()) {
     std::string source;
@@ -132,7 +133,7 @@ GURL Application::GetStartURL<Manifest::TYPE_WIDGET>() {
 }
 
 template<>
-GURL Application::GetStartURL<Manifest::TYPE_MANIFEST>() {
+GURL Application::GetStartURL<Manifest::TYPE_MANIFEST>() const {
   if (data_->IsHostedApp()) {
     std::string source;
     // Not trying to get a relative path for the "fake" application.
@@ -161,6 +162,16 @@ GURL Application::GetStartURL<Manifest::TYPE_MANIFEST>() {
   return GURL();
 }
 
+GURL Application::GetStartURL(Manifest::Type type) const {
+  switch (type) {
+    case Manifest::Type::TYPE_WIDGET:
+      return GetStartURL<Manifest::Type::TYPE_WIDGET>();
+    case Manifest::Type::TYPE_MANIFEST:
+      return GetStartURL<Manifest::Type::TYPE_MANIFEST>();
+    default:
+      NOTREACHED() << "Unknown manifest type";
+  }
+}
 
 template<>
 ui::WindowShowState Application::GetWindowShowState<Manifest::TYPE_WIDGET>() {
@@ -201,10 +212,8 @@ bool Application::Launch() {
   }
 
   CHECK(!render_process_host_);
-  bool is_wgt = data_->manifest_type() == Manifest::TYPE_WIDGET;
 
-  GURL url = is_wgt ? GetStartURL<Manifest::TYPE_WIDGET>() :
-                      GetStartURL<Manifest::TYPE_MANIFEST>();
+  GURL url = GetStartURL(data_->manifest_type());
   if (!url.is_valid())
     return false;
 
@@ -219,7 +228,7 @@ bool Application::Launch() {
   runtime->LoadURL(url);
 
   NativeAppWindow::CreateParams params;
-  params.state = is_wgt ?
+  params.state = data_->manifest_type() == Manifest::TYPE_WIDGET ?
       GetWindowShowState<Manifest::TYPE_WIDGET>() :
       GetWindowShowState<Manifest::TYPE_MANIFEST>();
 
@@ -232,7 +241,7 @@ bool Application::Launch() {
   return true;
 }
 
-GURL Application::GetAbsoluteURLFromKey(const std::string& key) {
+GURL Application::GetAbsoluteURLFromKey(const std::string& key) const {
   const Manifest* manifest = data_->GetManifest();
   std::string source;
 

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -132,6 +132,8 @@ class Application : public Runtime::Observer,
 
   NativeAppWindow::CreateParams window_show_params_;
 
+  virtual GURL GetStartURL(Manifest::Type type) const;
+
  private:
   // We enforce ApplicationService ownership.
   friend class ApplicationService;
@@ -147,11 +149,11 @@ class Application : public Runtime::Observer,
 
   // Try to extract the URL from different possible keys for entry points in the
   // manifest, returns it and the entry point used.
-  template <Manifest::Type> GURL GetStartURL();
+  template <Manifest::Type> GURL GetStartURL() const;
 
   template <Manifest::Type> ui::WindowShowState GetWindowShowState();
 
-  GURL GetAbsoluteURLFromKey(const std::string& key);
+  GURL GetAbsoluteURLFromKey(const std::string& key) const;
 
   void NotifyTermination();
 

--- a/application/browser/application_service_tizen.cc
+++ b/application/browser/application_service_tizen.cc
@@ -58,7 +58,8 @@ ApplicationServiceTizen::ApplicationServiceTizen(
 ApplicationServiceTizen::~ApplicationServiceTizen() {
 }
 
-Application* ApplicationServiceTizen::LaunchFromAppID(const std::string& id) {
+Application* ApplicationServiceTizen::LaunchFromAppID(
+    const std::string& id, const std::string& encoded_bundle) {
   if (!IsValidApplicationID(id)) {
      LOG(ERROR) << "The input parameter is not a valid app id: " << id;
      return NULL;
@@ -70,6 +71,9 @@ Application* ApplicationServiceTizen::LaunchFromAppID(const std::string& id) {
     LOG(ERROR) << "Application with id " << id << " is not installed.";
     return NULL;
   }
+
+  // Set bundle data for app
+  app_data->set_bundle(encoded_bundle);
 
   return Launch(app_data);
 }

--- a/application/browser/application_service_tizen.h
+++ b/application/browser/application_service_tizen.h
@@ -20,7 +20,8 @@ class ApplicationServiceTizen : public ApplicationService {
  public:
   ~ApplicationServiceTizen() override;
   // Launch an installed application using application id.
-  Application* LaunchFromAppID(const std::string& id);
+  Application* LaunchFromAppID(const std::string& id,
+      const std::string& encoded_bundle = std::string());
 
  private:
   friend class ApplicationService;

--- a/application/browser/application_system_tizen.cc
+++ b/application/browser/application_system_tizen.cc
@@ -102,7 +102,22 @@ void application_event_cb(app_event event, void* data, bundle* b) {
 
       ApplicationServiceTizen* app_service_tizen =
           ToApplicationServiceTizen(app_system->application_service());
-      Application* app = app_service_tizen->LaunchFromAppID(app_id);
+
+      // TODO(t.iwanek):
+      // In tizen platform RESET event should reload application
+      // It should be handled it here.
+      // By now it will just ignore second launch of an application
+
+      std::string encoded_bundle;
+      bundle_raw* r = nullptr;
+      int len = 0;
+      if (!bundle_encode(b, &r, &len)) {
+        encoded_bundle.assign(reinterpret_cast<char*>(r), len);
+        bundle_free_encoded_rawdata(&r);
+      }
+
+      Application* app =
+          app_service_tizen->LaunchFromAppID(app_id, encoded_bundle);
       LOG(INFO) << "Application launched with id: " << app->id();
       handler_data->current_app = static_cast<ApplicationTizen*>(app);
       break;

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -9,6 +9,7 @@
 
 #include "base/event_types.h"
 #include "xwalk/application/browser/application.h"
+#include "xwalk/application/common/tizen/app_control_info.h"
 #include "xwalk/application/common/tizen/cookie_manager.h"
 
 #if defined(USE_OZONE)
@@ -34,11 +35,16 @@ class ApplicationTizen :  // NOLINT
   void RemoveAllCookies();
   void SetUserAgentString(const std::string& user_agent_string);
 
+ protected:
+  GURL GetStartURL(Manifest::Type type) const override;
+
  private:
   friend class Application;
   ApplicationTizen(scoped_refptr<ApplicationData> data,
                    XWalkBrowserContext* context);
   bool Launch() override;
+
+  GURL GetAppControlStartURL(const AppControlInfo& app_control) const;
 
   base::FilePath GetSplashScreenPath() override;
 

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -90,8 +90,16 @@ void ApplicationData::SetManifestData(const std::string& key,
 }
 
 #if defined(OS_TIZEN)
+void ApplicationData::set_bundle(const std::string& bundle) {
+  bundle_ = bundle;
+}
+
 std::string ApplicationData::GetPackageID() const {
   return AppIdToPkgId(application_id_);
+}
+
+const std::string& ApplicationData::bundle() const {
+  return bundle_;
 }
 #endif
 

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -91,6 +91,10 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   // all SetManifestData calls should be on only one thread.
   void SetManifestData(const std::string& key, ManifestData* data);
 
+#if defined(OS_TIZEN)
+  void set_bundle(const std::string& bundle);
+#endif
+
   // Accessors:
   const base::FilePath& path() const { return path_; }
   const GURL& URL() const { return application_url_; }
@@ -99,6 +103,7 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   const std::string& ID() const { return application_id_; }
 #if defined(OS_TIZEN)
   std::string GetPackageID() const;
+  const std::string& bundle() const;
 #endif
   const base::Version* Version() const { return version_.get(); }
   const std::string VersionString() const;
@@ -199,6 +204,10 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   // The source the application was loaded from.
   SourceType source_type_;
+
+#if defined(OS_TIZEN)
+  std::string bundle_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationData);
 };

--- a/application/common/manifest_handlers/tizen_app_control_handler.cc
+++ b/application/common/manifest_handlers/tizen_app_control_handler.cc
@@ -9,6 +9,7 @@
 #include "base/third_party/xdg_mime/xdgmime.h"
 #include "base/values.h"
 #include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/tizen/app_control_info.h"
 
 namespace xwalk {
 

--- a/application/common/manifest_handlers/tizen_app_control_handler.h
+++ b/application/common/manifest_handlers/tizen_app_control_handler.h
@@ -15,38 +15,6 @@
 namespace xwalk {
 namespace application {
 
-class AppControlInfo {
- public:
-  AppControlInfo(const std::string& src, const std::string& operation,
-      const std::string& uri, const std::string& mime)
-      : src_(src),
-        operation_(operation),
-        uri_(uri),
-        mime_(mime) { }
-  const std::string& src() const {
-    return src_;
-  }
-  const std::string& operation() const {
-    return operation_;
-  }
-  const std::string& uri() const {
-    return uri_;
-  }
-  const std::string& mime() const {
-    return mime_;
-  }
-
- private:
-  std::string src_;
-  std::string operation_;
-  std::string uri_;
-  std::string mime_;
-};
-
-struct AppControlInfoList : public ApplicationData::ManifestData {
-  std::vector<AppControlInfo> controls;
-};
-
 class TizenAppControlHandler : public ManifestHandler {
  public:
   TizenAppControlHandler();

--- a/application/common/tizen/app_control_info.cc
+++ b/application/common/tizen/app_control_info.cc
@@ -1,0 +1,164 @@
+// Copyright (c) 2015 Samsung Electronics Co., Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/application/common/tizen/app_control_info.h"
+
+#include <app_service.h>
+#include <aul.h>
+#include <bundle.h>
+
+#include "base/logging.h"
+#include "third_party/re2/re2/re2.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+// FIXME: this is temporary hack for API that is private
+// this function signature matches the one in capi
+extern "C" int service_create_event(bundle* data, struct service_s** service);
+
+namespace {
+unsigned kMaximumMimeTypeLength = 256;
+
+bool CheckMimeMatch(const std::string& requested, const std::string& given) {
+  if (!given.empty()) {
+    std::string regex = re2::RE2::QuoteMeta(given);
+    re2::RE2::GlobalReplace(&regex, "\\\\\\*", ".*");
+    if (re2::RE2::FullMatch(requested, regex)) {
+      return true;
+    }
+    return false;
+  }
+  return true;
+}
+
+bool CheckUriMatch(const GURL& requested, const GURL& given) {
+  // match by wildcard
+  std::string regex = re2::RE2::QuoteMeta(given.spec());
+  re2::RE2::GlobalReplace(&regex, "\\\\\\*", ".*");
+  if (re2::RE2::FullMatch(requested.spec(), regex)) {
+    return true;
+  }
+
+  // try only scheme
+  if (!given.has_host()) {
+    if (requested.scheme() == given.scheme()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+namespace xwalk {
+namespace application {
+
+bool AppControlInfo::Covers(const AppControlInfo& requested) const {
+  if (!operation_.empty())
+    if (operation_ != requested.operation_)
+      return false;
+
+  // FIXME: Fixes/Workarounds that should be done in aul
+
+  // 1. Add file scheme if necessary
+  std::string requested_uri = requested.uri();
+  if (!requested_uri.empty() && requested_uri[0] == '/')
+    requested_uri = std::string(url::kFileScheme) +
+        url::kStandardSchemeSeparator + requested_uri;
+
+  GURL uri(requested_uri);
+  std::string mime(requested.mime());
+
+  // 2. Check mime type for file:// scheme if no mime type specified
+  if (uri.SchemeIsFile() && mime.empty()) {
+    char mime_from_aul[kMaximumMimeTypeLength] = {0, };
+    if (aul_get_mime_from_file(uri.spec().c_str(), mime_from_aul,
+        kMaximumMimeTypeLength) == AUL_R_OK) {
+      mime = mime_from_aul;
+    }
+  }
+
+  // 3. Fix uri if there is only scheme
+  GURL given_uri(uri_);
+  if (uri_.find(url::kStandardSchemeSeparator) == std::string::npos)
+    given_uri = GURL(uri_ + url::kStandardSchemeSeparator);
+
+  if (given_uri.is_valid())
+    if (!CheckUriMatch(uri, given_uri))
+      return false;
+
+  if (!CheckMimeMatch(mime, mime_))
+    return false;
+
+  return true;
+}
+
+std::unique_ptr<AppControlInfo> AppControlInfo::CreateFromBundle(
+    const std::string& bundle_str) {
+  std::string operation;
+  std::string uri;
+  std::string mime;
+
+  bundle* bundle = bundle_decode(
+      reinterpret_cast<const bundle_raw*>(
+          bundle_str.data()), bundle_str.size());
+  if (!bundle)
+    return nullptr;
+  service_h service;
+
+  service_create_event(bundle, &service);
+  if (!service)
+    return nullptr;
+
+  char* operation_str = nullptr;
+  if (service_get_operation(service, &operation_str) != SERVICE_ERROR_NONE) {
+    service_destroy(service);
+    bundle_free(bundle);
+    return nullptr;
+  }
+
+  if (!operation_str) {
+    // if no operation then bundle is invalid
+    service_destroy(service);
+    bundle_free(bundle);
+    return nullptr;
+  }
+  operation = operation_str;
+  free(operation_str);
+
+  char* mime_str = nullptr;
+  if (service_get_mime(service, &mime_str) != SERVICE_ERROR_NONE) {
+    LOG(ERROR) << "Failed to get mime for appcontrol request";
+    service_destroy(service);
+    bundle_free(bundle);
+    return nullptr;
+  }
+
+  if (mime_str)
+    mime = mime_str;
+  free(mime_str);
+
+  char* uri_str = nullptr;
+  if (service_get_uri(service, &uri_str) != SERVICE_ERROR_NONE) {
+    LOG(ERROR) << "Failed to get uri for appcontrol request";
+    service_destroy(service);
+    bundle_free(bundle);
+    return nullptr;
+  }
+
+  if (uri_str)
+    uri = uri_str;
+  free(uri_str);
+
+  service_destroy(service);
+
+  bundle_free(bundle);
+
+  return std::unique_ptr<AppControlInfo>(
+      new AppControlInfo("", operation, uri, mime));
+}
+
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/tizen/app_control_info.h
+++ b/application/common/tizen/app_control_info.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2015 Samsung Electronics Co., Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_TIZEN_APP_CONTROL_INFO_H_
+#define XWALK_APPLICATION_COMMON_TIZEN_APP_CONTROL_INFO_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "xwalk/application/common/application_data.h"
+
+namespace xwalk {
+namespace application {
+
+class AppControlInfo {
+ public:
+  AppControlInfo(const std::string& src, const std::string& operation,
+      const std::string& uri, const std::string& mime)
+      : src_(src),
+        operation_(operation),
+        uri_(uri),
+        mime_(mime) { }
+  const std::string& src() const {
+    return src_;
+  }
+  const std::string& operation() const {
+    return operation_;
+  }
+  const std::string& uri() const {
+    return uri_;
+  }
+  const std::string& mime() const {
+    return mime_;
+  }
+  bool Covers(const AppControlInfo& requested) const;
+
+  static std::unique_ptr<AppControlInfo> CreateFromBundle(
+      const std::string& bundle_str);
+
+ private:
+  std::string src_;
+  std::string operation_;
+  std::string uri_;
+  std::string mime_;
+};
+
+struct AppControlInfoList : public ApplicationData::ManifestData {
+  std::vector<AppControlInfo> controls;
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_TIZEN_APP_CONTROL_INFO_H_

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -79,6 +79,8 @@
             'manifest_handlers/tizen_setting_handler.h',
             'manifest_handlers/tizen_splash_screen_handler.cc',
             'manifest_handlers/tizen_splash_screen_handler.h',
+            'tizen/app_control_info.cc',
+            'tizen/app_control_info.h',
             'tizen/application_storage.cc',
             'tizen/application_storage.h',
             'tizen/application_storage_impl.cc',

--- a/application/tools/tizen/xwalk_package_installer.cc
+++ b/application/tools/tizen/xwalk_package_installer.cc
@@ -33,6 +33,7 @@
 #include "xwalk/application/common/manifest_handlers/tizen_metadata_handler.h"
 #include "xwalk/application/common/manifest_handlers/tizen_setting_handler.h"
 #include "xwalk/application/common/permission_policy_manager.h"
+#include "xwalk/application/common/tizen/app_control_info.h"
 #include "xwalk/application/common/tizen/application_storage.h"
 #include "xwalk/application/common/tizen/encryption.h"
 #include "xwalk/application/common/tizen/package_query.h"
@@ -156,21 +157,17 @@ bool GeneratePkgInfoXml(xwalk::application::ApplicationData* application,
       xml_writer.AddAttribute("name", item.operation());
       xml_writer.EndElement();
 
-      xml_writer.StartElement("uri");
       if (!item.uri().empty()) {
+        xml_writer.StartElement("uri");
         xml_writer.AddAttribute("name", item.uri());
-      } else {
-        xml_writer.AddAttribute("name", "*/*");
+        xml_writer.EndElement();
       }
-      xml_writer.EndElement();
 
-      xml_writer.StartElement("mime");
       if (!item.mime().empty()) {
+        xml_writer.StartElement("mime");
         xml_writer.AddAttribute("name", item.mime());
-      } else {
-        xml_writer.AddAttribute("name", "*/*");
+        xml_writer.EndElement();
       }
-      xml_writer.EndElement();
 
       xml_writer.EndElement();
     }

--- a/build/system.gyp
+++ b/build/system.gyp
@@ -100,6 +100,9 @@
           'variables': {
             'packages': [
               'ail',
+              'aul',
+              'bundle',
+              'capi-appfw-application',
               'dlog',
               'nss',
               'nspr',

--- a/packaging/crosswalk-bin.spec
+++ b/packaging/crosswalk-bin.spec
@@ -53,9 +53,12 @@ BuildRequires:  libelf-devel
 BuildRequires:  ninja
 BuildRequires:  perl
 BuildRequires:  pkgconfig(ail)
+BuildRequires:  pkgconfig(aul)
 BuildRequires:  pkgconfig(alsa)
 BuildRequires:  pkgconfig(appcore-common)
+BuildRequires:  pkgconfig(bundle)
 BuildRequires:  pkgconfig(cairo)
+BuildRequires:  pkgconfig(capi-appfw-application)
 BuildRequires:  pkgconfig(capi-location-manager)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(fontconfig)

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -98,6 +98,13 @@ class XWalkRunner {
   virtual scoped_ptr<SysAppsComponent> CreateSysAppsComponent();
   virtual scoped_ptr<StorageComponent> CreateStorageComponent();
 
+ protected:
+  // These variables are used to export some values from the browser process
+  // side to the extension side, such as application IDs and whatnot.
+  virtual void InitializeRuntimeVariablesForExtensions(
+      const content::RenderProcessHost* host,
+      base::ValueMap* runtime_variables);
+
  private:
   friend class XWalkMainDelegate;
   friend class ::XWalkTestSuiteInitializer;
@@ -138,12 +145,6 @@ class XWalkRunner {
 
   // Remote debugger server.
   scoped_ptr<RemoteDebuggingServer> remote_debugging_server_;
-
-  // These variables are used to export some values from the browser process
-  // side to the extension side, such as application IDs and whatnot.
-  void InitializeRuntimeVariablesForExtensions(
-      const content::RenderProcessHost* host,
-      base::ValueMap* runtime_variables);
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRunner);
 };

--- a/runtime/browser/xwalk_runner_tizen.cc
+++ b/runtime/browser/xwalk_runner_tizen.cc
@@ -9,6 +9,7 @@
 #include "crypto/nss_util.h"
 #include "xwalk/application/browser/application_service.h"
 #include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/browser/application_tizen.h"
 #include "xwalk/application/common/id_util.h"
 #include "xwalk/runtime/browser/sysapps_component.h"
 #include "xwalk/runtime/browser/xwalk_component.h"
@@ -37,6 +38,22 @@ void XWalkRunnerTizen::PreMainMessageLoopRun() {
       content::BrowserThread::IO,
       FROM_HERE,
       base::Bind(&crypto::EnsureNSSInit));
+}
+
+void XWalkRunnerTizen::InitializeRuntimeVariablesForExtensions(
+    const content::RenderProcessHost* host,
+    base::ValueMap* variables) {
+  XWalkRunner::InitializeRuntimeVariablesForExtensions(host, variables);
+
+  application::ApplicationTizen* app =
+      static_cast<application::ApplicationTizen*>(
+          app_system()->application_service()->
+              GetApplicationByRenderHostID(host->GetID()));
+
+  if (app) {
+    (*variables)["encoded_bundle"] =
+        new base::StringValue(app->data()->bundle());
+  }
 }
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_runner_tizen.h
+++ b/runtime/browser/xwalk_runner_tizen.h
@@ -24,6 +24,11 @@ class XWalkRunnerTizen : public XWalkRunner {
 
   void PreMainMessageLoopRun() override;
 
+ protected:
+  void InitializeRuntimeVariablesForExtensions(
+      const content::RenderProcessHost* host,
+      base::ValueMap* variables) override;
+
  private:
   friend class XWalkRunner;
   XWalkRunnerTizen();


### PR DESCRIPTION
This commit passes encoded bundle to extension server
as 'encoded_bundle' variable. This value will be used
by application tizen extension.

Loading start page will check bundle before loading
'normal' starting URL. If application was launched
from appcontrol then appcontrol src is used to
launch application.

BUG=XWALK-1490

Requires:
 - https://review.tizen.org/gerrit/#/c/35215/
 - https://review.tizen.org/gerrit/#/c/35689/
 - https://review.tizen.org/gerrit/#/c/35700/