### PR TITLE
Fix crash on startup after https://codereview.chromium.org/933893003

### DIFF
--- a/runtime/browser/runtime_ui_delegate.cc
+++ b/runtime/browser/runtime_ui_delegate.cc
@@ -4,13 +4,8 @@
 
 #include "xwalk/runtime/browser/runtime_ui_delegate.h"
 
-#include "base/command_line.h"
-#include "grit/xwalk_resources.h"
-#include "ui/base/resource/resource_bundle.h"
 #include "ui/gfx/image/image.h"
-#include "xwalk/runtime/browser/image_util.h"
 #include "xwalk/runtime/browser/runtime.h"
-#include "xwalk/runtime/common/xwalk_switches.h"
 
 namespace xwalk {
 // FIXME : Need to figure out what code paths are used by Android and not
@@ -24,21 +19,6 @@ const int kDefaultHeight = 600;
 NativeAppWindow* RuntimeCreateWindow(
     Runtime* runtime, const NativeAppWindow::CreateParams& params) {
   NativeAppWindow* window = NativeAppWindow::Create(params);
-  // FIXME : Pass an App icon in params.
-  // Set the app icon if it is passed from command line.
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  gfx::Image app_icon;
-  if (command_line->HasSwitch(switches::kAppIcon)) {
-    base::FilePath icon_file =
-        command_line->GetSwitchValuePath(switches::kAppIcon);
-    app_icon = xwalk_utils::LoadImageFromFilePath(icon_file);
-  } else {
-    // Otherwise, use the default icon for Crosswalk app.
-    ui::ResourceBundle& rb = ui::ResourceBundle::GetSharedInstance();
-    app_icon = rb.GetNativeImageNamed(IDR_XWALK_ICON_48);
-  }
-
-  window->UpdateIcon(app_icon);
 
   unsigned int fullscreen_options = runtime->fullscreen_options();
   if (params.state == ui::SHOW_STATE_FULLSCREEN)

--- a/runtime/browser/ui/native_app_window_views.cc
+++ b/runtime/browser/ui/native_app_window_views.cc
@@ -4,15 +4,20 @@
 
 #include "xwalk/runtime/browser/ui/native_app_window_views.h"
 
+#include "base/command_line.h"
 #include "content/public/browser/notification_service.h"
 #include "content/public/browser/web_contents.h"
+#include "grit/xwalk_resources.h"
+#include "ui/base/resource/resource_bundle.h"
 #include "ui/gfx/screen.h"
 #include "ui/views/controls/webview/webview.h"
 #include "ui/views/widget/desktop_aura/desktop_screen.h"
 #include "ui/views/widget/widget.h"
+#include "xwalk/runtime/browser/image_util.h"
 #include "xwalk/runtime/browser/ui/top_view_layout_views.h"
 #include "xwalk/runtime/browser/ui/xwalk_views_delegate.h"
 #include "xwalk/runtime/common/xwalk_notification_types.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 #if defined(OS_WIN)
 #include "ui/views/window/native_frame_view.h"
@@ -62,6 +67,18 @@ void NativeAppWindowViews::Initialize() {
   params.bounds = create_params_.bounds;
 #endif
   params.net_wm_pid = create_params_.net_wm_pid;
+  // Set the app icon if it is passed from command line.
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kAppIcon)) {
+    base::FilePath icon_file =
+      command_line->GetSwitchValuePath(switches::kAppIcon);
+    icon_ = xwalk_utils::LoadImageFromFilePath(icon_file);
+  }
+  else {
+    // Otherwise, use the default icon for Crosswalk app.
+    ui::ResourceBundle& rb = ui::ResourceBundle::GetSharedInstance();
+    icon_ = rb.GetNativeImageNamed(IDR_XWALK_ICON_48);
+  }
 
   window_->Init(params);
 


### PR DESCRIPTION
Commit above changed the way initialisation is done and expect the
application icon to be set before arriving in Init(). This commit fixes
it.