### PR TITLE
[Android] Fixed unit tests for XWalkViewInternal

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -250,6 +250,8 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     private static void init(Context context, Activity activity) {
         if (sInitialized) return;
 
+        XWalkViewDelegate.loadXWalkLibrary(null);
+
         // Initialize the ActivityStatus. This is needed and used by many internal
         // features such as location provider to listen to activity status.
         ApplicationStatusManager.init(activity.getApplication());


### PR DESCRIPTION
This patch is to fix the unit test errors that introduced by commit
9c144896c38da510ae25cf2d3705b65b408af14d "[Android] Provide
asynchronous interface for initializing the Crosswalk library"

Make XWalkViewInternal load native library by self if no external
initializer.