### PR TITLE
[Android] Fix the response stream crash issue.

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -258,6 +258,7 @@ def CopyResources(project_source, out_dir, out_project_dir, shared):
         'content_strings_grd.zip',
         'ui_java.zip',
         'ui_strings_grd.zip',
+        'web_contents_delegate_android_java.zip',
         'xwalk_core_internal_java.zip',
         'xwalk_core_strings.zip',
         'xwalk_app_strings.zip'

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkInternalResources.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkInternalResources.java
@@ -15,6 +15,7 @@ class XWalkInternalResources {
 
     private static boolean loaded = false;
     private final static String INTERNAL_RESOURCE_CLASSES[] = {
+        "org.chromium.components.web_contents_delegate_android.R",
         "org.chromium.content.R",
         "org.chromium.ui.R",
         "org.xwalk.core.internal.R"


### PR DESCRIPTION
This patch is to fix the response stream crash issue on android
platform.
The validation_message_bubble.xml was not copied to xwalk_core_library,
add the related zip file to copy list to generate this resource file.

BUG=XWALK-4213

(cherry picked from commit 8325a801ebfe0183a4de629245659fa73495a9e5)