### PR TITLE
Add loading Pepper Flash plugin from command line support.

### DIFF
--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -301,4 +301,13 @@ void Runtime::RequestMediaAccessPermission(
       web_contents, request, callback);
 }
 
+bool Runtime::CheckMediaAccessPermission(
+    content::WebContents* web_contents,
+    const GURL& security_origin,
+    content::MediaStreamType type) {
+  // TODO(xiang): Pepper flash plugin will trigger this check a lot, return
+  // false at the moment.
+  return false;
+}
+
 }  // namespace xwalk

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -137,6 +137,9 @@ class Runtime : public content::WebContentsDelegate,
       content::WebContents* web_contents,
       const content::MediaStreamRequest& request,
       const content::MediaResponseCallback& callback) override;
+  bool CheckMediaAccessPermission(content::WebContents* web_contents,
+                                  const GURL& security_origin,
+                                  content::MediaStreamType type) override;
 
   // Overridden from content::WebContentsObserver.
   void DidUpdateFaviconURL(

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -38,6 +38,7 @@
 #include "xwalk/runtime/browser/xwalk_render_message_filter.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 #if !defined(DISABLE_NACL)
 #include "components/nacl/browser/nacl_browser.h"
@@ -141,17 +142,18 @@ XWalkContentBrowserClient::CreateRequestContextForStoragePartition(
 // process we launch.
 void XWalkContentBrowserClient::AppendExtraCommandLineSwitches(
     base::CommandLine* command_line, int child_process_id) {
-  base::CommandLine* browser_process_cmd_line =
-      base::CommandLine::ForCurrentProcess();
-  const int extra_switches_count = 1;
-  const char* extra_switches[extra_switches_count] = {
-    switches::kXWalkDisableExtensionProcess
+  const base::CommandLine& browser_process_cmd_line =
+      *base::CommandLine::ForCurrentProcess();
+  const char* extra_switches[] = {
+    switches::kXWalkDisableExtensionProcess,
+#if defined(ENABLE_PLUGINS)
+    switches::kPpapiFlashPath,
+    switches::kPpapiFlashVersion
+#endif
   };
 
-  for (int i = 0; i < extra_switches_count; i++) {
-    if (browser_process_cmd_line->HasSwitch(extra_switches[i]))
-      command_line->AppendSwitch(extra_switches[i]);
-  }
+  command_line->CopySwitchesFrom(
+      browser_process_cmd_line, extra_switches, arraysize(extra_switches));
 }
 
 content::QuotaPermissionContext*

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -37,5 +38,15 @@ const char kAllowRunningInsecureContent[]   = "allow-running-insecure-content";
 // By default, an https page can load images, fonts or frames from an http
 // page. This switch overrides this to block this lesser mixed-content problem.
 const char kNoDisplayingInsecureContent[]   = "no-displaying-insecure-content";
+
+#if defined(ENABLE_PLUGINS)
+// Use the PPAPI (Pepper) Flash found at the given path.
+const char kPpapiFlashPath[] = "ppapi-flash-path";
+
+// Report the given version for the PPAPI (Pepper) Flash. The version should be
+// numbers separated by '.'s (e.g., "12.3.456.78"). If not specified, it
+// defaults to "10.2.999.999".
+const char kPpapiFlashVersion[] = "ppapi-flash-version";
+#endif
 
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -23,6 +23,11 @@ extern const char kNoDisplayingInsecureContent[];
 extern const char kXWalkProfileName[];
 #endif
 
+#if defined(ENABLE_PLUGINS)
+extern const char kPpapiFlashPath[];
+extern const char kPpapiFlashVersion[];
+#endif
+
 }  // namespace switches
 
 #endif  // XWALK_RUNTIME_COMMON_XWALK_SWITCHES_H_


### PR DESCRIPTION
In order to support sites using Adobe Flash on desktop we need to
support loading external Flash plugins. This patch added support to
loading Pepper Flash plugin specified from command line. The code
is mostly taken from Chromium chrome/common/chrome_content_client.cc.

The command line switches are the same with Chromium:
--ppapi-flash-path: full path of plugin library
--ppapi-flash-version: optional plugin version