### PR TITLE
[Android] Fix the file download issue.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -396,6 +396,10 @@ class XWalkContentsClientBridge extends XWalkContentsClient
                                 String contentDisposition,
                                 String mimeType,
                                 long contentLength) {
+        if (mDownloadListener != null) {
+            mDownloadListener.onDownloadStart(
+                    url, userAgent, contentDisposition, mimeType, contentLength);
+        }
     }
 
     @Override


### PR DESCRIPTION
This patch is to fix the issue that file could not be downloaded.
Download listener was registered, but the downloaded function in
listener was not called.

BUG=XWALK-3647

(cherry picked from commit 5a929a436b054e02428715b549f25440315a8701)