### PR TITLE
DEPS.xwalk: Roll blink-crosswalk (2a0323e -> 6e19c2e).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -27,7 +27,7 @@ ozone_wayland_rev = 'bd769b47008882f3d0fcb78070415a5ef2700032'
 # the blink-crosswalk repository, so that the devtools code can use it to fetch
 # assets from Chromium's servers with a revision that exists there. We need an
 # SVN revision while Blink is still in SVN.
-blink_crosswalk_rev = '2a0323ee8bca4f2fc15dc9dcaacb53df2e4226b9'
+blink_crosswalk_rev = '6e19c2e88e3d624862fd76afe9984ad4a3680920'
 blink_upstream_rev = '193294'
 
 crosswalk_git = 'https://github.com/crosswalk-project'


### PR DESCRIPTION
* 6e19c2e Merge pull request #52 from rakuco/revert-faulty-revert
* d00a85f Revert "Revert "Merge 192508 "Focus a page only if the page is different from cu..."""

This roll is to revert a reverted upstream commit that was not supposed
to be pushed to blink-crosswalk (it was reverted temporarily while we
were debugging XWALK-3863).