### PR TITLE
Fix build on Windows 64 bits.

### DIFF
--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -5,11 +5,10 @@
       'type': 'static_library',
       'dependencies': [
         '../../base/base.gyp:base',
-        '../../content/content.gyp:content',
         '../../ipc/ipc.gyp:ipc',
         '../../url/url.gyp:url_lib',
         '../../v8/tools/gyp/v8.gyp:v8',
-        '../../third_party/WebKit/public/blink.gyp:blink',
+        '../../third_party/WebKit/public/blink_headers.gyp:blink_headers',
         'extensions_resources.gyp:xwalk_extensions_resources',
       ],
       'includes': [

--- a/sysapps/sysapps.gyp
+++ b/sysapps/sysapps.gyp
@@ -73,7 +73,6 @@
         ['OS!="android"', {
           'dependencies': [
             '../../components/components.gyp:storage_monitor',
-            '../../content/content.gyp:content_common',
             '../../media/media.gyp:media',
             '../../third_party/ffmpeg/ffmpeg.gyp:ffmpeg',
           ],


### PR DESCRIPTION
Compilation was failing in some ffmpeg headers with _rmdir not
defined. This function should be defined by os_support.h in ffmpeg
however it requires a set of defines to be properly set by
config.h. Some changes in blink now add blink headers
in the include path and the config.h of Blink was picked up by
the compiler instead of the config.h of ffmpeg. Note that this
behavior is also in 32 bits but only Windows 64 bits requires
a special set of defines. Fix is to remove the content dependency
which is not needed and depend only on blink_headers instead of the
full blink.