### PR TITLE
[Android] Security check for shared mode

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -165,6 +165,8 @@ public abstract class XWalkActivity extends Activity implements XWalkLibraryList
         AlertDialog dialog = null;
         if (status == LibraryStatus.NOT_FOUND) {
             dialog = getStartupNotFoundDialog();
+        } else if (status == LibraryStatus.SIGNATURE_CHECK_ERROR) {
+            dialog = getStartupVerifyErrorDialog();
         } else if (status == LibraryStatus.OLDER_VERSION) {
             dialog = getStartupOlderVersionDialog();
         } else if (status == LibraryStatus.NEWER_VERSION) {
@@ -493,6 +495,25 @@ public abstract class XWalkActivity extends Activity implements XWalkLibraryList
         dialog.setMessage(getString(R.string.startup_not_found_message));
         dialog.setButton(DialogInterface.BUTTON_POSITIVE,
                 getString(R.string.get_crosswalk), positiveListener);
+        dialog.setButton(DialogInterface.BUTTON_NEGATIVE,
+                getString(R.string.xwalk_cancel), negativeListener);
+        dialog.setCancelable(false);
+        return dialog;
+    }
+
+    private AlertDialog getStartupVerifyErrorDialog() {
+        AlertDialog dialog = buildAlertDialog();
+
+        OnClickListener negativeListener = new OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int id) {
+                onXWalkLibraryCancelled();
+            }
+        };
+
+        dialog.setIcon(android.R.drawable.ic_dialog_alert);
+        dialog.setTitle(getString(R.string.startup_signature_check_error_title));
+        dialog.setMessage(getString(R.string.startup_signature_check_error_message));
         dialog.setButton(DialogInterface.BUTTON_NEGATIVE,
                 getString(R.string.xwalk_cancel), negativeListener);
         dialog.setCancelable(false);

--- a/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
@@ -5,8 +5,14 @@
 package org.xwalk.core;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.Signature;
 import android.util.Log;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import junit.framework.Assert;
 
