### PR TITLE
Remove unused includes in application_service.cc

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -4,15 +4,6 @@
 
 #include "xwalk/application/browser/application_service.h"
 
-#if defined(OS_MACOSX)
-#include <ext/hash_set>
-#else
-#include <hash_set>
-#endif
-#include <set>
-#include <string>
-#include <vector>
-
 #include "base/files/file_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_thread.h"
@@ -246,7 +237,7 @@ void ApplicationService::OnApplicationTerminated(
       // further we need to add an appropriate logic to handle it.
       content::BrowserContext::GarbageCollectStoragePartitions(
           browser_context_,
-          make_scoped_ptr(new base::hash_set<base::FilePath>()),
+          make_scoped_ptr(new base::hash_set<base::FilePath>()), // NOLINT
           base::Bind(&base::DoNothing));
   }
 


### PR DESCRIPTION
We do not use hash_set in the file (we use base/ version)
but the style checker complains we should include it.
Instead we can silence the warning and remove the include. I also
took the opportunity to remove some other unused includes.