### PR TITLE
Add a new hook to create Google Play Services's directory structure.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -44,6 +44,16 @@ hooks = [
     "action": ["python", "src/xwalk/tools/fetch_deps.py", "-v"],
   },
   {
+    # Make src/third_party/android_tools/android_tools.gyp shut up and not exit
+    # if the Google Play Services library is not installed (after
+    # https://chromium-review.googlesource.com/#/c/247861). We do not use it on
+    # Crosswalk, and installing it is a manual process that involves accepting
+    # an EULA.
+    "name": "empty-google-play-services_lib",
+    "pattern": ".",
+    "action": ["python", "src/xwalk/tools/empty_google_play_services_lib.py"],
+  },
+  {
     # A change to a .gyp, .gypi, or to GYP itself should run the generator.
     "name": "gyp-xwalk",
     "pattern": ".",

--- a/tools/empty_google_play_services_lib.py
+++ b/tools/empty_google_play_services_lib.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+Create an empty google-play-services.jar inside src/third_party/android_tools.
+
+https://chromium-review.googlesource.com/#/c/247861 has introduced a check in
+android_tools.gyp that makes the gyp configuration process fail if a certain
+file that is part of the Google Play Services library is not found.
+
+Since installing that library involves manually accepting an EULA and it is not
+used in Crosswalk, we create an empty file with the name android_tools.gyp
+checks for so that the build configuration proceeds. If the user chooses to
+manually install the library, the empty file is just overwritten and nothing
+breaks. Additionally, we also create res/ and src/ so that src/build/java.gypi
+can call find(1) in those directories without failing.
+"""
+
+import errno
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
+                             'build', 'android'))
+
+from pylib.constants import ANDROID_SDK_ROOT
+
+
+def CreateDirectory(path):
+  """
+  Creates |path| and all missing parent directories. Passing a directory that
+  already exists does not cause an error.
+  """
+  try:
+    os.makedirs(path)
+  except OSError, e:
+    if e.errno == errno.EEXIST:
+      pass
+
+
+def CreateFileIfMissing(path):
+  """
+  Creates an empty file called |path| if it does not already exist.
+  """
+  if os.path.isfile(path):
+    return
+  open(path, 'w').close()
+
+
+if __name__ == '__main__':
+  # If ANDROID_SDK_ROOT does not exist, we can assume the android_tools
+  # repository has not been checked out. Consequently, this is not an Android
+  # build and we do not need to worry about the issue this script works around.
+  if not os.path.isdir(ANDROID_SDK_ROOT):
+    sys.exit(0)
+
+  google_play_lib_root = os.path.join(
+    ANDROID_SDK_ROOT, 'extras', 'google', 'google_play_services', 'libproject',
+    'google-play-services_lib')
+
+  CreateDirectory(os.path.join(google_play_lib_root, 'libs'))
+  CreateDirectory(os.path.join(google_play_lib_root, 'res'))
+  CreateDirectory(os.path.join(google_play_lib_root, 'src'))
+  CreateFileIfMissing(os.path.join(google_play_lib_root, 'libs',
+                                   'google-play-services.jar'))


### PR DESCRIPTION
Ever since M42, building Chromium (and consequently Crosswalk) for
Android has required installing the Google Play Services library via the
`android` tool first. However, doing so involves manually accepting an
End User License Agreement (EULA), which makes things very difficult to
automate and also breaks our checkout+configuration process for users
who are building Crosswalk for the first time.

Since that library is actually needed only by Chromium but not
Crosswalk, we have been working around this requirement. When Crosswalk
started tracking Chromium M42, we added a few changes to
chormium-crosswalk. One of them was making gyp not fail if some
directories created by the Google Play Services library were not
present.

This solution needs to be rethought for the upcoming M43, as there is
now a build system check in the android_tools repository to fail if a
certain file installed by that library is not found.

The script being added by this change is the answer to this, and is
being landed before M43 itself because it also works independently of
it. If the android_tools repository is checked out, it tries to create
the Google Play Services directories gyp looks for as well as an empty
file with the name that the android_tools build system checks. This way,
we get rid of the corresponding change in chromium-crosswalk, prepare
for the upcoming change in android_tools and make most of these things
be controlled from the crosswalk repository itself.

Related to: XWALK-3955