### PR TITLE
Add SSL error page to handle SSL certificate error

### DIFF
--- a/runtime/browser/ssl_error_page.cc
+++ b/runtime/browser/ssl_error_page.cc
@@ -1,0 +1,91 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/ssl_error_page.h"
+
+#include "base/strings/string_number_conversions.h"
+#include "content/public/browser/interstitial_page.h"
+#include "content/public/browser/web_contents.h"
+
+using content::WebContents;
+using net::SSLInfo;
+
+namespace xwalk {
+
+enum UserCommandsFromPage {
+  CMD_DONT_PROCEED = 0,
+  CMD_PROCEED = 1,
+};
+
+SSLErrorPage::SSLErrorPage(WebContents* web_contents,
+                           int cert_error,
+                           const SSLInfo& ssl_info,
+                           const GURL& request_url,
+                           const base::Callback<void(bool)>& callback)
+    : web_contents_(web_contents),
+      cert_error_(cert_error),
+      ssl_info_(ssl_info),
+      request_url_(request_url),
+      callback_(callback),
+      interstitial_page_(nullptr) {
+}
+
+SSLErrorPage::~SSLErrorPage() {
+}
+
+void SSLErrorPage::Show() {
+  DCHECK(!interstitial_page_);
+  interstitial_page_ = content::InterstitialPage::Create(
+      web_contents_, true, request_url_, this);
+  interstitial_page_->Show();
+}
+
+void SSLErrorPage::OnProceed() {
+  // Allow certificate
+  callback_.Run(true);
+  callback_.Reset();
+}
+
+void SSLErrorPage::OnDontProceed() {
+  // Deny certificate
+  callback_.Run(false);
+  callback_.Reset();
+}
+
+void SSLErrorPage::CommandReceived(const std::string& command) {
+  int cmd = 0;
+  bool retval = base::StringToInt(command, &cmd);
+  DCHECK(retval);
+  switch (cmd) {
+    case CMD_DONT_PROCEED:
+      interstitial_page_->DontProceed();
+      break;
+    case CMD_PROCEED:
+      interstitial_page_->Proceed();
+      break;
+    default:
+      break;
+  }
+}
+
+// TODO(Peter Wang): Provide a more user-friendly page including
+// icons, localized strings, and the details of SSL error etc.
+std::string SSLErrorPage::GetHTMLContents() {
+  std::string proceed_link =
+      "<p><a href=\"javascript:proceed()\"> Proceed to " +
+      request_url_.spec() + "</a></p>";
+  return "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">"
+         "<html><head><title>Untrusted Connection</title>"
+         "<script>function proceed() {"
+         "window.domAutomationController.setAutomationId(1);"
+         "window.domAutomationController.send(1);}"
+         "</script></head>"
+         "<body><h1>This Connection is Untrusted</h1>"
+         "<p>This site uses an invalid security certificate.</p>"
+         "<p>Close or proceed if your understand the risks</p>" +
+         proceed_link +
+         "</body></html>";
+}
+
+}  // namespace xwalk

--- a/runtime/browser/ssl_error_page.h
+++ b/runtime/browser/ssl_error_page.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_SSL_ERROR_PAGE_H_
+#define XWALK_RUNTIME_BROWSER_SSL_ERROR_PAGE_H_
+
+#include <string>
+
+#include "base/callback.h"
+#include "content/public/browser/interstitial_page_delegate.h"
+#include "net/ssl/ssl_info.h"
+#include "url/gurl.h"
+
+namespace content {
+class InterstitialPage;
+class WebContents;
+}
+
+namespace xwalk {
+
+class SSLErrorPage : public content::InterstitialPageDelegate {
+ public:
+  SSLErrorPage(content::WebContents* web_contents,
+               int cert_error,
+               const net::SSLInfo& ssl_info,
+               const GURL& request_url,
+               const base::Callback<void(bool)>& callback);
+
+  ~SSLErrorPage() override;
+
+  // Show an interstitial page to let user to choose the next action
+  void Show();
+
+ protected:
+  // Overridden methods of InterstitialPageDelegate
+  void OnProceed() override;
+  void OnDontProceed() override;
+  void CommandReceived(const std::string& command) override;
+  std::string GetHTMLContents() override;
+
+ private:
+  content::WebContents* web_contents_;
+  const int cert_error_;
+  const net::SSLInfo ssl_info_;
+  const GURL request_url_;
+  base::Callback<void(bool)> callback_;
+  content::InterstitialPage* interstitial_page_;
+
+  DISALLOW_COPY_AND_ASSIGN(SSLErrorPage);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_SSL_ERROR_PAGE_H_

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -34,6 +34,7 @@
 #include "xwalk/runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h"
 #include "xwalk/runtime/browser/runtime_platform_util.h"
 #include "xwalk/runtime/browser/runtime_quota_permission_context.h"
+#include "xwalk/runtime/browser/ssl_error_page.h"
 #include "xwalk/runtime/browser/speech/speech_recognition_manager_delegate.h"
 #include "xwalk/runtime/browser/xwalk_browser_context.h"
 #include "xwalk/runtime/browser/xwalk_browser_main_parts.h"
@@ -275,6 +276,20 @@ void XWalkContentBrowserClient::AllowCertificateError(
                                   &cancel_request);
   if (cancel_request)
     *result = content::CERTIFICATE_REQUEST_RESULT_TYPE_DENY;
+#else
+  content::RenderFrameHost* render_frame_host =
+      content::RenderFrameHost::FromID(render_process_id, render_frame_id);
+  content::WebContents* web_contents =
+      content::WebContents::FromRenderFrameHost(render_frame_host);
+  if (!web_contents) {
+    NOTREACHED();
+    return;
+  }
+
+  // The interstitial page shown is responsible for destroying
+  // this instance of SSLErrorPage
+  (new SSLErrorPage(web_contents, cert_error,
+                    ssl_info, request_url, callback))->Show();
 #endif
 }
 

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -192,6 +192,8 @@
         'runtime/browser/runtime_url_request_context_getter.h',
         'runtime/browser/speech/speech_recognition_manager_delegate.cc',
         'runtime/browser/speech/speech_recognition_manager_delegate.h',
+        'runtime/browser/ssl_error_page.cc',
+        'runtime/browser/ssl_error_page.h',
         'runtime/browser/sysapps_component.cc',
         'runtime/browser/sysapps_component.h',
         'runtime/browser/storage_component.cc',


### PR DESCRIPTION
When SSL certificate error occurs, show an Interstitial Page to give user a chance to choose to proceed or just close the App.

Add "xwalk::SSLErrorPage" as a child class of "content::InterstitialPageDelegate" with these methods overridden: 
(1) Show()
     Creates the instance of "content::InterstitialPage" and show it.
(2) GetHTMLContents()
     Provides the html for the interstitial page. The web page includes a link to allow user to ignore the SSL error and proceed the network request.
(3)  OnProceed()
     When user chooses to proceed, this function will be invoked to call the "callback" provided by "content".

BUG=https://crosswalk-project.org/jira/browse/XWALK-3668