### PR TITLE
[Android] Fix immersive full screen mode doesn't recover.

### DIFF
--- a/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
+++ b/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
@@ -5,9 +5,10 @@
 package org.xwalk.app.template;
 
 import android.graphics.Color;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
+import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.Window;
 import android.view.WindowManager;
 import android.view.View;
 import android.widget.TextView;
@@ -15,9 +16,23 @@ import android.widget.TextView;
 import org.xwalk.app.XWalkRuntimeActivityBase;
 
 public class AppTemplateActivity extends XWalkRuntimeActivityBase {
+    private final int SYSTEM_UI_OPTIONS = View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+            View.SYSTEM_UI_FLAG_FULLSCREEN |
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+    private final String TAG = this.getClass().getName();
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        enterFullscreen();
     }
 
     @Override
@@ -35,24 +50,39 @@ public class AppTemplateActivity extends XWalkRuntimeActivityBase {
     }
 
     private void enterFullscreen() {
-        if (VERSION.SDK_INT >= VERSION_CODES.KITKAT &&
-                ((getWindow().getAttributes().flags &
-                        WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0)) {
+        if (isNewerThanKitkat() && ((getWindow().getAttributes().flags &
+                WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0)) {
             View decorView = getWindow().getDecorView();
-            decorView.setSystemUiVisibility(
-                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
-                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
-                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                    View.SYSTEM_UI_FLAG_FULLSCREEN |
-                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+            decorView.setSystemUiVisibility(SYSTEM_UI_OPTIONS);
         }
     }
 
     public void setIsFullscreen(boolean isFullscreen) {
-        if (isFullscreen) {
-            enterFullscreen();
+        if (!isFullscreen) return;
+        if (!isNewerThanKitkat()) {
+            Log.w(TAG, "setIsFullscreen() should not be called if " +
+                    "android version is older than Kitkat.");
+            return;
         }
+
+        setSystemUiVisibilityChangeListener();
     }
 
+    private void setSystemUiVisibilityChangeListener() {
+        final View decorView = getWindow().getDecorView();
+        decorView.setOnSystemUiVisibilityChangeListener(
+            new View.OnSystemUiVisibilityChangeListener() {
+                @Override
+                public void onSystemUiVisibilityChange(int visibility) {
+                    if ((visibility & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
+                        decorView.setSystemUiVisibility(SYSTEM_UI_OPTIONS);
+                    }
+                }
+            }
+        );
+    }
+
+    private boolean isNewerThanKitkat() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+    }
 }


### PR DESCRIPTION
Immersive Fullscreen mode does not recover after changing the volume on
the device.
Refer https://github.com/fujunwei/crosswalk-cordova-android/commit/c9e30e77cf71da2d189faecd861c29c04a1548f6
to fix this issue.

BUG=XWALK-3651, XWALK-2367