### PR TITLE
[Android] Fix the crash issue when launching cordova app.

### DIFF
--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -658,6 +658,7 @@ ${POST_WRAP_LINES}
     template = Template("""\
 ${DOC}
     public static ${RETURN_TYPE} ${NAME}(${PARAMS}) {
+        XWalkReflectionHelper.initEmbeddedMode();
         XWalkCoreWrapper coreWrapper = \
 XWalkCoreWrapper.getInstance();
         ReflectMethod method = new ReflectMethod(coreWrapper,


### PR DESCRIPTION
This patch is to fix the crash issue when launching cordova app.
"initEmbeddedMode()" should be called before get instance otherwise the
instance is always null.

BUG=XWALK-3812