### PR TITLE
[Tizen] Do not add NaCl's toolchain to the source tarball.

### DIFF
--- a/packaging/gbp-flat-tree.sh
+++ b/packaging/gbp-flat-tree.sh
@@ -55,6 +55,7 @@ echo "Creating a new ${TAR_FILE} from ${BASE_SRC_DIR}/src"
 tar --update --file "${TAR_FILE}" \
     --exclude-vcs --exclude=LayoutTests \
     --exclude=src/out --exclude=src/third_party/android_tools \
+    --exclude=src/native_client/toolchain \
     --directory="${BASE_SRC_DIR}" \
     --transform="s:^:crosswalk/:S" \
     src


### PR DESCRIPTION
Currently NaCl support is not enabled on Tizen, so we can save a few
gigabytes in the source tarball and the extracted archive if we do not
package NaCl's `toolchain/` directory.