### PR TITLE
[Linux] Fix open external URL in browser.

### DIFF
--- a/runtime/browser/runtime_platform_util_linux.cc
+++ b/runtime/browser/runtime_platform_util_linux.cc
@@ -21,6 +21,7 @@ void XDGUtil(const std::string& util, const std::string& arg) {
   argv.push_back(util);
   argv.push_back(arg);
   base::LaunchOptions options;
+  options.allow_new_privs = true;
 
   // xdg-open can fall back on mailcap which eventually might plumb through
   // to a command that needs a terminal.  Set the environment variable telling


### PR DESCRIPTION
If the default browser is Chrome, it will start zygote process with
SUID sandbox hepler which fail to check the root privilege. As by
default the prctl() has made the newly started process do not grant
any new privileges.

Also see upstream CL: https://codereview.chromium.org/235983009.

BUG=XWALK-3690