### PR TITLE
[Common]: Add window size configuration in manifest.

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -233,6 +233,12 @@ bool Application::Launch() {
       GetWindowShowState<Manifest::TYPE_WIDGET>() :
       GetWindowShowState<Manifest::TYPE_MANIFEST>();
 
+  params.bounds = data_->window_bounds();
+  params.minimum_size.set_width(data_->window_min_size().width());
+  params.minimum_size.set_height(data_->window_min_size().height());
+  params.maximum_size.set_width(data_->window_max_size().width());
+  params.maximum_size.set_height(data_->window_max_size().height());
+
   window_show_params_ = params;
   // Only the first runtime can have a launch screen.
   params.splash_screen_path = GetSplashScreenPath();

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -20,6 +20,7 @@
 #include "base/strings/string_util.h"
 #include "base/synchronization/lock.h"
 #include "base/threading/thread_checker.h"
+#include "ui/gfx/geometry/rect.h"
 #include "url/gurl.h"
 #include "xwalk/application/common/manifest.h"
 #include "xwalk/application/common/permission_types.h"
@@ -110,6 +111,13 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   const std::string& Name() const { return name_; }
   const std::string& NonLocalizedName() const { return non_localized_name_; }
   const std::string& Description() const { return description_; }
+  const gfx::Rect& window_bounds() const { return window_bounds_; }
+  const gfx::Size& window_min_size() const {
+    return window_min_size_;
+  }
+  const gfx::Size& window_max_size() const {
+    return window_max_size_;
+  }
 
   const Manifest* GetManifest() const {
     return manifest_.get();
@@ -149,6 +157,7 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   bool LoadName(base::string16* error);
   bool LoadVersion(base::string16* error);
   bool LoadDescription(base::string16* error);
+  bool LoadWindowSetting(base::string16* error);
 
   // The application's human-readable name. Name is used for display purpose. It
   // might be wrapped with unicode bidi control characters so that it is
@@ -204,6 +213,11 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
 
   // The source the application was loaded from.
   SourceType source_type_;
+
+  // Main window bounds
+  gfx::Rect window_bounds_;
+  gfx::Size window_min_size_;
+  gfx::Size window_max_size_;
 
 #if defined(OS_TIZEN)
   std::string bundle_;

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -14,6 +14,13 @@ const char kNameKey[] = "name";
 const char kDisplay[] = "display";
 const char kStartURLKey[] = "start_url";
 const char kCSPKey[] = "csp";
+const char kBoundsKey[] = "xwalk_bounds";
+const char kWidthKey[] = "width";
+const char kHeightKey[] = "height";
+const char kMinWidthKey[] = "min-width";
+const char kMinHeightKey[] = "min-height";
+const char kMaxWidthKey[] = "max-width";
+const char kMaxHeightKey[] = "max-height";
 
 // Deprecated entries:
 

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -19,6 +19,13 @@ namespace application_manifest_keys {
   // extern const char kOrientation[];
   extern const char kStartURLKey[];
   extern const char kCSPKey[];
+  extern const char kBoundsKey[];
+  extern const char kWidthKey[];
+  extern const char kHeightKey[];
+  extern const char kMinWidthKey[];
+  extern const char kMinHeightKey[];
+  extern const char kMaxWidthKey[];
+  extern const char kMaxHeightKey[];
 
   // Deprecated fields:
 


### PR DESCRIPTION
We proposed to add recommended window bounds for w3c manifest (see https://github.com/w3c/manifest/issues/310).
1, This is the implementation in crosswalk common which allows user to set window preferred bounds at launch time.
2, It also allows user to set minimum size and maximum size of the window.
