### PR TITLE
[Android] Fix the crash issue when exiting fullscreen for video.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
@@ -29,14 +29,7 @@ class XWalkContentVideoViewClient implements ContentVideoViewClient {
     @Override
     public void enterFullscreenVideo(View view) {
         mView.setOverlayVideoMode(true);
-        CustomViewCallback cb = new CustomViewCallback() {
-            @Override
-            public void onCustomViewHidden() {
-                ContentVideoView contentVideoView = ContentVideoView.getContentVideoView();
-                if (contentVideoView != null) contentVideoView.exitFullscreen(false);
-            }
-        };
-        mContentsClient.onShowCustomView(view, cb);
+        mContentsClient.onShowCustomView(view, null);
     }
 
     @Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
@@ -79,7 +79,7 @@ public class XWalkWebChromeClient {
         Activity activity = mXWalkView.getActivity();
 
         if (mCustomXWalkView != null || activity == null) {
-            callback.onCustomViewHidden();
+            if (callback != null) callback.onCustomViewHidden();
             return null;
         }
 
@@ -141,7 +141,6 @@ public class XWalkWebChromeClient {
      */
     public void onHideCustomView() {
         Activity activity = mXWalkView.getActivity();
-
         if (mCustomXWalkView == null || activity == null) return;
 
         if (mContentsClient != null) {
@@ -151,7 +150,7 @@ public class XWalkWebChromeClient {
         // Remove video view from activity's ContentView.
         FrameLayout decor = (FrameLayout) activity.getWindow().getDecorView();
         decor.removeView(mCustomXWalkView);
-        mCustomViewCallback.onCustomViewHidden();
+        if (mCustomViewCallback != null) mCustomViewCallback.onCustomViewHidden();
 
         if (mPreOrientation != INVALID_ORIENTATION &&
                 mPreOrientation >= ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED &&

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/OnShowOnHideCustomViewTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/OnShowOnHideCustomViewTest.java
@@ -39,17 +39,6 @@ public class OnShowOnHideCustomViewTest extends XWalkViewInternalTestBase {
 
     @MediumTest
     @Feature({"onShow/onHideCustomView"})
-    public void testOnShowAndHideCustomViewWithCallback() throws Throwable {
-        doOnShowAndHideCustomViewTest(new Runnable() {
-            @Override
-            public void run() {
-                mWebChromeClient.getExitCallback().onCustomViewHidden();
-            }
-        });
-    }
-
-    @MediumTest
-    @Feature({"onShow/onHideCustomView"})
     public void testOnShowAndHideCustomViewWithJavascript() throws Throwable {
         doOnShowAndHideCustomViewTest(new Runnable() {
             @Override


### PR DESCRIPTION
This patch is to fix the crash issue when exiting fullscreen for video.
In the native code, fullscreen requests have been moved to render frame,
then tear down ContentVideoView from content-layer to reduce code
duplication.
Android content embedder has no responsibility for releasing the surface
when exiting fullscreen.

BUG=XWALK-3796

(cherry picked from commit cf4cf2173617e35b352b5aa480aa9f5b4d973865)