### PR TITLE
[Android] Implement XWalkView.setZOrderOnTop

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -778,6 +778,11 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         }
     }
 
+    public void setZOrderOnTop(boolean onTop) {
+        if (mContentViewRenderView == null) return;
+        mContentViewRenderView.setZOrderOnTop(onTop);
+    }
+
     private native long nativeInit();
     private static native void nativeDestroy(long nativeXWalkContent);
     private native WebContents nativeGetWebContents(long nativeXWalkContent);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -941,6 +941,18 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         mContent.setOverlayVideoMode(enabled);
     }
 
+    /**
+    * Control whether the XWalkView's surface is placed on top of its window.
+    * Note this only works when XWalkPreferences.ANIMATABLE_XWALK_VIEW is false.
+    * @param onTop true for on top.
+    * @since 5.0
+    */
+    @XWalkAPI
+    public void setZOrderOnTop(boolean onTop) {
+        if (mContent == null) return;
+        mContent.setZOrderOnTop(onTop);
+    }
+
     // Below methods are for test shell and instrumentation tests.
     /**
      * @hide


### PR DESCRIPTION
Use this API to control whether the XWalkView's surface is placed on top of its window.
Note this only works when XWalkPreferences.ANIMATABLE_XWALK_VIEW is false.

BUG=XWALK-3778,XWALK-3742