### PR TITLE
disable multiple window support on Android crosswalk by default.

### DIFF
--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -92,7 +92,9 @@ void ApplicationSystem::CreateExtensions(
     return;  // We might be in browser mode.
 
   extensions->push_back(new ApplicationRuntimeExtension(application));
-  extensions->push_back(new ApplicationWidgetExtension(application));
+  // Register the widget extension only when the application is widget format.
+  if (application->data()->manifest_type() == Manifest::TYPE_WIDGET)
+      extensions->push_back(new ApplicationWidgetExtension(application));
 }
 
 }  // namespace application

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -181,8 +181,6 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         // Enable AllowFileAccessFromFileURLs, so that files under file:// path could be
         // loaded by XMLHttpRequest.
         mSettings.setAllowFileAccessFromFileURLs(true);
-        // Enable this by default to suppport new window creation
-        mSettings.setSupportMultipleWindows(true);
 
         nativeSetJavaPeers(mNativeContent, this, mXWalkContentsDelegateAdapter, mContentsClientBridge,
                 mIoThreadClient, mContentsClientBridge.getInterceptNavigationDelegate());

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
@@ -159,7 +159,7 @@ public class XWalkPreferencesInternal {
         sPrefMap.put(JAVASCRIPT_CAN_OPEN_WINDOW, new PreferenceValue(true));
         sPrefMap.put(
                 ALLOW_UNIVERSAL_ACCESS_FROM_FILE, new PreferenceValue(false));
-        sPrefMap.put(SUPPORT_MULTIPLE_WINDOWS, new PreferenceValue(true));
+        sPrefMap.put(SUPPORT_MULTIPLE_WINDOWS, new PreferenceValue(false));
         sPrefMap.put(ENABLE_EXTENSIONS, new PreferenceValue(true));
         sPrefMap.put(PROFILE_NAME, new PreferenceValue("Default"));
     }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettings.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettings.java
@@ -42,7 +42,7 @@ public class XWalkSettings {
     private boolean mAllowFileAccessFromFileURLs = false;
     private boolean mJavaScriptCanOpenWindowsAutomatically = true;
     private int mCacheMode = WebSettings.LOAD_DEFAULT;
-    private boolean mSupportMultipleWindows = true;
+    private boolean mSupportMultipleWindows = false;
     private boolean mAppCacheEnabled = true;
     private boolean mDomStorageEnabled = true;
     private boolean mDatabaseEnabled = true;

--- a/runtime/android/sample/src/org/xwalk/core/sample/OnCreateWindowRequestedActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/OnCreateWindowRequestedActivity.java
@@ -13,6 +13,7 @@ import android.webkit.ValueCallback;
 import java.util.LinkedList;
 
 import org.xwalk.core.XWalkNavigationHistory;
+import org.xwalk.core.XWalkPreferences;
 import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
 
@@ -29,6 +30,10 @@ public class OnCreateWindowRequestedActivity extends XWalkBaseActivity {
 
         mXWalkView = new XWalkView(OnCreateWindowRequestedActivity.this, 
                 OnCreateWindowRequestedActivity.this);
+
+        // Enable multiple window support for this sample, for this flag is
+        // off default.
+        XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, true);
         setClient(mXWalkView);
 
         mParent.addView(mXWalkView);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnCreateWindowRequestedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnCreateWindowRequestedTest.java
@@ -10,6 +10,7 @@ import android.webkit.ValueCallback;
 
 import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
+import org.xwalk.core.XWalkPreferences;
 import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
 
@@ -24,6 +25,7 @@ public class OnCreateWindowRequestedTest extends XWalkViewTestBase {
         super.setUp();
 
         mOnCreateWindowRequestedHelper = mTestHelperBridge.getOnCreateWindowRequestedHelper();
+        XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, true);
 
         setUIClient(new XWalkUIClient(getXWalkView()){
             @Override


### PR DESCRIPTION
BUG=https://crosswalk-project.org/jira/browse/XWALK-3575

[Android] Disable multiple windows support by default
    Crosswalk Android will not support multiple windows, such as window.open
    by default, unless you set XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS.

[Linux] do not register widget extension the app is not widget
    If the application is not a widget, access to exposed "widget" object will cause crash.

