### PR TITLE
[Android] Extract the initialization process from XWalkActivity

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -1,42 +1,21 @@
-// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 package org.xwalk.core;
 
 import android.app.Activity;
-import android.app.AlertDialog;
-import android.app.Dialog;
-import android.app.DownloadManager;
-import android.app.ProgressDialog;
-import android.content.ActivityNotFoundException;
-import android.content.Context;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnClickListener;
-import android.content.DialogInterface.OnDismissListener;
-import android.content.DialogInterface.OnShowListener;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
-import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
-
-import org.xwalk.core.XWalkLibraryInterface.DecompressionListener;
-import org.xwalk.core.XWalkLibraryInterface.DownloadListener;
-import org.xwalk.core.XWalkLibraryInterface.InitializationListener;
 
 /**
- * <p><code>XWalkActivity</code> helps to execute all procedures for makeing the Crosswalk Project
- * runtime workable and displays dialogs for interacting with the end-user if necessary. The
+ * <p><code>XWalkActivity</code> helps to execute all procedures for makeing the Crosswalk runtime
+ * workable and displays dialogs for interacting with the end-user if necessary. The
  * activities that hold the {@link XWalkView} object might want to extend <code>XWalkActivity</code>
  * to obtain this capability. For those activities, it's important to override the abstract method
- * {@link #onXWalkReady} that notifies the Crosswalk Project runtime is ready.<p>
+ * {@link #onXWalkReady} that notifies the Crosswalk runtime is ready.<p>
  *
- * <p>In shared mode, the Crosswalk Project runtime is not loaded yet at the moment the activity is
+ * <p>In shared mode, the Crosswalk runtime is not loaded yet at the moment the activity is
  * created. So the developer can't use embedding API in <code>onCreate()</code> as usual. All
  * routines using the embedding API should be inside {@link #onXWalkReady} or after
  * {@link #onXWalkReady} is invoked.</p>
@@ -76,7 +55,7 @@ import org.xwalk.core.XWalkLibraryInterface.InitializationListener;
  *
  * <p>Besides, you must use {@link XWalkApplication} in the Android manifest if the application is
  * intended to run in shared mode.</p>
- *
+ *mLibraryDelegate
  * <pre>
  * &lt;application android:name="org.xwalk.core.XWalkApplication"&gt;
  * </pre>
@@ -91,99 +70,47 @@ import org.xwalk.core.XWalkLibraryInterface.InitializationListener;
  * </pre>
  */
 public abstract class XWalkActivity extends Activity {
-    private static final String XWALK_APK_MARKET_URL = "market://details?id=org.xwalk.core";
-    private static final String TAG = "XWalkActivity";
-
-    private XWalkLibraryListener mLibraryListener;
-    private Dialog mActiveDialog;
+    private XWalkActivityDelegate mActivityDelegate;
     private boolean mIsXWalkReady;
-    private boolean mDecoratedBackground;
-    private String mXWalkApkDownloadUrl;
 
-    private static class XWalkLibraryListener
-            implements DecompressionListener, DownloadListener, InitializationListener {
-        XWalkActivity mXWalkActivity;
+    /**
+     * Runs on the UI thread to notify the Crosswalk runtime is ready
+     */
+    protected abstract void onXWalkReady();
 
-        XWalkLibraryListener(XWalkActivity activity) {
-            mXWalkActivity = activity;
-        }
-
-        @Override
-        public void onDecompressionStarted() {
-            mXWalkActivity.showDialog(mXWalkActivity.getDecompressionProgressDialog());
-        }
-
-        @Override
-        public void onDecompressionCancelled() {
-            mXWalkActivity.dismissDialog();
-            mXWalkActivity.finish();
-        }
-
-        @Override
-        public void onDecompressionCompleted() {
-            mXWalkActivity.dismissDialog();
-            mXWalkActivity.initXWalkLibrary();
-        }
-
-        @Override
-        public void onDownloadStarted() {
-            mXWalkActivity.showDialog(mXWalkActivity.getDownloadProgressDialog());
-        }
-
-        @Override
-        public void onDownloadUpdated(int percentage) {
-            ProgressDialog dialog = (ProgressDialog) mXWalkActivity.mActiveDialog;
-            dialog.setIndeterminate(false);
-            dialog.setMax(100);
-            dialog.setProgress(percentage);
-        }
-
-        @Override
-        public void onDownloadCancelled() {
-            mXWalkActivity.dismissDialog();
-            mXWalkActivity.finish();
-        }
-
-        @Override
-        public void onDownloadCompleted(Uri uri) {
-            mXWalkActivity.dismissDialog();
-
-            Log.d(TAG, "Install the Crosswalk library, " + uri.toString());
-            Intent install = new Intent(Intent.ACTION_VIEW);
-            install.setDataAndType(uri, "application/vnd.android.package-archive");
-            mXWalkActivity.startActivity(install);
-        }
-
-        @Override
-        public void onDownloadFailed(int status, int error) {
-            mXWalkActivity.dismissDialog();
-            mXWalkActivity.showDialog(mXWalkActivity.getDownloadFailedDialog(status, error));
-        }
-
-        @Override
-        public void onInitializationStarted() {
-        }
-
-        @Override
-        public void onInitializationCompleted() {
-            mXWalkActivity.mIsXWalkReady = true;
-            mXWalkActivity.onXWalkReady();
-        }
+    /**
+     * True if the Crosswalk runtime is ready, false otherwise
+     */
+    protected boolean isXWalkReady() {
+        return mIsXWalkReady;
     }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mLibraryListener = new XWalkLibraryListener(this);
-        XWalkLibraryLoader.prepareToInit();
-        XWalkLibraryLoader.startDecompression(mLibraryListener, this);
+        Runnable completeCommand = new Runnable() {
+            @Override
+            public void run() {
+                mIsXWalkReady = true;
+                onXWalkReady();
+            }
+        };
+        Runnable cancelCommand = new Runnable() {
+            @Override
+            public void run() {
+                finish();
+            }
+        };
+
+        mActivityDelegate = new XWalkActivityDelegate(this, completeCommand, cancelCommand);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        if (!mIsXWalkReady && !(mActiveDialog instanceof ProgressDialog)) initXWalkLibrary();
+
+        if (!mIsXWalkReady) mActivityDelegate.initialize();
     }
 
     /**
@@ -192,279 +119,5 @@ public abstract class XWalkActivity extends Activity {
     @Override
     public Resources getResources() {
         return getApplicationContext().getResources();
-    }
-
-    /**
-     * Returns true if the Crosswalk environment is ready, false otherwise
-     */
-    protected boolean isXWalkReady() {
-        return mIsXWalkReady;
-    }
-
-    /**
-     * This method will be invoked when the Crosswalk environment is ready
-     */
-    protected abstract void onXWalkReady();
-
-    private void initXWalkLibrary() {
-        int status = XWalkLibraryLoader.initXWalkLibrary(this);
-        if (status == XWalkLibraryInterface.STATUS_MATCH) {
-            if (mActiveDialog != null) dismissDialog();
-            if (mDecoratedBackground) {
-                getWindow().setBackgroundDrawable(null);
-                mDecoratedBackground = false;
-            }
-            XWalkLibraryLoader.startInitialization(mLibraryListener);
-            return;
-        }
-
-        if (mActiveDialog != null) return;
-
-        // Set background to screen_background_dark temporarily if default background is null
-        // to avoid the visual artifacts around the alert dialog
-        if (getWindow().getDecorView().getBackground() == null) {
-            getWindow().setBackgroundDrawableResource(android.R.drawable.screen_background_dark);
-            mDecoratedBackground = true;
-        }
-
-        if (status == XWalkLibraryInterface.STATUS_NOT_FOUND) {
-            showDialog(getStartupNotFoundDialog());
-        } else if (status == XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH) {
-            showDialog(getStartupArchitectureMismatchDialog());
-        } else if (status == XWalkLibraryInterface.STATUS_SIGNATURE_CHECK_ERROR) {
-            showDialog(getStartupSignatureCheckErrorDialog());
-        } else if (status == XWalkLibraryInterface.STATUS_OLDER_VERSION) {
-            showDialog(getStartupOlderVersionDialog());
-        } else if (status == XWalkLibraryInterface.STATUS_NEWER_VERSION) {
-            showDialog(getStartupNewerVersionDialog());
-        }
-    }
-
-    private void getXWalkLibrary() {
-        // The download url is defined by the meta-data item with the name of "xwalk_apk_url"
-        // under the application tag in AndroidManifest.xml. It can also be specified via
-        // --xwalk-apk-url option of make_apk script indirectly.
-        if (mXWalkApkDownloadUrl == null) {
-            try {
-                PackageManager packageManager = getPackageManager();
-                ApplicationInfo appInfo = packageManager.getApplicationInfo(
-                        getPackageName(), PackageManager.GET_META_DATA);
-                if (appInfo.metaData != null) {
-                    mXWalkApkDownloadUrl = appInfo.metaData.getString("xwalk_apk_url");
-                }
-            } catch (NameNotFoundException e) {
-            }
-            if (mXWalkApkDownloadUrl == null) mXWalkApkDownloadUrl = "";
-            Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkDownloadUrl);
-        }
-
-        if (!mXWalkApkDownloadUrl.isEmpty()) {
-            downloadXWalkLibrary();
-        } else {
-            try {
-                Intent intent = new Intent(Intent.ACTION_VIEW);
-                startActivity(intent.setData(Uri.parse(XWALK_APK_MARKET_URL)));
-            } catch (ActivityNotFoundException e) {
-                Log.d(TAG, "Market open failed");
-                showDialog(getMarketOpenFailedDialog());
-            }
-        }
-    }
-
-    private void downloadXWalkLibrary() {
-        XWalkLibraryLoader.startDownload(mLibraryListener, this, mXWalkApkDownloadUrl);
-    }
-
-    private void showDialog(Dialog dialog) {
-        mActiveDialog = dialog;
-        mActiveDialog.show();
-    }
-
-    private void dismissDialog() {
-        mActiveDialog.dismiss();
-        mActiveDialog = null;
-    }
-
-    private ProgressDialog buildProgressDialog() {
-        ProgressDialog dialog = new ProgressDialog(this);
-        dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
-        dialog.setIndeterminate(true);
-        dialog.setCancelable(false);
-        dialog.setCanceledOnTouchOutside(false);
-        return dialog;
-    }
-
-    private AlertDialog buildAlertDialog() {
-        AlertDialog dialog = new AlertDialog.Builder(this).create();
-        dialog.setIcon(android.R.drawable.ic_dialog_alert);
-        dialog.setCancelable(false);
-        dialog.setCanceledOnTouchOutside(false);
-        return dialog;
-    }
-
-    private ProgressDialog getDecompressionProgressDialog() {
-        ProgressDialog dialog = buildProgressDialog();
-        dialog.setTitle(getString(R.string.crosswalk_install_title));
-        dialog.setMessage(getString(R.string.decompression_progress_message));
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.xwalk_cancel),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        XWalkLibraryLoader.cancelDecompression();
-                    }
-                });
-        return dialog;
-    }
-
-    private ProgressDialog getDownloadProgressDialog() {
-        ProgressDialog dialog = buildProgressDialog();
-        dialog.setTitle(getString(R.string.crosswalk_install_title));
-        dialog.setMessage(getString(R.string.download_progress_message));
-        dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.xwalk_cancel),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        XWalkLibraryLoader.cancelDownload();
-                    }
-                });
-        return dialog;
-    }
-
-    private AlertDialog getDownloadFailedDialog(int status, int error) {
-        String message = getString(R.string.download_failed_message);
-        if (status == DownloadManager.STATUS_FAILED) {
-            if (error == DownloadManager.ERROR_DEVICE_NOT_FOUND) {
-                message = getString(R.string.download_failed_device_not_found) ;
-            } else if (error == DownloadManager.ERROR_INSUFFICIENT_SPACE) {
-                message = getString(R.string.download_failed_insufficient_space);
-            }
-        } else if (status == DownloadManager.STATUS_PAUSED) {
-            message = getString(R.string.download_failed_time_out);
-        }
-
-        AlertDialog dialog = buildAlertDialog();
-        dialog.setTitle(getString(R.string.crosswalk_install_title));
-        dialog.setMessage(message);
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.xwalk_retry),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        downloadXWalkLibrary();
-                    }
-                });
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.xwalk_close),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        finish();
-                    }
-                });
-        return dialog;
-    }
-
-    private AlertDialog getMarketOpenFailedDialog() {
-        AlertDialog dialog = buildAlertDialog();
-        dialog.setTitle(getString(R.string.crosswalk_install_title));
-        dialog.setMessage(getString(R.string.market_open_failed_message));
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.xwalk_close),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        finish();
-                    }
-                });
-        return dialog;
-    }
-
-    private AlertDialog getStartupNotFoundDialog() {
-        AlertDialog dialog = buildAlertDialog();
-        dialog.setTitle(getString(R.string.startup_not_found_title));
-        dialog.setMessage(getString(R.string.startup_not_found_message));
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.xwalk_continue),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        getXWalkLibrary();
-                    }
-                });
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.xwalk_close),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        finish();
-                    }
-                });
-        return dialog;
-    }
-
-    private AlertDialog getStartupArchitectureMismatchDialog() {
-        AlertDialog dialog = buildAlertDialog();
-        dialog.setTitle(getString(R.string.startup_architecture_mismatch_title));
-        dialog.setMessage(getString(R.string.startup_architecture_mismatch_message));
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.xwalk_continue),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        getXWalkLibrary();
-                    }
-                });
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.xwalk_close),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        finish();
-                    }
-                });
-        return dialog;
-    }
-
-    private AlertDialog getStartupSignatureCheckErrorDialog() {
-        AlertDialog dialog = buildAlertDialog();
-        dialog.setTitle(getString(R.string.startup_signature_check_error_title));
-        dialog.setMessage(getString(R.string.startup_signature_check_error_message));
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.xwalk_close),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        finish();
-                    }
-                });
-        return dialog;
-    }
-
-    private AlertDialog getStartupOlderVersionDialog() {
-        AlertDialog dialog = buildAlertDialog();
-        dialog.setTitle(getString(R.string.startup_older_version_title));
-        dialog.setMessage(getString(R.string.startup_older_version_message));
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.xwalk_continue),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        getXWalkLibrary();
-                    }
-                });
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.xwalk_close),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        finish();
-                    }
-                });
-        return dialog;
-    }
-
-    private AlertDialog getStartupNewerVersionDialog() {
-        AlertDialog dialog = buildAlertDialog();
-        dialog.setTitle(getString(R.string.startup_newer_version_title));
-        dialog.setMessage(getString(R.string.startup_newer_version_message));
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.xwalk_close),
-                new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        finish();
-                    }
-                });
-        return dialog;
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkActivityDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivityDelegate.java
@@ -1,0 +1,101 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.app.Activity;
+import android.view.Window;
+
+import org.xwalk.core.XWalkLibraryLoader.ActivateListener;
+import org.xwalk.core.XWalkLibraryLoader.DecompressListener;
+import org.xwalk.core.XWalkLibraryLoader.DockListener;
+import org.xwalk.core.XWalkUpdater.XWalkUpdateListener;
+
+public class XWalkActivityDelegate
+            implements DecompressListener, DockListener, ActivateListener, XWalkUpdateListener {
+    private Activity mActivity;
+    private Runnable mCompleteCommand;
+    private Runnable mCancelCommand;
+    private XWalkDialogManager mDialogManager;
+    private boolean mBackgroundDecorated;
+
+    public XWalkActivityDelegate(Activity activity,
+            Runnable completeCommand, Runnable cancelCommand) {
+        mActivity = activity;
+        mCompleteCommand = completeCommand;
+        mCancelCommand = cancelCommand;
+
+        XWalkLibraryLoader.prepareToInit();
+    }
+
+    public void initialize() {
+        XWalkLibraryLoader.startDecompress(this, mActivity);
+    }
+
+    @Override
+    public void onDecompressStarted() {
+        if (mDialogManager == null) mDialogManager = new XWalkDialogManager(mActivity);
+        mDialogManager.showDecompressProgress(new Runnable() {
+            @Override
+            public void run() {
+                XWalkLibraryLoader.cancelDecompress();
+            }
+        });
+    }
+
+    @Override
+    public void onDecompressCancelled() {
+        mDialogManager.dismissDialog();
+        mCancelCommand.run();
+    }
+
+    @Override
+    public void onDecompressCompleted() {
+        mDialogManager.dismissDialog();
+        XWalkLibraryLoader.startDock(this, mActivity);
+    }
+
+    @Override
+    public void onDockStarted() {
+    }
+
+    @Override
+    public void onDockFailed() {
+        if (XWalkUpdater.updateXWalkRuntime(this, mActivity)) {
+            // Set background to screen_background_dark temporarily if default background is
+            // null to avoid the visual artifacts around the alert dialog
+            Window window = mActivity.getWindow();
+            if (window != null && window.getDecorView().getBackground() == null) {
+                window.setBackgroundDrawableResource(android.R.drawable.screen_background_dark);
+                mBackgroundDecorated = true;
+            }
+        }
+    }
+
+    @Override
+    public void onDockCompleted() {
+        XWalkLibraryLoader.startActivate(this);
+    }
+
+    @Override
+    public void onActivateStarted() {
+    }
+
+    @Override
+    public void onActivateCompleted() {
+        if (XWalkUpdater.isWaitingForInput()) XWalkUpdater.dismissDialog();
+
+        if (mBackgroundDecorated) {
+            mActivity.getWindow().setBackgroundDrawable(null);
+            mBackgroundDecorated = false;
+        }
+
+        mCompleteCommand.run();
+    }
+
+    @Override
+    public void onXWalkUpdateCancelled() {
+        mCancelCommand.run();
+    }
+}

