### PR TITLE
crosswalk-13: [Android] make_apk: Stop suggesting architectures without downloads.

### DIFF
--- a/app/tools/android/util.py
+++ b/app/tools/android/util.py
@@ -27,10 +27,6 @@ def CleanDir(path):
     shutil.rmtree(path)
 
 
-def AllArchitectures():
-  return ("x86", "x86_64", "arm")
-
-
 def RunCommand(command, verbose=False, shell=False):
   """Runs the command list, print the output, and propagate its result."""
   proc = subprocess.Popen(command, stdout=subprocess.PIPE,


### PR DESCRIPTION
Even though we do not provide official Crosswalk downloads for ARM64 and
x86_64, we were still nagging users to provide APKs for both
architectures whenever they used make_apk.py in embedded mode.

Stop doing that and only suggest the architectures for which we provide
official downloads (ARM and x86). The code supporting ARM64 and x86_64
remains in place, and we do allow users to specify them in the
command-line if they have build Crosswalk for those architectures
themselves.

While here, reword and improve the message listing all the APKs that
have been created by the make_apk invocation.

(cherry picked from commit fc30d8ad1938fe9010a5e2fd7e5fdd3f5816dcd1)

Conflicts:
	app/tools/android/make_apk.py
	app/tools/android/util.py