### PR TITLE
Add PepperFlash hosts in renderer.

### DIFF
--- a/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.cc
+++ b/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.cc
@@ -4,7 +4,13 @@
 
 #include "xwalk/runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.h"
 
+#include "chrome/renderer/pepper/pepper_flash_drm_renderer_host.h"
+#include "chrome/renderer/pepper/pepper_flash_font_file_host.h"
+#include "chrome/renderer/pepper/pepper_flash_fullscreen_host.h"
+#include "chrome/renderer/pepper/pepper_flash_menu_host.h"
+#include "chrome/renderer/pepper/pepper_flash_renderer_host.h"
 #include "content/public/renderer/renderer_ppapi_host.h"
+#include "ppapi/host/ppapi_host.h"
 #include "ppapi/proxy/ppapi_messages.h"
 #include "xwalk/runtime/renderer/pepper/pepper_uma_host.h"
 
@@ -29,6 +35,50 @@ XWalkRendererPepperHostFactory::CreateResourceHost(
   // Make sure the plugin is giving us a valid instance for this resource.
   if (!host_->IsValidInstance(instance))
     return scoped_ptr<ResourceHost>();
+
+  if (host_->GetPpapiHost()->permissions().HasPermission(
+          ppapi::PERMISSION_FLASH)) {
+    switch (message.type()) {
+      case PpapiHostMsg_Flash_Create::ID: {
+        return scoped_ptr<ResourceHost>(
+            new PepperFlashRendererHost(host_, instance, resource));
+      }
+      case PpapiHostMsg_FlashFullscreen_Create::ID: {
+        return scoped_ptr<ResourceHost>(
+            new PepperFlashFullscreenHost(host_, instance, resource));
+      }
+      case PpapiHostMsg_FlashMenu_Create::ID: {
+        ppapi::proxy::SerializedFlashMenu serialized_menu;
+        if (ppapi::UnpackMessage<PpapiHostMsg_FlashMenu_Create>(
+                message, &serialized_menu)) {
+          return scoped_ptr<ResourceHost>(new PepperFlashMenuHost(
+              host_, instance, resource, serialized_menu));
+        }
+        break;
+      }
+    }
+  }
+
+  if (host_->GetPpapiHost()->permissions().HasPermission(
+          ppapi::PERMISSION_FLASH) ||
+      host_->GetPpapiHost()->permissions().HasPermission(
+          ppapi::PERMISSION_PRIVATE)) {
+    switch (message.type()) {
+      case PpapiHostMsg_FlashFontFile_Create::ID: {
+        ppapi::proxy::SerializedFontDescription description;
+        PP_PrivateFontCharset charset;
+        if (ppapi::UnpackMessage<PpapiHostMsg_FlashFontFile_Create>(
+                message, &description, &charset)) {
+          return scoped_ptr<ResourceHost>(new PepperFlashFontFileHost(
+              host_, instance, resource, description, charset));
+        }
+        break;
+      }
+      case PpapiHostMsg_FlashDRM_Create::ID:
+        return scoped_ptr<ResourceHost>(
+            new PepperFlashDRMRendererHost(host_, instance, resource));
+    }
+  }
 
   // Permissions for the following interfaces will be checked at the
   // time of the corresponding instance's method calls.  Currently these

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -438,7 +438,20 @@
             ],
         }],
         ['enable_plugins==1', {
+          'sources': [
+            '../chrome/renderer/pepper/pepper_flash_drm_renderer_host.cc',
+            '../chrome/renderer/pepper/pepper_flash_drm_renderer_host.h',
+            '../chrome/renderer/pepper/pepper_flash_font_file_host.cc',
+            '../chrome/renderer/pepper/pepper_flash_font_file_host.h',
+            '../chrome/renderer/pepper/pepper_flash_fullscreen_host.cc',
+            '../chrome/renderer/pepper/pepper_flash_fullscreen_host.h',
+            '../chrome/renderer/pepper/pepper_flash_menu_host.cc',
+            '../chrome/renderer/pepper/pepper_flash_menu_host.h',
+            '../chrome/renderer/pepper/pepper_flash_renderer_host.cc',
+            '../chrome/renderer/pepper/pepper_flash_renderer_host.h',
+          ],
           'dependencies': [
+            '../components/components.gyp:pdf_renderer',
             '../ppapi/ppapi_internal.gyp:ppapi_host',
             '../ppapi/ppapi_internal.gyp:ppapi_proxy',
             '../ppapi/ppapi_internal.gyp:ppapi_ipc',


### PR DESCRIPTION
In order to implement some functionalties these pepper hosts are need in
renderer. These code is copied from src/chrome/renderer/pepper/.

BUG=XWALK-3670,XWALK-3791