--- a/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
@@ -1,0 +1,164 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DownloadManager;
+import android.app.ProgressDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnClickListener;
+
+class XWalkDialogManager {
+    private Context mContext;
+    private Dialog mActiveDialog;
+
+    public XWalkDialogManager(Context context) {
+        mContext = context;
+    }
+
+    private void showDialog(Dialog dialog) {
+        mActiveDialog = dialog;
+        mActiveDialog.show();
+    }
+
+    public void dismissDialog() {
+        mActiveDialog.dismiss();
+        mActiveDialog = null;
+    }
+
+    public boolean isShowingDialog() {
+        return mActiveDialog != null && mActiveDialog.isShowing();
+    }
+
+    public boolean isShowingProgressDialog() {
+        return isShowingDialog() && mActiveDialog instanceof ProgressDialog;
+    }
+
+    public void setProgress(int progress, int max) {
+        ProgressDialog dialog = (ProgressDialog) mActiveDialog;
+        dialog.setIndeterminate(false);
+        dialog.setMax(max);
+        dialog.setProgress(progress);
+    }
+
+    public void showInitializationError(int status, Runnable cancelCommand,
+            Runnable downloadCommand) {
+        AlertDialog dialog = buildAlertDialog();
+        String cancelText = mContext.getString(R.string.xwalk_close);
+        String downloadText = mContext.getString(R.string.xwalk_continue);
+
+        if (status == XWalkLibraryInterface.STATUS_NOT_FOUND) {
+            dialog.setTitle(mContext.getString(R.string.startup_not_found_title));
+            dialog.setMessage(mContext.getString(R.string.startup_not_found_message));
+            setPositiveButton(dialog, downloadText, downloadCommand);
+            setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH) {
+            dialog.setTitle(mContext.getString(R.string.startup_architecture_mismatch_title));
+            dialog.setMessage(mContext.getString(R.string.startup_architecture_mismatch_message));
+            setPositiveButton(dialog, downloadText, downloadCommand);
+            setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_SIGNATURE_CHECK_ERROR) {
+            dialog.setTitle(mContext.getString(R.string.startup_signature_check_error_title));
+            dialog.setMessage(mContext.getString(R.string.startup_signature_check_error_message));
+            setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_OLDER_VERSION) {
+            dialog.setTitle(mContext.getString(R.string.startup_older_version_title));
+            dialog.setMessage(mContext.getString(R.string.startup_older_version_message));
+            setPositiveButton(dialog, downloadText, downloadCommand);
+            setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_NEWER_VERSION) {
+            dialog.setTitle(mContext.getString(R.string.startup_newer_version_title));
+            dialog.setMessage(mContext.getString(R.string.startup_newer_version_message));
+            setNegativeButton(dialog, cancelText, cancelCommand);
+        }
+        showDialog(dialog);
+    }
+
+    public void showMarketOpenError(Runnable cancelCommand) {
+        AlertDialog dialog = buildAlertDialog();
+        dialog.setTitle(mContext.getString(R.string.crosswalk_install_title));
+        dialog.setMessage(mContext.getString(R.string.market_open_failed_message));
+        setNegativeButton(dialog, mContext.getString(R.string.xwalk_close), cancelCommand);
+        showDialog(dialog);
+    }
+
+    public void showDecompressProgress(Runnable cancelCommand) {
+        ProgressDialog dialog = buildProgressDialog();
+        dialog.setTitle(mContext.getString(R.string.crosswalk_install_title));
+        dialog.setMessage(mContext.getString(R.string.decompression_progress_message));
+        setNegativeButton(dialog, mContext.getString(R.string.xwalk_cancel), cancelCommand);
+        showDialog(dialog);
+    }
+
+    public void showDownloadProgress(Runnable cancelCommand) {
+        ProgressDialog dialog = buildProgressDialog();
+        dialog.setTitle(mContext.getString(R.string.crosswalk_install_title));
+        dialog.setMessage(mContext.getString(R.string.download_progress_message));
+        dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+        setNegativeButton(dialog, mContext.getString(R.string.xwalk_cancel), cancelCommand);
+        showDialog(dialog);
+
+    }
+
+    public void showDownloadError(int status, int error, Runnable cancelCommand,
+            Runnable downloadCommand) {
+        String message = mContext.getString(R.string.download_failed_message);
+        if (status == DownloadManager.STATUS_FAILED) {
+            if (error == DownloadManager.ERROR_DEVICE_NOT_FOUND) {
+                message = mContext.getString(R.string.download_failed_device_not_found) ;
+            } else if (error == DownloadManager.ERROR_INSUFFICIENT_SPACE) {
+                message = mContext.getString(R.string.download_failed_insufficient_space);
+            }
+        } else if (status == DownloadManager.STATUS_PAUSED) {
+            message = mContext.getString(R.string.download_failed_time_out);
+        }
+
+        AlertDialog dialog = buildAlertDialog();
+        dialog.setTitle(mContext.getString(R.string.crosswalk_install_title));
+        dialog.setMessage(message);
+        setPositiveButton(dialog, mContext.getString(R.string.xwalk_retry), downloadCommand);
+        setNegativeButton(dialog, mContext.getString(R.string.xwalk_cancel), cancelCommand);
+        showDialog(dialog);
+    }
+
+    private ProgressDialog buildProgressDialog() {
+        ProgressDialog dialog = new ProgressDialog(mContext);
+        dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        dialog.setIndeterminate(true);
+        dialog.setCancelable(false);
+        dialog.setCanceledOnTouchOutside(false);
+        return dialog;
+    }
+
+    private AlertDialog buildAlertDialog() {
+        AlertDialog dialog = new AlertDialog.Builder(mContext).create();
+        dialog.setIcon(android.R.drawable.ic_dialog_alert);
+        dialog.setCancelable(false);
+        dialog.setCanceledOnTouchOutside(false);
+        return dialog;
+    }
+
+    private void setPositiveButton(AlertDialog dialog, String text, final Runnable command) {
+        dialog.setButton(DialogInterface.BUTTON_POSITIVE, text,
+                new OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int id) {
+                        command.run();
+                    }
+                });
+    }
+
+    private void setNegativeButton(AlertDialog dialog, String text, final Runnable command) {
+        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, text,
+                new OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int id) {
+                        command.run();
+                    }
+                });
+    }
+}

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryInterface.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryInterface.java
@@ -4,104 +4,37 @@
 
 package org.xwalk.core;
 
