### PR TITLE
Enable open external url in web browser.

### DIFF
--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -425,7 +425,8 @@ bool ApplicationData::HasCSPDefined() const {
           manifest_->HasPath(widget_keys::kCSPReportOnlyKey) ||
           manifest_->HasPath(widget_keys::kAllowNavigationKey);
 #else
-  return manifest_->HasPath(GetCSPKey(manifest_type()));
+  return manifest_->HasPath(GetCSPKey(manifest_type())) ||
+         manifest_->HasPath(keys::kScopeKey);
 #endif
 }
 

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -13,6 +13,7 @@ namespace application_manifest_keys {
 const char kNameKey[] = "name";
 const char kDisplay[] = "display";
 const char kStartURLKey[] = "start_url";
+const char kScopeKey[] = "scope";
 const char kCSPKey[] = "csp";
 const char kBoundsKey[] = "xwalk_bounds";
 const char kWidthKey[] = "width";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -18,6 +18,7 @@ namespace application_manifest_keys {
   extern const char kDisplay[];
   // extern const char kOrientation[];
   extern const char kStartURLKey[];
+  extern const char kScopeKey[];
   extern const char kCSPKey[];
   extern const char kBoundsKey[];
   extern const char kWidthKey[];

--- a/runtime/browser/runtime_platform_util_linux.cc
+++ b/runtime/browser/runtime_platform_util_linux.cc
@@ -43,7 +43,13 @@ void XDGUtil(const std::string& util, const std::string& arg) {
 }
 
 void XDGOpen(const std::string& path) {
-  XDGUtil("xdg-open", path);
+  GURL url(path);
+  if (url.is_valid() && url.SchemeIsHTTPOrHTTPS()) {
+    std::string cmd = "xdg-open " + path;
+    std::system(cmd.c_str());
+  } else {
+    XDGUtil("xdg-open", path);
+  }
 }
 
 void XDGEmail(const std::string& email) {

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -32,6 +32,7 @@
 #include "xwalk/runtime/browser/geolocation/xwalk_access_token_store.h"
 #include "xwalk/runtime/browser/media/media_capture_devices_dispatcher.h"
 #include "xwalk/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h"
+#include "xwalk/runtime/browser/runtime_platform_util.h"
 #include "xwalk/runtime/browser/runtime_quota_permission_context.h"
 #include "xwalk/runtime/browser/speech/speech_recognition_manager_delegate.h"
 #include "xwalk/runtime/browser/xwalk_browser_context.h"
@@ -70,7 +71,6 @@
 #if defined(OS_TIZEN)
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/runtime/browser/geolocation/tizen/location_provider_tizen.h"
-#include "xwalk/runtime/browser/runtime_platform_util.h"
 #include "xwalk/runtime/browser/tizen/xwalk_web_contents_view_delegate.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts_tizen.h"
 #endif
@@ -397,9 +397,7 @@ bool XWalkContentBrowserClient::CanCreateWindow(const GURL& opener_url,
   }
 
   LOG(INFO) << "[BlOCK] CreateWindow: " << target_url.spec();
-#if defined(OS_TIZEN)
   platform_util::OpenExternal(target_url);
-#endif
   return false;
 }
 #endif

--- a/runtime/browser/xwalk_render_message_filter.cc
+++ b/runtime/browser/xwalk_render_message_filter.cc
@@ -16,23 +16,17 @@ XWalkRenderMessageFilter::XWalkRenderMessageFilter()
 bool XWalkRenderMessageFilter::OnMessageReceived(
     const IPC::Message& message) {
   bool handled = true;
-#if defined(OS_TIZEN)
   IPC_BEGIN_MESSAGE_MAP(XWalkRenderMessageFilter, message)
     IPC_MESSAGE_HANDLER(ViewMsg_OpenLinkExternal, OnOpenLinkExternal)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
-#else
-  handled = false;
-#endif
 
   return handled;
 }
 
-#if defined(OS_TIZEN)
 void XWalkRenderMessageFilter::OnOpenLinkExternal(const GURL& url) {
   LOG(INFO) << "OpenLinkExternal: " << url.spec();
   platform_util::OpenExternal(url);
 }
-#endif
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_render_message_filter.h
+++ b/runtime/browser/xwalk_render_message_filter.h
@@ -16,9 +16,7 @@ class XWalkRenderMessageFilter : public content::BrowserMessageFilter {
   bool OnMessageReceived(const IPC::Message& message) override;
 
  private:
-#if defined(OS_TIZEN)
   void OnOpenLinkExternal(const GURL& url);
-#endif
   ~XWalkRenderMessageFilter() override {}
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRenderMessageFilter);

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -53,7 +53,5 @@ IPC_MESSAGE_CONTROL1(ViewMsg_UserAgentStringChanged,  // NOLINT
 IPC_MESSAGE_ROUTED1(ViewMsg_HWKeyPressed, int /*keycode*/)  // NOLINT
 
 // These are messages sent from the renderer to the browser process.
-#if defined(OS_TIZEN)
 IPC_MESSAGE_CONTROL1(ViewMsg_OpenLinkExternal,  // NOLINT
                      GURL /* target link */)
-#endif  // OS_TIZEN  // NOLINT

--- a/runtime/renderer/xwalk_render_process_observer_generic.cc
+++ b/runtime/renderer/xwalk_render_process_observer_generic.cc
@@ -128,19 +128,18 @@ bool XWalkRenderProcessObserver::CanRequest(const GURL& orig,
   for (const auto& whitelist_entry : access_whitelist_) {
     if (whitelist_entry->source_.GetOrigin() != orig.GetOrigin())
       continue;
-
     if (!whitelist_entry->allow_subdomains_ &&
-        whitelist_entry->dest_.GetOrigin() == dest.GetOrigin())
+        whitelist_entry->dest_.GetOrigin() == dest.GetOrigin() &&
+        StartsWithASCII(dest.path(), whitelist_entry->dest_.path(), false))
       return true;
-
     const GURL& rule = whitelist_entry->dest_;
     if (whitelist_entry->allow_subdomains_ &&
         dest.scheme() == rule.scheme() &&
         dest.DomainIs(rule.host().c_str()) &&
-        dest.port() == rule.port())
+        dest.port() == rule.port() &&
+        StartsWithASCII(dest.path(), rule.path(), false))
       return true;
   }
-
   return false;
 }
 


### PR DESCRIPTION
The XPK package format should support 'scope' field in manifest.json, which is defined in spec: 
https://w3c.github.io/manifest/#scope-member, this patch will enable this feature for XPK package, and open an external link in web browser.

BUG=XWALK-3690