### PR TITLE
Need to allow WebNotification for Linux in function 'CheckPermissionOnUIThread'

### DIFF
--- a/runtime/browser/xwalk_platform_notification_service.cc
+++ b/runtime/browser/xwalk_platform_notification_service.cc
@@ -38,6 +38,8 @@ XWalkPlatformNotificationService::CheckPermissionOnUIThread(
     int render_process_id) {
 #if defined(OS_ANDROID)
   return blink::WebNotificationPermissionAllowed;
+#elif defined(OS_LINUX) && defined(USE_LIBNOTIFY)
+  return blink::WebNotificationPermissionAllowed;
 #else
   return blink::WebNotificationPermissionDenied;
 #endif


### PR DESCRIPTION
The function 'XWalkPlatformNotificationService::CheckPermissionOnUIThread' has been involved with patch SHA#3eec718b, in it, we should pass the permission check for WebNotification of Crosswalk for Linux also.