### PR TITLE
[Android] Fix remote debugging doesn't work issue after M41 rebasing

### DIFF
--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -44,7 +44,7 @@ namespace {
 // for remote debugging to work in chrome (see chrome's devtools_ui.cc).
 // Currently, the chrome version is hardcoded because of this dependancy.
 const char kFrontEndURL[] =
-    "http://chrome-devtools-frontend.appspot.com/serve_rev/%s/devtools.html";
+    "http://chrome-devtools-frontend.appspot.com/serve_rev/%s/inspector.html";
 
 bool AuthorizeSocketAccessWithDebugPermission(
      const net::UnixDomainServerSocket::Credentials& credentials) {


### PR DESCRIPTION
Remote protocol handler should now report "inspector.html", according to
upstream change: https://crrev.com/a1409c477411b0467b4bc729d9a2c972e79347d1

BUG=XWALK-3522
(cherry picked from commit 45a2623d6192da531b129ed81bca6be8b88d6d32)