### PR TITLE
Implementation of W3C WebNotification for Crosswalk Linux

### DIFF
--- a/build/system.gyp
+++ b/build/system.gyp
@@ -11,6 +11,19 @@
   },
   'targets' : [
     {
+      'target_name': 'libnotify',
+      'type': 'none',
+      'conditions': [
+        ['building_crosswalk_bin==1 and tizen!=1', {
+          'link_settings': {
+            'libraries': [
+              '<!@(pkg-config --libs libnotify)',
+            ],
+          },
+        }],
+      ],
+    },
+    {
       'target_name': 'gio',
       'type': 'none',
       'variables': {

--- a/runtime/browser/linux/xwalk_notification_manager.cc
+++ b/runtime/browser/linux/xwalk_notification_manager.cc
@@ -1,0 +1,139 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/linux/xwalk_notification_manager.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/desktop_notification_delegate.h"
+#include "content/public/common/platform_notification_data.h"
+#include "url/gurl.h"
+
+namespace {
+
+using content::BrowserThread;
+using xwalk::XWalkNotificationManager;
+
+// Defined by 'org.freedesktop.Notifications'.
+const int g_closed_by_user = 2;
+
+void NotificationClosedCallback(NotifyNotification* notification,
+                                gpointer user_data) {
+  XWalkNotificationManager* service =
+      static_cast<XWalkNotificationManager*>(user_data);
+
+  gint reason = notify_notification_get_closed_reason(notification);
+
+  bool by_user = (reason == g_closed_by_user);
+  if (by_user)
+    service->NotificationClicked(notification);
+  service->NotificationClosed(notification, by_user);
+  g_signal_handler_disconnect(notification,
+                              service->GetClosedHandler(notification));
+}
+
+void CancelDesktopNotificationCallback(
+    XWalkNotificationManager* service,
+    NotifyNotification* notification) {
+  g_signal_handler_disconnect(notification,
+                              service->GetClosedHandler(notification));
+  notify_notification_close(notification, nullptr);
+}
+
+}  // namespace
+
+namespace xwalk {
+
+XWalkNotificationManager::XWalkNotificationManager() :
+    initialized_(false) {
+  initialized_ = notify_init("xwalk");
+}
+
+XWalkNotificationManager::~XWalkNotificationManager() {
+  if (initialized_)
+    notify_uninit();
+}
+
+void XWalkNotificationManager::ShowDesktopNotification(
+    content::BrowserContext* browser_context,
+    const GURL& origin,
+    const content::PlatformNotificationData& notification_data,
+    scoped_ptr<content::DesktopNotificationDelegate> delegate,
+    int render_process_id,
+    base::Closure* cancel_callback) {
+  if (!initialized_)
+      return;
+
+  NotifyNotification* notification = nullptr;
+
+  if (!notification_data.tag.empty() &&
+      notifications_replace_map_.find(notification_data.tag) !=
+          notifications_replace_map_.end()) {
+    notification = notifications_replace_map_[notification_data.tag];
+    notify_notification_update(notification,
+        base::UTF16ToUTF8(notification_data.title).c_str(),
+        base::UTF16ToUTF8(notification_data.body).c_str(),
+        nullptr);
+  } else {
+    notification = notify_notification_new(
+        base::UTF16ToUTF8(notification_data.title).c_str(),
+        base::UTF16ToUTF8(notification_data.body).c_str(),
+        nullptr);
+
+    notifications_map_.set(reinterpret_cast<int64>(notification),
+                           delegate.Pass());
+    if (!notification_data.tag.empty()) {
+      notifications_replace_map_[notification_data.tag] = notification;
+    }
+
+    notifications_handler_map_[notification] =
+        g_signal_connect(G_OBJECT(notification),
+                                  "closed",
+                                  G_CALLBACK(NotificationClosedCallback),
+                                  this);
+    if (cancel_callback)
+      *cancel_callback = base::Bind(&CancelDesktopNotificationCallback,
+                                    this,
+                                    notification);
+    content::BrowserThread::PostTask(
+        content::BrowserThread::UI,
+        FROM_HERE,
+        base::Bind(&XWalkNotificationManager::NotificationDisplayed,
+        base::Unretained(this),
+        notification));
+  }
+
+  notify_notification_show(notification, nullptr);
+}
+
+void XWalkNotificationManager::NotificationDisplayed(
+    NotifyNotification* notification) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  content::DesktopNotificationDelegate* notification_delegate =
+      notifications_map_.get(reinterpret_cast<int64>(notification));
+  if (notification_delegate)
+    notification_delegate->NotificationDisplayed();
+}
+
+void XWalkNotificationManager::NotificationClicked(
+    NotifyNotification* notification) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  content::DesktopNotificationDelegate* notification_delegate =
+      notifications_map_.get(reinterpret_cast<int64>(notification));
+  if (notification_delegate) {
+    notification_delegate->NotificationClick();
+  }
+}
+
+void XWalkNotificationManager::NotificationClosed(
+    NotifyNotification* notification, bool by_user) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  scoped_ptr<content::DesktopNotificationDelegate> notification_delegate =
+      notifications_map_.take_and_erase(reinterpret_cast<int64>(notification));
+  if (notification_delegate) {
+    notification_delegate->NotificationClosed(by_user);
+  }
+}
+
+}  // namespace xwalk

