### PR TITLE
Lzma backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ Thumbs.db
 cscope.*
 Session.vim
 UPSTREAM.blink
+third_party/lzma_sdk/*.bz2
+third_party/lzma_sdk/*.7z
+third_party/lzma_sdk/src
+raw/

--- a/DEPS
+++ b/DEPS
@@ -38,6 +38,12 @@ hooks = [
     "action": ["python", "src/xwalk/tools/generate_gclient-xwalk.py"],
   },
   {
+    # Fetch and prepare SevenZip LZMA SDK
+    "name": "download-lzma-sdk",
+    "pattern": ".",
+    "action": ["python", "src/xwalk/third_party/lzma_sdk/download_lzma_sdk.py"],
+  },
+  {
     # Fetch Crosswalk dependencies.
     "name": "fetch-deps",
     "pattern": ".",

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -30,9 +30,10 @@ from manifest_json_parser import ManifestJsonParser
 
 
 NATIVE_LIBRARY = 'libxwalkcore.so'
+DUMMY_LIBRARY = 'libxwalkdummy.so'
 EMBEDDED_LIBRARY = 'xwalk_core_library'
 SHARED_LIBRARY = 'xwalk_shared_library'
-DUMMY_LIBRARY = 'libxwalkdummy.so'
+
 
 # FIXME(rakuco): Only ALL_ARCHITECTURES should exist. We keep these two
 # separate lists because SUPPORTED_ARCHITECTURES contains the architectures
@@ -43,6 +44,7 @@ SUPPORTED_ARCHITECTURES = (
   'arm',
   'x86',
 )
+
 ALL_ARCHITECTURES = (
   'arm',
   'arm64',
@@ -95,7 +97,11 @@ def GetAndroidApiLevel(android_path):
 
 
 def ContainsNativeLibrary(path):
-  return os.path.isfile(os.path.join(path, NATIVE_LIBRARY)) or os.path.isfile(os.path.join(path, DUMMY_LIBRARY))
+  return os.path.isfile(os.path.join(path, NATIVE_LIBRARY))
+
+
+def ContainsCompressedLibrary(path):
+  return os.path.isfile(os.path.join(path, NATIVE_LIBRARY + ".lzma"))
 
 
 def ParseManifest(options):
@@ -295,6 +301,39 @@ def Customize(options, app_info, manifest):
                options.xwalk_command_line, options.compressor)
 
 
+def CleanCompressedLibrary(library_path, arch):
+  useless = os.path.join(library_path, NATIVE_LIBRARY + '.' + arch)
+  if (os.path.isfile(useless)):
+    os.remove(useless)
+
+
+def CleanNativeLibrary(library_path, arch):
+  lib_dir = os.path.join(library_path, arch)
+  if (os.path.isdir(lib_dir)):
+    shutil.rmtree(lib_dir)
+
+
+def CopyCompressedLibrary(native_path, library_path, raw_path, arch):
+  # need dummy library file to keep the arch info if enable lzma.
+  arch_path = os.path.join(library_path, arch)
+  if (not os.path.isdir(arch_path)):
+      os.mkdir(arch_path)
+  dummy_library = os.path.join(native_path, DUMMY_LIBRARY);
+  shutil.copy(dummy_library, arch_path)
+
+  compressed_library = os.path.join(native_path, NATIVE_LIBRARY + '.lzma')
+  shutil.copy(compressed_library, raw_path)
+
+
+def CopyNativeLibrary(native_path, library_path, raw_path, arch):
+  # do not need dummy library when lzma disabled.
+  dummy_library = os.path.join(native_path, DUMMY_LIBRARY);
+  if (os.path.isfile(dummy_library)):
+    os.remove(dummy_library)
+
+  shutil.copytree(native_path, os.path.join(library_path, arch))
+
+
 def Execution(options, app_info):
   # Now we've got correct app_version and correct ABI value,
   # start to generate suitable versionCode
@@ -378,26 +417,30 @@ def Execution(options, app_info):
     if not arch:
       print ('Invalid CPU arch: %s.' % arch)
       sys.exit(10)
-    library_lib_path = os.path.join(app_dir, EMBEDDED_LIBRARY, 'libs')
+
+    native_path = os.path.join(app_dir, 'native_libs', arch)
+    library_path = os.path.join(app_dir, EMBEDDED_LIBRARY, 'libs')
     raw_path = os.path.join(app_dir, EMBEDDED_LIBRARY, 'res', 'raw')
-    for dir_name in os.listdir(library_lib_path):
-      lib_dir = os.path.join(library_lib_path, dir_name)
-      if ContainsNativeLibrary(lib_dir):
-        shutil.rmtree(lib_dir)
-      other_lib = os.path.join(raw_path, NATIVE_LIBRARY + '.' + dir_name)
-      if (os.path.isfile(other_lib)):
-        os.remove(other_lib)
-    native_lib_path = os.path.join(app_dir, 'native_libs', arch)
-    if ContainsNativeLibrary(native_lib_path):
-      shutil.copytree(native_lib_path, os.path.join(library_lib_path, arch))
+
+    if options.enable_lzma:
+      contains_library = ContainsCompressedLibrary
+      clean_library = CleanCompressedLibrary
+      copy_library = CopyCompressedLibrary
+    else:
+      contains_library = ContainsNativeLibrary
+      clean_library = CleanNativeLibrary
+      copy_library = CopyNativeLibrary
+
+    # cleanup previous build's library first.
+    for dir_name in os.listdir(library_path):
+      clean_library(library_path, dir_name)
+
+    if contains_library(native_path):
+      copy_library(native_path, library_path, raw_path, arch)
     else:
       print('No %s native library has been found for creating a Crosswalk '
             'embedded APK.' % arch)
       sys.exit(10)
-
-    compressed_lib = os.path.join(app_dir, 'native_libs',
-                                  NATIVE_LIBRARY + '.' + arch)
-    shutil.copy(compressed_lib, raw_path)
 
   if options.project_only:
     print (' (Skipping apk package creation)')
@@ -492,6 +535,73 @@ def CheckSystemRequirements():
   print('ok')
 
 
+def MakeCompressedLibrary(lib_dir):
+  # use lzma to compress the native library.
+  native_library = os.path.join(lib_dir, NATIVE_LIBRARY)
+  RunCommand(['lzma', '-f', native_library])
+  return True
+
+
+def MakeNativeLibrary(lib_dir):
+  # use lzma to decompress the compressed library.
+  compressed_library = os.path.join(lib_dir, NATIVE_LIBRARY + '.lzma')
+  RunCommand(['lzma', '-d', compressed_library])
+  return True
+
+
+def MakeSharedApk(options, app_info, app_dir):
+  # Copy xwalk_shared_library into app folder
+  target_library_path = os.path.join(app_dir, SHARED_LIBRARY)
+  shutil.copytree(os.path.join(xwalk_dir, SHARED_LIBRARY),
+                  target_library_path)
+  Execution(options, app_info)
+
+
+def MakeEmbeddedApk(options, app_info, app_dir, packaged_archs):
+  # Copy xwalk_core_library into app folder and move the native libraries out.
+  # When making apk for specified CPU arch, will only include the
+  # corresponding native library by copying it back into xwalk_core_library.
+  target_library_path = os.path.join(app_dir, EMBEDDED_LIBRARY)
+  shutil.copytree(os.path.join(xwalk_dir, EMBEDDED_LIBRARY),
+                  target_library_path)
+  library_path = os.path.join(target_library_path, 'libs')
+  native_path = os.path.join(app_dir, 'native_libs')
+  os.makedirs(native_path)
+  available_archs = []
+
+  if options.enable_lzma:
+    contains_library = ContainsCompressedLibrary
+    make_library = MakeCompressedLibrary
+  else:
+    contains_library = ContainsNativeLibrary
+    make_library = MakeNativeLibrary
+
+  for dir_name in os.listdir(library_path):
+    lib_dir = os.path.join(library_path, dir_name)
+    if os.path.isdir(lib_dir) and \
+    (contains_library(lib_dir) or make_library(lib_dir)):
+      shutil.move(lib_dir, os.path.join(native_path, dir_name))
+      available_archs.append(dir_name)
+
+  if options.arch:
+    Execution(options, app_info)
+    packaged_archs.append(options.arch)
+  else:
+    # If the arch option is unspecified, all of available platform APKs
+    # will be generated.
+    for arch in ALL_ARCHITECTURES:
+      if ConvertArchNameToArchFolder(arch) in available_archs:
+        options.arch = arch
+        Execution(options, app_info)
+        packaged_archs.append(options.arch)
+      else:
+        print('Warning: failed to create package for arch "%s" '
+              'due to missing native library' % arch)
+    if len(packaged_archs) == 0:
+      print('No packages created, aborting')
+      sys.exit(13)
+
+
 def MakeApk(options, app_info, manifest):
   CheckSystemRequirements()
   Customize(options, app_info, manifest)
@@ -499,46 +609,9 @@ def MakeApk(options, app_info, manifest):
   app_dir = GetBuildDir(name)
   packaged_archs = []
   if options.mode == 'shared':
-    # Copy xwalk_shared_library into app folder
-    target_library_path = os.path.join(app_dir, SHARED_LIBRARY)
-    shutil.copytree(os.path.join(xwalk_dir, SHARED_LIBRARY),
-                    target_library_path)
-    Execution(options, app_info)
-  elif options.mode == 'embedded':
-    # Copy xwalk_core_library into app folder and move the native libraries
-    # out.
-    # When making apk for specified CPU arch, will only include the
-    # corresponding native library by copying it back into xwalk_core_library.
-    target_library_path = os.path.join(app_dir, EMBEDDED_LIBRARY)
-    shutil.copytree(os.path.join(xwalk_dir, EMBEDDED_LIBRARY),
-                    target_library_path)
-    library_lib_path = os.path.join(target_library_path, 'libs')
-    native_lib_path = os.path.join(app_dir, 'native_libs')
-    os.makedirs(native_lib_path)
-    available_archs = []
-    for dir_name in os.listdir(library_lib_path):
-      lib_dir = os.path.join(library_lib_path, dir_name)
-      if ContainsNativeLibrary(lib_dir):
-        shutil.move(lib_dir, os.path.join(native_lib_path, dir_name))
-        compressed_lib = os.path.join(target_library_path, 'res', 'raw',
-                                      NATIVE_LIBRARY + '.' + dir_name)
-        if (os.path.isfile(compressed_lib)):
-          shutil.move(compressed_lib, native_lib_path)
-        available_archs.append(dir_name)
-    if options.arch:
-      Execution(options, app_info)
-      packaged_archs.append(options.arch)
-    else:
-      # If the arch option is unspecified, all of available platform APKs
-      # will be generated.
-      for arch in ALL_ARCHITECTURES:
-        if ConvertArchNameToArchFolder(arch) in available_archs:
-          options.arch = arch
-          Execution(options, app_info)
-          packaged_archs.append(options.arch)
-      if len(packaged_archs) == 0:
-        print('No packages created, aborting')
-        sys.exit(13)
+    MakeSharedApk(options, app_info, app_dir)
+  else: # default
+    MakeEmbeddedApk(options, app_info, app_dir, packaged_archs)
 
   # if project_dir, save build directory
   if options.project_dir:
@@ -710,6 +783,9 @@ def main(argv):
                    callback=ParseParameterForCompressor, type='string',
                    nargs=0, help=info)
   parser.add_option_group(group)
+  parser.add_option('--enable-lzma', action='store_true', dest='enable_lzma',
+          default=False, help='Enable LZMA.')
+
   options, _ = parser.parse_args()
   if len(argv) == 1:
     parser.print_help()
@@ -785,7 +861,11 @@ def main(argv):
   if not options.package:
     parser.error('A package name is required. Please use the "--package" '
                  'option.')
+
   VerifyPackageName(options.package)
+
+  if options.mode != 'embedded' and options.enable_lzma:
+    parser.error('LZMA is only available in embedded mode.')
 
   if (options.app_root and options.app_local_path and
       not os.path.isfile(os.path.join(options.app_root,

--- a/dummy/dummy.cc
+++ b/dummy/dummy.cc
@@ -1,0 +1,9 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// a placeholder used by Google Play to recognize architecture.
+void __no_used_dummy_function(void)
+{
+}

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -349,6 +349,8 @@ if __name__ == '__main__':
   if gyp_vars_dict.get('OS') == 'android':
     args.append('-Dnotifications=1')
     args.append('-Drelease_unwind_tables=0')
+    # LZMA is disalbed by default.
+    args.append('-Duse_lzma=0')
 
   if not use_analyzer:
     print 'Updating projects from gyp files...'

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryListener.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryListener.java
@@ -10,7 +10,8 @@ interface XWalkLibraryListener {
         NOT_FOUND,
         SIGNATURE_CHECK_ERROR,
         NEWER_VERSION,
-        OLDER_VERSION
+        OLDER_VERSION,
+        COMPRESSED
     }
 
     public void onXWalkLibraryCancelled();

--- a/runtime/android/core/strings/xwalk_app_strings.grd
+++ b/runtime/android/core/strings/xwalk_app_strings.grd
@@ -65,6 +65,9 @@
       <message desc="Market Open Failed Message [CHAR-LIMIT=100]" name="IDS_MARKET_OPEN_FAILED_MESSAGE">
         Please set up your app market
       </message>
+      <message desc="Decompress Library Message [CHAR-LIMIT=100]" name="IDS_DECOMPRESS_LIBRARY_MESSAGE">
+        Runtime is preparing...
+      </message>
       <message desc="Label of Cancel [CHAR-LIMIT=100]" name="IDS_XWALK_CANCEL">
         Cancel
       </message>

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCompressUtil.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCompressUtil.java
@@ -1,0 +1,127 @@
+package org.xwalk.core.internal;
+
+import SevenZip.Compression.LZMA.Decoder;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.util.Log;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class XWalkCompressUtil {
+    private static final String TAG = "XWalkCompressUtil";
+
+    public static boolean XWalkLibraryCompressed(Context context, String[] libraries) {
+        if (context == null) return false;
+
+        for (String library : libraries) {
+            InputStream is = openRawResource(context, library);
+            if (is == null) return false;
+        }
+
+        return true;
+    }
+
+    public static boolean decompressXWalkLibrary(Context context, String[] libraries, String libDir) throws Exception {
+        if (context == null) return false;
+
+        File f = new File(libDir);
+        if (f.exists() && f.isFile()) f.delete();
+        if (!f.exists() && !f.mkdirs()) return false;
+
+        for (String library : libraries) {
+            File tmpfile = null;
+            InputStream input = null;
+            OutputStream output = null;
+
+            try {
+                File outfile = new File(libDir, library);
+                tmpfile = new File(libDir, library + ".tmp");
+                input = new BufferedInputStream(openRawResource(context, library));
+                output = new BufferedOutputStream(new FileOutputStream(tmpfile));
+                if (!decodeLzma(input, output)) {
+                    Log.d(TAG, "Decompress failed");
+                    return false;
+                }
+                tmpfile.renameTo(outfile);
+            } catch (Exception e) {
+                Log.d(TAG, "Decompress failed: " + e.getMessage());
+                throw e;
+            } finally {
+                if (output != null) {
+                    try {
+                        output.flush();
+                    } catch (IOException e) {
+                    }
+                    try {
+                        output.close();
+                    } catch (IOException e) {
+                    }
+                }
+                if (input != null) {
+                    try {
+                        input.close();
+                    } catch (IOException e) {
+                    }
+                }
+                tmpfile.delete();
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean decodeLzma(InputStream input, OutputStream output) throws IOException {
+        final int propSize = 5;
+        final int outSizeLength = 8;
+
+        byte[] properties = new byte[propSize];
+        if (input.read(properties, 0, propSize) != propSize) {
+            Log.w(TAG, "Input .lzma file is too short");
+            return false;
+        }
+
+        Decoder decoder = new Decoder();
+        if (!decoder.SetDecoderProperties(properties)) {
+            Log.w(TAG, "Incorrect stream properties");
+        }
+
+        long outSize = 0;
+        for (int i = 0; i < outSizeLength; i++) {
+            int v = input.read();
+            if (v < 0) {
+                Log.w(TAG, "Can't read stream size");
+            }
+            outSize |= ((long)v) << (8 * i);
+        }
+
+        if (!decoder.Code(input, output, outSize)) {
+            Log.w(TAG, "Error in data stream");
+        }
+
+        return true;
+    }
+
+    private static InputStream openRawResource(Context context, String library) {
+        Resources res = context.getResources();
+        String libraryName = library.split("\\.")[0];
+        InputStream is = null;
+
+        int id = res.getIdentifier(libraryName, "raw", context.getPackageName());
+        if (id > 0) {
+            try {
+                is = res.openRawResource(id);
+            } catch (Resources.NotFoundException e) {
+                Log.d(TAG, "Could not find resource: " + e.getMessage());
+            }
+        }
+
+        return is;
+    }
+}

--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -9,7 +9,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.core.xwview.shell">
 
-    <application android:name="android.app.Application"
+    <application android:name="org.xwalk.core.XWalkApplication"
         android:label="XWalkCoreShell" android:hardwareAccelerated="true">
         <activity android:name="org.xwalk.core.xwview.shell.XWalkViewShellActivity"
             android:theme="@android:style/Theme.Holo.Light"

--- a/third_party/lzma_sdk/download_lzma_sdk.py
+++ b/third_party/lzma_sdk/download_lzma_sdk.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""This script will do:
+  1. Download 7zip SDK.
+  2. unzip SDK and prepare under xwalk directory.
+"""
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import urllib2
+
+SDK_URL = 'http://downloads.sourceforge.net/sevenzip/lzma920.tar.bz2'
+SDK_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def DownloadFromURL(url, dest_file):
+  if os.path.exists(dest_file) and os.path.isfile(dest_file):
+    return True
+
+  f = urllib2.urlopen(url)
+  # TODO(halton): return False when error
+  with open(dest_file, 'wb') as code:
+    code.write(f.read())
+  return True
+
+
+def ExtractJavaSDK(lzma_file):
+  # Determine the file type
+  cmd = shlex.split('file --mime-type {0}'.format(lzma_file))
+  result = subprocess.check_output(cmd)
+  mime_type = result.split()[-1]
+
+  if mime_type == 'application/x-bzip2':
+    cmd = ['tar', 'xjf', lzma_file, '-C', SDK_DIR, 'Java']
+  elif mime_type == 'application/x-7z-compressed':
+    cmd = ['7zr', 'x', '-o' + SDK_DIR, lzma_file, 'Java']
+  else:
+    print('Error: mime type of %s is not supported.' % lzma_file)
+    return False
+
+  target_dir = os.path.join(SDK_DIR, 'src')
+  if os.path.exists(target_dir):
+    shutil.rmtree(os.path.join(SDK_DIR, 'src'))
+
+  subprocess.call(cmd)
+  # Need rename Java to src so that java.gypi can recognize.
+  os.rename(os.path.join(SDK_DIR, 'Java'), os.path.join(SDK_DIR, 'src'))
+  return True
+
+
+def main():
+  sdk_file = os.path.join(SDK_DIR, os.path.basename(SDK_URL))
+  valid_java_file = os.path.join(SDK_DIR, 'src', 'SevenZip', 'CRC.java')
+
+  if not os.path.exists(SDK_DIR):
+    os.mkdir(SDK_DIR)
+  elif os.path.exists(sdk_file) and os.path.exists(valid_java_file):
+    print('LZMA SDK already exists. Nothing done.')
+    return 0
+
+  if not DownloadFromURL(SDK_URL, sdk_file):
+    return 1
+
+  return (1, 0)[ExtractJavaSDK(sdk_file)]
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/third_party/lzma_sdk/lzma_sdk_android.gyp
+++ b/third_party/lzma_sdk/lzma_sdk_android.gyp
@@ -1,0 +1,12 @@
+{
+  'targets': [
+    {
+      'target_name': 'lzma_sdk_java',
+      'type': 'none',
+      'variables': {
+        'java_in_dir': '.',
+      },
+      'includes': ['../../../build/java.gypi']
+    },
+  ],
+}

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -118,6 +118,7 @@
         '../components/components.gyp:web_contents_delegate_android_java',
         '../content/content.gyp:content_java',
         '../ui/android/ui_android.gyp:ui_java',
+        'third_party/lzma_sdk/lzma_sdk_android.gyp:lzma_sdk_java',
         'xwalk_core_extensions_java',
         'xwalk_core_strings',
         'xwalk_core_reflection_layer_java_gen',

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -30,7 +30,6 @@
       'type': 'none',
       'dependencies': [
         '../third_party/android_tools/android_tools.gyp:android_support_v13_javalib',
-        'libxwalkcore',
         'xwalk_core_extensions_java',
         'xwalk_core_internal_java',
         'xwalk_core_java',
@@ -40,7 +39,6 @@
         'apk_name': 'XWalkCoreShell',
         'java_in_dir': 'runtime/android/core_shell',
         'resource_dir': 'runtime/android/core_shell/res',
-        'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
           '<(PRODUCT_DIR)/xwalk_xwview/assets/www/index.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/www/request_focus_left_frame.html',
@@ -60,11 +58,8 @@
               '<(PRODUCT_DIR)/xwalk_xwview/assets/icudtl.dat',
             ],
           }],
-          ['v8_use_external_startup_data==1', {
-            'additional_input_paths': [
-              '<(PRODUCT_DIR)/natives_blob.bin',
-              '<(PRODUCT_DIR)/snapshot_blob.bin',
-            ],
+          ['use_lzma==0', {
+            'native_lib_target': 'libxwalkcore',
           }],
         ],
         'asset_location': '<(PRODUCT_DIR)/xwalk_xwview/assets',
@@ -91,7 +86,19 @@
           ],
         },
       ],
-      'includes': [ '../build/java_apk.gypi' ],
+      'conditions': [
+        ['use_lzma==1', {
+          'dependencies': [
+            'libxwalkdummy',
+          ],
+          'includes': [ 'xwalk_lzma.gypi' ],
+        },{
+          'dependencies': [
+            'libxwalkcore',
+          ],
+          'includes': [ '../build/java_apk.gypi' ],
+        }],
+      ],
     },
     {
       'target_name': 'xwalk_core_shell_apk_pak',
@@ -312,7 +319,6 @@
       'target_name': 'xwalk_runtime_client_embedded_shell_apk',
       'type': 'none',
       'dependencies': [
-        'libxwalkcore',
         'xwalk_app_runtime_java',
         'xwalk_core_internal_java',
         'xwalk_runtime_client_embedded_shell_apk_pak',
@@ -322,7 +328,6 @@
         'apk_name': 'XWalkRuntimeClientEmbeddedShell',
         'java_in_dir': 'app/android/runtime_client_embedded_shell',
         'resource_dir': 'app/android/runtime_client_embedded_shell/res',
-        'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
           '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/extensions-config.json',
           '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/index.html',
@@ -348,11 +353,8 @@
               '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/icudtl.dat',
             ],
           }],
-          ['v8_use_external_startup_data==1', {
-            'additional_input_paths': [
-              '<(PRODUCT_DIR)/natives_blob.bin',
-              '<(PRODUCT_DIR)/snapshot_blob.bin',
-            ],
+          ['use_lzma==0', {
+            'native_lib_target': 'libxwalkcore',
           }],
         ],
         'asset_location': '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets',
@@ -393,7 +395,19 @@
           ],
         },
       ],
-      'includes': [ '../build/java_apk.gypi' ],
+      'conditions': [
+        ['use_lzma==1', {
+          'dependencies': [
+            'libxwalkdummy',
+          ],
+          'includes': [ 'xwalk_lzma.gypi' ],
+        },{
+          'dependencies': [
+            'libxwalkcore',
+          ],
+          'includes': [ '../build/java_apk.gypi' ],
+        }],
+      ],
     },
     {
       'target_name': 'xwalk_runtime_client_embedded_shell_apk_pak',
@@ -726,6 +740,13 @@
         },
       ],
       'includes': [ '../build/java_apk.gypi' ],
+    },
+    {
+      'target_name': 'libxwalkdummy',
+      'type': 'shared_library',
+      'sources': [
+        'dummy/dummy.cc',
+      ],
     },
   ],
 }

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -149,19 +149,35 @@
       'target_name': 'xwalk_core_internal_empty_embedder_apk',
       'type': 'none',
       'dependencies': [
-        'libxwalkcore',
         'generate_resource_maps',
       ],
       'variables': {
         'apk_name': '<(core_internal_empty_embedder_apk_name)',
         'java_in_dir': 'runtime/android/core_internal_empty',
-        'native_lib_target': 'libxwalkcore',
         'is_test_apk': 1,
         'additional_input_paths': [ '>(resource_map_gen_timestamp)' ],
         'generated_src_dirs': [
            '<(PRODUCT_DIR)/resource_map',
         ],
+        'conditions': [
+          ['use_lzma==1', {
+            'native_lib_target': 'libxwalkdummy',
+          },{
+            'native_lib_target': 'libxwalkcore',
+          }],
+        ],
       },
+      'conditions': [
+        ['use_lzma==1', {
+          'dependencies': [
+            'libxwalkdummy',
+          ],
+        },{
+          'dependencies': [
+            'libxwalkcore',
+          ],
+        }],
+      ],
       'includes': [ '../build/java_apk.gypi' ],
       'all_dependent_settings': {
         'variables': {
@@ -284,6 +300,17 @@
         'xwalk_core_shell_apk',
         'xwalk_core_library_java',
       ],
+      'conditions': [
+        ['use_lzma==1', {
+          'variables': {
+            'use_lzma_param': ' --use-lzma',
+          },
+        }, {
+          'variables': {
+            'use_lzma_param': '',
+          },
+        }],
+      ],
       'actions': [
         {
           'action_name': 'generate_xwalk_core_library',
@@ -297,7 +324,8 @@
           ],
           'action': [
             'python', '<(DEPTH)/xwalk/build/android/generate_xwalk_core_library.py',
-            '-s',  '<(DEPTH)',
+            '<(use_lzma_param)',
+            '-s', '<(DEPTH)',
             '-t', '<(PRODUCT_DIR)'
           ],
         },
@@ -327,7 +355,6 @@
             '--shared',
           ],
         },
-
       ],
     },
     {

--- a/xwalk_lzma.gypi
+++ b/xwalk_lzma.gypi
@@ -1,0 +1,42 @@
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+{
+  'variables': {
+    'stripped_library': '<(intermediate_dir)/libs/<(android_app_abi)/libxwalkcore.>(android_product_extension)',
+    'compressed_library': '<(resource_dir)/raw/libxwalkcore.>(android_product_extension).<(android_app_abi)',
+    'native_lib_target': 'libxwalkdummy',
+    'additional_bundled_libs': [
+      '<(PRODUCT_DIR)/lib/libxwalkcore.>(android_product_extension)',
+    ],
+    'additional_input_paths': [
+      '<(resource_dir)/raw/libxwalkcore.>(android_product_extension).<(android_app_abi)',
+    ],
+  },
+  'actions': [
+    {
+      'action_name': 'lzma_compression',
+      'message': 'compress library',
+      'inputs': [
+        '<(strip_additional_stamp)',
+      ],
+      'outputs': [
+        '<(stripped_library).lzma',
+      ],
+      'action': ['lzma', '-f', '<(stripped_library)'],
+    },
+    {
+      'action_name': 'copy_compressed_library',
+      'message': 'copy compressed library',
+      'inputs': [
+        '<(stripped_library).lzma',
+      ],
+      'outputs': [
+        '<(compressed_library)',
+      ],
+      'action': ['cp', '<(stripped_library).lzma', '<(compressed_library)'],
+    },
+  ],
+  'includes': [ '../build/java_apk.gypi' ],
+}


### PR DESCRIPTION
This involve 2 commits here:

1. LZMA compression support
   Use lzma compress libxwalkcore.so to reduce apk size.
This feature is backport from lite.

2. add support for runtime build flag.
    Add --enable_lzma parameter into make_apk.py:
    True: compress the libxwalkcore.so into libxwalkcore.so.$arch, then move it into apk's res/raw directory.
    False: do not compress libxwalkcore.so (default behavior).
Besides, also include some refactor work, for the shared-mode/embedded mode/embedded mode with lzma support is too much complicated when they involved in one script.

@halton @shawngao5 @lincsoon please help review, thanks!