### PR TITLE
Partial revert of #2898

### DIFF
--- a/runtime/browser/runtime_platform_util_linux.cc
+++ b/runtime/browser/runtime_platform_util_linux.cc
@@ -43,13 +43,7 @@ void XDGUtil(const std::string& util, const std::string& arg) {
 }
 
 void XDGOpen(const std::string& path) {
-  GURL url(path);
-  if (url.is_valid() && url.SchemeIsHTTPOrHTTPS()) {
-    std::string cmd = "xdg-open " + path;
-    std::system(cmd.c_str());
-  } else {
-    XDGUtil("xdg-open", path);
-  }
+  XDGUtil("xdg-open", path);
 }
 
 void XDGEmail(const std::string& email) {


### PR DESCRIPTION
We should not call "std::system"