### PR TITLE
[Android] Set the command line to webkit Preference

### DIFF
--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -17,6 +17,7 @@
 #include "content/public/common/web_preferences.h"
 #include "jni/XWalkSettings_jni.h"
 #include "xwalk/runtime/common/xwalk_content_client.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 #include "xwalk/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h"
 #include "xwalk/runtime/browser/android/xwalk_content.h"
 
@@ -197,6 +198,12 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
 
   prefs.user_gesture_required_for_media_playback = env->GetBooleanField(
       obj, field_ids_->media_playback_requires_user_gesture);
+
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  prefs.allow_running_insecure_content =
+      command_line->HasSwitch(switches::kAllowRunningInsecureContent);
+  prefs.allow_displaying_insecure_content =
+      !command_line->HasSwitch(switches::kNoDisplayingInsecureContent);
 
   ScopedJavaLocalRef<jstring> str;
   str.Reset(

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -30,4 +30,12 @@ const char kXWalkDataPath[] = "data-path";
 const char kXWalkProfileName[] = "profile-name";
 #endif
 
+// By default, an https page cannot run JavaScript, CSS or plug-ins from http
+// URLs. This provides an override to get the old insecure behavior.
+const char kAllowRunningInsecureContent[]   = "allow-running-insecure-content";
+
+// By default, an https page can load images, fonts or frames from an http
+// page. This switch overrides this to block this lesser mixed-content problem.
+const char kNoDisplayingInsecureContent[]   = "no-displaying-insecure-content";
+
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -16,6 +16,8 @@ extern const char kExperimentalFeatures[];
 extern const char kListFeaturesFlags[];
 extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
 extern const char kXWalkDataPath[];
+extern const char kAllowRunningInsecureContent[];
+extern const char kNoDisplayingInsecureContent[];
 
 #if defined(OS_ANDROID)
 extern const char kXWalkProfileName[];


### PR DESCRIPTION
The command of "--allow-running-insecure-content" in assets directory
do not effect the Webkit behavior because not set it to Webkit
preference.

(cherry picked from commit 19971ff4b322372b622f3432a9ea89c1f4cf2cdd)