-import android.net.Uri;
-
 /**
- * Interface used by Crosswalk library
+ * Interface used by the Crosswalk runtime
  */
 interface XWalkLibraryInterface {
     /**
-     * The Crosswalk library matches current application
+     * The Crosswalk runtime matches current application
      */
     public static final int STATUS_MATCH = 0;
 
     /**
-     * The Crosswalk library is not found
+     * The Crosswalk runtime is not found
      */
     public static final int STATUS_NOT_FOUND = 1;
 
     /**
-     * The architecture of the Crosswalk library doesn't match current device
+     * Mismatch of CPU Architecture for the Crosswalk Runtime
      */
     public static final int STATUS_ARCHITECTURE_MISMATCH = 2;
 
     /**
-     * The integrity of the Crosswalk library can not be verified
+     * The Crosswalk signature verification failed
      */
     public static final int STATUS_SIGNATURE_CHECK_ERROR = 3;
 
     /**
-     * The version of the Crosswalk library is older than current application
+     * The version of the Crosswalk runtime is older than current application
      */
     public static final int STATUS_OLDER_VERSION = 4;
 
     /**
-     * The version of the Crosswalk library is newer than current application
+     * The version of the Crosswalk runtime is newer than current application
      */
     public static final int STATUS_NEWER_VERSION = 5;
-
-    /**
-     * Interface used to decompress native library
-     */
-    public interface DecompressionListener {
-        /**
-         * Runs on the UI thread to notify decompression is started
-         */
-        public void onDecompressionStarted();
-        /**
-         * Runs on the UI thread to notify decompression is cancelled
-         */
-        public void onDecompressionCancelled();
-        /**
-         * Runs on the UI thread to notify decompression is completed successfully
-         */
-        public void onDecompressionCompleted();
-    }
-
-    /**
-     * Interface used to initialize the Crosswalk environment
-     */
-    public interface InitializationListener {
-        /**
-         * Runs on the UI thread to notify initialization is started
-         */
-        public void onInitializationStarted();
-        /**
-         * Runs on the UI thread to notify initialization is completed successfully
-         */
-        public void onInitializationCompleted();
-    }
-
-    /**
-     * Interface used to download the Crosswalk library
-     */
-    public interface DownloadListener {
-        /**
-         * Runs on the UI thread to notify download is started
-         */
-        public void onDownloadStarted();
-        /**
-         * Runs on the UI thread to notify the download progress
-         * @param percentage Shows the download progress in percentage
-         */
-        public void onDownloadUpdated(int percentage);
-        /**
-         * Runs on the UI thread to notify download is cancelled
-         */
-        public void onDownloadCancelled();
-        /**
-         * Runs on the UI thread to notify download is completed successfully
-         * @param uri Uri where downloaded file is stored
-         */
-        public void onDownloadCompleted(Uri uri);
-        /**
-         * Runs on the UI thread to notify download failed
-         *
-         * @param status The download status that defined in android.app.DownloadManager.
-         *               The value maybe STATUS_FAILED or STATUS_PAUSED
-         * @param error The download error that defined in android.app.DownloadManager.
-         *              This parameter only makes sense when the status is STATUS_FAILED
-         */
-        public void onDownloadFailed(int status, int error);
-    }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryLoader.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryLoader.java
@@ -18,24 +18,102 @@ import java.lang.Thread;
 
 import junit.framework.Assert;
 
-import org.xwalk.core.XWalkLibraryInterface.DecompressionListener;
-import org.xwalk.core.XWalkLibraryInterface.DownloadListener;
-import org.xwalk.core.XWalkLibraryInterface.InitializationListener;
-
 /**
- * <code>XWalkLibraryLoader</code> is a low level inteface to schedule decompressing,
- * downloading, initializing the Crosswalk Library. Normal user is recommended to use
- * {@link XWalkActivity}(with UI) or {@link XWalkInitializer}(without UI) which is more
- * simple and more user friendly.
+ * XWalkLibraryLoader is a low level inteface to schedule decompressing, downloading, activating
+ * the Crosswalk runtime. Normal user is recommended to use XWalkActivity or XWalkInitializer which
+ * is simpler and more user-friendly.
  *
- * <p>The appropriate invocation order is:
+ * The appropriate invocation order is:
  * prepareToInit() -
- * [ if native library is supposed to be compressed - startDecompression() ] -
- * initXWalkLibrary() -
- * [ if the library doesn't match - install suitable library - initXWalkLibrary() ] -
- * startInitialization() - over
+ * [ if the Crosswalk runtime is supposed to be compressed - startDecompress() ] -
+ * startDock() -
+ * [ if the Crosswalk runtime doesn't match - download suitable version - startDock() ] -
+ * startActivate() - over
  */
 class XWalkLibraryLoader {
+    /**
+     * Interface used to decompress the Crosswalk runtime
+     */
+    public interface DecompressListener {
+        /**
+         * Runs on the UI thread to notify decompression is started
+         */
+        public void onDecompressStarted();
+        /**
+         * Runs on the UI thread to notify decompression is cancelled
+         */
+        public void onDecompressCancelled();
+        /**
+         * Runs on the UI thread to notify decompression is completed successfully
+         */
+        public void onDecompressCompleted();
+    }
+
+    /**
+     * Interface used to dock the Crosswalk runtime
+     */
+    public interface DockListener {
+        /**
+         * Runs on the UI thread to notify docking is started
+         */
+        public void onDockStarted();
+        /**
+         * Runs on the UI thread to notify docking failed
+         */
+        public void onDockFailed();
+        /**
+         * Runs on the UI thread to notify docking is completed successfully
+         */
+        public void onDockCompleted();
+    }
+
+    /**
+     * Interface used to activate the Crosswalk runtime
+     */
+    public interface ActivateListener {
+        /**
+         * Runs on the UI thread to notify activation is started
+         */
+        public void onActivateStarted();
+        /**
+         * Runs on the UI thread to notify activation is completed successfully
+         */
+        public void onActivateCompleted();
+    }
+
+    /**
+     * Interface used to download the Crosswalk runtime
+     */
+    public interface DownloadListener {
+        /**
+         * Runs on the UI thread to notify download is started
+         */
+        public void onDownloadStarted();
+        /**
+         * Runs on the UI thread to notify the download progress
+         * @param percentage Shows the download progress in percentage
+         */
+        public void onDownloadUpdated(int percentage);
+        /**
+         * Runs on the UI thread to notify download is cancelled
+         */
+        public void onDownloadCancelled();
+        /**
+         * Runs on the UI thread to notify download is completed successfully
+         * @param uri The Uri where the downloaded file is stored
+         */
+        public void onDownloadCompleted(Uri uri);
+        /**
+         * Runs on the UI thread to notify download failed
+         *
+         * @param status The download status defined in android.app.DownloadManager.
+         *               The value maybe STATUS_FAILED or STATUS_PAUSED
+         * @param error The download error defined in android.app.DownloadManager.
+         *              This parameter makes sense only when the status is STATUS_FAILED
+         */
+        public void onDownloadFailed(int status, int error);
+    }
+
     private static final String XWALK_APK_NAME = "XWalkRuntimeLib.apk";
     private static final String TAG = "XWalkLib";
 
@@ -48,13 +126,14 @@ class XWalkLibraryLoader {
      * <p>This method must be invoked after initXWalkLibrary returns STATUS_MATCH
      */
     public static boolean isSharedMode() {
+        if (XWalkCoreWrapper.getInstance() == null) Assert.fail("Invoke initXWalkLibrary first");
         return XWalkCoreWrapper.getInstance().isSharedMode();
     }
 
     /**
-     * Prepares to start initialization.
+     * Prepares to start initializing before all other procedures.
      *
-     * <p>This method must be invoked on the UI thread and before other procedures
+     * <p>This method must be invoked on the UI thread.
      */
     public static void prepareToInit() {
         if (sPreparedToInit) return;
@@ -63,43 +142,15 @@ class XWalkLibraryLoader {
     }
 
     /**
-     * Links to the Crosswalk library either is embedded in current application or is shared
-     * across package
+     * Starts decompressing the Crosswalk runtime in background
      *
      * <p>This method must be invoked on the UI thread.
      *
-     * @return The library status that defined in {@link XWalkLibrarayInterface}
+     * @param listener The {@link DecompressListener} to use
+     * @param context The context of the package that holds the compressed Crosswalk runtime
      */
-    public static int initXWalkLibrary(Context context) {
-        if (!sPreparedToInit) Assert.fail("Invoke prepareToInit first");
-        return XWalkCoreWrapper.initXWalkLibrary(context);
-    }
-
-    /**
-     * Starts initializing the Crosswalk environment in background. The initialization is not
-     * cancelable.
-     *
-     * <p>This method must be invoked on the UI thread.
-     *
-     * @param listener The {@link XWalkLibraryInterface.InitializationListener} to use
-     */
-    public static void startInitialization(InitializationListener listener) {
-        if (XWalkCoreWrapper.getInstance() == null) Assert.fail("Invoke initXWalkLibrary first");
-        new InitializationTask(listener).execute();
-    }
-
-    /**
-     * Starts decompressing native library in background
-     *
-     * <p>This method must be invoked on the UI thread.
-     *
-     * @param listener The {@link XWalkLibraryInterface.DecompressionListener} to use
-     * @param context The context of the package that holds the compressed native library
-     *
-     * @return False if native library is not compressed, true otherwise
-     */
-    public static boolean startDecompression(DecompressionListener listener, Context context) {
-        return new DecompressionTask(listener, context).executeIfNeeded();
+    public static void startDecompress(DecompressListener listener, Context context) {
+        new DecompressTask(listener, context).execute();
     }
 
     /**
@@ -107,19 +158,43 @@ class XWalkLibraryLoader {
      *
      * @return False if decompression is not running or could not be cancelled, true otherwise
      */
-    public static boolean cancelDecompression() {
-        DecompressionTask task = (DecompressionTask) sActiveTask;
+    public static boolean cancelDecompress() {
+        DecompressTask task = (DecompressTask) sActiveTask;
         return task != null && task.cancel(true);
     }
 
     /**
-     * Starts downloading Crosswalk library in background via Android DownlomadManager
+     * Docks the Crosswalk runtime either is embedded in current application or is shared
+     * across package. The docking is not cancelable.
      *
      * <p>This method must be invoked on the UI thread.
      *
-     * @param listener The {@link XWalkLibraryInterface.InitializationListener} to use
+     * @param listener The {@link DockListener} to use
+     * @param context The application context
+     */
+    public static void startDock(DockListener listener, Context context) {
+        new DockTask(listener, context).execute();
+    }
+
+    /**
+     * Starts activating the Crosswalk runtime in background. The activation is not cancelable.
+     *
+     * <p>This method must be invoked on the UI thread.
+     *
+     * @param listener The {@link ActivateListener} to use
+     */
+    public static void startActivate(ActivateListener listener) {
+        new ActivateTask(listener).execute();
+    }
+
+    /**
+     * Starts downloading the Crosswalk runtime in background via Android DownlomadManager
+     *
+     * <p>This method must be invoked on the UI thread.
+     *
+     * @param listener The {@link DownloadListener} to use
      * @param context The context to get DownloadManager
-     * @param url The URL of the Crosswalk library
+     * @param url The URL of the Crosswalk runtime
      */
     public static void startDownload(DownloadListener listener, Context context, String url) {
         new DownloadTask(listener, context, url).execute();
@@ -135,62 +210,33 @@ class XWalkLibraryLoader {
         return task != null && task.cancel(true);
     }
 
-    private static class InitializationTask extends AsyncTask<Void, Integer, Integer> {
-        InitializationListener mListener;
-
-        InitializationTask(InitializationListener listener) {
-            super();
-            mListener = listener;
-        }
-
-        @Override
-        protected void onPreExecute() {
-            Log.d(TAG, "InitializationTask started");
-            sActiveTask = this;
-            mListener.onInitializationStarted();
-        }
-
-        @Override
-        protected Integer doInBackground(Void... params) {
-            XWalkCoreWrapper.initXWalkEnvironment();
-            return 0;
-        }
-
-        @Override
-        protected void onPostExecute(Integer result) {
-            Log.d(TAG, "InitializationTask finished");
-            sActiveTask = null;
-            XWalkCoreWrapper.handlePostInit();
-            mListener.onInitializationCompleted();
-        }
-    }
-
-    private static class DecompressionTask extends AsyncTask<Void, Integer, Integer> {
-        DecompressionListener mListener;
+    private static class DecompressTask extends AsyncTask<Void, Integer, Integer> {
+        DecompressListener mListener;
         Context mContext;
 
-        DecompressionTask(DecompressionListener listener, Context context) {
+        DecompressTask(DecompressListener listener, Context context) {
             super();
             mListener = listener;
             mContext = context;
         }
 
         public boolean executeIfNeeded() {
-            if (!XWalkLibraryDecompressor.isCompressed(mContext)) return false;
-            Log.d(TAG, "Using compressed native library");
             execute();
             return true;
         }
 
         @Override
         protected void onPreExecute() {
-            Log.d(TAG, "DecompressionTask started");
+            Log.d(TAG, "DecompressTask started");
             sActiveTask = this;
-            mListener.onDecompressionStarted();
+            mListener.onDecompressStarted();
         }
 
         @Override
         protected Integer doInBackground(Void... params) {
+            if (!XWalkLibraryDecompressor.isCompressed(mContext)) return 0;
+            Log.d(TAG, "Using compressed native library");
+
             if (!XWalkLibraryDecompressor.isDecompressed(mContext) &&
                     !XWalkLibraryDecompressor.decompressLibrary(mContext)) {
                 Assert.fail();
@@ -202,16 +248,81 @@ class XWalkLibraryLoader {
 
         @Override
         protected void onCancelled(Integer result) {
-            Log.d(TAG, "DecompressionTask cancelled");
+            Log.d(TAG, "DecompressTask cancelled");
             sActiveTask = null;
-            mListener.onDecompressionCancelled();
+            mListener.onDecompressCancelled();
         }
 
         @Override
         protected void onPostExecute(Integer result) {
-            Log.d(TAG, "DecompressionTask finished");
+            Log.d(TAG, "DecompressTask finished");
             sActiveTask = null;
-            mListener.onDecompressionCompleted();
+            mListener.onDecompressCompleted();
+        }
+    }
+
+    private static class DockTask extends AsyncTask<Void, Integer, Integer> {
+        DockListener mListener;
+        Context mContext;
+
+        DockTask(DockListener listener, Context context) {
+            super();
+            mListener = listener;
+            mContext = context;
+        }
+
+        @Override
+        protected void onPreExecute() {
+            Log.d(TAG, "DockTask started");
+            sActiveTask = this;
+            mListener.onDockStarted();
+        }
+
+        @Override
+        protected Integer doInBackground(Void... params) {
+            return XWalkCoreWrapper.attachXWalkCore(mContext);
+        }
+
+        @Override
+        protected void onPostExecute(Integer result) {
+            Log.d(TAG, "DockTask finished");
+            sActiveTask = null;
+            if (result == XWalkLibraryInterface.STATUS_MATCH) {
+                XWalkCoreWrapper.dockXWalkCore();
+                mListener.onDockCompleted();
+            } else {
+                mListener.onDockFailed();
+            }
+        }
+    }
+
+    private static class ActivateTask extends AsyncTask<Void, Integer, Integer> {
+        ActivateListener mListener;
+
+        ActivateTask(ActivateListener listener) {
+            super();
+            mListener = listener;
+        }
+
+        @Override
+        protected void onPreExecute() {
+            Log.d(TAG, "ActivateTask started");
+            sActiveTask = this;
+            mListener.onActivateStarted();
+        }
+
+        @Override
+        protected Integer doInBackground(Void... params) {
+            XWalkCoreWrapper.activateXWalkCore();
+            return 0;
+        }
+
+        @Override
+        protected void onPostExecute(Integer result) {
+            Log.d(TAG, "ActivateTask finished");
+            sActiveTask = null;
+            XWalkCoreWrapper.handlePostInit();
+            mListener.onActivateCompleted();
         }
     }
 

--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -1,0 +1,229 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.net.Uri;
+import android.util.Log;
+
+import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
+
+/**
+ * <p><code>XWalkUpdater</code> helps to update the Crosswalk runtime and displays dialogs to
+ * interact with the user. After the Crosswalk runtime is downloaded and installed properly,
+ * the user will return to current activity from the play store or the installer. You should check
+ * this point and invoke <code>XWalkInitializer.initAsync()</code> again to repeat the installation
+ * process. Please note that from now on, the application will be running in shared mode.</p>
+ *
+ * <p>For example:</p>
+ *
+ * <pre>
+ * public class MyActivity extends Activity
+ *         implements XWalkInitializer.XWalkInitListener, XWalkUpdater.XWalkUpdateListener {
+ *
+ *     ......
+ *
+ *     &#64;Override
+ *     protected void onResume() {
+ *         super.onResume();
+ *
+ *         if (mIsXWalkReady) XWalkInitializer.initAsync(this, this);
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkInitCompleted() {
+ *         mIsXWalkReady = true;
+ *
+ *         // Do anyting with the embedding API
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkInitFailed() {
+ *         XWalkUpdater.updateXWalkRuntime(this, this);
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkUpdateCancelled() {
+ *         // Perform error handling here
+ *     }
+ * }
+ * </pre>
+ */
+
+public class XWalkUpdater {
+    /**
+     * Interface used to update the Crosswalk runtime
+     */
+    public interface XWalkUpdateListener {
+        /**
+         * Runs on the UI thread to notify update is cancelled. It could be the user refused to
+         * update or the download (from the specified URL) is cancelled
+         */
+        public void onXWalkUpdateCancelled();
+    }
+
+    private static XWalkUpdater sInstance;
+
+    /**
+     * Update the Crosswalk runtime. There are 2 ways to download the Crosswalk runtime: from the
+     * play store or the specified URL. The download URL is defined by the meta-data element with
+     * the name "xwalk_apk_url" enclosed the application tag in the Android manifest. If the download
+     * URL is not defined, it will download from the play store.
+     *
+     * <p>This method must be invoked on the UI thread.
+     *
+     * @param listener The {@link XWalkUpdateListener} to use
+     * @param context The context that update is to run it
+     *
+     * @return False if is in updating or the Crosswalk runtime doesn't need to be updated,
+     *         true otherwise.
+     */
+    public static boolean updateXWalkRuntime(XWalkUpdateListener listener, Context context) {
+        if (sInstance != null) return false;
+        return new XWalkUpdater(listener, context).tryUpdate();
+    }
+
+    /**
+     * Check whether the dialog is being displayed and waiting for user's input
+     */
+    public static boolean isWaitingForInput() {
+        return sInstance != null && sInstance.mDialogManager.isShowingDialog();
+    }
+
+    /**
+     * Dismiss the dialog which is waiting for user's input. Please check with isWaitingForInput()
+     * before invoking this method.
+     */
+    public static void dismissDialog() {
+        sInstance.mDialogManager.dismissDialog();
+    }
+
+    private static final String XWALK_APK_MARKET_URL = "market://details?id=org.xwalk.core";
+    private static final String TAG = "XWalkLib";
+
+    private XWalkUpdateListener mUpdateListener;
+    private Context mContext;
+    private XWalkDialogManager mDialogManager;
+    private Runnable mDownloadCommand;
+    private Runnable mCancelCommand;
+    private String mXWalkApkUrl;
+
+    private XWalkUpdater(XWalkUpdateListener listener, Context context) {
+        mUpdateListener = listener;
+        mContext = context;
+        mDialogManager = new XWalkDialogManager(context);
+
+        mDownloadCommand = new Runnable() {
+            @Override
+            public void run() {
+                downloadXWalkLibrary();
+            }
+        };
+        mCancelCommand = new Runnable() {
+            @Override
+            public void run() {
+                sInstance = null;
+                mUpdateListener.onXWalkUpdateCancelled();
+            }
+        };
+
+        XWalkLibraryLoader.prepareToInit();
+    }
+
+    private boolean tryUpdate() {
+        if (XWalkCoreWrapper.getInstance() != null) return false;
+
+        sInstance = this;
+        int status = XWalkCoreWrapper.getProvisionalStatus();
+        mDialogManager.showInitializationError(status, mCancelCommand, mDownloadCommand);
+        return true;
+    }
+
+    private void downloadXWalkLibrary() {
+        String downloadUrl = getXWalkApkUrl();
+        if (!downloadUrl.isEmpty()) {
+            XWalkLibraryLoader.startDownload(new XWalkLibraryListener(), mContext, downloadUrl);
+            return;
+        }
+
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            mContext.startActivity(intent.setData(Uri.parse(XWALK_APK_MARKET_URL)));
+
+            mDialogManager.dismissDialog();
+            sInstance = null;
+        } catch (ActivityNotFoundException e) {
+            Log.d(TAG, "Market open failed");
+            mDialogManager.showMarketOpenError(mCancelCommand);
+        }
+    }
+
+    protected String getXWalkApkUrl() {
+        if (mXWalkApkUrl != null) return mXWalkApkUrl;
+
+        // The download url is defined by the meta-data element with the name "xwalk_apk_url"
+        // inside the application tag in the Android manifest. It can also be specified via
+        // --xwalk-apk-url option of make_apk script indirectly.
+        try {
+            PackageManager packageManager = mContext.getPackageManager();
+            ApplicationInfo appInfo = packageManager.getApplicationInfo(
+                mContext.getPackageName(), PackageManager.GET_META_DATA);
+            if (appInfo.metaData != null) {
+                mXWalkApkUrl = appInfo.metaData.getString("xwalk_apk_url");
+            }
+        } catch (NameNotFoundException e) {
+        }
+
+        if (mXWalkApkUrl == null) mXWalkApkUrl = "";
+        Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
+        return mXWalkApkUrl;
+    }
+
+    private class XWalkLibraryListener implements DownloadListener {
+        @Override
+        public void onDownloadStarted() {
+            mDialogManager.showDownloadProgress(new Runnable() {
+                @Override
+                public void run() {
+                    XWalkLibraryLoader.cancelDownload();
+                }
+            });
+        }
+
+        @Override
+        public void onDownloadUpdated(int percentage) {
+            mDialogManager.setProgress(percentage, 100);
+        }
+
+        @Override
+        public void onDownloadCancelled() {
+            sInstance = null;
+            mUpdateListener.onXWalkUpdateCancelled();
+        }
+
+        @Override
+        public void onDownloadCompleted(Uri uri) {
+            mDialogManager.dismissDialog();
+            sInstance = null;
+
+            Log.d(TAG, "Install the Crosswalk library, " + uri.toString());
+            Intent install = new Intent(Intent.ACTION_VIEW);
+            install.setDataAndType(uri, "application/vnd.android.package-archive");
+            mContext.startActivity(install);
+        }
+
+        @Override
+        public void onDownloadFailed(int status, int error) {
+            mDialogManager.dismissDialog();
+            mDialogManager.showDownloadError(status, error, mCancelCommand, mDownloadCommand);
+        }
+    }
+}

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -20,6 +20,7 @@
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java',
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkApplication.java',
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkInitializer.java',
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkDownloadListener.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkExtension.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkJavascriptResult.java',


### PR DESCRIPTION
Some activities might want to integrate the initialization process but
can't extend XWalkActivity due to its limitations. So we extract this
part from XWalkActivity for other's reuse. This is especially for the
integration into Cordova Plugin.