### PR TITLE
[Tizen] Fix parser handlers

### DIFF
--- a/application/common/manifest_handlers/tizen_app_control_handler.cc
+++ b/application/common/manifest_handlers/tizen_app_control_handler.cc
@@ -69,8 +69,9 @@ bool TizenAppControlHandler::Parse(scoped_refptr<ApplicationData> application,
     base::string16* error) {
   const Manifest* manifest = application->GetManifest();
   scoped_ptr<AppControlInfoList> aplist(new AppControlInfoList());
-  base::Value* value;
-  manifest->Get(keys::kTizenApplicationAppControlsKey, &value);
+  base::Value* value = nullptr;
+  if (!manifest->Get(keys::kTizenApplicationAppControlsKey, &value))
+    return true;
 
   if (value->GetType() == base::Value::TYPE_LIST) {
     // multiple entries
@@ -107,6 +108,9 @@ bool TizenAppControlHandler::Validate(
   const AppControlInfoList* app_controls =
       static_cast<const AppControlInfoList*>(
           application->GetManifestData(keys::kTizenApplicationAppControlsKey));
+
+  if (!app_controls)
+    return true;
 
   for (const auto& item : app_controls->controls) {
     if (item.src().empty()) {

--- a/application/common/manifest_handlers/tizen_category_handler.cc
+++ b/application/common/manifest_handlers/tizen_category_handler.cc
@@ -43,8 +43,9 @@ bool TizenCategoryHandler::Parse(scoped_refptr<ApplicationData> application,
     base::string16* error) {
   const Manifest* manifest = application->GetManifest();
   scoped_ptr<CategoryInfoList> aplist(new CategoryInfoList());
-  base::Value* value;
-  manifest->Get(keys::kTizenCategoryKey, &value);
+  base::Value* value = nullptr;
+  if (!manifest->Get(keys::kTizenCategoryKey, &value))
+    return true;
 
   if (value->GetType() == base::Value::TYPE_LIST) {
     // multiple entries
@@ -79,6 +80,9 @@ bool TizenCategoryHandler::Validate(
   const CategoryInfoList* categories_list =
       static_cast<const CategoryInfoList*>(
           application->GetManifestData(keys::kTizenCategoryKey));
+
+  if (!categories_list)
+    return true;
 
   for (const auto& item : categories_list->categories) {
     if (item.empty()) {

--- a/application/common/manifest_handlers/tizen_ime_handler.cc
+++ b/application/common/manifest_handlers/tizen_ime_handler.cc
@@ -122,8 +122,9 @@ bool TizenImeHandler::Parse(scoped_refptr<ApplicationData> application,
   const Manifest* manifest = application->GetManifest();
   DCHECK(manifest);
 
-  base::Value* value;
-  manifest->Get(keys::kTizenImeKey, &value);
+  base::Value* value = nullptr;
+  if (!manifest->Get(keys::kTizenImeKey, &value))
+    return true;
 
   bool result = true;
 
@@ -148,6 +149,9 @@ bool TizenImeHandler::Validate(
   const TizenImeInfo* ime_info =
       static_cast<const TizenImeInfo*>(
           application->GetManifestData(keys::kTizenImeKey));
+
+  if (!ime_info)
+    return true;
 
   if (ime_info->uuid().empty()) {
     *error = kErrMsgValidatingUuidEmpty;

--- a/application/common/manifest_handlers/tizen_metadata_handler.cc
+++ b/application/common/manifest_handlers/tizen_metadata_handler.cc
@@ -66,9 +66,9 @@ bool TizenMetaDataHandler::Parse(scoped_refptr<ApplicationData> application,
   const Manifest* manifest = application->GetManifest();
   DCHECK(manifest);
 
-  base::Value* metadata_value = NULL;
+  base::Value* metadata_value = nullptr;
   if (!manifest->Get(keys::kTizenMetaDataKey, &metadata_value)) {
-    *error = base::ASCIIToUTF16("Failed to get value of tizen metaData");
+    return true;
   }
 
   MetaDataPair metadata_item;


### PR DESCRIPTION
In current execution flow, there is call of Parse() function
for each handler. Handler should be prepared for situation that
there is no value it expects.

Following handlers are broken:
 - AppControl,
 - Category,
 - Ime,
 - Metadata.

BUG=XWALK-3774