### PR TITLE
crosswalk-11: DEPS.xwalk: Roll chromium-crosswalk (9a9776f -> e39380a)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '9a9776f9a1567dfe33045017613c1addd41cbbd1'
+chromium_crosswalk_rev = 'e39380a3c6d28863a6a2ea758e697116ccef8357'
 v8_crosswalk_rev = 'd2bddb995a4f0cf5e92b4188e50648e84504f945'
 ozone_wayland_rev = '5d7baa9bc3b8c88e9b7e476e3d6bc8cd44a887fe'
 


### PR DESCRIPTION
* e39380a Merge pull request #234 from axinging/xing_crosswalk-11-40.0.2214.91
* 0be529c Revert @viewport enabling patches

This roll includes a cherry-pick from an upstream commit disabling
support for the `@viewport` CSS rule, which was not supposed to be enabled
in M40 and is causing problems in web apps that use it.

BUG=XWALK-3574