### PR TITLE
[Android] No need to disable ChannelMojo in XWalk

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -109,11 +109,6 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   // External extensions will run in the BrowserProcess (in process mode).
   command_line->AppendSwitch(switches::kXWalkDisableExtensionProcess);
 
-  // kDisableMojoChannel is not an exported symbol, so we cannot use it. We
-  // have to disable ChannelMojo for now as otherwise we only get a blank
-  // screen. See XWALK-3650.
-  command_line->AppendSwitch("disable-mojo-channel");
-
   // Only force to enable WebGL for Android for IA platforms because
   // we've tested the WebGL conformance test. For other platforms, just
   // follow up the behavior defined by Chromium upstream.


### PR DESCRIPTION
As we've fixed the root case of bug XWALK-3650 on upstream side:
https://codereview.chromium.org/1003123002/
and currently upstream side disabled ChannelMojo,
and, we've also done back port the disablement commit to Chromium-Crosswalk:
https://github.com/crosswalk-project/chromium-crosswalk/pull/237
now no need to disable ChannelMojo in XWalk side anymore.

BUG=XWALK-3650