### PR TITLE
[Android] Implement XWalkView.setZOrderOnTop

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '4281fabd3a7b4b5b87f5653e51a851045bbd5d55'
+chromium_crosswalk_rev = '903b90ad4b6c7a459cdaeb64e50dc54fb1ead0df'
 v8_crosswalk_rev = 'e192569693ad7de42287ef9e4a299524a670ce18'
 ozone_wayland_rev = 'eacaa23d129961f94993a30438aa9e4cd7dfefb7'
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -778,6 +778,11 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         }
     }
 
+    public void setZOrderOnTop(boolean onTop) {
+        if (mContentViewRenderView == null) return;
+        mContentViewRenderView.setZOrderOnTop(onTop);
+    }
+
     private native long nativeInit();
     private static native void nativeDestroy(long nativeXWalkContent);
     private native WebContents nativeGetWebContents(long nativeXWalkContent);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -941,6 +941,18 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         mContent.setOverlayVideoMode(enabled);
     }
 
+    /**
+    * Control whether the XWalkView's surface is placed on top of its window.
+    * Note this only works when XWalkPreferences.ANIMATABLE_XWALK_VIEW is false.
+    * @param onTop true for on top.
+    * @since 5.0
+    */
+    @XWalkAPI
+    public void setZOrderOnTop(boolean onTop) {
+        if (mContent == null) return;
+        mContent.setZOrderOnTop(onTop);
+    }
+
     // Below methods are for test shell and instrumentation tests.
     /**
      * @hide


### PR DESCRIPTION
Use this API to control whether the XWalkView's surface is placed on top of its window.
Note this only works when XWalkPreferences.ANIMATABLE_XWALK_VIEW is false.

BUG=XWALK-3778,XWALK-3742