### PR TITLE
[Android] Use the locale from system by default

### DIFF
--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -50,6 +50,7 @@
 #endif
 
 #if defined(OS_ANDROID)
+#include "base/android/locale_utils.h"
 #include "base/android/path_utils.h"
 #include "base/base_paths_android.h"
 #include "xwalk/runtime/browser/android/xwalk_cookie_access_policy.h"
@@ -463,5 +464,13 @@ void XWalkContentBrowserClient::GetAdditionalMappedFilesForChildProcess(
 #endif  // V8_USE_EXTERNAL_STARTUP_DATA
 }
 #endif  // defined(OS_POSIX) && !defined(OS_MACOSX)
+
+std::string XWalkContentBrowserClient::GetApplicationLocale() {
+#if defined(OS_ANDROID)
+  return base::android::GetDefaultLocale();
+#else
+  return content::ContentBrowserClient::GetApplicationLocale();
+#endif
+}
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -164,6 +164,8 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
   }
 #endif
 
+  std::string GetApplicationLocale() override;
+
  private:
   XWalkRunner* xwalk_runner_;
   net::URLRequestContextGetter* url_request_context_getter_;


### PR DESCRIPTION
The browser can use the locale via system by default and the --lang command line flag.

BUG=XWALK-2132

(cherry picked from commit 6d89b1d4dc988bb47e8244f9e7ee08108baaf01d)