### PR TITLE
Fix the compiling warning of unused result.

### DIFF
--- a/runtime/browser/runtime_platform_util_linux.cc
+++ b/runtime/browser/runtime_platform_util_linux.cc
@@ -46,7 +46,8 @@ void XDGOpen(const std::string& path) {
   GURL url(path);
   if (url.is_valid() && url.SchemeIsHTTPOrHTTPS()) {
     std::string cmd = "xdg-open " + path;
-    std::system(cmd.c_str());
+    if (std::system(cmd.c_str()) != 0)
+      LOG(ERROR) << "Web browser is launched with errors.";
   } else {
     XDGUtil("xdg-open", path);
   }


### PR DESCRIPTION
The 'std::system()' call has a return value, if not use it, there would cause a
warning of unused return value, this patch will solve this issue.