### PR TITLE
[Android] Move onReceivedHttpAuthRequest to XWalkResourceClientInternal.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkClient.java
@@ -16,7 +16,6 @@
 
 package org.xwalk.core.internal;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -26,9 +25,7 @@ import android.os.Message;
 import android.view.KeyEvent;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
-import android.widget.EditText;
 import android.widget.FrameLayout;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 /**
@@ -136,51 +133,6 @@ public class XWalkClient {
     //         ClientCertRequestHandler handler, String host_and_port) {
     //     handler.cancel();
     // }
-
-    /**
-     * Notify the host application to handle an authentication request. The
-     * default behavior is to cancel the request.
-     *
-     * @param view The XWalkViewInternal that is initiating the callback.
-     * @param handler The XWalkHttpAuthHandler that will handle the user's response.
-     * @param host The host requiring authentication.
-     * @param realm A description to help store user credentials for future
-     *            visits.
-     */
-    public void onReceivedHttpAuthRequest(XWalkViewInternal view,
-            XWalkHttpAuthHandler handler, String host, String realm) {
-        if (view == null) return;
-
-        final XWalkHttpAuthHandler haHandler = handler;
-        LinearLayout layout = new LinearLayout(mContext);
-        final EditText userNameEditText = new EditText(mContext);
-        final EditText passwordEditText = new EditText(mContext);
-        layout.setOrientation(LinearLayout.VERTICAL);
-        layout.setPaddingRelative(10, 0, 10, 20);
-        userNameEditText.setHint(R.string.http_auth_user_name);
-        passwordEditText.setHint(R.string.http_auth_password);
-        layout.addView(userNameEditText);
-        layout.addView(passwordEditText);
-
-        final Activity curActivity = mXWalkView.getActivity();
-        AlertDialog.Builder httpAuthDialog = new AlertDialog.Builder(curActivity);
-        httpAuthDialog.setTitle(R.string.http_auth_title)
-                .setView(layout)
-                .setCancelable(false)
-                .setPositiveButton(R.string.http_auth_log_in, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int whichButton) {
-                        String userName = userNameEditText.getText().toString();
-                        String password = passwordEditText.getText().toString();
-                        haHandler.proceed(userName, password);
-                        dialog.dismiss();
-                    }
-                }).setNegativeButton(android.R.string.cancel, null)
-                .setOnCancelListener(new DialogInterface.OnCancelListener() {
-                    public void onCancel(DialogInterface dialog) {
-                        haHandler.cancel();
-                    }
-                }).create().show();
-    }
 
     /**
      * Notify the host application that a request to automatically log in the

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -156,7 +156,7 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
     public abstract boolean onConsoleMessage(ConsoleMessage consoleMessage);
 
-    public abstract void onReceivedHttpAuthRequest(XWalkHttpAuthHandler handler,
+    public abstract void onReceivedHttpAuthRequest(XWalkHttpAuthHandlerInternal handler,
             String host, String realm);
 
     public abstract void onReceivedSslError(ValueCallback<Boolean> callback, SslError error);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -315,9 +315,10 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @CalledByNative
-    public void onReceivedHttpAuthRequest(XWalkHttpAuthHandler handler, String host, String realm) {
-        if (mXWalkClient != null && isOwnerActivityRunning()) {
-            mXWalkClient.onReceivedHttpAuthRequest(mXWalkView, handler, host, realm);
+    public void onReceivedHttpAuthRequest(
+            XWalkHttpAuthHandlerInternal handler, String host, String realm) {
+        if (mXWalkResourceClient != null && isOwnerActivityRunning()) {
+            mXWalkResourceClient.onReceivedHttpAuthRequest(mXWalkView, handler, host, realm);
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java
@@ -12,11 +12,13 @@ import org.chromium.base.JNINamespace;
  * @hide
  */
 @JNINamespace("xwalk")
