### PR TITLE
To link libgtk2ui of Chrome directly

### DIFF
--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -252,7 +252,8 @@ content::ColorChooser* Runtime::OpenColorChooser(
 void Runtime::RunFileChooser(
     content::WebContents* web_contents,
     const content::FileChooserParams& params) {
-#if defined(USE_AURA) && defined(OS_LINUX) && !defined(USE_WEBUI_FILE_PICKER)
+#if defined(USE_AURA) && defined(OS_LINUX) && \
+    !defined(USE_WEBUI_FILE_PICKER) && !defined(USE_GTK_UI)
   NOTIMPLEMENTED();
 #else
   RuntimeFileSelectHelper::RunFileChooser(web_contents, params);

--- a/runtime/browser/ui/gtk2_ui.h
+++ b/runtime/browser/ui/gtk2_ui.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_UI_GTK2_UI_H_
+#define XWALK_RUNTIME_BROWSER_UI_GTK2_UI_H_
+
+#include "ui/views/linux_ui/linux_ui.h"
+
+// Return the unique instance of class 'Gtk2UI'.
+extern views::LinuxUI* BuildGtk2UI();
+
+#endif  // XWALK_RUNTIME_BROWSER_UI_GTK2_UI_H_

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -27,6 +27,9 @@
 #include "xwalk/application/browser/application_system.h"
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
+#if defined(USE_GTK_UI)
+#include "xwalk/runtime/browser/ui/gtk2_ui.h"
+#endif
 #include "xwalk/runtime/browser/xwalk_runner.h"
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
@@ -138,6 +141,10 @@ void XWalkBrowserMainParts::PreEarlyInitialization() {
 #if defined(USE_WEBUI_FILE_PICKER)
   ui::LinuxShellDialog::SetInstance(BuildWebUI());
   wm_state_.reset(new wm::WMState);
+#elif defined(USE_GTK_UI)
+  views::LinuxUI* gtk2_ui = BuildGtk2UI();
+  gtk2_ui->Initialize();
+  views::LinuxUI::SetInstance(gtk2_ui);
 #endif
 #endif
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -452,6 +452,12 @@
             'runtime/common/url_constants.h',
           ],
         }],
+        ['OS=="linux" and tizen!=1', {
+          'defines': ['USE_GTK_UI'],
+          'dependencies': [
+            '../chrome/browser/ui/libgtk2ui/libgtk2ui.gyp:gtk2ui',
+          ],
+        }],  # OS=="linux" and tizen!=1
         ['disable_nacl==0', {
             'conditions': [
                 ['OS=="linux"', {


### PR DESCRIPTION
Maybe, we can make GTK2-related UI as an outside library and link to it.
At current stage, we can directly use 'libgtkui.a' (target 'gtk2ui') built by Chrome, in future, we can move these code out as an independent project to add our own code or WebUI eventraully.
With this patch, Crosswalk for Linux can support GTK-based 'File Picker', and input method context, and font to save our effort to move the code case by case.