### PR TITLE
[Android] make_apk: Fix Python 3 regression after 2e723a9.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -161,7 +161,7 @@ def MakeCodeBaseFromAppVersion(app_version):
   version_re = r'\d{1,2}(\.\d{1,2}(\.\d{1,3})?)?$'
   if not re.match(version_re, app_version):
     return None
-  version_numbers = map(int, app_version.split('.'))
+  version_numbers = [int(i) for i in app_version.split('.')]
   version_numbers.extend([0] * (3 - len(version_numbers))) # Pad to 3 parts.
   return '%02d%02d%03d' % tuple(version_numbers)
 


### PR DESCRIPTION
Commit 2e723a9 ("[Android] make_apk: Simplify TryCodeBaseFromVersionName()") introduced a regression when run with Python 3.

In Python 3, `map()` returns an iterator, so we cannot call `extend()` on it. Fix it by using a list comprehension instead of `map()`.

BUG=XWALK-3903