### PR TITLE
[Tizen] Sensor header has changed for new sensor API

### DIFF
--- a/tizen/mobile/sensor/tizen_platform_sensor.h
+++ b/tizen/mobile/sensor/tizen_platform_sensor.h
@@ -16,7 +16,7 @@
 #ifndef XWALK_TIZEN_MOBILE_SENSOR_TIZEN_PLATFORM_SENSOR_H_
 #define XWALK_TIZEN_MOBILE_SENSOR_TIZEN_PLATFORM_SENSOR_H_
 
-#include <sensor.h>
+#include <sensor_internal.h>
 #include <vconf.h>
 
 #include "base/native_library.h"


### PR DESCRIPTION
Sensor header has changed from "sensor.h" to "sensor_internal.h"
This commit should be merged and submitted to avoid build-break.

https://review.tizen.org/gerrit/#/c/29547/