### PR TITLE
Move to Chromium 42.0.2311.90.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,9 +17,9 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '7e1ccae3e41e237e52032627b52e2804445bdea3'
-v8_crosswalk_rev = '291a3d32821ea2be983076911e72a4a3d5bae8cc'
-ozone_wayland_rev = '5e056d8d5f2eadaea34d0352556a197dd700d6e0'
+chromium_crosswalk_rev = '1de2acc9e408e87c1dd31d54f85d6267084db908'
+v8_crosswalk_rev = '556255773803c24bc618695d173f376fe7bb0567'
+ozone_wayland_rev = 'bd769b47008882f3d0fcb78070415a5ef2700032'
 
 # |blink_crosswalk_rev| specifies the SHA1 hash of the blink-crosswalk commit
 # we want to point to, very much like the variables above.
@@ -27,8 +27,8 @@ ozone_wayland_rev = '5e056d8d5f2eadaea34d0352556a197dd700d6e0'
 # the blink-crosswalk repository, so that the devtools code can use it to fetch
 # assets from Chromium's servers with a revision that exists there. We need an
 # SVN revision while Blink is still in SVN.
-blink_crosswalk_rev = 'c74608426e970d4bfdd35fb2cee19939efbba405'
-blink_upstream_rev = '192846'
+blink_crosswalk_rev = '2a0323ee8bca4f2fc15dc9dcaacb53df2e4226b9'
+blink_upstream_rev = '193294'
 
 crosswalk_git = 'https://github.com/crosswalk-project'
 ozone_wayland_git = 'https://github.com/01org'


### PR DESCRIPTION
This is the first stable M42 release. In addition, we are now tracking
ozone-wayland's Milestone-Mazama, which is oz-wl's branch tracking M42.