--- a/runtime/browser/linux/xwalk_notification_manager.h
+++ b/runtime/browser/linux/xwalk_notification_manager.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_LINUX_XWALK_NOTIFICATION_MANAGER_H_
+#define XWALK_RUNTIME_BROWSER_LINUX_XWALK_NOTIFICATION_MANAGER_H_
+
+#include <libnotify/notification.h>
+#include <libnotify/notify.h>
+
+#include <map>
+
+#include "base/callback.h"
+#include "base/containers/scoped_ptr_hash_map.h"
+#include "base/strings/string16.h"
+
+class GURL;
+
+namespace content {
+class BrowserContext;
+class DesktopNotificationDelegate;
+class RenderFrameHost;
+struct PlatformNotificationData;
+}  // namespace content
+
+namespace xwalk {
+
+class XWalkNotificationManager {
+ public:
+  XWalkNotificationManager();
+  ~XWalkNotificationManager();
+
+  // Show a desktop notification. If |cancel_callback| is non-null, it's set to
+  // a callback which can be used to cancel the notification.
+  void ShowDesktopNotification(
+      content::BrowserContext* browser_context,
+      const GURL& origin,
+      const content::PlatformNotificationData& notification_data,
+      scoped_ptr<content::DesktopNotificationDelegate> delegate,
+      int render_process_id,
+      base::Closure* cancel_callback);
+
+  void NotificationDisplayed(NotifyNotification* notification);
+  void NotificationClicked(NotifyNotification* notification);
+  void NotificationClosed(NotifyNotification* notification, bool by_user);
+
+  gulong GetClosedHandler(NotifyNotification* notification) const {
+    return notifications_handler_map_.find(notification) !=
+        notifications_handler_map_.end() ?
+        notifications_handler_map_.find(notification)->second : 0;
+  }
+
+ private:
+  base::ScopedPtrHashMap<int64, content::DesktopNotificationDelegate>
+      notifications_map_;
+  std::map<base::string16, NotifyNotification*> notifications_replace_map_;
+  std::map<NotifyNotification*, gulong> notifications_handler_map_;
+
+  bool initialized_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_LINUX_XWALK_NOTIFICATION_MANAGER_H_

--- a/runtime/browser/xwalk_platform_notification_service.cc
+++ b/runtime/browser/xwalk_platform_notification_service.cc
@@ -15,6 +15,8 @@
 
 #if defined(OS_ANDROID)
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
+#elif !defined(OS_TIZEN) && defined(OS_LINUX)
+#include "xwalk/runtime/browser/linux/xwalk_notification_manager.h"
 #endif
 
 namespace xwalk {
@@ -35,6 +37,8 @@ XWalkPlatformNotificationService::CheckPermission(
     const GURL& origin,
     int render_process_id) {
 #if defined(OS_ANDROID)
+  return blink::WebNotificationPermissionAllowed;
+#elif !defined(OS_TIZEN) && defined(OS_LINUX)
   return blink::WebNotificationPermissionAllowed;
 #else
   return blink::WebNotificationPermissionDenied;
@@ -68,6 +72,17 @@ void XWalkPlatformNotificationService::DisplayNotification(
                              cancel_callback);
     return;
   }
+#elif !defined(OS_TIZEN) && defined(OS_LINUX)
+  if (!notification_manager_linux_)
+    notification_manager_linux_.reset(new XWalkNotificationManager());
+  notification_manager_linux_->ShowDesktopNotification(
+      browser_context,
+      origin,
+      notification_data,
+      delegate.Pass(),
+      render_process_id,
+      cancel_callback);
+#else
 #endif
 }
 

--- a/runtime/browser/xwalk_platform_notification_service.h
+++ b/runtime/browser/xwalk_platform_notification_service.h
@@ -12,6 +12,9 @@
 #include "content/public/browser/platform_notification_service.h"
 
 namespace xwalk {
+#if !defined(OS_TIZEN) && defined(OS_LINUX)
+class XWalkNotificationManager;
+#endif
 
 // The platform notification service is the profile-agnostic entry point
 // through which Web Notifications can be controlled. Heavily based on
@@ -52,6 +55,10 @@ class XWalkPlatformNotificationService
 
   XWalkPlatformNotificationService();
   ~XWalkPlatformNotificationService() override;
+
+#if !defined(OS_TIZEN) && defined(OS_LINUX)
+  scoped_ptr<XWalkNotificationManager> notification_manager_linux_;
+#endif
 };
 
 }  // namespace xwalk

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -151,6 +151,7 @@
         'runtime/browser/geolocation/xwalk_access_token_store.h',
         'runtime/browser/image_util.cc',
         'runtime/browser/image_util.h',
+        'runtime/browser/linux/xwalk_notification_manager.cc',
         'runtime/browser/media/media_capture_devices_dispatcher.cc',
         'runtime/browser/media/media_capture_devices_dispatcher.h',
         'runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.cc',
@@ -325,6 +326,7 @@
             'runtime/browser/runtime_platform_util_linux.cc',
             'runtime/browser/android/xwalk_web_contents_view_delegate.cc',
             'runtime/browser/android/xwalk_web_contents_view_delegate.h',
+            'runtime/browser/linux/xwalk_notification_manager.cc',
           ],
         }],
         ['OS=="android"',{
@@ -360,6 +362,7 @@
         }],  # OS=="win"
         ['OS=="linux"', {
           'dependencies': [
+            'build/system.gyp:libnotify',
             '../build/linux/system.gyp:fontconfig',
             '../build/linux/system.gyp:dbus',
           ],


### PR DESCRIPTION
The WebNotification of Crosswalk Linux is implemented based on 'libnotify'.
Refering to https://wiki.archlinux.org/index.php/Desktop_notifications,
the 'libnotify' is a desktop independent lib to invoke 'notification server'
through DBus named 'org.freedesktop.Notifications' (on Ubuntu it's 'notify-osd' behind).

There 3 reasons to use 'libnotify':
(1) The Chrome Linux creates 'desktop notification' by self and it's hard to port since most of
code is for 'Rich notification' proveded by extension.
refer to https://developer.chrome.com/apps/richNotifications.
(2) Firefox and WebKit using 'libnotify' to implement WebNotification.
(3) The desktop of Deepin supports 'libnotify' by default.

Add a new class 'XWalkNotificationManagerLinux' to implement logic to invoke 'libnotify':
(1) Init and uninit 'libnotify' in constructor and destructor.
(2) In 'ShowDesktopNotification', call 'notify_notification_new' and 'notify_notification_show'
to create new notifaication record and show it.
If just need to relace old notification, call 'notify_notification_update' to update the
record.
(3) Listen signal 'closed' with callback 'NotificationClosedCallback' to trigger the JS callbacks,
such as 'Notification.onclose'.
(4) The memeber 'notifications_map_' is for saving the map between 'notification' and its
'delegate' (used to trigger JS callbacks).
The 'notifications_replace_map_' is used to record the notification created with relace tag,
like this:
new Notification("", {tag: ''});

Notice that this patch only enabled for Crosswalk Linux, for Crosswalk Tizen it's still left
unimplemented.

BUG=https://crosswalk-project.org/jira/browse/XWALK-286