### PR TITLE
[Extensions] Enable cross-context reference for lazy loading

### DIFF
--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -357,6 +357,7 @@ void XWalkModuleSystem::DeleteExtensionModules() {
 void XWalkModuleSystem::LoadExtensionForTrampoline(
     v8::Isolate* isolate,
     v8::Local<v8::Value> data) {
+  v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Array> params = data.As<v8::Array>();
   void* ptr = params->Get(
       v8::Integer::New(isolate, 0)).As<v8::External>()->Value();
@@ -365,8 +366,10 @@ void XWalkModuleSystem::LoadExtensionForTrampoline(
 
   if (!entry)
     return;
+  v8::Handle<v8::Context> context = params->CreationContext();
 
-  v8::Handle<v8::Context> context = isolate->GetCurrentContext();
+  // Switch to the target context in case cross-context reference.
+  v8::Context::Scope context_scope(context);
 
   DeleteAccessorForEntryPoint(context, entry->name);
 
@@ -382,7 +385,7 @@ void XWalkModuleSystem::LoadExtensionForTrampoline(
             module_system->require_native_template_);
 
   XWalkExtensionModule* module = entry->module;
-  module->LoadExtensionCode(module_system->GetV8Context(),
+  module->LoadExtensionCode(context,
                             require_native_template->GetFunction());
 
   module_system->EnsureExtensionNamespaceIsReadOnly(context, entry->name);
@@ -401,7 +404,7 @@ v8::Handle<v8::Value> XWalkModuleSystem::RefetchHolder(
   path.pop_back();
 
   std::string error;
-  return GetObjectForPath(isolate->GetCurrentContext(), path, &error);
+  return GetObjectForPath(params->CreationContext(), path, &error);
 }
 
 // static

--- a/extensions/test/data/cross_contexts_reference.html
+++ b/extensions/test/data/cross_contexts_reference.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>Fail</title>
+  </head>
+  <body>
+    <h1>Reference to subframes' extension entry points should not crash!</h1>
+    <p>CPU info:<span id="result"></span></p>
+    <iframe id="subFrame"></iframe>
+    <script>
+      var iframe = document.getElementById("subFrame");
+      crossExtension = eval(iframe.contentWindow.xwalk);
+      eval(crossExtension.experimental.system);
+      console.log(crossExtension.experimental.system.getCPUInfo());
+      var result = document.getElementById("result");
+      result.innerHTML = crossExtension.experimental.system.getCPUInfo();
+      document.title = "Pass";
+    </script>
+  </body>
+</html>

--- a/extensions/test/extension_in_iframe.cc
+++ b/extensions/test/extension_in_iframe.cc
@@ -124,3 +124,14 @@ IN_PROC_BROWSER_TEST_F(XWalkExtensionsIFrameTest,
   EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
   ASSERT_EQ(g_count, 1);
 }
+
+IN_PROC_BROWSER_TEST_F(XWalkExtensionsIFrameTest,
+                       CrossContextsReferenceShouldNotCrash) {
+  Runtime* runtime = CreateRuntime();
+  GURL url = GetExtensionsTestURL(base::FilePath(),
+      base::FilePath().AppendASCII("cross_contexts_reference.html"));
+
+  content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
+  xwalk_test_utils::NavigateToURL(runtime, url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}


### PR DESCRIPTION
By default, crosswalk extensions are lazy loaded when they
are actually accessed through Trampoline callbacks. But cross
context reference(JS reference to the leaf extension objects
iframes' contentWindow or popup window by window.open) will
mess up the contexts in the callback which will cause runtime
crash. This commit enable the cross-context reference for
trampoline callback.

BUG=https://crosswalk-project.org/jira/browse/XWALK-3575