### PR TITLE
[Android] Limit disk cache size

### DIFF
--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -6,8 +6,10 @@
 #include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
 
 #include <algorithm>
+#include <string>
 #include <vector>
 
+#include "base/command_line.h"
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
@@ -41,6 +43,7 @@
 #include "xwalk/application/common/constants.h"
 #include "xwalk/runtime/browser/runtime_network_delegate.h"
 #include "xwalk/runtime/common/xwalk_content_client.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 #if defined(OS_ANDROID)
 #include "xwalk/runtime/browser/android/cookie_manager.h"
@@ -53,6 +56,24 @@
 using content::BrowserThread;
 
 namespace xwalk {
+
+int GetDiskCacheSize() {
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+
+  if (!command_line->HasSwitch(switches::kDiskCacheSize))
+      return 0;
+
+  std::string str_value = command_line->GetSwitchValueASCII(
+      switches::kDiskCacheSize);
+
+  int size = 0;
+  if (!base::StringToInt(str_value, &size)) {
+      LOG(ERROR) << "The value " << str_value
+                 << " can not be converted to integer, ignoring!";
+  }
+
+  return size;
+}
 
 RuntimeURLRequestContextGetter::RuntimeURLRequestContextGetter(
     bool ignore_certificate_errors,
@@ -139,7 +160,7 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
             net::DISK_CACHE,
             net::CACHE_BACKEND_DEFAULT,
             cache_path,
-            0,
+            GetDiskCacheSize(),
             BrowserThread::GetMessageLoopProxyForThread(
                 BrowserThread::CACHE));
 

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -13,6 +13,9 @@ const char kAppIcon[] = "app-icon";
 // Disables the usage of Portable Native Client.
 const char kDisablePnacl[] = "disable-pnacl";
 
+// Forces the maximum disk space to be used by the disk cache, in bytes.
+const char kDiskCacheSize[] = "disk-cache-size";
+
 // Enable all the experimental features in XWalk.
 const char kExperimentalFeatures[] = "enable-xwalk-experimental-features";
 

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -12,6 +12,7 @@ namespace switches {
 
 extern const char kAppIcon[];
 extern const char kDisablePnacl[];
+extern const char kDiskCacheSize[];
 extern const char kExperimentalFeatures[];
 extern const char kListFeaturesFlags[];
 extern const char kXWalkAllowExternalExtensionsForRemoteSources[];


### PR DESCRIPTION
Limit the disk cache size with a very small number with an command line:
--disk-cache-size = N
where N is the cache is size limit, by bytes.
Zero size means use the default that is 80m.

BUG=XWALK-3821