### PR TITLE
[Android] Enable proguard for crosswalk to compress apk size

### DIFF
--- a/app/android/app_template/proguard-xwalk.txt
+++ b/app/android/app_template/proguard-xwalk.txt
@@ -1,0 +1,100 @@
+# Android common:
+-keep public class * extends android.app.Activity
+-keep public class * extends android.app.Application
+-keep public class * extends android.app.Service
+-keep public class * extends android.content.BroadcastReceiver
+-keep public class * extends android.content.ContentProvider
+
+-keepclassmembers class * {
+    static final %                *;
+    static final java.lang.String *;
+}
+
+-keep public class * extends android.view.View {
+    public <init>(android.content.Context);
+    public <init>(android.content.Context, android.util.AttributeSet);
+    public <init>(android.content.Context, android.util.AttributeSet, int);
+    public void set*(...);
+}
+
+-keepclasseswithmembers class * {
+    public <init>(android.content.Context, android.util.AttributeSet);
+}
+
+-keepclasseswithmembers class * {
+    public <init>(android.content.Context, android.util.AttributeSet, int);
+}
+
+-keepclassmembers class * extends android.content.Context {
+   public void *(android.view.View);
+   public void *(android.view.MenuItem);
+}
+
+-keepclassmembers class * implements android.os.Parcelable {
+    static ** CREATOR;
+}
+
+-keepattributes InnerClasses
+-keep class **.R
+-keep class **.R$* {
+    <fields>;
+}
+
+-adaptresourcefilenames    **.properties,**.gif,**.jpg
+-adaptresourcefilecontents **.properties,META-INF/MANIFEST.MF
+
+# Keep native & callbacks
+-keepclasseswithmembernames class *{
+    native <methods>;
+}
+
+-keepattributes JNINamespace
+-keepattributes CalledByNative
+-keepattributes *Annotation*
+-keepattributes EnclosingMethod
+
+# Too many hard code reflections between xwalk wrapper and bridge,so
+# keep all xwalk classes.
+-keep class org.xwalk.**{ *; }
+-keep interface org.xwalk.**{ *; }
+-keep class com.example.extension.**{ *; }
+-keep class org.crosswalkproject.**{ *; }
+
+# Rules for org.chromium classes:
+# Keep annotations used by chromium to keep members referenced by native code
+-keep class org.chromium.base.*Native*
+-keep class org.chromium.base.JNINamespace
+-keepclasseswithmembers class org.chromium.** {
+    @org.chromium.base.AccessedByNative <fields>;
+}
+-keepclasseswithmembers class org.chromium.** {
+    @org.chromium.base.*Native* <methods>;
+}
+
+-keep class org.chromium.** {
+    native <methods>;
+}
+
+# Keep methods used by reflection and native code
+-keep class org.chromium.base.UsedBy*
+-keep @org.chromium.base.UsedBy* class *
+-keepclassmembers class * {
+    @org.chromium.base.UsedBy* *;
+}
+
+-keep @org.chromium.base.JNINamespace* class *
+-keepclassmembers class * {
+    @org.chromium.base.CalledByNative* *;
+}
+
+# Suppress unnecessary warnings.
+-dontnote org.chromium.net.AndroidKeyStore
+# Objects of this type are passed around by native code, but the class
+# is never used directly by native code. Since the class is not loaded, it does
+# not need to be preserved as an entry point.
+-dontnote org.chromium.net.UrlRequest$ResponseHeadersMap
+
+# Generate by aapt. may only need for testing, just add them here.
+-keep class org.chromium.ui.ColorPickerAdvanced { <init>(...); }
+-keep class org.chromium.ui.ColorPickerMoreButton { <init>(...); }
+-keep class org.chromium.ui.ColorPickerSimple { <init>(...); }


### PR DESCRIPTION
Add flag --enable-proguard, disable by default. Only works with
Embedded mode.  Approximately shrinked 150k apk size(tested in x86)

BUG=XWALK-3854