### PR TITLE
[Android] Fix the display for the website's title after navigation.

### DIFF
--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -297,6 +297,12 @@ public class XWalkViewShellActivity extends FragmentActivity
                 }
                 mUrlTextView.setText(mActiveView.getUrl());
             }
+
+            @Override
+            public void onLoadFinished(XWalkView view, String url) {
+                if (view != mActiveView) return;
+                mSectionsPagerAdapter.setPageTitle(view, view.getTitle());
+            }
         });
 
         xwalkView.setUIClient(new XWalkUIClient(xwalkView) {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/NavigateTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/NavigateTest.java
@@ -6,30 +6,61 @@
 package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.chromium.base.test.util.Feature;
+import org.chromium.net.test.util.TestWebServer;
+
+import org.xwalk.core.xwview.test.util.CommonResources;
 
 /**
  * Test suite for Navigate().
  */
 public class NavigateTest extends XWalkViewTestBase {
+    private TestWebServer mWebServer;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        mWebServer = TestWebServer.start();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        mWebServer.shutdown();
+        super.tearDown();
+    }
+
+    private String addPageToTestServer(TestWebServer webServer, String httpPath, String html) {
+        List<Pair<String, String>> headers = new ArrayList<Pair<String, String>>();
+        headers.add(Pair.create("Content-Type", "text/html"));
+        headers.add(Pair.create("Cache-Control", "no-store"));
+        return webServer.setResponse(httpPath, html, headers);
     }
 
     @SmallTest
     @Feature({"Navigate"})
     public void testNavigate() throws Throwable {
-        final String url1 = "about:blank";
-        final String url2 = "file:///android_asset/www/index.html";
-        final String title ="Crosswalk Sample Application";
-        loadUrlSync(url1);
-        loadUrlSync(url2);
-        assertEquals(title, getTitleOnUiThread());
+        String path = "/test.html";
+        String pageContent = CommonResources.makeHtmlPageFrom("<title>Test</title>",
+                "<div> The title is: Test </div>");
+        final String firstUrl = addPageToTestServer(mWebServer, path, pageContent);
+        final String firstTitle = "Test";
+        final String secondUrl = "file:///android_asset/www/index.html";
+        final String secondTitle ="Crosswalk Sample Application";
+
+        loadUrlSync(firstUrl);
+        loadUrlSync(secondUrl);
+        assertEquals(secondUrl, getUrlOnUiThread());
+        assertEquals(secondTitle, getTitleOnUiThread());
         goBackSync();
-        assertEquals(url1, getUrlOnUiThread());
+        assertEquals(firstUrl, getUrlOnUiThread());
+        assertEquals(firstTitle, getTitleOnUiThread());
         goForwardSync();
-        assertEquals(url2, getUrlOnUiThread());
+        assertEquals(secondUrl, getUrlOnUiThread());
+        assertEquals(secondTitle, getTitleOnUiThread());
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnLoadFinishedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnLoadFinishedTest.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.net.test.util.TestWebServer;
+
+import org.xwalk.core.xwview.test.util.CommonResources;
+
+/**
+ * Test suite for OnLoadFinished().
+ */
+public class OnLoadFinishedTest extends XWalkViewTestBase {
+    private TestWebServer mWebServer;
+    private TestHelperBridge.OnLoadFinishedHelper mOnLoadFinishedHelper;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mWebServer = TestWebServer.start();
+        mOnLoadFinishedHelper = mTestHelperBridge.getOnLoadFinishedHelper();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        mWebServer.shutdown();
+        super.tearDown();
+    }
+
+    private String addPageToTestServer(TestWebServer webServer, String httpPath, String html) {
+        List<Pair<String, String>> headers = new ArrayList<Pair<String, String>>();
+        headers.add(Pair.create("Content-Type", "text/html"));
+        headers.add(Pair.create("Cache-Control", "no-store"));
+        return webServer.setResponse(httpPath, html, headers);
+    }
+
+    @SmallTest
+    @Feature({"OnLoadFinished"})
+    public void testOnLoadFinished() throws Throwable {
+        String path = "/test.html";
+        String pageContent = CommonResources.makeHtmlPageFrom("<title>Test</title>",
+                "<div> The title is: Test </div>");
+        final String firstUrl = addPageToTestServer(mWebServer, path, pageContent);
+        final String firstTitle = "Test";
+        final String secondUrl = "file:///android_asset/www/index.html";
+        final String secondTitle ="Crosswalk Sample Application";
+        int count = 0;
+
+        loadUrlSync(firstUrl);
+        loadUrlSync(secondUrl);
+        assertEquals(secondUrl, getUrlOnUiThread());
+        assertEquals(secondTitle, getTitleOnUiThread());
+
+        count = mOnLoadFinishedHelper.getCallCount();
+        goBackAsync();
+        mOnLoadFinishedHelper.waitForCallback(count);
+        assertEquals(firstUrl, mOnLoadFinishedHelper.getUrl());
+        assertEquals(firstTitle, getTitleOnUiThread());
+
+        count = mOnLoadFinishedHelper.getCallCount();
+        goForwardAsync();
+        mOnLoadFinishedHelper.waitForCallback(count);
+        assertEquals(secondUrl, mOnLoadFinishedHelper.getUrl());
+        assertEquals(secondTitle, getTitleOnUiThread());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
@@ -85,6 +85,20 @@ class TestHelperBridge {
         }
     }
 
+    public class OnLoadFinishedHelper extends CallbackHelper {
+        private String mUrl;
+
+        public String getUrl() {
+            assert getCallCount() > 0;
+            return mUrl;
+        }
+
+        public void notifyCalled(String url) {
+            mUrl = url;
+            notifyCalled();
+        }
+    }
+
     public class OnProgressChangedHelper extends CallbackHelper {
         private int mProgress;
 
@@ -358,6 +372,7 @@ class TestHelperBridge {
     private final OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper;
     private final OnConsoleMessageHelper mOnConsoleMessageHelper;
     private final OnReceivedIconHelper mOnReceivedIconHelper;
+    private final OnLoadFinishedHelper mOnLoadFinishedHelper;
 
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -379,6 +394,7 @@ class TestHelperBridge {
         mOnCreateWindowRequestedHelper = new OnCreateWindowRequestedHelper();
         mOnConsoleMessageHelper = new OnConsoleMessageHelper();
         mOnReceivedIconHelper = new OnReceivedIconHelper();
+        mOnLoadFinishedHelper = new OnLoadFinishedHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -407,6 +423,10 @@ class TestHelperBridge {
 
     public OnLoadStartedHelper getOnLoadStartedHelper() {
         return mOnLoadStartedHelper;
+    }
+
+    public OnLoadFinishedHelper getOnLoadFinishedHelper() {
+        return mOnLoadFinishedHelper;
     }
 
     public OnJavascriptCloseWindowHelper getOnJavascriptCloseWindowHelper() {
@@ -491,6 +511,10 @@ class TestHelperBridge {
 
     public void onLoadStarted(String url) {
         mOnLoadStartedHelper.notifyCalled(url);
+    }
+
+    public void onLoadFinished(String url) {
+        mOnLoadFinishedHelper.notifyCalled(url);
     }
 
     public void onJavascriptCloseWindow() {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -150,6 +150,11 @@ public class XWalkViewTestBase
         public boolean shouldOverrideUrlLoading(XWalkView view, String url) {
             return mTestHelperBridge.shouldOverrideUrlLoading(url);
         }
+
+        @Override
+        public void onLoadFinished(XWalkView view, String url) {
+            mInnerContentsClient.onLoadFinished(url);
+        }
     }
 
     class TestXWalkResourceClient extends TestXWalkResourceClientBase {
@@ -385,13 +390,11 @@ public class XWalkViewTestBase
         runTestWaitPageFinished(new Runnable(){
             @Override
             public void run() {
-                getInstrumentation().runOnMainSync(new Runnable() {
-                    @Override
-                    public void run() {
-                        mXWalkView.getNavigationHistory().navigate(
-                            XWalkNavigationHistory.Direction.BACKWARD, 1);
-                    }
-                });
+                try {
+                    goBackAsync();
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
             }
         });
     }
@@ -400,13 +403,31 @@ public class XWalkViewTestBase
         runTestWaitPageFinished(new Runnable(){
             @Override
             public void run() {
-                getInstrumentation().runOnMainSync(new Runnable() {
-                    @Override
-                    public void run() {
-                        mXWalkView.getNavigationHistory().navigate(
-                            XWalkNavigationHistory.Direction.FORWARD, 1);
-                    }
-                });
+                try {
+                    goForwardAsync();
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        });
+    }
+
+    protected void goBackAsync() throws Throwable {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.getNavigationHistory().navigate(
+                    XWalkNavigationHistory.Direction.BACKWARD, 1);
+            }
+        });
+    }
+
+    protected void goForwardAsync() throws Throwable {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.getNavigationHistory().navigate(
+                    XWalkNavigationHistory.Direction.FORWARD, 1);
             }
         });
     }


### PR DESCRIPTION
This patch is to display the website's title when open multiple URLs and
press the back or forward button.
The event of update title will be fired in render frame host and title will be
compared to the one in navigation entry, if they are same, the update
title event will not be sent to Java layer.

BUG=XWALK-2333