### PR TITLE
crosswalk-7: Backport commits that track Chromium dependencies with git.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -20,5 +20,3 @@ deps_xwalk = {
   # Ozone-Wayland is required for Wayland support in Chromium.
   'src/ozone': 'https://github.com/01org/ozone-wayland.git@%s' % ozone_wayland_point,
 }
-vars_xwalk = {
-}

--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -30,53 +30,50 @@ ozone_wayland_git = 'https://github.com/01org'
 # You do not need to worry about these most of the time.
 # ------------------------------------------------------
 
-chromium_solution = {
-  'name': 'src',
-  'url': crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
-  'deps_file': '.DEPS.git',
-  'custom_deps': {
-    'src':
-      crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
-    'src/third_party/WebKit':
-      crosswalk_git + '/blink-crosswalk.git@' + blink_crosswalk_rev,
-    'src/v8':
-      crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
+# ------------------------------------------------------
+# gclient solutions.
+# You do not need to worry about these most of the time.
+# ------------------------------------------------------
+solutions = [
+  { 'name': 'src',
+    'url': crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
+    'deps_file': '.DEPS.git',
+    'custom_deps': {
+      'src':
+        crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
+      'src/third_party/WebKit':
+        crosswalk_git + '/blink-crosswalk.git@' + blink_crosswalk_rev,
+      'src/v8':
+        crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
+
+      # These directories are not relevant to Crosswalk and can be safely ignored
+      # in a checkout. It avoids creating additional directories outside src/ that
+      # are not used and also saves some bandwidth.
+      'build': None,
+      'build/scripts/command_wrapper/bin': None,
+      'build/scripts/gsd_generate_index': None,
+      'build/scripts/private/data/reliability': None,
+      'build/scripts/tools/deps2git': None,
+      'build/third_party/cbuildbot_chromite': None,
+      'build/third_party/gsutil': None,
+      'build/third_party/lighttpd': None,
+      'build/third_party/swarm_client': None,
+      'build/third_party/xvfb': None,
+      'build/xvfb': None,
+      'commit-queue': None,
+      'depot_tools': None,
+    },
+  },
+
+  # ozone-wayland is set as a separate solution because we gclient _not_ to read
+  # its .DEPS.git: it changes the recursion limit and tries to check Chromium
+  # upstream out itself, leading to URL conflicts and errors about duplicate
+  # entries.
+  { 'name': 'src/ozone',
+    'url': ozone_wayland_git + '/ozone-wayland.git@' + ozone_wayland_rev,
+    'deps_file': '',
   }
-}
-
-# These directories are not relevant to Crosswalk and can be safely ignored
-# in a checkout. It avoids creating additional directories outside src/ that
-# are not used and also saves some bandwidth.
-ignored_directories = [
-  'build',
-  'build/scripts/command_wrapper/bin',
-  'build/scripts/gsd_generate_index',
-  'build/scripts/private/data/reliability',
-  'build/scripts/tools/deps2git',
-  'build/third_party/cbuildbot_chromite',
-  'build/third_party/gsutil',
-  'build/third_party/lighttpd',
-  'build/third_party/swarm_client',
-  'build/third_party/xvfb',
-  'build/xvfb',
-  'commit-queue',
-  'depot_tools',
 ]
-for ignored_directory in ignored_directories:
-  chromium_solution['custom_deps'][ignored_directory] = None
-
-# ozone-wayland is set as a separate solution because we gclient _not_ to read
-# its .DEPS.git: it changes the recursion limit and tries to check Chromium
-# upstream out itself, leading to URL conflicts and errors about duplicate
-# entries.
-ozone_wayland_solution = {
-  'name': 'src/ozone',
-  'url': ozone_wayland_git + '/ozone-wayland.git@' + ozone_wayland_rev,
-  'deps_file': '',
-}
-
-solutions = [chromium_solution,
-             ozone_wayland_solution]
 
 # -------------------------------------------------
 # This area is edited by generate_gclient-xwalk.py.

--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -1,22 +1,75 @@
-''' This file indicate the dependencies crosswalk lays on.
-    DO NOT use this DEPS to checkout code, it's for tools/generate_gclient-xwalk.py.
-'''
+# Source code dependencies required for building Crosswalk.
+#
+# This file is used as a template to generate .gclient-xwalk, which is a
+# regular .gclient file pointing to additional source code repositories that
+# need to be checked out in order to build Crosswalk.
+#
+# These dependencies are not specified in DEPS for historical compatibility
+# reasons and also to allow us to perform some additional manipulation on some
+# entries (such as setting a custom value for "deps_file" in certain
+# solutions).
+#
+# If you are doing a DEPS roll, you should only need to worry about the *_rev
+# variables below.
 
-# chromium_version is the version of chromium crosswalk based,
-# Usually it's major.minor.build.patch
-# Use 'Trunk' for trunk.
-# If using trunk, will use '.DEPS.git' for gclient.
+# -----------------------------------
+# Crosswalk dependencies.
+# Edit these when rolling DEPS.xwalk.
+# -----------------------------------
+
 chromium_version = '36.0.1985.144'
-chromium_crosswalk_point = '999bf1e8083cadc1815bc0a1d4e7144bfb934397'
-blink_crosswalk_point = 'd1ccce8c48c838ae502d5ac7c91e8888f9b3605b'
-v8_crosswalk_point = '6da7ea3bcb772dd2b09bedea3c19645b7e6a25df'
-ozone_wayland_point = 'a5ca2e9203e6a0567751cc0400995982b703dde4'
 
-deps_xwalk = {
-  'src': 'https://github.com/crosswalk-project/chromium-crosswalk.git@%s' % chromium_crosswalk_point,
-  'src/third_party/WebKit': 'https://github.com/crosswalk-project/blink-crosswalk.git@%s' % blink_crosswalk_point,
-  'src/v8': 'https://github.com/crosswalk-project/v8-crosswalk.git@%s' % v8_crosswalk_point,
+chromium_crosswalk_rev = '999bf1e8083cadc1815bc0a1d4e7144bfb934397'
+blink_crosswalk_rev = 'd1ccce8c48c838ae502d5ac7c91e8888f9b3605b'
+v8_crosswalk_rev = '6da7ea3bcb772dd2b09bedea3c19645b7e6a25df'
+ozone_wayland_rev = 'a5ca2e9203e6a0567751cc0400995982b703dde4'
 
-  # Ozone-Wayland is required for Wayland support in Chromium.
-  'src/ozone': 'https://github.com/01org/ozone-wayland.git@%s' % ozone_wayland_point,
+crosswalk_git = 'https://github.com/crosswalk-project'
+ozone_wayland_git = 'https://github.com/01org'
+
+# ------------------------------------------------------
+# gclient solutions.
+# You do not need to worry about these most of the time.
+# ------------------------------------------------------
+
+chromium_solution = {
+  'name': chromium_version,
+  'url': 'http://src.chromium.org/svn/releases/' + chromium_version,
+  'custom_deps': {
+    'src':
+      crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
+    'src/third_party/WebKit':
+      crosswalk_git + '/blink-crosswalk.git@' + blink_crosswalk_rev,
+    'src/v8':
+      crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
+    'src/ozone':
+      ozone_wayland_git + '/ozone-wayland.git@' + ozone_wayland_rev,
+  }
 }
+
+# These directories are not relevant to Crosswalk and can be safely ignored
+# in a checkout. It avoids creating additional directories outside src/ that
+# are not used and also saves some bandwidth.
+ignored_directories = [
+  'build',
+  'build/scripts/command_wrapper/bin',
+  'build/scripts/gsd_generate_index',
+  'build/scripts/private/data/reliability',
+  'build/scripts/tools/deps2git',
+  'build/third_party/cbuildbot_chromite',
+  'build/third_party/gsutil',
+  'build/third_party/lighttpd',
+  'build/third_party/swarm_client',
+  'build/third_party/xvfb',
+  'build/xvfb',
+  'commit-queue',
+  'depot_tools',
+]
+for ignored_directory in ignored_directories:
+  chromium_solution['custom_deps'][ignored_directory] = None
+
+solutions = [chromium_solution]
+
+# -------------------------------------------------
+# This area is edited by generate_gclient-xwalk.py.
+# -------------------------------------------------

--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,8 +17,6 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_version = '36.0.1985.144'
-
 chromium_crosswalk_rev = '999bf1e8083cadc1815bc0a1d4e7144bfb934397'
 blink_crosswalk_rev = 'd1ccce8c48c838ae502d5ac7c91e8888f9b3605b'
 v8_crosswalk_rev = '6da7ea3bcb772dd2b09bedea3c19645b7e6a25df'
@@ -33,8 +31,9 @@ ozone_wayland_git = 'https://github.com/01org'
 # ------------------------------------------------------
 
 chromium_solution = {
-  'name': chromium_version,
-  'url': 'http://src.chromium.org/svn/releases/' + chromium_version,
+  'name': 'src',
+  'url': crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
+  'deps_file': '.DEPS.git',
   'custom_deps': {
     'src':
       crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
@@ -42,8 +41,6 @@ chromium_solution = {
       crosswalk_git + '/blink-crosswalk.git@' + blink_crosswalk_rev,
     'src/v8':
       crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
-    'src/ozone':
-      ozone_wayland_git + '/ozone-wayland.git@' + ozone_wayland_rev,
   }
 }
 
@@ -68,7 +65,18 @@ ignored_directories = [
 for ignored_directory in ignored_directories:
   chromium_solution['custom_deps'][ignored_directory] = None
 
-solutions = [chromium_solution]
+# ozone-wayland is set as a separate solution because we gclient _not_ to read
+# its .DEPS.git: it changes the recursion limit and tries to check Chromium
+# upstream out itself, leading to URL conflicts and errors about duplicate
+# entries.
+ozone_wayland_solution = {
+  'name': 'src/ozone',
+  'url': ozone_wayland_git + '/ozone-wayland.git@' + ozone_wayland_rev,
+  'deps_file': '',
+}
+
+solutions = [chromium_solution,
+             ozone_wayland_solution]
 
 # -------------------------------------------------
 # This area is edited by generate_gclient-xwalk.py.

--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -47,46 +47,31 @@ class GClientFileGenerator(object):
     self._deps = exec_globals['deps_xwalk']
     self._chromium_version = exec_globals['chromium_version']
 
-  def _AddIgnorePathFromEnv(self):
-    """Read paths from environ XWALK_SYNC_IGNORE.
-       Set the path with None value to ignore it when syncing chromium.
-
-       If environ not set, will ignore the ones upstream wiki recommended
-       by default.
+  def _AddIgnoredPaths(self):
     """
-    ignores_str = os.environ.get("XWALK_SYNC_IGNORE")
-    if not ignores_str:
-      ignores = ['build',
-                 'build/scripts/command_wrapper/bin',
-                 'build/scripts/gsd_generate_index',
-                 'build/scripts/private/data/reliability',
-                 'build/scripts/tools/deps2git',
-                 'build/third_party/cbuildbot_chromite',
-                 'build/third_party/gsutil',
-                 'build/third_party/lighttpd',
-                 'build/third_party/swarm_client',
-                 'build/third_party/xvfb',
-                 'build/xvfb',
-                 'commit-queue',
-                 'depot_tools',
-                 'src/webkit/data/layout_tests/LayoutTests',
-                 'src/third_party/WebKit/LayoutTests',
-                 'src/content/test/data/layout_tests/LayoutTests',
-                 'src/chrome/tools/test/reference_build/chrome_win',
-                 'src/chrome_frame/tools/test/reference_build/chrome_win',
-                 'src/chrome/tools/test/reference_build/chrome_linux',
-                 'src/chrome/tools/test/reference_build/chrome_mac',
-                 'src/third_party/chromite',
-                 'src/third_party/hunspell_dictionaries',
-                 'src/third_party/pyelftools']
-    else:
-      ignores_str = ignores_str.replace(':', ';')
-      ignores = ignores_str.split(';')
+    Excludes certain directories from a checkout that are not relevant to
+    Crosswalk (basically, directories outside src/).
+    """
+    ignores = [
+      'build',
+      'build/scripts/command_wrapper/bin',
+      'build/scripts/gsd_generate_index',
+      'build/scripts/private/data/reliability',
+      'build/scripts/tools/deps2git',
+      'build/third_party/cbuildbot_chromite',
+      'build/third_party/gsutil',
+      'build/third_party/lighttpd',
+      'build/third_party/swarm_client',
+      'build/third_party/xvfb',
+      'build/xvfb',
+      'commit-queue',
+      'depot_tools',
+    ]
     for ignore in ignores:
       self._deps[ignore] = None
 
   def Generate(self):
-    self._AddIgnorePathFromEnv()
+    self._AddIgnoredPaths()
     solution = {
       'name': self._chromium_version,
       'url': 'http://src.chromium.org/svn/releases/%s' %

--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -96,8 +96,7 @@ def main():
                                 'cached there and shared across multiple '
                                 'clones.')
 
-  # pylint: disable=W0612
-  options, args = option_parser.parse_args()
+  options, _ = option_parser.parse_args()
 
   sys.exit(GClientFileGenerator(options).Generate())
 

--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -26,7 +26,6 @@ class GClientFileGenerator(object):
     else:
       self._deps_file = os.path.join(self._xwalk_dir, 'DEPS.xwalk')
     self._deps = None
-    self._vars = None
     self._chromium_version = None
     self._ParseDepsFile()
     if not 'src' in self._deps:
@@ -46,7 +45,6 @@ class GClientFileGenerator(object):
 
     execfile(self._deps_file, exec_globals)
     self._deps = exec_globals['deps_xwalk']
-    self._vars = exec_globals['vars_xwalk']
     self._chromium_version = exec_globals['chromium_version']
 
   def _AddIgnorePathFromEnv(self):
@@ -95,8 +93,6 @@ class GClientFileGenerator(object):
               self._chromium_version,
       'custom_deps': self._deps,
     }
-    if self._vars:
-      solution['custom_vars'] = self._vars
     solutions = [solution]
     gclient_file = open(self._new_gclient_file, 'w')
     print "Place %s with solutions:\n%s" % (self._new_gclient_file, solutions)

--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -6,99 +6,40 @@
 
 """
 This script is responsible for generating .gclient-xwalk in the top-level
-source directory by parsing .DEPS.xwalk.
+source directory from DEPS.xwalk.
 """
 
 import optparse
 import os
 import pprint
-import sys
 
 
-class GClientFileGenerator(object):
-  def __init__(self, options):
-    self._options = options
-    self._xwalk_dir = os.path.dirname(
-        os.path.dirname(os.path.abspath(__file__)))
-    self._deps_file = os.path.join(self._xwalk_dir, 'DEPS.xwalk')
-    self._deps = None
-    self._chromium_version = None
-    self._ParseDepsFile()
-    if not 'src' in self._deps:
-      raise RuntimeError("'src' not specified in deps file(%s)" % options.deps)
-    self._src_dep = self._deps['src']
-    # self should be at src/xwalk/tools/fetch_deps.py
-    # so src is at self/../../../
-    self._src_dir = os.path.dirname(self._xwalk_dir)
-    self._root_dir = os.path.dirname(self._src_dir)
-    self._new_gclient_file = os.path.join(self._root_dir,
-                                          '.gclient-xwalk')
+CROSSWALK_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GCLIENT_ROOT = os.path.dirname(os.path.dirname(CROSSWALK_ROOT))
 
-  def _ParseDepsFile(self):
-    if not os.path.exists(self._deps_file):
-      raise IOError('Deps file does not exist (%s).' % self._deps_file)
-    exec_globals = {}
 
-    execfile(self._deps_file, exec_globals)
-    self._deps = exec_globals['deps_xwalk']
-    self._chromium_version = exec_globals['chromium_version']
+def GenerateGClientXWalk(options):
+  with open(os.path.join(CROSSWALK_ROOT, 'DEPS.xwalk')) as deps_file:
+    deps_contents = deps_file.read()
 
-  def _AddIgnoredPaths(self):
-    """
-    Excludes certain directories from a checkout that are not relevant to
-    Crosswalk (basically, directories outside src/).
-    """
-    ignores = [
-      'build',
-      'build/scripts/command_wrapper/bin',
-      'build/scripts/gsd_generate_index',
-      'build/scripts/private/data/reliability',
-      'build/scripts/tools/deps2git',
-      'build/third_party/cbuildbot_chromite',
-      'build/third_party/gsutil',
-      'build/third_party/lighttpd',
-      'build/third_party/swarm_client',
-      'build/third_party/xvfb',
-      'build/xvfb',
-      'commit-queue',
-      'depot_tools',
-    ]
-    for ignore in ignores:
-      self._deps[ignore] = None
+  if 'XWALK_OS_ANDROID' in os.environ:
+    deps_contents += 'target_os = [\'android\']\n'
+  if options.cache_dir:
+    deps_contents += 'cache_dir = %s\n' % pprint.pformat(options.cache_dir)
 
-  def Generate(self):
-    self._AddIgnoredPaths()
-    solution = {
-      'name': self._chromium_version,
-      'url': 'http://src.chromium.org/svn/releases/%s' %
-              self._chromium_version,
-      'custom_deps': self._deps,
-    }
-    solutions = [solution]
-    gclient_file = open(self._new_gclient_file, 'w')
-    print "Place %s with solutions:\n%s" % (self._new_gclient_file, solutions)
-    gclient_file.write('solutions = %s\n' % pprint.pformat(solutions))
-    # Check whether the target OS is Android.
-    if os.environ.get('XWALK_OS_ANDROID'):
-      target_os = ['android']
-      gclient_file.write('target_os = %s\n' % target_os)
-    if self._options.cache_dir:
-      gclient_file.write('cache_dir = %s\n' %
-                         pprint.pformat(self._options.cache_dir))
+  with open(os.path.join(GCLIENT_ROOT, '.gclient-xwalk'), 'w') as gclient_file:
+    gclient_file.write(deps_contents)
 
 
 def main():
   option_parser = optparse.OptionParser()
-
   option_parser.add_option('--cache-dir',
                            help='Set "cache_dir" in the .gclient file to this '
                                 'directory, so that all git repositories are '
                                 'cached there and shared across multiple '
                                 'clones.')
-
   options, _ = option_parser.parse_args()
-
-  sys.exit(GClientFileGenerator(options).Generate())
+  GenerateGClientXWalk(options)
 
 
 if __name__ == '__main__':

--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -7,8 +7,11 @@
 """
 This script is responsible for generating .gclient-xwalk in the top-level
 source directory from DEPS.xwalk.
+
+User-configurable values such as |cache_dir| are fetched from .gclient instead.
 """
 
+import logging
 import optparse
 import os
 import pprint
@@ -18,14 +21,33 @@ CROSSWALK_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GCLIENT_ROOT = os.path.dirname(os.path.dirname(CROSSWALK_ROOT))
 
 
+def ParseGClientConfig():
+  """
+  Parses the top-level .gclient file (NOT .gclient-xwalk) and returns the
+  values set there as a dictionary.
+  """
+  with open(os.path.join(GCLIENT_ROOT, '.gclient')) as dot_gclient:
+    config = {}
+    exec(dot_gclient, config)
+  return config
+
+
 def GenerateGClientXWalk(options):
   with open(os.path.join(CROSSWALK_ROOT, 'DEPS.xwalk')) as deps_file:
     deps_contents = deps_file.read()
 
   if 'XWALK_OS_ANDROID' in os.environ:
     deps_contents += 'target_os = [\'android\']\n'
+
+  gclient_config = ParseGClientConfig()
   if options.cache_dir:
-    deps_contents += 'cache_dir = %s\n' % pprint.pformat(options.cache_dir)
+    logging.warning('--cache_dir is deprecated and will be removed in '
+                    'Crosswalk 8. You should set cache_dir in .gclient '
+                    'instead.')
+    cache_dir = options.cache_dir
+  else:
+    cache_dir = gclient_config.get('cache_dir')
+  deps_contents += 'cache_dir = %s\n' % pprint.pformat(cache_dir)
 
   with open(os.path.join(GCLIENT_ROOT, '.gclient-xwalk'), 'w') as gclient_file:
     gclient_file.write(deps_contents)
@@ -33,11 +55,11 @@ def GenerateGClientXWalk(options):
 
 def main():
   option_parser = optparse.OptionParser()
+  # TODO(rakuco): Remove in Crosswalk 8.
   option_parser.add_option('--cache-dir',
-                           help='Set "cache_dir" in the .gclient file to this '
-                                'directory, so that all git repositories are '
-                                'cached there and shared across multiple '
-                                'clones.')
+                           help='DEPRECATED Set "cache_dir" in .gclient-xwalk '
+                                'to this directory, so that all git '
+                                'repositories are cached there.')
   options, _ = option_parser.parse_args()
   GenerateGClientXWalk(options)
 

--- a/tools/generate_gclient-xwalk.py
+++ b/tools/generate_gclient-xwalk.py
@@ -6,8 +6,7 @@
 
 """
 This script is responsible for generating .gclient-xwalk in the top-level
-source directory by parsing .DEPS.xwalk (or any other file passed to the --deps
-option).
+source directory by parsing .DEPS.xwalk.
 """
 
 import optparse
@@ -21,10 +20,7 @@ class GClientFileGenerator(object):
     self._options = options
     self._xwalk_dir = os.path.dirname(
         os.path.dirname(os.path.abspath(__file__)))
-    if options.deps:
-      self._deps_file = options.deps
-    else:
-      self._deps_file = os.path.join(self._xwalk_dir, 'DEPS.xwalk')
+    self._deps_file = os.path.join(self._xwalk_dir, 'DEPS.xwalk')
     self._deps = None
     self._chromium_version = None
     self._ParseDepsFile()
@@ -94,9 +90,6 @@ class GClientFileGenerator(object):
 def main():
   option_parser = optparse.OptionParser()
 
-  option_parser.add_option('--deps', default=None,
-                           help='The deps file contains the dependencies path '
-                                'and url')
   option_parser.add_option('--cache-dir',
                            help='Set "cache_dir" in the .gclient file to this '
                                 'directory, so that all git repositories are '


### PR DESCRIPTION
This pull request backports several commits related to XWALK-1894 (which was about tracking all Chromium dependencies with git repositories instead of SVN ones). They are present in Crosswalk >= 8, but we may need to do one additional Crosswalk 7 build, and since the 36.0.1985.144 release is not present in SVN we need those commits for the build to work.