### PR TITLE
 Make gyp check more generious. tizen is subset of ozone

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -454,7 +454,7 @@
             'runtime/common/url_constants.h',
           ],
         }],
-        ['OS=="linux" and tizen!=1', {
+        ['OS=="linux" and use_ozone!=1', {
           'defines': ['USE_GTK_UI'],
           'dependencies': [
             '../chrome/browser/ui/libgtk2ui/libgtk2ui.gyp:gtk2ui',


### PR DESCRIPTION
 Ozone-wayland desktop build was broken, because it is not Tizen but needs same settings. 
We should check against ozone if gtk can be used.
 Tizen is only part of platforms that needs ozone.