### PR TITLE
Enable WebNotification for Linux defautly.

### DIFF
--- a/build/system.gyp
+++ b/build/system.gyp
@@ -265,6 +265,32 @@
           ],
         }
       ],  # targets
+    }, {  # tizen == 0
+      'targets': [
+        {
+          'target_name': 'libnotify',
+          'type': 'none',
+          'conditions': [
+            ['building_crosswalk_bin==1', {
+              'direct_dependent_settings': {
+                'defines': ['USE_LIBNOTIFY=1'],
+                'cflags': [
+                  '<!@(pkg-config --cflags libnotify)',
+                ],
+              },
+              'link_settings': {
+                'ldflags': [
+                  '<!@(pkg-config --libs-only-L --libs-only-other libnotify)',
+                ],
+                'libraries': [
+                  '<!@(pkg-config --libs-only-l libnotify)',
+                ],
+              },
+            },
+           ],
+          ],
+        },
+      ],
     }],
   ],  # conditions
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -3,7 +3,6 @@
     'xwalk_product_name': 'XWalk',
     'xwalk_version': '<!(python ../build/util/version.py -f VERSION -t "@MAJOR@.@MINOR@.@BUILD@.@PATCH@")',
     'chrome_version': '<!(python ../build/util/version.py -f ../chrome/VERSION -t "@MAJOR@.@MINOR@.@BUILD@.@PATCH@")',
-    'use_libnotify%': 0,
     'conditions': [
       ['OS=="win" or OS=="mac"', {
         'disable_nacl': 1,
@@ -363,6 +362,15 @@
           # TODO(jschuh): crbug.com/167187 fix size_t to int truncations.
           'msvs_disabled_warnings': [ 4267, ],
         }],  # OS=="win"
+        ['OS=="linux" and tizen!=1', {
+          'dependencies': [
+            'build/system.gyp:libnotify',
+          ],
+          'sources': [
+            'runtime/browser/linux/xwalk_notification_manager.cc',
+            'runtime/browser/linux/xwalk_notification_manager.h',
+          ]
+        }],  # OS=="linux" and tizen!=1
         ['OS=="linux"', {
           'dependencies': [
             '../build/linux/system.gyp:fontconfig',
@@ -400,18 +408,6 @@
             '../ui/aura/aura.gyp:aura',
             '../ui/base/ime/ui_base_ime.gyp:ui_base_ime',
           ],
-        }],
-        ['OS=="linux" and use_libnotify==1', {
-          'defines': ['USE_LIBNOTIFY=1'],
-          'link_settings': {
-            'libraries': [
-              '<!@(pkg-config --libs libnotify)',
-            ],
-          },
-          'sources': [
-            'runtime/browser/linux/xwalk_notification_manager.cc',
-            'runtime/browser/linux/xwalk_notification_manager.h',
-          ]
         }],
         ['disable_nacl==0', {
             'conditions': [


### PR DESCRIPTION
To enable WebNotification for Linux defautly. 
Add "pkg-config --cflags gdk-pixbuf-2.0", since some header files need to include files from that patch.