### PR TITLE
[Linux] Fix window title doesn't update with current navigation's entry

### DIFF
--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -292,6 +292,21 @@ void Runtime::DidUpdateFaviconURL(const std::vector<FaviconURL>& candidates) {
           &Runtime::DidDownloadFavicon, weak_ptr_factory_.GetWeakPtr()));
 }
 
+void Runtime::DidStartNavigationToPendingEntry(
+    const GURL& url,
+    content::NavigationController::ReloadType reload_type) {
+    std::string title;
+    if (ui_delegate_ &&
+        reload_type == content::NavigationController::NO_RELOAD) {
+      title = base::UTF16ToUTF8(
+          web_contents()->GetController().GetActiveEntry()->GetTitle());
+      if (title.empty())
+        ui_delegate_->UpdateTitle(base::UTF8ToUTF16("Untitled"));
+      else
+        ui_delegate_->UpdateTitle(base::UTF8ToUTF16(title));
+    }
+}
+
 void Runtime::DidDownloadFavicon(int id,
                                  int http_status_code,
                                  const GURL& image_url,

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -155,6 +155,10 @@ class Runtime : public content::WebContentsDelegate,
   void DidUpdateFaviconURL(
       const std::vector<content::FaviconURL>& candidates) override;
 
+  void DidStartNavigationToPendingEntry(
+      const GURL& url,
+      content::NavigationController::ReloadType reload_type) override;
+
   // Callback method for WebContents::DownloadImage.
   void DidDownloadFavicon(int id,
                           int http_status_code,


### PR DESCRIPTION
Override "WebContentsObserver::DidStartNavigationToPendingEntry" method to
track window title update with navigating button pressed since the signal
"NOTIFICATION_WEB_CONTENTS_TITLE_UPDATED" isn't always fired from notification
service which leads to webcontens changed while window title has no chance to
update.

@rakuco @pozdnyakov @PeterWangIntel Please spare time to take a look, thanks.