### PR TITLE
XWALK-3569

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -161,8 +161,13 @@ class XWalkViewDelegate {
         }
 
         ResourceExtractor.setMandatoryPaksToExtract(MANDATORY_PAKS);
-        final int resourcesListResId = context.getResources().getIdentifier(
-                XWALK_RESOURCES_LIST_RES_NAME, "array", context.getPackageName());
+        int resListResId = context.getResources().getIdentifier(
+                XWALK_RESOURCES_LIST_RES_NAME, "array", context.getClass().getPackage().getName());
+        if (resListResId == 0) {
+            resListResId = context.getResources().getIdentifier(
+                    XWALK_RESOURCES_LIST_RES_NAME, "array", context.getPackageName());
+        }
+        final int resourcesListResId = resListResId;
         final AssetManager assets = context.getAssets();
         if (!context.getPackageName().equals(context.getApplicationContext().getPackageName()) ||
                 resourcesListResId != 0) {
@@ -209,7 +214,11 @@ class XWalkViewDelegate {
                     if (resourcesListResId != 0) {
                         String resourceName = resource.split("\\.")[0];
                         int resId = context.getResources().getIdentifier(
-                                resourceName, "raw", context.getPackageName());
+                                resourceName, "raw", context.getClass().getPackage().getName());
+                        if (resId == 0) {
+                            resId = context.getResources().getIdentifier(
+                                    resourceName, "raw", context.getPackageName());
+                        }
                         try {
                             if (resId != 0) return context.getResources().openRawResource(resId);
                         } catch (NotFoundException e) {


### PR DESCRIPTION
[Android] Correctly handle package name change at build time.

Sometimes there is a need to change the package name of an application at
build time.  This is usually done when more than one version of an application
is required.  For example, a free vs a paid version of an application.
An application package name can be changed with aapt, using the
--rename-manifest-package parameter
See this page for further description:
 http://www.piwai.info/renaming-android-manifest-package/

This change has that working correctly.

BUG=XWALK-3569