@@ -132,12 +138,12 @@ class XWalkCoreWrapper implements ReflectExceptionHandler {
     private boolean findEmbeddedCore() {
         mBridgeContext = null;
         mBridgeLoader = XWalkCoreWrapper.class.getClassLoader();
-        if (!checkCoreVersion() || !checkCoreArchitecture()) {
+        if (!checkCoreArchitecture()) {
             mBridgeLoader = null;
             return false;
         }
 
-        Log.d(TAG, "Running on embedded mode");
+        Log.d(TAG, "Running in embedded mode");
         return true;
     }
 
@@ -145,11 +151,31 @@ class XWalkCoreWrapper implements ReflectExceptionHandler {
         XWalkApplication application = XWalkApplication.getApplication();
         if (application == null) Assert.fail("Must use or extend XWalkApplication");
 
+        if (!XWalkSdkVersion.VERIFY_XWALK_APK) {
+            Log.d(TAG, "Not verifying the package integrity of Crosswalk runtime library");
+        } else {
+            try {
+                PackageInfo packageInfo = application.getPackageManager().getPackageInfo(
+                        XWALK_APK_PACKAGE, PackageManager.GET_SIGNATURES);
+                if (!verifyPackageInfo(packageInfo,
+                        XWalkSdkVersion.XWALK_APK_HASH_ALGORITHM,
+                        XWalkSdkVersion.XWALK_APK_HASH_CODE)) {
+                    mCoreStatus = LibraryStatus.SIGNATURE_CHECK_ERROR;
+                    return false;
+                }
+            } catch (NameNotFoundException e) {
+                Log.d(TAG, "Crosswalk package not found");
+                mCoreStatus = LibraryStatus.NOT_FOUND;
+                return false;
+            }
+        }
+
         try {
             mBridgeContext = application.createPackageContext(XWALK_APK_PACKAGE,
                     Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY);
         } catch (NameNotFoundException e) {
-            Log.d(TAG, "XWalk apk not found");
+            Log.d(TAG, "Crosswalk package not found");
+            mCoreStatus = LibraryStatus.NOT_FOUND;
             return false;
         }
 
@@ -160,8 +186,8 @@ class XWalkCoreWrapper implements ReflectExceptionHandler {
             return false;
         }
 
-        Log.d(TAG, "Running on shared mode");
         application.addResource(mBridgeContext.getResources());
+        Log.d(TAG, "Running in shared mode");
         return true;
     }
 
@@ -182,10 +208,12 @@ class XWalkCoreWrapper implements ReflectExceptionHandler {
                 mCoreStatus = LibraryStatus.MATCHED;
             }
         } catch (RuntimeException e) {
+            Log.d(TAG, "Failed to check library version");
             mCoreStatus = LibraryStatus.NOT_FOUND;
+            return false;
         }
 
-        return mCoreStatus != LibraryStatus.NOT_FOUND;
+        return true;
     }
 
     private boolean checkCoreArchitecture() {
@@ -194,6 +222,7 @@ class XWalkCoreWrapper implements ReflectExceptionHandler {
             ReflectMethod method =
                     new ReflectMethod(null, clazz, "loadXWalkLibrary", Context.class);
             method.invoke(mBridgeContext);
+            mCoreStatus = LibraryStatus.MATCHED;
         } catch (RuntimeException e) {
             Log.d(TAG, "Failed to load native library");
             mCoreStatus = LibraryStatus.NOT_FOUND;
@@ -201,6 +230,54 @@ class XWalkCoreWrapper implements ReflectExceptionHandler {
         }
 
         return true;
+    }
+
+    private boolean verifyPackageInfo(PackageInfo packageInfo,
+            String hashAlgorithm, String hashCode) {
+        if (packageInfo.signatures == null) {
+            Log.e(TAG, "No signature in package info");
+            return false;
+        }
+
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance(hashAlgorithm);
+        } catch (NoSuchAlgorithmException | NullPointerException e) {
+            Assert.fail("Hash algorithm " + hashAlgorithm + " is not available");
+        }
+
+        byte[] hashArray = hexStringToByteArray(hashCode);
+        if (hashArray == null) {
+            Assert.fail("Hash code is invalid");
+        }
+
+        for (int i = 0; i < packageInfo.signatures.length; ++i) {
+            Log.d(TAG, "Checking signature " + i);
+            byte[] binaryCert = packageInfo.signatures[i].toByteArray();
+            byte[] digest = md.digest(binaryCert);
+            if (!MessageDigest.isEqual(digest, hashArray)) {
+                Log.e(TAG, "Hash code does not match");
+                continue;
+            }
+
+            Log.d(TAG, "Signature passed verification");
+            return true;
+        }
+
+        return false;
+    }
+
+    private byte[] hexStringToByteArray(String str) {
+        if (str == null || str.isEmpty() || str.length()%2 != 0) return null;
+
+        byte[] result = new byte[str.length() / 2];
+        for (int i = 0; i < str.length(); i += 2) {
+            int digit = Character.digit(str.charAt(i), 16);
+            digit <<= 4;
+            digit += Character.digit(str.charAt(i+1), 16);
+            result[i/2] = (byte) digit;
+        }
+        return result;
     }
 
     public boolean isSharedMode() {

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryListener.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryListener.java
@@ -8,6 +8,7 @@ interface XWalkLibraryListener {
     public enum LibraryStatus {
         MATCHED,
         NOT_FOUND,
+        SIGNATURE_CHECK_ERROR,
         NEWER_VERSION,
         OLDER_VERSION
     }

--- a/runtime/android/core/strings/xwalk_app_strings.grd
+++ b/runtime/android/core/strings/xwalk_app_strings.grd
@@ -29,6 +29,12 @@
       <message desc="Startup Not Found Message [CHAR-LIMIT=100]" name="IDS_STARTUP_NOT_FOUND_MESSAGE">
         Please get Crosswalk Runtime Library
       </message>
+      <message desc="Startup Signature Check Error Title [CHAR-LIMIT=100]" name="IDS_STARTUP_SIGNATURE_CHECK_ERROR_TITLE">
+        Crosswalk Signature Verification Failed
+      </message>
+      <message desc="Startup Signature Check Error Message [CHAR-LIMIT=100]" name="IDS_STARTUP_SIGNATURE_CHECK_ERROR_MESSAGE">
+        The integrity of Crosswalk runtime library can not be verified. Please uninstall the runtime library and restart this application
+      </message>
       <message desc="Startup Older Version Title [CHAR-LIMIT=100]" name="IDS_STARTUP_OLDER_VERSION_TITLE">
         Crosswalk Version Too Old
       </message>

--- a/runtime/android/templates/XWalkSdkVersion.template
+++ b/runtime/android/templates/XWalkSdkVersion.template
@@ -2,4 +2,10 @@ package org.xwalk.core;
 
 class XWalkSdkVersion {
     public static final int SDK_VERSION = ${SDK_VERSION};
+    public static final boolean VERIFY_XWALK_APK = ${VERIFY_XWALK_APK};
+    // This is the hash of the "xwalk_cert" signing key and the algorithm with which the hash is generated
+    public static final String XWALK_APK_HASH_ALGORITHM = "SHA-256";
+    public static final String XWALK_APK_HASH_CODE =
+            "6fd3002c5ca9a1f55ed51e92233ed4626120c266efea9d9746058c995ece68c4";
+
 }

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -80,7 +80,7 @@ def GenerateJavaReflectClass(input_dir):
 
 
 def GenerateJavaTemplateClass(template_dir,
-    target_arch, sdk_version, min_sdk_version):
+    target_arch, sdk_version, min_sdk_version, verify_xwalk_apk):
   template_file = os.path.join(template_dir, 'XWalkCoreVersion.template')
   template = Template(open(template_file, 'r').read())
   value = {'TARGET_ARCH': target_arch,
@@ -92,7 +92,9 @@ def GenerateJavaTemplateClass(template_dir,
 
   template_file = os.path.join(template_dir, 'XWalkSdkVersion.template')
   template = Template(open(template_file, 'r').read())
-  value = {'SDK_VERSION': sdk_version}
+
+  value = {'SDK_VERSION': sdk_version,
+           'VERIFY_XWALK_APK': 'true' if verify_xwalk_apk == 1 else 'false'}
   output_file = os.path.join(wrapper_path, "XWalkSdkVersion.java")
   with open(output_file, 'w') as f:
     f.write(template.substitute(value))
@@ -127,6 +129,8 @@ This script can generate bridge and wrap source files for given directory.
   option_parser.add_option('--target-arch', help='Target Architecture')
   option_parser.add_option('--sdk-version', help='API Version')
   option_parser.add_option('--min-sdk-version', help='Min API Version')
+  option_parser.add_option('--verify-xwalk-apk', default=0, type='int',
+      help='Verify Crosswalk library APK before loading')
 
   options, _ = option_parser.parse_args(argv)
   if (not options.input_dir or
@@ -155,8 +159,8 @@ This script can generate bridge and wrap source files for given directory.
     GenerateJavaReflectClass(options.input_dir)
 
   if options.template_dir:
-    GenerateJavaTemplateClass(options.template_dir,
-        options.target_arch, options.sdk_version, options.min_sdk_version)
+    GenerateJavaTemplateClass(options.template_dir, options.target_arch,
+        options.sdk_version, options.min_sdk_version, options.verify_xwalk_apk)
 
   if options.stamp:
     Touch(options.stamp)

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -10,6 +10,10 @@
       }],
       ['OS=="android"', {
         'enable_extensions': 1,
+        'sdk_version': '<!(python ../build/util/version.py -f SDK_VERSION -t "@SDK@")',
+        'min_sdk_version': '<!(python ../build/util/version.py -f SDK_VERSION -t "@MIN_SDK@")',
+        # Whether we should verify package integrity before loading Crosswalk runtime libraray in shared mode
+        'verify_xwalk_apk%': 0,
       }],
     ], # conditions
   },
