### PR TITLE
[Android] Check shared library in onResume instead of onStart

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -149,8 +149,8 @@ public abstract class XWalkActivity extends Activity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
+    protected void onResume() {
+        super.onResume();
         if (!mIsXWalkReady && !(mActiveDialog instanceof ProgressDialog)) initXWalkLibrary();
     }
 


### PR DESCRIPTION
Originally, the application checks shared library in onStart() in order
to initialize the Crosswalk library after jumped into the install page
and switched back to the application. But on tablets, the install
process is not in full screen, so only onResume() get called after
switched back to the application. In this case, the check method won't
be invoked. This patch is to fix this issue.

BUG=XWALK-3953