### PR TITLE
Revert "[Android] Enable Experimental WebPlatform Features"

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -116,10 +116,6 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   command_line->AppendSwitch(switches::kIgnoreGpuBlacklist);
 #endif
 
-  // Enable experiemntal features like polymer and css animations because
-  // CrossWalk is testbed of state of art of web technology.
-  command_line->AppendSwitch(switches::kEnableExperimentalWebPlatformFeatures);
-
 #if defined(ENABLE_WEBRTC)
   // Disable HW encoding/decoding acceleration for WebRTC on Android.
   // FIXME: Remove these switches for Android when Android OS is removed from


### PR DESCRIPTION
Enabling the entire set of web platform features currently marked
experimental in Blink is dangerous. The features in this set changes
across Chromium releases, and it can be the case that some of them just
are not ready for production at all.

Case in point: this enables support for the @viewport CSS rule, which
currently has problems and causes regressions for our users (see
XWALK-3574).

If we are interested in enabling certain features (the commit message of
the change being reverted mentions CSS Animations, for example), they
should be enabled individually.

This reverts commit 9255613355cf56547953f2ac816fbc4581659a49.

Related to: XWALK-322
BUG=XWALK-3574