### PR TITLE
Remove lzma SDK from .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,4 @@ Thumbs.db
 cscope.*
 Session.vim
 UPSTREAM.blink
-third_party/lzma_sdk/*.bz2
-third_party/lzma_sdk/*.7z
-third_party/lzma_sdk/src
 raw/


### PR DESCRIPTION
This is the first step to land the LZMA SDK part of Crosswalk
source tree. Taking the files away from .gitignore will make gclient
clean up the source tree of the old extracted files coming from the old
way to fetch the SDK (downloading it and then extracting it).

We should be able to import the SDK in a following commit without
the infra complaining about overwriting untracked files.