### PR TITLE
[Android] Back port commits for dropped IndexedDB  to Crosswalk 11

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -10,6 +10,7 @@
 #include "base/base_paths_android.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/macros.h"
 #include "base/message_loop/message_loop.h"
 #include "base/path_service.h"
 #include "base/threading/sequenced_worker_pool.h"
@@ -61,9 +62,10 @@ void MoveUserDataDirIfNecessary(const base::FilePath& user_data_dir,
       "Cache",
       "Cookies",
       "Cookies-journal",
+      "IndexedDB",
       "Local Storage",
   };
-  for (int i = 0; i < 4; i++) {
+  for (size_t i = 0; i < arraysize(possible_data_dir_names); i++) {
     base::FilePath dir = user_data_dir.Append(possible_data_dir_names[i]);
     if (base::PathExists(dir)) {
       if (!base::Move(dir, profile.Append(possible_data_dir_names[i]))) {


### PR DESCRIPTION
Because of multiple profile support, from crosswalk 9 IndexedDB
will be put under profile's subfolder.
Issue is reported from https://github.com/MobileChromeApps/mobile-chrome-apps/issues/554.

BUG=XWALK-4047

(cherry picked from commit 36231eaa85f54622210f9999819cb68994d64432)