### PR TITLE
[Linux] Add Linux IME support.

### DIFF
--- a/runtime/browser/ui/x11_input_method_context_factory.cc
+++ b/runtime/browser/ui/x11_input_method_context_factory.cc
@@ -1,0 +1,108 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ui/x11_input_method_context_factory.h"
+
+#include <gdk/gdk.h>
+#include <gdk/gdkx.h>
+#include <gtk/gtk.h>
+#include <X11/X.h>
+
+#include <string>
+#include <vector>
+
+#include "base/command_line.h"
+#include "base/debug/leak_annotations.h"
+#include "ui/gfx/x/x11_types.h"
+#include "xwalk/runtime/browser/ui/x11_input_method_context_impl_gtk2.h"
+
+namespace {
+
+void GtkInitFromCommandLine(const base::CommandLine& command_line) {
+  const std::vector<std::string>& args = command_line.argv();
+  int argc = args.size();
+  scoped_ptr<char *[]> argv(new char *[argc + 1]);
+  for (size_t i = 0; i < args.size(); ++i) {
+    // TODO(piman@google.com): can gtk_init modify argv? Just being safe
+    // here.
+    argv[i] = strdup(args[i].c_str());
+  }
+  argv[argc] = NULL;
+  char **argv_pointer = argv.get();
+
+  {
+    // http://crbug.com/423873
+    ANNOTATE_SCOPED_MEMORY_LEAK;
+    gtk_init(&argc, &argv_pointer);
+  }
+  for (size_t i = 0; i < args.size(); ++i) {
+    free(argv[i]);
+  }
+}
+
+void ProcessGdkEventKey(const GdkEventKey& gdk_event_key) {
+  // This function translates GdkEventKeys into XKeyEvents and puts them to
+  // the X event queue.
+  //
+  // base::MessagePumpX11 is using the X11 event queue and all key events should
+  // be processed there.  However, there are cases(*1) that GdkEventKeys are
+  // created instead of XKeyEvents.  In these cases, we have to translate
+  // GdkEventKeys to XKeyEvents and puts them to the X event queue so our main
+  // event loop can handle those key events.
+  //
+  // (*1) At least ibus-gtk in async mode creates a copy of user's key event and
+  // pushes it back to the GDK event queue.  In this case, there is no
+  // corresponding key event in the X event queue.  So we have to handle this
+  // case.  ibus-gtk is used through gtk-immodule to support IMEs.
+
+  XEvent x_event = {0};
+  x_event.xkey.type =
+      gdk_event_key.type == GDK_KEY_PRESS ? KeyPress : KeyRelease;
+  x_event.xkey.send_event = gdk_event_key.send_event;
+  x_event.xkey.display = gfx::GetXDisplay();
+  x_event.xkey.window = GDK_WINDOW_XID(gdk_event_key.window);
+  x_event.xkey.root = DefaultRootWindow(x_event.xkey.display);
+  x_event.xkey.time = gdk_event_key.time;
+  x_event.xkey.state = gdk_event_key.state;
+  x_event.xkey.keycode = gdk_event_key.hardware_keycode;
+  x_event.xkey.same_screen = true;
+
+  XPutBackEvent(x_event.xkey.display, &x_event);
+}
+
+void DispatchGdkEvent(GdkEvent* gdk_event, gpointer) {
+  switch (gdk_event->type) {
+    case GDK_KEY_PRESS:
+    case GDK_KEY_RELEASE:
+      ProcessGdkEventKey(gdk_event->key);
+      break;
+    default:
+      break;  // Do nothing.
+  }
+
+  gtk_main_do_event(gdk_event);
+}
+
+}  // namespace
+
+namespace xwalk {
+
+X11InputMethodContextFactory::X11InputMethodContextFactory() {
+  GtkInitFromCommandLine(*base::CommandLine::ForCurrentProcess());
+  gdk_event_handler_set(DispatchGdkEvent, NULL, NULL);
+}
+
+X11InputMethodContextFactory::~X11InputMethodContextFactory() {
+  gdk_event_handler_set(reinterpret_cast<GdkEventFunc>(gtk_main_do_event),
+                        NULL, NULL);
+}
+
+scoped_ptr<ui::LinuxInputMethodContext>
+X11InputMethodContextFactory::CreateInputMethodContext(
+    ui::LinuxInputMethodContextDelegate* delegate) const {
+  return make_scoped_ptr(new X11InputMethodContextImplGtk2(delegate));
+}
+
+}  // namespace xwalk

