### PR TITLE
tests: Always call document.close() after using document.write().

### DIFF
--- a/extensions/test/data/iframe_using_document_write.html
+++ b/extensions/test/data/iframe_using_document_write.html
@@ -7,6 +7,7 @@ var c = document.createElement("iframe");
 document.body.appendChild(c);
 c.contentDocument.write('lala');
 c.src = "counter.html";
+c.contentDocument.close();
 document.title = 'Pass';
 </script>
 </body>

--- a/test/android/data/displayAvailableTest.html
+++ b/test/android/data/displayAvailableTest.html
@@ -12,6 +12,7 @@
       document.write("Secondary display <font color=green>Unavailable</font>.");
       document.title = "Unavailable";
     }
+    document.close();
   } catch(e) {
       document.title = "Fail";
   }

--- a/test/android/data/echo.html
+++ b/test/android/data/echo.html
@@ -16,6 +16,7 @@ try {
       document.write("Async echo <font color=red>failed</font>.");
       document.title = "Fail";
     }
+    document.close();
   });
 } catch(e) {
   console.log(e);

--- a/test/android/data/echoSync.html
+++ b/test/android/data/echoSync.html
@@ -16,6 +16,7 @@ try {
     document.write("Sync echo <font color=red>failed</font>.");
     document.title = "Fail";
   }
+  document.close();
 } catch(e) {
   console.log(e);
   document.title = "Fail";

--- a/test/android/data/framesEcho.html
+++ b/test/android/data/framesEcho.html
@@ -31,6 +31,7 @@
         + "  <\/script>\n"
         + "  <\/head>\n"
         + "</html>");
+      iframe.contentDocument.close();
 
       function setTestResult(result) {
         var resultDiv = document.getElementById('result');

--- a/test/android/data/window.close.html
+++ b/test/android/data/window.close.html
@@ -6,7 +6,6 @@
 <script>
     var testWindow;
     testWindow = window.open("", "_parent", "width=200, height=100");
-    testWindow.document.write("testWindow");
     setTimeout(function(){ testWindow.close(); }, 100);
 </script>
 </body>


### PR DESCRIPTION
This commit is in preparation for M42.

Blink has recently changed the definition of load completion, which exposed some flakiness in our HTML tests: `document.write()` keeps the document stream open and can cause Blink to never consider it has finished loading the document, causing time outs in our tests.

[Chromium bug 426520](https://code.google.com/p/chromium/issues/detail?id=426520) contains more information and a list of commits related to the Blink changes.

While `document.write()` is not strictly needed by the majority of the tests that use it, I chose to keep the calls and just explicitly close the document in most cases, those calls provide some information on what the test is doing (though we could consider replacing those calls with something similar to what Blink does in its layout tests).