### PR TITLE
crosswalk-14: [Android] Make the version code for IA higher than for ARM

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -939,19 +939,19 @@
       'variables': {
         'variables': {
           'conditions': [
-            ['android_app_abi=="x86"', {
+            ['android_app_abi=="armeabi"', {
               'version_code_shift%': 1,
             }],
             ['android_app_abi=="armeabi-v7a"', {
               'version_code_shift%': 2,
             }],
-            ['android_app_abi=="armeabi"', {
+            ['android_app_abi=="arm64-v8a"', {
               'version_code_shift%': 3,
             }],
-            ['android_app_abi=="x86_64"', {
+            ['android_app_abi=="x86"', {
               'version_code_shift%': 4,
             }],
-            ['android_app_abi=="arm64-v8a"', {
+            ['android_app_abi=="x86_64"', {
               'version_code_shift%': 5,
             }],
           ], # conditions


### PR DESCRIPTION
Many x86 ABI devices can also run ARM binaries. This patch reorders
the version codes so that the binary with best performance runs on
each device. For example, the x86 APK has the highest version code,
followed by ARMv7. Thus x86 binaries will be preferred for x86
devices and ARMv7 binaries preferred for ARMv7 devices

(cherry picked from commit 73fce35624f950acfbd79136ef27feaf0c3c11c5)