### PR TITLE
[Windows] Fix SysApp CPU load API.

### DIFF
--- a/sysapps/device_capabilities/cpu_info_provider.cc
+++ b/sysapps/device_capabilities/cpu_info_provider.cc
@@ -12,6 +12,7 @@ namespace sysapps {
 CPUInfoProvider::CPUInfoProvider()
     : number_of_processors_(base::SysInfo::NumberOfProcessors()),
       processor_architecture_(base::SysInfo::OperatingSystemArchitecture()) {
+  init();
 }
 
 CPUInfoProvider::~CPUInfoProvider() {}

--- a/sysapps/device_capabilities/cpu_info_provider.h
+++ b/sysapps/device_capabilities/cpu_info_provider.h
@@ -30,6 +30,8 @@ class CPUInfoProvider {
   // Android (via /proc/loadavg).
   double GetCPULoad() const;
 
+  void init();
+
   int number_of_processors_;
   std::string processor_architecture_;
 

--- a/sysapps/device_capabilities/cpu_info_provider_android.cc
+++ b/sysapps/device_capabilities/cpu_info_provider_android.cc
@@ -20,6 +20,8 @@ const char kProcLoadavg[] = "/proc/loadavg";
 namespace xwalk {
 namespace sysapps {
 
+void CPUInfoProvider::init() {}
+
 double CPUInfoProvider::GetCPULoad() const {
   // Bionic doesn't have a getloadavg() implementation.
   const base::FilePath proc_loadavg(kProcLoadavg);

--- a/sysapps/device_capabilities/cpu_info_provider_linux.cc
+++ b/sysapps/device_capabilities/cpu_info_provider_linux.cc
@@ -10,6 +10,8 @@
 namespace xwalk {
 namespace sysapps {
 
+void CPUInfoProvider::init() {}
+
 double CPUInfoProvider::GetCPULoad() const {
   double load;
   getloadavg(&load, 1);

--- a/sysapps/device_capabilities/cpu_info_provider_win.cc
+++ b/sysapps/device_capabilities/cpu_info_provider_win.cc
@@ -4,14 +4,30 @@
 
 #include "xwalk/sysapps/device_capabilities/cpu_info_provider.h"
 
+#include <pdh.h>
+
 #include "base/logging.h"
 
 namespace xwalk {
 namespace sysapps {
 
+namespace {
+  PDH_HQUERY cpu_query;
+  PDH_HCOUNTER cpu_total;
+}
+
+void CPUInfoProvider::init() {
+  PdhOpenQuery(nullptr, NULL, &cpu_query);
+  PdhAddCounter(cpu_query,
+                L"\\Processor(_Total)\\% Processor Time", NULL, &cpu_total);
+}
+
 double CPUInfoProvider::GetCPULoad() const {
-  NOTIMPLEMENTED();
-  return 0;
+  PDH_FMT_COUNTERVALUE counter_value;
+  PdhCollectQueryData(cpu_query);
+  PdhGetFormattedCounterValue(cpu_total, PDH_FMT_DOUBLE,
+                              nullptr, &counter_value);
+  return counter_value.doubleValue / 100;
 }
 
 }  // namespace sysapps

--- a/sysapps/sysapps.gyp
+++ b/sysapps/sysapps.gyp
@@ -83,6 +83,13 @@
             'device_capabilities/storage_info_provider_chromium.h',
           ],
         }],
+        ['OS=="win"', {
+          'link_settings': {
+            'libraries': [
+              '-lPdh.lib',
+            ],
+          },
+        }]
       ],
       'direct_dependent_settings': {
         'include_dirs': [


### PR DESCRIPTION
Implement getting the CPU load from the performance counters API.
This API needs to be initialized so I've added an init() function
which is used only on Windows (other platforms are not doing anything).