### PR TITLE
[Android] Disable gpu rasterization when using animatable xwalk view

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSwitches.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSwitches.java
@@ -11,6 +11,8 @@ public abstract class XWalkSwitches {
     // Native switch - xwalk_switches::kXWalkProfileName
     public static final String PROFILE_NAME = "profile-name";
 
+    public static final String DISABLE_GPU_RASTERIZATION = "disable-gpu-rasterization";
+
     // Prevent instantiation.
     private XWalkSwitches() {}
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -252,6 +252,12 @@ class XWalkViewDelegate {
                 CommandLine.getInstance().appendSwitchWithValue(
                         XWalkSwitches.PROFILE_NAME,
                         XWalkPreferencesInternal.getStringValue(XWalkPreferencesInternal.PROFILE_NAME));
+
+                if (XWalkPreferencesInternal.getValue(XWalkPreferencesInternal.ANIMATABLE_XWALK_VIEW) &&
+                        !CommandLine.getInstance().hasSwitch(XWalkSwitches.DISABLE_GPU_RASTERIZATION)) {
+                    CommandLine.getInstance().appendSwitch(XWalkSwitches.DISABLE_GPU_RASTERIZATION);
+                }
+
                 try {
                     BrowserStartupController.get(context, LibraryProcessType.PROCESS_BROWSER).
                         startBrowserProcessesSync(true);


### PR DESCRIPTION
The TextureView of onSurfaceTextureAvailable can't be triggered before PictureLayerImpl::CalculateTileSize
because of using gpu rasterization, so the tile  width is unavailable to render page.

BUG=XWALK-4012