### PR TITLE
Support to replace user agent string for XPK package

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -19,14 +19,20 @@
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/site_instance.h"
 #include "net/base/net_util.h"
+#include "net/url_request/static_http_user_agent_settings.h"
+#include "net/url_request/url_request_context.h"
 #include "xwalk/application/common/application_manifest_constants.h"
 #include "xwalk/application/common/constants.h"
+#include "xwalk/application/common/manifest_handlers/user_agent_handler.h"
 #include "xwalk/application/common/manifest_handlers/warp_handler.h"
 #include "xwalk/application/common/package/wgt_package.h"
 #include "xwalk/runtime/browser/runtime.h"
 #include "xwalk/runtime/browser/runtime_ui_delegate.h"
+#include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
 #include "xwalk/runtime/browser/xwalk_browser_context.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
+#include "xwalk/runtime/common/xwalk_common_messages.h"
+#include "xwalk/runtime/common/xwalk_content_client.h"
 
 #if defined(OS_TIZEN)
 #include "xwalk/application/browser/application_tizen.h"
@@ -219,12 +225,32 @@ bool Application::Launch() {
     return false;
 
   auto site = content::SiteInstance::CreateForURL(browser_context_, url);
+  UserAgentInfo* user_agent_info = static_cast<UserAgentInfo*>(
+      data_->GetManifestData(keys::kXWalkUserAgentKey));
+  if (user_agent_info && !user_agent_info->UserAgent().empty()) {
+    user_agent_ = user_agent_info->UserAgent();
+    xwalk::RuntimeURLRequestContextGetter* context_getter =
+        static_cast<xwalk::RuntimeURLRequestContextGetter*>(
+            browser_context_->GetRequestContext());
+    net::URLRequestContext* context = context_getter->GetURLRequestContext();
+    context->set_http_user_agent_settings(
+        new net::StaticHttpUserAgentSettings("*", user_agent_));
+    LOG(INFO) << "Set User Agent: " << user_agent_;
+  }
+
   Runtime* runtime = Runtime::Create(browser_context_, site);
   runtime->set_observer(this);
   runtimes_.push_back(runtime);
   render_process_host_ = runtime->GetRenderProcessHost();
   render_process_host_->AddObserver(this);
+
   web_contents_ = runtime->web_contents();
+
+  if (!user_agent_.empty()) {
+    render_process_host_->Send(
+        new ViewMsg_UserAgentStringChanged(user_agent_info->UserAgent()));
+    web_contents_->SetUserAgentOverride(user_agent_);
+  }
   InitSecurityPolicy();
   runtime->LoadURL(url);
 
@@ -271,6 +297,7 @@ int Application::GetRenderProcessHostID() const {
 
 void Application::OnNewRuntimeAdded(Runtime* runtime) {
   runtime->set_observer(this);
+  runtime->web_contents()->SetUserAgentOverride(user_agent_);
   runtime->set_ui_delegate(
       DefaultRuntimeUIDelegate::Create(runtime, window_show_params_));
   runtime->Show();

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -164,6 +164,8 @@ class Application : public Runtime::Observer,
   StoredPermissionMap permission_map_;
   // Security policy.
   scoped_ptr<ApplicationSecurityPolicy> security_policy_;
+  // User Agent string
+  std::string user_agent_;
   // WeakPtrFactory should be always declared the last.
   base::WeakPtrFactory<Application> weak_factory_;
   DISALLOW_COPY_AND_ASSIGN(Application);

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -66,6 +66,7 @@ const char kXWalkLaunchScreenPortrait[] =
     "xwalk_launch_screen.portrait";
 const char kXWalkLaunchScreenReadyWhen[] =
     "xwalk_launch_screen.ready_when";
+const char kXWalkUserAgentKey[] = "xwalk_user_agent";
 
 #if defined(OS_TIZEN)
 const char kTizenAppIdKey[] = "tizen_app_id";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -59,6 +59,7 @@ namespace application_manifest_keys {
   extern const char kXWalkLaunchScreenLandscape[];
   extern const char kXWalkLaunchScreenPortrait[];
   extern const char kXWalkLaunchScreenReadyWhen[];
+  extern const char kXWalkUserAgentKey[];
 
 #if defined(OS_TIZEN)
   extern const char kTizenAppIdKey[];

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -9,6 +9,7 @@
 #include "base/stl_util.h"
 #include "xwalk/application/common/manifest_handlers/csp_handler.h"
 #include "xwalk/application/common/manifest_handlers/permissions_handler.h"
+#include "xwalk/application/common/manifest_handlers/user_agent_handler.h"
 #include "xwalk/application/common/manifest_handlers/warp_handler.h"
 #include "xwalk/application/common/manifest_handlers/widget_handler.h"
 #if defined(OS_TIZEN)
@@ -133,6 +134,7 @@ ManifestHandlerRegistry::GetInstanceForXPK() {
   // handlers.push_back(new xxxHandler);
   handlers.push_back(new CSPHandler(Manifest::TYPE_MANIFEST));
   handlers.push_back(new PermissionsHandler);
+  handlers.push_back(new UserAgentHandler);
   xpk_registry_ = new ManifestHandlerRegistry(handlers);
   return xpk_registry_;
 }

--- a/application/common/manifest_handlers/user_agent_handler.cc
+++ b/application/common/manifest_handlers/user_agent_handler.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include "xwalk/application/common/manifest_handlers/user_agent_handler.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace keys = application_manifest_keys;
+
+namespace application {
+
+UserAgentInfo::UserAgentInfo() {
+}
+
+UserAgentInfo::~UserAgentInfo() {
+}
+
+UserAgentHandler::UserAgentHandler() {
+}
+
+UserAgentHandler::~UserAgentHandler() {
+}
+
+bool UserAgentHandler::Parse(scoped_refptr<ApplicationData> application,
+                             base::string16* error) {
+  if (!application->GetManifest()->HasKey(keys::kXWalkUserAgentKey)) {
+    application->SetManifestData(keys::kXWalkUserAgentKey, new UserAgentInfo);
+    return true;
+  }
+
+  std::string user_agent;
+  if (!application->GetManifest()->GetString(keys::kXWalkUserAgentKey,
+                                             &user_agent) ||
+      user_agent.empty()) {
+    *error = base::ASCIIToUTF16("Invalid value of xwalk user agent.");
+    return false;
+  }
+
+  scoped_ptr<UserAgentInfo> user_agent_info(new UserAgentInfo);
+  user_agent_info->SetUserAgent(user_agent);
+  application->SetManifestData(keys::kXWalkUserAgentKey,
+                               user_agent_info.release());
+  return true;
+}
+
+std::vector<std::string> UserAgentHandler::Keys() const {
+  return std::vector<std::string>(1, keys::kXWalkUserAgentKey);
+}
+
+}  // namespace application
+}  // namespace xwalk

--- a/application/common/manifest_handlers/user_agent_handler.h
+++ b/application/common/manifest_handlers/user_agent_handler.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_USER_AGENT_HANDLER_H_
+#define XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_USER_AGENT_HANDLER_H_
+
+#include <string>
+#include <vector>
+
+#include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/manifest_handler.h"
+namespace xwalk {
+namespace application {
+
+class UserAgentInfo : public ApplicationData::ManifestData {
+ public:
+  UserAgentInfo();
+  ~UserAgentInfo() override;
+
+  void SetUserAgent(const std::string& user_agent) {
+    user_agent_ = user_agent;
+  }
+
+  const std::string& UserAgent() const {
+    return user_agent_;
+  }
+
+ private:
+  std::string user_agent_;
+};
+
+class UserAgentHandler : public ManifestHandler {
+ public:
+  UserAgentHandler();
+  ~UserAgentHandler() override;
+
+  bool Parse(scoped_refptr<ApplicationData> application,
+             base::string16* error) override;
+  std::vector<std::string> Keys() const override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(UserAgentHandler);
+};
+
+}  // namespace application
+}  // namespace xwalk
+
+#endif  // XWALK_APPLICATION_COMMON_MANIFEST_HANDLERS_USER_AGENT_HANDLER_H_

--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -35,6 +35,8 @@
         'manifest_handlers/csp_handler.h',
         'manifest_handlers/permissions_handler.cc',
         'manifest_handlers/permissions_handler.h',
+        'manifest_handlers/user_agent_handler.cc',
+        'manifest_handlers/user_agent_handler.h',
         'manifest_handlers/warp_handler.cc',
         'manifest_handlers/warp_handler.h',
         'manifest_handlers/widget_handler.cc',

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -45,10 +45,8 @@ IPC_MESSAGE_CONTROL2(ViewMsg_EnableSecurityMode,    // NOLINT
 IPC_MESSAGE_CONTROL1(ViewMsg_SuspendJSEngine,  // NOLINT
                      bool /* is suspend */)
 
-#if defined(OS_TIZEN)
 IPC_MESSAGE_CONTROL1(ViewMsg_UserAgentStringChanged,  // NOLINT
                      std::string /*new user agent string*/)
-#endif
 
 IPC_MESSAGE_ROUTED1(ViewMsg_HWKeyPressed, int /*keycode*/)  // NOLINT
 

--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -30,8 +30,8 @@
 #include "xwalk/application/common/constants.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
-#if (defined(OS_TIZEN))
 #include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
+#if (defined(OS_TIZEN))
 #include "xwalk/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h"
 #endif
 
@@ -189,7 +189,7 @@ std::string XWalkContentClient::GetProduct() const {
 }
 
 std::string XWalkContentClient::GetUserAgent() const {
-#if (defined(OS_TIZEN))
+#if !defined(OS_ANDROID)
   // TODO(jizydorczyk):
   // const_cast below is required to invoke ContentClient::renderer() method,
   // I think there is no reason for ContentClient::renderer() in content API
@@ -199,11 +199,10 @@ std::string XWalkContentClient::GetUserAgent() const {
   content::ContentRendererClient* content_renderer_client =
       content_client->renderer();
   if (content_renderer_client) {
-    XWalkContentRendererClientTizen* content_renderer_client_tizen =
-        static_cast<XWalkContentRendererClientTizen*>(
-            content_renderer_client);
-    const std::string& user_agent_string = content_renderer_client_tizen->
-        GetOverridenUserAgent();
+    XWalkContentRendererClient* xwalk_content_renderer_client =
+        static_cast<XWalkContentRendererClient*>(content_renderer_client);
+    const std::string& user_agent_string =
+        xwalk_content_renderer_client->GetOverridenUserAgent();
     if (!user_agent_string.empty())
       return user_agent_string;
   }

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.cc
@@ -139,10 +139,4 @@ void XWalkContentRendererClientTizen::DidCreateScriptContext(
   frame->executeScript(source);
 }
 
-std::string XWalkContentRendererClientTizen::GetOverridenUserAgent() const {
-  if (!xwalk_render_process_observer_)
-    return "";
-  return xwalk_render_process_observer_->GetOverridenUserAgent();
-}
-
 }  // namespace xwalk

--- a/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
+++ b/runtime/renderer/tizen/xwalk_content_renderer_client_tizen.h
@@ -37,7 +37,6 @@ class XWalkContentRendererClientTizen : public XWalkContentRendererClient {
       const blink::WebURLError& error,
       std::string* error_html,
       base::string16* error_description) override;
-  std::string GetOverridenUserAgent() const;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkContentRendererClientTizen);

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -291,4 +291,12 @@ void XWalkContentRendererClient::GetNavigationErrorStrings(
   }
 }
 
+#if !defined(OS_ANDROID)
+std::string XWalkContentRendererClient::GetOverridenUserAgent() const {
+  if (!xwalk_render_process_observer_)
+    return "";
+  return xwalk_render_process_observer_->GetOverridenUserAgent();
+}
+#endif
+
 }  // namespace xwalk

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -61,6 +61,9 @@ class XWalkContentRendererClient
                        const GURL& url,
                        const GURL& first_party_for_cookies,
                        GURL* new_url) override;
+#if !defined(OS_ANDROID)
+  std::string GetOverridenUserAgent() const;
+#endif
 
  protected:
   scoped_ptr<XWalkRenderProcessObserver> xwalk_render_process_observer_;

--- a/runtime/renderer/xwalk_render_process_observer_generic.cc
+++ b/runtime/renderer/xwalk_render_process_observer_generic.cc
@@ -58,9 +58,7 @@ bool XWalkRenderProcessObserver::OnControlMessageReceived(
     IPC_MESSAGE_HANDLER(ViewMsg_SetAccessWhiteList, OnSetAccessWhiteList)
     IPC_MESSAGE_HANDLER(ViewMsg_EnableSecurityMode, OnEnableSecurityMode)
     IPC_MESSAGE_HANDLER(ViewMsg_SuspendJSEngine, OnSuspendJSEngine)
-#if defined(OS_TIZEN)
     IPC_MESSAGE_HANDLER(ViewMsg_UserAgentStringChanged, OnUserAgentChanged)
-#endif
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
   return handled;
@@ -107,7 +105,6 @@ void XWalkRenderProcessObserver::OnSuspendJSEngine(bool is_suspend) {
   is_suspended_ = is_suspend;
 }
 
-#if defined(OS_TIZEN)
 void XWalkRenderProcessObserver::OnUserAgentChanged(
     const std::string& userAgentString) {
   overriden_user_agent_ = userAgentString;
@@ -116,7 +113,6 @@ void XWalkRenderProcessObserver::OnUserAgentChanged(
 std::string XWalkRenderProcessObserver::GetOverridenUserAgent() const {
   return overriden_user_agent_;
 }
-#endif
 
 bool XWalkRenderProcessObserver::CanRequest(const GURL& orig,
                                             const GURL& dest) const {

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -45,9 +45,7 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   }
 
   const GURL& app_url() const { return app_url_; }
-#if defined(OS_TIZEN)
   std::string GetOverridenUserAgent() const;
-#endif
   bool CanRequest(const GURL& orig, const GURL& dest) const;
 
  private:
@@ -57,10 +55,8 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
       const GURL& url,
       application::ApplicationSecurityPolicy::SecurityMode mode);
   void OnSuspendJSEngine(bool is_pause);
-#if defined(OS_TIZEN)
   void OnUserAgentChanged(const std::string& userAgentString);
   std::string overriden_user_agent_;
-#endif
   void AddAccessWhiteListEntry(const GURL& source,
                                const GURL& dest,
                                bool allow_subdomains);


### PR DESCRIPTION
The Crosswalk web runtime should support to replace the user agent string when a
web application running on top of it, so that the remote server could return the
right response to the web application as expecting. The patch will enable this
feature by adding the 'xwalk_user_agent' field in manifest.json file on all
platforms except the Android.

BUG=XWALK-3689