### PR TITLE
Fix compilation on Windows 64 bits

### DIFF
--- a/application/browser/application_security_policy.cc
+++ b/application/browser/application_security_policy.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 
+#include "base/numerics/safe_conversions.h"
 #include "content/public/browser/render_process_host.h"
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/common/application_manifest_constants.h"
@@ -227,7 +228,9 @@ void ApplicationSecurityPolicyCSP::Enforce() {
         !scope.empty()) {
       enabled_ = true;
       url::Replacements<char> replacements;
-      replacements.SetPath(scope.c_str(), url::Component(0, scope.length()));
+      replacements.SetPath(
+                   scope.c_str(),
+                   url::Component(0, base::checked_cast<int>(scope.length())));
       internalUrl = internalUrl.ReplaceComponents(replacements);
     }
     if (internalUrl.is_valid())

--- a/application/common/manifest_handler.cc
+++ b/application/common/manifest_handler.cc
@@ -211,7 +211,7 @@ void ManifestHandlerRegistry::ReorderHandlersGivenDependencies() {
       ManifestHandler* handler = *iter;
       const std::vector<std::string>& prerequisites =
           handler->PrerequisiteKeys();
-      int unsatisfied = prerequisites.size();
+      size_t unsatisfied = prerequisites.size();
       for (size_t i = 0; i < prerequisites.size(); ++i) {
         ManifestHandlerMap::const_iterator prereq_iter =
             handlers_.find(prerequisites[i]);

--- a/application/common/manifest_handlers/widget_handler_unittest.cc
+++ b/application/common/manifest_handlers/widget_handler_unittest.cc
@@ -136,11 +136,10 @@ TEST_F(WidgetHandlerTest, ParseManifestWithOnlyNameAndVersion) {
   EXPECT_NE(nullptr, application.get());
 
   WidgetInfo* info = GetWidgetInfo(application);
-  int size = info->GetWidgetInfo()->size();
 
   // Only name and version ,others are empty string "",but exist.
   // And widget have 10 items.
-  EXPECT_EQ(size, 10);
+  EXPECT_EQ(info->GetWidgetInfo()->size(), 10);
 
   base::DictionaryValue* widget = info->GetWidgetInfo();
   base::DictionaryValue::Iterator it(*widget);

--- a/application/common/package/xpk_package.cc
+++ b/application/common/package/xpk_package.cc
@@ -8,6 +8,7 @@
 
 #include "base/files/file_util.h"
 #include "base/files/scoped_file.h"
+#include "base/numerics/safe_conversions.h"
 #include "crypto/signature_verifier.h"
 #include "xwalk/application/common/id_util.h"
 
@@ -79,14 +80,14 @@ bool XPKPackage::VerifySignature() {
   if (!verifier.VerifyInit(kSignatureAlgorithm,
                            sizeof(kSignatureAlgorithm),
                            &signature_.front(),
-                           signature_.size(),
+                           base::checked_cast<int>(signature_.size()),
                            &key_.front(),
-                           key_.size()))
+                           base::checked_cast<int>(key_.size())))
     return false;
   unsigned char buf[1 << 12];
   size_t len = 0;
   while ((len = fread(buf, 1, sizeof(buf), file_->get())) > 0)
-    verifier.VerifyUpdate(buf, len);
+    verifier.VerifyUpdate(buf, base::checked_cast<int>(len));
   if (!verifier.VerifyFinal())
     return false;
 

--- a/extensions/renderer/xwalk_extension_client.cc
+++ b/extensions/renderer/xwalk_extension_client.cc
@@ -5,6 +5,7 @@
 #include "xwalk/extensions/renderer/xwalk_extension_client.h"
 
 #include "base/values.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/stl_util.h"
 #include "ipc/ipc_sender.h"
 #include "xwalk/extensions/common/xwalk_extension_messages.h"
@@ -87,7 +88,8 @@ void XWalkExtensionClient::OnPostOutOfLineMessageToJS(
   if (!shared_memory.Map(size))
     return;
 
-  IPC::Message message(static_cast<char*>(shared_memory.memory()), size);
+  IPC::Message message(static_cast<char*>(shared_memory.memory()),
+                       base::checked_cast<int>(size));
   OnMessageReceived(message);
 }
 

--- a/extensions/test/internal_extension_browsertest.cc
+++ b/extensions/test/internal_extension_browsertest.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include "base/logging.h"
+#include "base/numerics/safe_conversions.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "grit/xwalk_extensions_resources.h"
@@ -103,10 +104,10 @@ void TestExtensionInstance::OnGetAllPersons(
     return;
   }
 
-  unsigned max_size = std::min<unsigned>(database()->size(), params->max_size);
+  size_t max_size = std::min<size_t>(database()->size(), params->max_size);
   std::vector<linked_ptr<Person> > persons;
 
-  for (unsigned i = 0; i < max_size; ++i) {
+  for (size_t i = 0; i < max_size; ++i) {
     linked_ptr<Person> person(new Person);
     person->name = database()->at(i).first;
     person->age = database()->at(i).second;
@@ -114,7 +115,8 @@ void TestExtensionInstance::OnGetAllPersons(
     persons.push_back(person);
   }
 
-  info->PostResult(GetAllPersons::Results::Create(persons, max_size));
+  info->PostResult(
+    GetAllPersons::Results::Create(persons, base::checked_cast<int>(max_size)));
 }
 
 void TestExtensionInstance::OnGetPersonAge(

--- a/sysapps/common/sysapps_manager_unittest.cc
+++ b/sysapps/common/sysapps_manager_unittest.cc
@@ -53,7 +53,7 @@ class DummyExtension : public XWalkExtension {
   }
 };
 
-int CountExtensions(SysAppsManager* manager) {
+size_t CountExtensions(SysAppsManager* manager) {
   XWalkExtensionVector extensions;
   STLElementDeleter<XWalkExtensionVector> deleter(&extensions);
   manager->CreateExtensionsForExtensionThread(&extensions);
@@ -65,17 +65,17 @@ int CountExtensions(SysAppsManager* manager) {
 
 TEST_F(XWalkSysAppsManagerTest, DisableDeviceCapabilities) {
   SysAppsManager manager;
-  int count_before_disable = CountExtensions(&manager);
+  size_t count_before_disable = CountExtensions(&manager);
   manager.DisableDeviceCapabilities();
-  int count_after_disable = CountExtensions(&manager);
+  size_t count_after_disable = CountExtensions(&manager);
   EXPECT_EQ(count_before_disable, count_after_disable + 1);
 }
 
 TEST_F(XWalkSysAppsManagerTest, DisableRawSockets) {
   SysAppsManager manager;
-  int count_before_disable = CountExtensions(&manager);
+  size_t count_before_disable = CountExtensions(&manager);
   manager.DisableRawSockets();
-  int count_after_disable = CountExtensions(&manager);
+  size_t count_after_disable = CountExtensions(&manager);
   EXPECT_EQ(count_before_disable, count_after_disable + 1);
 }
 

--- a/sysapps/device_capabilities/display_info_provider_unittest.cc
+++ b/sysapps/device_capabilities/display_info_provider_unittest.cc
@@ -56,7 +56,7 @@ TEST(XWalkSysAppsDeviceCapabilitiesTest, DisplayInfoProvider) {
 
   std::vector<linked_ptr<DisplayUnit> > displays = info->displays;
 
-  unsigned display_count = displays.size();
+  size_t display_count = displays.size();
   EXPECT_GE(display_count, 0u);
 
   for (size_t i = 0; i < display_count; ++i) {

--- a/sysapps/device_capabilities/storage_info_provider_unittest.cc
+++ b/sysapps/device_capabilities/storage_info_provider_unittest.cc
@@ -39,7 +39,7 @@ void TestClosure() {
 
   // We should have at least one storage, otherwise where is the binary
   // of this unit test being stored?
-  unsigned storage_count = storages.size();
+  size_t storage_count = storages.size();
   EXPECT_GT(storage_count, 0u);
 
   // The only information we can verify is the fact that the storage

--- a/sysapps/raw_socket/tcp_socket_object.cc
+++ b/sysapps/raw_socket/tcp_socket_object.cc
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include "base/logging.h"
+#include "base/numerics/safe_conversions.h"
 #include "net/base/net_errors.h"
 #include "net/base/net_util.h"
 #include "xwalk/sysapps/raw_socket/tcp_socket.h"
@@ -148,7 +149,7 @@ void TCPSocketObject::OnSendString(
   memcpy(write_buffer_->data(), params->data.data(), params->data.size());
 
   int ret = socket_->Write(write_buffer_.get(),
-                           params->data.size(),
+                           base::checked_cast<int>(params->data.size()),
                            base::Bind(&TCPSocketObject::OnWrite,
                                       base::Unretained(this)));
 

--- a/sysapps/raw_socket/udp_socket_object.cc
+++ b/sysapps/raw_socket/udp_socket_object.cc
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "base/logging.h"
+#include "base/numerics/safe_conversions.h"
 #include "net/base/net_errors.h"
 #include "xwalk/sysapps/raw_socket/udp_socket.h"
 
@@ -266,7 +267,7 @@ void UDPSocketObject::OnSend(int status) {
 
   int ret = socket_->SendTo(
       write_buffer_.get(),
-      write_buffer_size_,
+      base::checked_cast<int>(write_buffer_size_),
       addresses_[0],
       base::Bind(&UDPSocketObject::OnWrite, base::Unretained(this)));
 

--- a/sysapps/raw_socket/udp_socket_object.h
+++ b/sysapps/raw_socket/udp_socket_object.h
@@ -49,7 +49,7 @@ class UDPSocketObject : public RawSocketObject {
   scoped_refptr<net::IOBuffer> write_buffer_;
   scoped_ptr<net::UDPSocket> socket_;
 
-  unsigned write_buffer_size_;
+  size_t write_buffer_size_;
 
   scoped_ptr<net::HostResolver> resolver_;
   scoped_ptr<net::SingleRequestHostResolver> single_resolver_;


### PR DESCRIPTION
Code usually uses std functions which returns a size_t and size_t
is not going to fit into an int on 64 bits. Today it triggers a
warning of potential data loss.

We could disable the warning but it's better to fix the code.
Please note that we have various casts, these are mandatory (though
unfortunate) at the moment because the API in Chromium requires
explicitely an int for example. This can be fixed upstream and
bugs have been reported (e.g. crbug.com/167187).