### PR TITLE
[Android] Fix the Cordova package failed issue.

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -226,6 +226,7 @@ def ReplaceCrunchedImage(project_source, filename, filepath):
   """Replace crunched images with source images.
   """
   search_dir = [
+      'components/web_contents_delegate_android/android/java/res',
       'content/public/android/java/res',
       'ui/android/java/res'
   ]


### PR DESCRIPTION
Pack cordova 4.0 failed with cordova canary 15.43.355.0, this patch is
to fix it.
The resources copied from components zip file are invalid 9-patch images,
can't be used for Android studio/Maven, so copy these resources from
Chromium source folder directly to CrossWalk.

BUG=XWALK-4313