### PR TITLE
crosswalk-13: Move to Chromium 42.0.2311.90, the first M42 stable release.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,9 +17,9 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'e2836625981907e8283f2a53442144b8fea9bb63'
-v8_crosswalk_rev = '540c31a4027e44bc03b472d60e2e7c4b065201a9'
-ozone_wayland_rev = 'eacaa23d129961f94993a30438aa9e4cd7dfefb7'
+chromium_crosswalk_rev = '45fdd15ed520dd5b12cf75c43dd1d257659e6c72'
+v8_crosswalk_rev = 'bb68636c00b9c8ce6b4fdda6b77bd0a47acc753b'
+ozone_wayland_rev = 'bd769b47008882f3d0fcb78070415a5ef2700032'
 
 # |blink_crosswalk_rev| specifies the SHA1 hash of the blink-crosswalk commit
 # we want to point to, very much like the variables above.
@@ -27,8 +27,8 @@ ozone_wayland_rev = 'eacaa23d129961f94993a30438aa9e4cd7dfefb7'
 # the blink-crosswalk repository, so that the devtools code can use it to fetch
 # assets from Chromium's servers with a revision that exists there. We need an
 # SVN revision while Blink is still in SVN.
-blink_crosswalk_rev = '6223e0825bc64ba598653a8ac117a9319269c072'
-blink_upstream_rev = '192846'
+blink_crosswalk_rev = '104cc9465d7f8365a0629c5f5ca40a0434e52b4c'
+blink_upstream_rev = '193294'
 
 crosswalk_git = 'https://github.com/crosswalk-project'
 ozone_wayland_git = 'https://github.com/01org'


### PR DESCRIPTION
While here, also make ozone-wayland track Milestone-Mazama, its
M42-based branch.