### PR TITLE
libxwalkcore.so upgrade support

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -162,8 +162,9 @@ def CopyBinaries(out_dir, no_icu_data, use_lzma):
   source_dir = os.path.join(out_dir, XWALK_CORE_SHELL_APK, 'libs')
   distutils.dir_util.copy_tree(source_dir, libs_dir)
 
+  # NOTE: Gradle doesn't accept '-', use '_' instead.
   if use_lzma:
-    for arch in ['x86', 'armeabi-v7a']:
+    for arch in ['x86', 'armeabi_v7a']:
       arch_dir = os.path.join(libs_dir, arch)
       lib = os.path.join(arch_dir, 'libxwalkcore.so.lzma')
       if os.path.isfile(lib):

--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -354,7 +354,7 @@ public abstract class XWalkActivity extends Activity
         }
     }
     
-    private static class DecompressTask extends AsyncTask<Void, Integer, Void> {
+    private static class DecompressTask extends AsyncTask<Void, Integer, Boolean> {
         XWalkActivity mXWalkActivity;
         AlertDialog mDialog;
 
@@ -365,15 +365,16 @@ public abstract class XWalkActivity extends Activity
         }
 
         @Override
-        protected Void doInBackground(Void... params) {
+        protected Boolean doInBackground(Void... params) {
+            boolean success = false;
             try {
-                XWalkCoreWrapper.decompressXWalkLibrary();
+                success = XWalkCoreWrapper.decompressXWalkLibrary();
                 // TODO: use publishProgress to update percentage.
             } catch (Exception e) {
                 Log.w("XWalkActivity", "Decompress library failed: " + e.getMessage());
             }
 
-            return null;
+            return success;
         }
 
         @Override
@@ -382,13 +383,15 @@ public abstract class XWalkActivity extends Activity
         }
 
         @Override
-        protected void onPostExecute(Void v) {
+        protected void onPostExecute(Boolean success) {
             mXWalkActivity.onXWalkCoreReady();
+            XWalkCoreWrapper wrapper = XWalkCoreWrapper.getInstance();
+            if (success) wrapper.setLocalVersion(mXWalkActivity);
             mDialog.dismiss();
         }
 
         @Override
-        protected void onCancelled(Void v) {
+        protected void onCancelled(Boolean b) {
             Log.d("XWalkActivity", "Decompress cancelled");
             mXWalkActivity.finish();
         }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCompressUtil.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCompressUtil.java
@@ -42,10 +42,6 @@ public class XWalkCompressUtil {
 
             try {
                 File outfile = new File(libDir, library);
-                // FIXME: perhaps need to check validation.
-                if (outfile.isFile()) {
-                    continue;
-                }
                 tmpfile = new File(libDir, library + ".tmp");
                 input = new BufferedInputStream(openRawResource(context, library));
                 output = new BufferedOutputStream(new FileOutputStream(tmpfile));

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -85,14 +85,15 @@ class XWalkViewDelegate {
         return XWalkCompressUtil.XWalkLibraryCompressed(context, MANDATORY_LIBRARIES);
     }
 
-    public static void decompressXWalkLibrary(Context context) throws Exception {
-        if (context == null) return;
+    public static boolean decompressXWalkLibrary(Context context) throws Exception {
+        if (context == null) return false;
 
         String lib = PathUtils.getDataDirectory(context.getApplicationContext());
         long start = System.currentTimeMillis();
-        XWalkCompressUtil.decompressXWalkLibrary(context, MANDATORY_LIBRARIES, lib);
+        boolean success = XWalkCompressUtil.decompressXWalkLibrary(context, MANDATORY_LIBRARIES, lib);
         long end = System.currentTimeMillis();
         Log.d(TAG, "decompress library cost: " + (end - start) + " milliseconds.");
+        return success;
     }
 
     public static void loadXWalkLibrary(Context context) throws UnsatisfiedLinkError {

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -419,7 +419,7 @@ public class XWalkViewShellActivity extends FragmentActivity
         }
     }
 
-    private static class DecompressTask extends AsyncTask<Void, Integer, Void> {
+    private static class DecompressTask extends AsyncTask<Void, Integer, Boolean> {
         XWalkViewShellActivity mActivity;
         AlertDialog mDialog;
 
@@ -430,15 +430,16 @@ public class XWalkViewShellActivity extends FragmentActivity
         }
 
         @Override
-        protected Void doInBackground(Void... params) {
+        protected Boolean doInBackground(Void... params) {
+            boolean success = false;
             try {
-                XWalkCoreWrapper.decompressXWalkLibrary();
+                success = XWalkCoreWrapper.decompressXWalkLibrary();
                 // TODO: use publishProgress to update percentage.
             } catch (Exception e) {
                 Log.w(TAG, "decompress library failed: " + e.getMessage());
             }
 
-            return null;
+            return success;
         }
 
         @Override
@@ -447,9 +448,16 @@ public class XWalkViewShellActivity extends FragmentActivity
         }
 
         @Override
-        protected void onPostExecute(Void v) {
+        protected void onPostExecute(Boolean success) {
             mActivity.onXWalkCoreReady();
+            XWalkCoreWrapper wrapper = XWalkCoreWrapper.getInstance();
+            if (success) wrapper.setLocalVersion(mActivity);
             mDialog.dismiss();
+        }
+
+        @Override
+        protected void onCancelled(Boolean b) {
+            mActivity.finish();
         }
     }
 }


### PR DESCRIPTION
I pushed 2 commits for review:

1) libxwalkcore upgrade support
    we could upgrade/downgrade libxwalkcore.so when it's changed.

2) a workaround for upgrade from Crosswalk to Crosswalk-lite
    When do so, this will leave a unused libxwalkcore.so in lib directory(we can not delete it anyway).
    Now I provide an empty libxwalkcore.so which will override the previous one after re-install.

@halton, please help review, thanks!