### PR TITLE
crosswalk-14: [Android] Use only ASCII characters in XWalkActivity.java.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -32,12 +32,12 @@ import org.xwalk.core.XWalkLibraryInterface.InitializationListener;
  * <code>XWalkActivity</code> helps to execute all procedures for initializing the Crosswalk
  * environment, and displays dialogs for interacting with the end-user if necessary. The
  * activities that hold the {@link XWalkView} object might want to extend
- * <code>XWalkActivity</code> to obtain this capability. For those activities, it’s important
+ * <code>XWalkActivity</code> to obtain this capability. For those activities, it's important
  * to override the abstract method {@link #onXWalkReady} that notifies the Crosswalk
  * environment is ready.
  *
  * <p>In shared mode, the Crosswalk runtime library is not loaded yet at the moment the
- * activity is created. So the developer can’t use embedding API in <code>onCreate()</code>
+ * activity is created. So the developer can't use embedding API in <code>onCreate()</code>
  * as usual. All routines using embedding API should be inside {@link #onXWalkReady} or after
  * {@link #onXWalkReady} is invoked.
  */


### PR DESCRIPTION
This fixes another regression introduced by 021bfe0 ("[Android] Provide
asynchronous interface for initializing the Crosswalk Library") that
caused all new canaries and betas to fail:

```
FAILED: cd ../../xwalk; javadoc -quiet -XDignore.symbol.file -d ../out/Release/xwalk_core_library_docs -classpath /home/builder/src/src/third_party/android_tools/sdk//platforms/android-22/android.jar ../xwalk/runtime/android/core/src/org/xwalk/core/JavascriptInterface.java ../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java ../xwalk/runtime/android/core/src/org/xwalk/core/XWalkApplication.java ../xwalk/runtime/android/core/src/org/xwalk/core/XWalkInitializer.java ../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkExtension.java ../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkJavascriptResult.java ../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkNavigationHistory.java ../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkNavigationItem.java ../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkPreferences.java ../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkResourceClient.java ../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkUIClient.java ../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkView.java
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:35: error: unmappable character for encoding ASCII
 * <code>XWalkActivity</code> to obtain this capability. For those activities, it???s important
                                                                                 ^
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:35: error: unmappable character for encoding ASCII
 * <code>XWalkActivity</code> to obtain this capability. For those activities, it???s important
                                                                                  ^
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:35: error: unmappable character for encoding ASCII
 * <code>XWalkActivity</code> to obtain this capability. For those activities, it???s important
                                                                                   ^
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:40: error: unmappable character for encoding ASCII
 * activity is created. So the developer can???t use embedding API in <code>onCreate()</code>
                                            ^
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:40: error: unmappable character for encoding ASCII
 * activity is created. So the developer can???t use embedding API in <code>onCreate()</code>
                                             ^
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:40: error: unmappable character for encoding ASCII
 * activity is created. So the developer can???t use embedding API in <code>onCreate()</code>
                                              ^
```

(cherry picked from commit b42e0238486f08e12727873a2b2e579f11240048)