### PR TITLE
Fix compiling error of WebNotification of Crosswalk for linux

### DIFF
--- a/runtime/browser/linux/xwalk_notification_manager.cc
+++ b/runtime/browser/linux/xwalk_notification_manager.cc
@@ -65,7 +65,6 @@ void XWalkNotificationManager::ShowDesktopNotification(
     const GURL& origin,
     const content::PlatformNotificationData& notification_data,
     scoped_ptr<content::DesktopNotificationDelegate> delegate,
-    int render_process_id,
     base::Closure* cancel_callback) {
   if (!initialized_)
     return;

--- a/runtime/browser/linux/xwalk_notification_manager.h
+++ b/runtime/browser/linux/xwalk_notification_manager.h
@@ -39,7 +39,6 @@ class XWalkNotificationManager {
       const GURL& origin,
       const content::PlatformNotificationData& notification_data,
       scoped_ptr<content::DesktopNotificationDelegate> delegate,
-      int render_process_id,
       base::Closure* cancel_callback);
 
   void NotificationDisplayed(NotifyNotification* notification);

--- a/runtime/browser/xwalk_platform_notification_service.cc
+++ b/runtime/browser/xwalk_platform_notification_service.cc
@@ -91,7 +91,6 @@ void XWalkPlatformNotificationService::DisplayNotification(
       origin,
       notification_data,
       delegate.Pass(),
-      render_process_id,
       cancel_callback);
 #endif
 }


### PR DESCRIPTION
Due to a redundant parameter of the caller has been removed in Version Bump, the callee should be change despondently.  