@@ -924,8 +928,6 @@
         },
         'version_code_shift%': '<(version_code_shift)',
         'xwalk_version_code': '<!(python tools/build/android/generate_version_code.py -f VERSION -s <(version_code_shift))',
-        'sdk_version': '<!(python ../build/util/version.py -f SDK_VERSION -t "@SDK@")',
-        'min_sdk_version': '<!(python ../build/util/version.py -f SDK_VERSION -t "@MIN_SDK@")',
       },
       'includes': [
         'xwalk_android.gypi',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -104,6 +104,7 @@
             '--target-arch=<(target_arch)',
             '--sdk-version=<(sdk_version)',
             '--min-sdk-version=<(min_sdk_version)',
+            '--verify-xwalk-apk=<(verify_xwalk_apk)',
           ],
         },
       ],


### PR DESCRIPTION
Before the application loading the Crosswalk runtime library, it is
necessary to make sure the library's package is not tampered and is
exactly the one we published.

The verification process is:
1. Get the binary certificates of the Crosswalk runtime library
   via package manager
2. Generate the hash value with SHA256 algorithm from each certificate
3. Check against the preset hash code generated with the the public key
   of the signing key

This verification is disabled by default. Use option
"./xwalk/gyp -Dverify_xwalk_apk=1" to enable it.

BUG=XWALK-3804