### PR TITLE
[Android] Configure download url of crosswalk library apk

### DIFF
--- a/app/tools/android/app_info.py
+++ b/app/tools/android/app_info.py
@@ -23,3 +23,4 @@ class AppInfo:
     self.package = 'org.xwalk.app.template'
     self.remote_debugging = ''
     self.use_animatable_view = ''
+    self.xwalk_apk_url = ''

--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -285,6 +285,16 @@ def CustomizeXML(app_info, description, icon_dict, manifest, permissions):
     EditElementAttribute(xmldoc, 'application', 'android:icon',
                          '@drawable/%s' % icon_name)
 
+  if app_info.xwalk_apk_url:
+    meta_data = xmldoc.createElement('meta-data')
+    meta_data.setAttribute('android:name', 'xwalk_apk_url')
+    meta_data.setAttribute('android:value', app_info.xwalk_apk_url)
+    app_node = xmldoc.getElementsByTagName('application')[0]
+    comment = 'The download URL of Crosswalk runtime library APK. \n\
+        Default updater use the Android download manager to fetch the url'
+    app_node.appendChild(xmldoc.createComment(comment))
+    app_node.appendChild(meta_data)
+
   file_handle = open(os.path.join(app_dir, 'AndroidManifest.xml'), 'w')
   xmldoc.writexml(file_handle, encoding='utf-8')
   file_handle.close()

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -97,6 +97,8 @@ def ParseManifest(options):
   else:
     print('Error: there is no app launch path defined in manifest.json.')
     sys.exit(9)
+  if not options.xwalk_apk_url and parser.GetXWalkApkUrl():
+    options.xwalk_apk_url = parser.GetXWalkApkUrl()
   options.icon_dict = {}
   if parser.GetAppRoot():
     options.app_root = parser.GetAppRoot()
@@ -254,6 +256,8 @@ def Customize(options, app_info, manifest):
     app_info.orientation = options.orientation
   if options.icon:
     app_info.icon = '%s' % os.path.expanduser(options.icon)
+  if options.xwalk_apk_url:
+    app_info.xwalk_apk_url = options.xwalk_apk_url
 
   #Add local extensions to extension list.
   extension_binary_path_list = GetExtensionBinaryPathList()
@@ -280,7 +284,7 @@ def Execution(options, app_info):
   # start to generate suitable versionCode
   app_info.app_versionCode = MakeVersionCode(options, app_info.app_version)
   # Write generated versionCode into AndroidManifest.xml.
-  # Later if we have other customization, 
+  # Later if we have other customization,
   # we can put them together into CustomizeManifest func.
   CustomizeManifest(app_info)
   name = app_info.android_name
@@ -581,6 +585,11 @@ def main(argv):
           '\'app_root\'. This flag should work with \'--app-root\' together. '
           'For example, --app-local-path=/relative/path/of/entry/file')
   group.add_option('--app-local-path', help=info)
+  info = ('The download URL of the Crosswalk runtime library APK. '
+          'The built-in updater uses the Android download manager to fetch '
+          'the url. '
+          'For example, --xwalk-apk-url=http://myhost/XWalkRuntimeLib.apk')
+  group.add_option('--xwalk-apk-url', help=info)
   parser.add_option_group(group)
   # Mandatory options group
   group = optparse.OptionGroup(parser, 'Mandatory arguments',

--- a/app/tools/android/manifest_json_parser.py
+++ b/app/tools/android/manifest_json_parser.py
@@ -102,6 +102,7 @@ class ManifestJsonParser(object):
     version:          The version number.
     icons:            An array of icons.
     app_url:          The url of application, e.g. hosted app.
+    xwalk_apk_url:    The download URL of the Crosswalk runtime library APK
     description:      The description of application.
     app_root:         The root path of the web, this flag allows to package
                       local web application as apk.
@@ -146,6 +147,10 @@ class ManifestJsonParser(object):
     else:
       app_local_path = app_url
       app_url = ''
+    if 'xwalk_apk_url' in self.data_src:
+      ret_dict['xwalk_apk_url'] = self.data_src['xwalk_apk_url']
+    else:
+      ret_dict['xwalk_apk_url'] = ''
     file_path_prefix = os.path.split(self.input_path)[0]
     if 'icons' in self.data_src:
       icons = self.data_src['icons']
@@ -234,6 +239,7 @@ class ManifestJsonParser(object):
     print("description: %s" % self.GetDescription())
     print("icons: %s" % self.GetIcons())
     print("app_url: %s" % self.GetAppUrl())
+    print("xwalk_apk_url: %s" % self.GetXWalkApkUrl())
     print("app_root: %s" % self.GetAppRoot())
     print("app_local_path: %s" % self.GetAppLocalPath())
     print("permissions: %s" % self.GetPermissions())
@@ -279,6 +285,10 @@ class ManifestJsonParser(object):
   def GetAppUrl(self):
     """Return the URL of the application."""
     return self.ret_dict['app_url']
+
+  def GetXWalkApkUrl(self):
+    """Return the download URL of the Crosswalk runtime library APK"""
+    return self.ret_dict['xwalk_apk_url']
 
   def GetDescription(self):
     """Return the description of the application."""


### PR DESCRIPTION
When crosswalk app running on shared mode, there's a built-in updater to help to download and update crosswalk library apk. By default, the updater will get library apk from Google Play Store.

By this feature, the developer of crosswalk app could self-deploy library apk according to their own requirements, and specify the download url of apk in the app. The updater will fetch the library apk using android download manager.

Setup Method 1: define a meta-data item with the name of "xwalk_apk_url" under application tag in AndroidManifest.xml. For example,

```
<application android:name="org.xwalk.core.XWalkApplication">
    <meta-data android:name="xwalk_apk_url"
               android:value="http://host/XWalkRuntimeLib.apk" />
    ...
</application>
```

Setup Method 2: use --xwalk-apk-url option for make_apk.py. For example,

```
make_apk.py --xwalk-apk-url=http://host/XWalkRuntimeLib.apk ...
```