-public class XWalkHttpAuthHandler {
+@XWalkAPI(createExternally = true)
+public class XWalkHttpAuthHandlerInternal {
 
     private long mNativeXWalkHttpAuthHandler;
     private final boolean mFirstAttempt;
 
+    @XWalkAPI
     public void proceed(String username, String password) {
         if (mNativeXWalkHttpAuthHandler != 0) {
             nativeProceed(mNativeXWalkHttpAuthHandler, username, password);
@@ -24,6 +26,7 @@ public class XWalkHttpAuthHandler {
         }
     }
 
+    @XWalkAPI
     public void cancel() {
         if (mNativeXWalkHttpAuthHandler != 0) {
             nativeCancel(mNativeXWalkHttpAuthHandler);
@@ -36,11 +39,12 @@ public class XWalkHttpAuthHandler {
     }
 
     @CalledByNative
-    public static XWalkHttpAuthHandler create(long nativeXWalkAuthHandler, boolean firstAttempt) {
-        return new XWalkHttpAuthHandler(nativeXWalkAuthHandler, firstAttempt);
+    public static XWalkHttpAuthHandlerInternal create(long nativeXWalkAuthHandler, boolean firstAttempt) {
+        return new XWalkHttpAuthHandlerInternal(nativeXWalkAuthHandler, firstAttempt);
     }
 
-    private XWalkHttpAuthHandler(long nativeXWalkHttpAuthHandler, boolean firstAttempt) {
+    @XWalkAPI
+    public XWalkHttpAuthHandlerInternal(long nativeXWalkHttpAuthHandler, boolean firstAttempt) {
         mNativeXWalkHttpAuthHandler = nativeXWalkHttpAuthHandler;
         mFirstAttempt = firstAttempt;
     }

--- a/runtime/browser/android/xwalk_http_auth_handler.cc
+++ b/runtime/browser/android/xwalk_http_auth_handler.cc
@@ -10,7 +10,7 @@
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
 #include "content/public/browser/browser_thread.h"
-#include "jni/XWalkHttpAuthHandler_jni.h"
+#include "jni/XWalkHttpAuthHandlerInternal_jni.h"
 #include "net/base/auth.h"
 #include "content/public/browser/web_contents.h"
 
@@ -27,13 +27,13 @@ XWalkHttpAuthHandler::XWalkHttpAuthHandler(XWalkLoginDelegate* login_delegate,
   DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
   JNIEnv* env = base::android::AttachCurrentThread();
   http_auth_handler_.Reset(
-      Java_XWalkHttpAuthHandler_create(
+      Java_XWalkHttpAuthHandlerInternal_create(
           env, reinterpret_cast<intptr_t>(this), first_auth_attempt));
 }
 
 XWalkHttpAuthHandler:: ~XWalkHttpAuthHandler() {
   DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
-  Java_XWalkHttpAuthHandler_handlerDestroyed(
+  Java_XWalkHttpAuthHandlerInternal_handlerDestroyed(
       base::android::AttachCurrentThread(),
       http_auth_handler_.obj());
 }

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/OnReceivedHttpAuthRequestTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/OnReceivedHttpAuthRequestTest.java
@@ -1,0 +1,37 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.DisabledTest;
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Tests for the OnReceivedHttpAuthRequest.
+ */
+public class OnReceivedHttpAuthRequestTest extends XWalkViewInternalTestBase {
+    TestHelperBridge.OnReceivedHttpAuthRequestHelper mOnReceivedHttpAuthRequestHelper;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mOnReceivedHttpAuthRequestHelper = mTestHelperBridge.getOnReceivedHttpAuthRequestHelper();
+    }
+
+    // TODO(hengzhi): Since the device issue, it can not access the network,
+    // so disabled this test temporarily. It will be enabled later.
+    // @SmallTest
+    // @Feature({"OnReceivedHttpAuthRequest"})
+    @DisabledTest
+    public void testOnReceivedHttpAuthRequest() throws Throwable {
+        String url = "http://httpbin.org/basic-auth/user/passwd";
+        String host = "httpbin.org";
+        int count = mOnReceivedHttpAuthRequestHelper.getCallCount();
+        loadUrlAsync(url);
+        mOnReceivedHttpAuthRequestHelper.waitForCallback(count);
+        assertEquals(host, mOnReceivedHttpAuthRequestHelper.getHost());
+    }
+}

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/TestHelperBridge.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/TestHelperBridge.java
@@ -126,6 +126,20 @@ class TestHelperBridge {
         }
     }
 
+    public class OnReceivedHttpAuthRequestHelper extends CallbackHelper {
+        private String mHost;
+
+        public String getHost() {
+            assert getCallCount() > 0;
+            return mHost;
+        }
+
+        public void notifyCalled(String host) {
+            mHost = host;
+            notifyCalled();
+        }
+    }
+
     private String mChangedTitle;
     private final OnPageStartedHelper mOnPageStartedHelper;
     private final OnPageFinishedHelper mOnPageFinishedHelper;
@@ -136,6 +150,7 @@ class TestHelperBridge {
     private final OnTitleUpdatedHelper mOnTitleUpdatedHelper;
     private final ShouldInterceptLoadRequestHelper mShouldInterceptLoadRequestHelper;
     private final OnLoadStartedHelper mOnLoadStartedHelper;
+    private final OnReceivedHttpAuthRequestHelper mOnReceivedHttpAuthRequestHelper;
 
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -145,6 +160,7 @@ class TestHelperBridge {
         mOnTitleUpdatedHelper = new OnTitleUpdatedHelper();
         mShouldInterceptLoadRequestHelper = new ShouldInterceptLoadRequestHelper();
         mOnLoadStartedHelper = new OnLoadStartedHelper();
+        mOnReceivedHttpAuthRequestHelper = new OnReceivedHttpAuthRequestHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -173,6 +189,10 @@ class TestHelperBridge {
 
     public OnLoadStartedHelper getOnLoadStartedHelper() {
         return mOnLoadStartedHelper;
+    }
+
+    public OnReceivedHttpAuthRequestHelper getOnReceivedHttpAuthRequestHelper() {
+        return mOnReceivedHttpAuthRequestHelper;
     }
 
     public void onTitleChanged(String title) {
@@ -204,5 +224,9 @@ class TestHelperBridge {
 
     public void onLoadStarted(String url) {
         mOnLoadStartedHelper.notifyCalled(url);
+    }
+
+    public void onReceivedHttpAuthRequest(String host) {
+        mOnReceivedHttpAuthRequestHelper.notifyCalled(host);
     }
 }

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
@@ -32,6 +32,7 @@ import org.chromium.content.browser.test.util.Criteria;
 import org.chromium.content.browser.test.util.CriteriaHelper;
 import org.chromium.ui.gfx.DeviceDisplayInfo;
 
+import org.xwalk.core.internal.XWalkHttpAuthHandlerInternal;
 import org.xwalk.core.internal.XWalkNavigationHistoryInternal;
 import org.xwalk.core.internal.XWalkNavigationItemInternal;
 import org.xwalk.core.internal.XWalkResourceClientInternal;
@@ -102,6 +103,12 @@ public class XWalkViewInternalTestBase
         public WebResourceResponse shouldInterceptLoadRequest(XWalkViewInternal view,
                 String url) {
             return mInnerContentsClient.shouldInterceptLoadRequest(url);
+        }
+
+        @Override
+        public void onReceivedHttpAuthRequest(XWalkViewInternal view,
+                XWalkHttpAuthHandlerInternal handler, String host, String realm) {
+            mInnerContentsClient.onReceivedHttpAuthRequest(host);
         }
     }
 

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -20,6 +20,7 @@ CLASSES_TO_BE_PROCESS = [
     'XWalkCookieManagerInternal',
     'XWalkDownloadListenerInternal',
     'XWalkExtensionInternal',
+    'XWalkHttpAuthHandlerInternal',
     'XWalkViewInternal',
     'XWalkUIClientInternal',
     'XWalkResourceClientInternal',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -180,7 +180,7 @@
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsIoThreadClient.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDevToolsServer.java',
-        'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandler.java',
+        'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPathHelper.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettings.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java',

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -23,6 +23,7 @@
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/ClientCertRequest.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkDownloadListener.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkExtension.java',
+          '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkHttpAuthHandler.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkJavascriptResult.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkNavigationHistory.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkNavigationItem.java',


### PR DESCRIPTION
This patch is to move onReceivedHttpAuthRequest from XWalkClient to
XWalkResourceClientInternal.
Customer could override this API to display dialog or show other
customize information.

BUG=XWALK-3477