### PR TITLE
[Android] Fix make_apk fail to pack app when API level is lower than 21

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -453,8 +453,8 @@ def CheckSystemRequirements():
     print('failed\nThe "android" binary could not be found. Check your Android '
           'SDK installation and your PATH environment variable.')
     sys.exit(1)
-  if GetAndroidApiLevel(android_path) < 14:
-    print('failed\nPlease install Android API level (>=14) first.')
+  if GetAndroidApiLevel(android_path) < 21:
+    print('failed\nPlease install Android API level (>=21) first.')
     sys.exit(3)
 
   # Check ant install


### PR DESCRIPTION
Some attributes in layout files introduced by upstream is added from
API level 21. These resources are also included in xwalk core library.
When building app by make_apk, command "ant release" will fail if API
level is lower than 21.

BUG=XWALK-3219