--- a/runtime/browser/ui/x11_input_method_context_factory.h
+++ b/runtime/browser/ui/x11_input_method_context_factory.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_X11_INPUT_METHOD_CONTEXT_FACTORY_H_
+#define XWALK_RUNTIME_BROWSER_UI_X11_INPUT_METHOD_CONTEXT_FACTORY_H_
+
+#include "ui/base/ime/linux/linux_input_method_context_factory.h"
+
+namespace xwalk {
+
+class X11InputMethodContextFactory : public ui::LinuxInputMethodContextFactory {
+ public:
+  X11InputMethodContextFactory();
+  ~X11InputMethodContextFactory() override;
+
+  // LinuxInputMethodContextFactory implementation.
+  scoped_ptr<ui::LinuxInputMethodContext> CreateInputMethodContext(
+      ui::LinuxInputMethodContextDelegate* delegate) const override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(X11InputMethodContextFactory);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_X11_INPUT_METHOD_CONTEXT_FACTORY_H_

--- a/runtime/browser/ui/x11_input_method_context_impl_gtk2.cc
+++ b/runtime/browser/ui/x11_input_method_context_impl_gtk2.cc
@@ -1,0 +1,391 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ui/x11_input_method_context_impl_gtk2.h"
+
+#include <gdk/gdk.h>
+#include <gdk/gdkkeysyms.h>
+#include <gdk/gdkx.h>
+#include <gtk/gtk.h>
+
+#include <X11/X.h>
+#include <X11/Xlib.h>
+
+#include <string>
+
+#include "base/message_loop/message_loop.h"
+#include "base/strings/utf_string_conversions.h"
+#include "ui/base/ime/composition_text.h"
+#include "ui/base/ime/composition_text_util_pango.h"
+#include "ui/base/ime/text_input_client.h"
+#include "ui/events/event.h"
+#include "ui/events/keycodes/keyboard_code_conversion_x.h"
+#include "ui/gfx/x/x11_types.h"
+
+namespace xwalk {
+
+X11InputMethodContextImplGtk2::X11InputMethodContextImplGtk2(
+    ui::LinuxInputMethodContextDelegate* delegate)
+    : delegate_(delegate),
+      gtk_context_simple_(NULL),
+      gtk_multicontext_(NULL),
+      gtk_context_(NULL),
+      gdk_last_set_client_window_(NULL) {
+  CHECK(delegate_);
+
+  ResetXModifierKeycodesCache();
+
+  gtk_context_simple_ = gtk_im_context_simple_new();
+  gtk_multicontext_ = gtk_im_multicontext_new();
+
+  GtkIMContext* contexts[] = {gtk_context_simple_, gtk_multicontext_};
+  for (size_t i = 0; i < arraysize(contexts); ++i) {
+    g_signal_connect(contexts[i], "commit",
+                     G_CALLBACK(OnCommitThunk), this);
+    g_signal_connect(contexts[i], "preedit-changed",
+                     G_CALLBACK(OnPreeditChangedThunk), this);
+    g_signal_connect(contexts[i], "preedit-end",
+                     G_CALLBACK(OnPreeditEndThunk), this);
+    g_signal_connect(contexts[i], "preedit-start",
+                     G_CALLBACK(OnPreeditStartThunk), this);
+    // TODO(yukishiino): Handle operations on surrounding text.
+    // "delete-surrounding" and "retrieve-surrounding" signals should be
+    // handled.
+  }
+}
+
+X11InputMethodContextImplGtk2::~X11InputMethodContextImplGtk2() {
+  gtk_context_ = NULL;
+  if (gtk_context_simple_) {
+    g_object_unref(gtk_context_simple_);
+    gtk_context_simple_ = NULL;
+  }
+  if (gtk_multicontext_) {
+    g_object_unref(gtk_multicontext_);
+    gtk_multicontext_ = NULL;
+  }
+}
+
+// Overriden from ui::LinuxInputMethodContext
+
+bool X11InputMethodContextImplGtk2::DispatchKeyEvent(
+    const ui::KeyEvent& key_event) {
+  if (!key_event.HasNativeEvent())
+    return false;
+
+  // The caller must call Focus() first.
+  if (!gtk_context_)
+    return false;
+
+  // Translate a XKeyEvent to a GdkEventKey.
+  GdkEvent* event = GdkEventFromNativeEvent(key_event.native_event());
+  if (!event) {
+    LOG(ERROR) << "Cannot translate a XKeyEvent to a GdkEvent.";
+    return false;
+  }
+
+  // Set the client window and cursor location.
+  if (event->key.window != gdk_last_set_client_window_) {
+    gtk_im_context_set_client_window(gtk_context_, event->key.window);
+    gdk_last_set_client_window_ = event->key.window;
+  }
+  // Convert the last known caret bounds relative to the screen coordinates
+  // to a GdkRectangle relative to the client window.
+  gint x = 0;
+  gint y = 0;
+  gdk_window_get_origin(event->key.window, &x, &y);
+  GdkRectangle rect = {last_caret_bounds_.x() - x,
+                       last_caret_bounds_.y() - y,
+                       last_caret_bounds_.width(),
+                       last_caret_bounds_.height()};
+  gtk_im_context_set_cursor_location(gtk_context_, &rect);
+
+  // Let an IME handle the key event.
+  commit_signal_trap_.StartTrap(event->key.keyval);
+  const gboolean handled = gtk_im_context_filter_keypress(gtk_context_,
+                                                          &event->key);
+  commit_signal_trap_.StopTrap();
+  gdk_event_free(event);
+
+  return handled && !commit_signal_trap_.IsSignalCaught();
+}
+
+void X11InputMethodContextImplGtk2::Reset() {
+  // Reset all the states of the context, not only preedit, caret but also
+  // focus.
+  gtk_context_ = NULL;
+  gtk_im_context_reset(gtk_context_simple_);
+  gtk_im_context_reset(gtk_multicontext_);
+  gtk_im_context_focus_out(gtk_context_simple_);
+  gtk_im_context_focus_out(gtk_multicontext_);
+  gdk_last_set_client_window_ = NULL;
+}
+
+void X11InputMethodContextImplGtk2::OnTextInputTypeChanged(
+    ui::TextInputType text_input_type) {
+  switch (text_input_type) {
+    case ui::TEXT_INPUT_TYPE_NONE:
+    case ui::TEXT_INPUT_TYPE_PASSWORD:
+      gtk_context_ = gtk_context_simple_;
+      break;
+    default:
+      gtk_context_ = gtk_multicontext_;
+  }
+  gtk_im_context_focus_in(gtk_context_);
+}
+
+void X11InputMethodContextImplGtk2::OnCaretBoundsChanged(
+    const gfx::Rect& caret_bounds) {
+  // Remember the caret bounds so that we can set the cursor location later.
+  // gtk_im_context_set_cursor_location() takes the location relative to the
+  // client window, which is unknown at this point.  So we'll call
+  // gtk_im_context_set_cursor_location() later in ProcessKeyEvent() where
+  // (and only where) we know the client window.
+  last_caret_bounds_ = caret_bounds;
+}
+
+// private:
+
+void X11InputMethodContextImplGtk2::ResetXModifierKeycodesCache() {
+  modifier_keycodes_.clear();
+  meta_keycodes_.clear();
+  super_keycodes_.clear();
+  hyper_keycodes_.clear();
+
+  Display* display = gfx::GetXDisplay();
+  const XModifierKeymap* modmap = XGetModifierMapping(display);
+  int min_keycode = 0;
+  int max_keycode = 0;
+  int keysyms_per_keycode = 1;
+  XDisplayKeycodes(display, &min_keycode, &max_keycode);
+  const KeySym* keysyms = XGetKeyboardMapping(
+      display, min_keycode, max_keycode - min_keycode + 1,
+      &keysyms_per_keycode);
+  for (int i = 0; i < 8 * modmap->max_keypermod; ++i) {
+    const int keycode = modmap->modifiermap[i];
+    if (!keycode)
+      continue;
+    modifier_keycodes_.insert(keycode);
+
+    if (!keysyms)
+      continue;
+    for (int j = 0; j < keysyms_per_keycode; ++j) {
+      switch (keysyms[(keycode - min_keycode) * keysyms_per_keycode + j]) {
+        case XK_Meta_L:
+        case XK_Meta_R:
+          meta_keycodes_.push_back(keycode);
+          break;
+        case XK_Super_L:
+        case XK_Super_R:
+          super_keycodes_.push_back(keycode);
+          break;
+        case XK_Hyper_L:
+        case XK_Hyper_R:
+          hyper_keycodes_.push_back(keycode);
+          break;
+      }
+    }
+  }
+  XFree(const_cast<KeySym*>(keysyms));
+  XFreeModifiermap(const_cast<XModifierKeymap*>(modmap));
+}
+
+GdkEvent* X11InputMethodContextImplGtk2::GdkEventFromNativeEvent(
+    const base::NativeEvent& native_event) {
+  XEvent xkeyevent;
+  if (native_event->type == GenericEvent) {
+    // If this is an XI2 key event, build a matching core X event, to avoid
+    // having two cases for every use.
+    ui::InitXKeyEventFromXIDeviceEvent(*native_event, &xkeyevent);
+  } else {
+    DCHECK(native_event->type == KeyPress || native_event->type == KeyRelease);
+    xkeyevent.xkey = native_event->xkey;
+  }
+  XKeyEvent& xkey = xkeyevent.xkey;
+
+  // Get a GdkDisplay.
+  GdkDisplay* display = gdk_x11_lookup_xdisplay(xkey.display);
+  if (!display) {
+    // Fall back to the default display.
+    display = gdk_display_get_default();
+  }
+  if (!display) {
+    LOG(ERROR) << "Cannot get a GdkDisplay for a key event.";
+    return NULL;
+  }
+  // Get a keysym and group.
+  KeySym keysym = NoSymbol;
+  guint8 keyboard_group = 0;
+  XLookupString(&xkey, NULL, 0, &keysym, NULL);
+  GdkKeymap* keymap = gdk_keymap_get_for_display(display);
+  GdkKeymapKey* keys = NULL;
+  guint* keyvals = NULL;
+  gint n_entries = 0;
+  if (keymap &&
+      gdk_keymap_get_entries_for_keycode(keymap, xkey.keycode,
+                                         &keys, &keyvals, &n_entries)) {
+    for (gint i = 0; i < n_entries; ++i) {
+      if (keyvals[i] == keysym) {
+        keyboard_group = keys[i].group;
+        break;
+      }
+    }
+  }
+  g_free(keys);
+  keys = NULL;
+  g_free(keyvals);
+  keyvals = NULL;
+  // Get a GdkWindow.
+#if GTK_CHECK_VERSION(2, 24, 0)
+  GdkWindow* window = gdk_x11_window_lookup_for_display(display, xkey.window);
+#else
+  GdkWindow* window = gdk_window_lookup_for_display(display, xkey.window);
+#endif
+  if (window)
+    g_object_ref(window);
+  else
+#if GTK_CHECK_VERSION(2, 24, 0)
+    window = gdk_x11_window_foreign_new_for_display(display, xkey.window);
+#else
+    window = gdk_window_foreign_new_for_display(display, xkey.window);
+#endif
+  if (!window) {
+    LOG(ERROR) << "Cannot get a GdkWindow for a key event.";
+    return NULL;
+  }
+
+  // Create a GdkEvent.
+  GdkEventType event_type = xkey.type == KeyPress ?
+                            GDK_KEY_PRESS : GDK_KEY_RELEASE;
+  GdkEvent* event = gdk_event_new(event_type);
+  event->key.type = event_type;
+  event->key.window = window;
+  // GdkEventKey and XKeyEvent share the same definition for time and state.
+  event->key.send_event = xkey.send_event;
+  event->key.time = xkey.time;
+  event->key.state = xkey.state;
+  event->key.keyval = keysym;
+  event->key.length = 0;
+  event->key.string = NULL;
+  event->key.hardware_keycode = xkey.keycode;
+  event->key.group = keyboard_group;
+  event->key.is_modifier = IsKeycodeModifierKey(xkey.keycode);
+
+  char keybits[32] = {0};
+  XQueryKeymap(xkey.display, keybits);
+  if (IsAnyOfKeycodesPressed(meta_keycodes_, keybits, sizeof keybits * 8))
+    event->key.state |= GDK_META_MASK;
+  if (IsAnyOfKeycodesPressed(super_keycodes_, keybits, sizeof keybits * 8))
+    event->key.state |= GDK_SUPER_MASK;
+  if (IsAnyOfKeycodesPressed(hyper_keycodes_, keybits, sizeof keybits * 8))
+    event->key.state |= GDK_HYPER_MASK;
+
+  return event;
+}
+
+bool X11InputMethodContextImplGtk2::IsKeycodeModifierKey(
+    unsigned int keycode) const {
+  return modifier_keycodes_.find(keycode) != modifier_keycodes_.end();
+}
+
+bool X11InputMethodContextImplGtk2::IsAnyOfKeycodesPressed(
+    const std::vector<int>& keycodes,
+    const char* keybits,
+    int num_keys) const {
+  for (size_t i = 0; i < keycodes.size(); ++i) {
+    const int keycode = keycodes[i];
+    if (keycode < 0 || num_keys <= keycode)
+      continue;
+    if (keybits[keycode / 8] & 1 << (keycode % 8))
+      return true;
+  }
+  return false;
+}
+
+// GtkIMContext event handlers.
+
+void X11InputMethodContextImplGtk2::OnCommit(GtkIMContext* context,
+                                             gchar* text) {
+  if (context != gtk_context_)
+    return;
+
+  const base::string16& text_in_utf16 = base::UTF8ToUTF16(text);
+  // If an underlying IME is emitting the "commit" signal to insert a character
+  // for a direct input key event, ignores the insertion of the character at
+  // this point, because we have to call DispatchKeyEventPostIME() for direct
+  // input key events.  DispatchKeyEvent() takes care of the trapped character
+  // and calls DispatchKeyEventPostIME().
+  if (commit_signal_trap_.Trap(text_in_utf16))
+    return;
+
+  delegate_->OnCommit(text_in_utf16);
+}
+
+void X11InputMethodContextImplGtk2::OnPreeditChanged(GtkIMContext* context) {
+  if (context != gtk_context_)
+    return;
+
+  gchar* str = NULL;
+  PangoAttrList* attrs = NULL;
+  gint cursor_pos = 0;
+  gtk_im_context_get_preedit_string(context, &str, &attrs, &cursor_pos);
+  ui::CompositionText composition_text;
+  ui::ExtractCompositionTextFromGtkPreedit(str, attrs, cursor_pos,
+                                           &composition_text);
+  g_free(str);
+  pango_attr_list_unref(attrs);
+
+  delegate_->OnPreeditChanged(composition_text);
+}
+
+void X11InputMethodContextImplGtk2::OnPreeditEnd(GtkIMContext* context) {
+  if (context != gtk_context_)
+    return;
+
+  delegate_->OnPreeditEnd();
+}
+
+void X11InputMethodContextImplGtk2::OnPreeditStart(GtkIMContext* context) {
+  if (context != gtk_context_)
+    return;
+
+  delegate_->OnPreeditStart();
+}
+
+// GtkCommitSignalTrap
+
+X11InputMethodContextImplGtk2::GtkCommitSignalTrap::GtkCommitSignalTrap()
+    : is_trap_enabled_(false),
+#if GTK_CHECK_VERSION (2, 22, 0)
+      gdk_event_key_keyval_(GDK_KEY_VoidSymbol),
+#else
+      gdk_event_key_keyval_(GDK_VoidSymbol),
+#endif
+      is_signal_caught_(false) {}
+
+void X11InputMethodContextImplGtk2::GtkCommitSignalTrap::StartTrap(
+    guint keyval) {
+  is_signal_caught_ = false;
+  gdk_event_key_keyval_ = keyval;
+  is_trap_enabled_ = true;
+}
+
+void X11InputMethodContextImplGtk2::GtkCommitSignalTrap::StopTrap() {
+  is_trap_enabled_ = false;
+}
+
+bool X11InputMethodContextImplGtk2::GtkCommitSignalTrap::Trap(
+    const base::string16& text) {
+  DCHECK(!is_signal_caught_);
+  if (is_trap_enabled_ &&
+      text.length() == 1 &&
+      text[0] == gdk_keyval_to_unicode(gdk_event_key_keyval_)) {
+    is_signal_caught_ = true;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+}  // namespace xwalk

--- a/runtime/browser/ui/x11_input_method_context_impl_gtk2.h
+++ b/runtime/browser/ui/x11_input_method_context_impl_gtk2.h
@@ -1,0 +1,142 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_X11_INPUT_METHOD_CONTEXT_IMPL_GTK2_H_
+#define XWALK_RUNTIME_BROWSER_UI_X11_INPUT_METHOD_CONTEXT_IMPL_GTK2_H_
+
+#include <vector>
+
+#include "base/containers/hash_tables.h"
+#include "base/event_types.h"
+#include "base/gtest_prod_util.h"
+#include "base/strings/string16.h"
+#include "ui/base/glib/glib_integers.h"
+#include "ui/base/glib/glib_signal.h"
+#include "ui/base/ime/linux/linux_input_method_context.h"
+#include "ui/gfx/geometry/rect.h"
+
+typedef union _GdkEvent GdkEvent;
+typedef struct _GdkDrawable GdkWindow;
+typedef struct _GtkIMContext GtkIMContext;
+
+namespace xwalk {
+
+// An implementation of LinuxInputMethodContext which is based on X11 event loop
+// and uses GtkIMContext(gtk-immodule) as a bridge from/to underlying IMEs.
+class X11InputMethodContextImplGtk2 : public ui::LinuxInputMethodContext {
+ public:
+  explicit X11InputMethodContextImplGtk2(
+      ui::LinuxInputMethodContextDelegate* delegate);
+  ~X11InputMethodContextImplGtk2() override;
+
+  // Overriden from ui::LinuxInputMethodContext
+  bool DispatchKeyEvent(const ui::KeyEvent& key_event) override;
+  void Reset() override;
+  void OnTextInputTypeChanged(ui::TextInputType text_input_type) override;
+  void OnCaretBoundsChanged(const gfx::Rect& caret_bounds) override;
+
+ private:
+  // Resets the cache of X modifier keycodes.
+  // TODO(yukishiino): We should call this method whenever X keyboard mapping
+  // changes, for example when a user switched to another keyboard layout.
+  void ResetXModifierKeycodesCache();
+
+  // Constructs a GdkEventKey from a XKeyEvent and returns it.  Otherwise,
+  // returns NULL.  The returned GdkEvent must be freed by gdk_event_free.
+  GdkEvent* GdkEventFromNativeEvent(const base::NativeEvent& native_event);
+
+  // Returns true if the hardware |keycode| is assigned to a modifier key.
+  bool IsKeycodeModifierKey(unsigned int keycode) const;
+
+  // Returns true if one of |keycodes| is pressed.  |keybits| is a bit vector
+  // returned by XQueryKeymap, and |num_keys| is the number of keys in
+  // |keybits|.
+  bool IsAnyOfKeycodesPressed(const std::vector<int>& keycodes,
+                              const char* keybits,
+                              int num_keys) const;
+
+  // GtkIMContext event handlers.  They are shared among |gtk_context_simple_|
+  // and |gtk_multicontext_|.
+  CHROMEG_CALLBACK_1(X11InputMethodContextImplGtk2, void, OnCommit,
+                     GtkIMContext*, gchar*);
+  CHROMEG_CALLBACK_0(X11InputMethodContextImplGtk2, void, OnPreeditChanged,
+                     GtkIMContext*);
+  CHROMEG_CALLBACK_0(X11InputMethodContextImplGtk2, void, OnPreeditEnd,
+                     GtkIMContext*);
+  CHROMEG_CALLBACK_0(X11InputMethodContextImplGtk2, void, OnPreeditStart,
+                     GtkIMContext*);
+
+  // A set of callback functions.  Must not be NULL.
+  ui::LinuxInputMethodContextDelegate* delegate_;
+
+  // IME's input context used for TEXT_INPUT_TYPE_NONE and
+  // TEXT_INPUT_TYPE_PASSWORD.
+  GtkIMContext* gtk_context_simple_;
+  // IME's input context used for the other text input types.
+  GtkIMContext* gtk_multicontext_;
+
+  // An alias to |gtk_context_simple_| or |gtk_multicontext_| depending on the
+  // text input type.  Can be NULL when it's not focused.
+  GtkIMContext* gtk_context_;
+
+  // Last set client window.
+  GdkWindow* gdk_last_set_client_window_;
+
+  // Last known caret bounds relative to the screen coordinates.
+  gfx::Rect last_caret_bounds_;
+
+  // A set of hardware keycodes of modifier keys.
+  base::hash_set<unsigned int> modifier_keycodes_;  // NOLINT
+
+  // A list of keycodes of each modifier key.
+  std::vector<int> meta_keycodes_;
+  std::vector<int> super_keycodes_;
+  std::vector<int> hyper_keycodes_;
+
+  // The helper class to trap GTK+'s "commit" signal for direct input key
+  // events.
+  //
+  // gtk_im_context_filter_keypress() emits "commit" signal in order to insert
+  // a character which is not actually processed by a IME.  This behavior seems,
+  // in Javascript world, that a keydown event with keycode = VKEY_PROCESSKEY
+  // (= 229) is fired.  So we have to trap such "commit" signal for direct input
+  // key events.  This class helps to trap such events.
+  class GtkCommitSignalTrap {
+   public:
+    GtkCommitSignalTrap();
+
+    // Enables the trap which monitors a direct input key event of |keyval|.
+    void StartTrap(guint keyval);
+
+    // Disables the trap.
+    void StopTrap();
+
+    // Checks if the committed |text| has come from a direct input key event,
+    // and returns true in that case.  Once it's trapped, IsSignalCaught()
+    // returns true.
+    // Must be called at most once between StartTrap() and StopTrap().
+    bool Trap(const base::string16& text);
+
+    // Returns true if a direct input key event is detected.
+    bool IsSignalCaught() const { return is_signal_caught_; }
+
+   private:
+    bool is_trap_enabled_;
+    guint gdk_event_key_keyval_;
+    bool is_signal_caught_;
+
+    DISALLOW_COPY_AND_ASSIGN(GtkCommitSignalTrap);
+  };
+
+  GtkCommitSignalTrap commit_signal_trap_;
+
+  FRIEND_TEST_ALL_PREFIXES(X11InputMethodContextImplGtk2FriendTest,
+                           GtkCommitSignalTrap);
+
+  DISALLOW_COPY_AND_ASSIGN(X11InputMethodContextImplGtk2);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_X11_INPUT_METHOD_CONTEXT_IMPL_GTK2_H_

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -45,6 +45,10 @@
 #include "ui/base/ime/input_method_initializer.h"
 #endif
 
+#if defined(OS_LINUX) && defined(USE_X11)
+#include "xwalk/runtime/browser/ui/x11_input_method_context_factory.h"
+#endif
+
 namespace {
 
 // FIXME: Compare with method in startup_browser_creator.cc.
@@ -127,7 +131,11 @@ void XWalkBrowserMainParts::PostMainMessageLoopStart() {
 }
 
 void XWalkBrowserMainParts::PreEarlyInitialization() {
-#if !defined(OS_CHROMEOS) && defined(USE_AURA) && defined(OS_LINUX)
+#if defined(OS_LINUX) && defined(USE_X11)
+  ui::LinuxInputMethodContextFactory* instance =
+      new X11InputMethodContextFactory();
+  ui::LinuxInputMethodContextFactory::SetInstance(instance);
+#elif !defined(OS_CHROMEOS) && defined(USE_AURA) && defined(OS_LINUX)
   ui::InitializeInputMethodForTesting();
 #endif
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -372,6 +372,17 @@
             'experimental/native_file_system/virtual_root_provider_linux.cc',
           ]
         }],  # OS=="linux"
+        ['OS=="linux"' and 'tizen==0', {
+          'dependencies': [
+            '../build/linux/system.gyp:gtk',
+          ],
+          'sources': [
+            'runtime/browser/ui/x11_input_method_context_factory.cc',
+            'runtime/browser/ui/x11_input_method_context_factory.h',
+            'runtime/browser/ui/x11_input_method_context_impl_gtk2.cc',
+            'runtime/browser/ui/x11_input_method_context_impl_gtk2.h',
+          ]
+        }], # OS=="linux" and tizen==0
         ['os_posix==1 and OS != "mac" and use_allocator=="tcmalloc"', {
           'dependencies': [
             # This is needed by content/app/content_main_runner.cc


### PR DESCRIPTION
Before this patch we use the default FakeInputMethodContext, IMEs like
Chinese IME is not work. This patch leverages Chromium
X11InputMethodContextImplGtk2 to communicate with underlying IMEs.

Manually tested with Chinese IME on Ubuntu & Deepin.

BUG=XWALK-3823