### PR TITLE
Ignore checking out reference chrome build

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -71,6 +71,9 @@ solutions = [
       'build/xvfb': None,
       'commit-queue': None,
       'depot_tools': None,
+      'src/chrome/tools/test/reference_build/chrome_linux': None,
+      'src/chrome/tools/test/reference_build/chrome_mac': None,
+      'src/chrome/tools/test/reference_build/chrome_win': None,
     },
 
     'custom_hooks': [


### PR DESCRIPTION
The reference chrome builds (win/linux/mac) is not used for Crosswalk, so
simply not checking them out to save gclient sync time.