### PR TITLE
[Android] Implement the zoom APIs and add test case.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -781,6 +781,34 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         mContentViewRenderView.setZOrderOnTop(onTop);
     }
 
+    public boolean zoomIn() {
+        if (mNativeContent == 0) return false;
+        return mContentViewCore.zoomIn();
+    }
+
+    public boolean zoomOut() {
+        if (mNativeContent == 0) return false;
+        return mContentViewCore.zoomOut();
+    }
+
+    public void zoomBy(float delta) {
+        if (mNativeContent == 0) return;
+        if (delta < 0.01f || delta > 100.0f) {
+            throw new IllegalStateException("zoom delta value outside [0.01, 100] range.");
+        }
+        mContentViewCore.pinchByDelta(delta);
+    }
+
+    public boolean canZoomIn() {
+        if (mNativeContent == 0) return false;
+        return mContentViewCore.canZoomIn();
+    }
+
+    public boolean canZoomOut() {
+        if (mNativeContent == 0) return false;
+        return mContentViewCore.canZoomOut();
+    }
+
     private native long nativeInit();
     private static native void nativeDestroy(long nativeXWalkContent);
     private native WebContents nativeGetWebContents(long nativeXWalkContent);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -818,6 +818,68 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     }
 
     /**
+    * Performs zoom in in this XWalkView.
+    * @return true if zoom in succeeds, false if no zoom changes
+    * @since 5.0
+    */
+    @XWalkAPI
+    public boolean zoomIn() {
+        if (mContent == null) return false;
+        checkThreadSafety();
+        return mContent.zoomIn();
+    }
+
+    /**
+    * Performs zoom out in this XWalkView.
+    * @return true if zoom out succeeds, false if no zoom changes
+    * @since 5.0
+    */
+    @XWalkAPI
+    public boolean zoomOut() {
+        if (mContent == null) return false;
+        checkThreadSafety();
+        return mContent.zoomOut();
+    }
+
+    /**
+    * Performs a zoom operation in this XWalkView.
+    * @param zoomFactor the zoom factor to apply.
+    * The zoom factor will be clamped to the XWalkView's zoom limits.
+    * This value must be in the range 0.01 to 100.0 inclusive.
+    * @since 5.0
+    */
+    @XWalkAPI
+    public void zoomBy(float factor) {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.zoomBy(factor);
+    }
+
+    /**
+    * Gets whether this XWalkView can be zoomed in.
+    * @return true if this XWalkView can be zoomed in
+    * @since 5.0
+    */
+    @XWalkAPI
+    public boolean canZoomIn() {
+        if (mContent == null) return false;
+        checkThreadSafety();
+        return mContent.canZoomIn();
+    }
+
+    /**
+    * Gets whether this XWalkView can be zoomed out.
+    * @return true if this XWalkView can be zoomed out
+    * @since 5.0
+    */
+    @XWalkAPI
+    public boolean canZoomOut() {
+        if (mContent == null) return false;
+        checkThreadSafety();
+        return mContent.canZoomOut();
+    }
+
+    /**
      * It's used for Presentation API.
      * @hide
      */

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/ZoomTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/ZoomTest.java
@@ -1,0 +1,65 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+
+import java.util.Locale;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for zoomBy(), zoomIn(), zoomOut().
+ */
+public class ZoomTest extends XWalkViewInternalTestBase {
+    private static final float MAXIMUM_SCALE = 2.0f;
+    private final float mPageMinimumScale = 0.5f;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    private String getZoomableHtml(float scale) {
+        final int divWidthPercent = (int) (100.0f / scale);
+        return String.format(Locale.US, "<html><head><meta name=\"viewport\" content=\""
+                + "width=device-width, minimum-scale=%f, maximum-scale=%f, initial-scale=%f"
+                + "\"/></head><body style='margin:0'>"
+                + "<div style='width:%d%%;height:100px;border:1px solid black'>Zoomable</div>"
+                + "</body></html>",
+                scale, MAXIMUM_SCALE, scale, divWidthPercent);
+    }
+
+    @SmallTest
+    @Feature({"zoomBy, zoomIn, zoomOut"})
+    public void testZoom() throws Throwable {
+        assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
+
+        loadDataSync(null, getZoomableHtml(mPageMinimumScale), "text/html", false);
+        waitForScaleToBecome(mPageMinimumScale);
+        assertTrue("Should be able to zoom in", canZoomInOnUiThread());
+        assertFalse("Should not be able to zoom out", canZoomOutOnUiThread());
+
+        while (canZoomInOnUiThread()) {
+            zoomInOnUiThreadAndWait();
+        }
+        assertTrue("Should be able to zoom out", canZoomOutOnUiThread());
+
+        while (canZoomOutOnUiThread()) {
+            zoomOutOnUiThreadAndWait();
+        }
+        assertTrue("Should be able to zoom in", canZoomInOnUiThread());
+
+        zoomByOnUiThreadAndWait(4.0f);
+        waitForScaleToBecome(MAXIMUM_SCALE);
+
+        zoomByOnUiThreadAndWait(0.5f);
+        waitForScaleToBecome(MAXIMUM_SCALE * 0.5f);
+
+        zoomByOnUiThreadAndWait(0.01f);
+        waitForScaleToBecome(mPageMinimumScale);
+    }
+}


### PR DESCRIPTION
This patch is to implement the zoom APIs(zoomBy, zoomIn, zoomOut,
canZoomIn, canZoomOut), add test case.
The implementation of these APIs was to call the related functions
in ContentViewCore.java

BUG=XWALK-4169, XWALK-4170, XWALK-4171