### PR TITLE
[Android] Implement XWalkResourceClient.onDocumentLoadedInFrame.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -86,6 +86,11 @@ abstract class XWalkContentsClient extends ContentViewClient {
             // So it is safe for Crosswalk to rely on didStopLoading to ensure onPageFinished
             // can be called.
         }
+
+        @Override
+        public void documentLoadedInFrame(long frameId) {
+            onDocumentLoadedInFrame(frameId);
+        }
     }
 
     @Override
@@ -163,6 +168,8 @@ abstract class XWalkContentsClient extends ContentViewClient {
     protected abstract boolean onCreateWindow(boolean isDialog, boolean isUserGesture);
 
     protected abstract void onCloseWindow();
+
+    public abstract void onDocumentLoadedInFrame(long frameId);
 
     public abstract void onReceivedIcon(Bitmap bitmap);
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -238,6 +238,13 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
+    public void onDocumentLoadedInFrame(long frameId) {
+        if (isOwnerActivityRunning()) {
+            mXWalkResourceClient.onDocumentLoadedInFrame(mXWalkView,frameId);
+        }
+    }
+
+    @Override
     public void onResourceLoadStarted(String url) {
         if (isOwnerActivityRunning()) {
             mXWalkResourceClient.onLoadStarted(mXWalkView, url);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -125,6 +125,18 @@ public class XWalkResourceClientInternal {
     }
 
     /**
+     * Notify the client that initial HTML document has been completely loaded and
+     * parsed, without waiting for stylesheets, images, and subframes to finish loading.
+     * This is similar to JavaScript DOMContentLoaded.
+     * @param view the owner XWalkViewInternal instance.
+     * @param frameId the loaded and parsed frame.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void onDocumentLoadedInFrame(XWalkViewInternal view, long frameId) {
+    }
+
+    /**
      * Notify the client that the XWalkViewInternal will load the resource specified
      * by the given url.
      * @param view the owner XWalkViewInternal instance.

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnDocumentLoadedInFrameTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnDocumentLoadedInFrameTest.java
@@ -1,0 +1,58 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.net.test.util.TestWebServer;
+
+import org.xwalk.core.xwview.test.util.CommonResources;
+
+/**
+ * Test suite for OnDocumentLoadedInFrame().
+ */
+public class OnDocumentLoadedInFrameTest extends XWalkViewTestBase {
+    private TestWebServer mWebServer;
+    private TestHelperBridge.OnDocumentLoadedInFrameHelper mOnDocumentLoadedInFrameHelper;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mWebServer = TestWebServer.start();
+        mOnDocumentLoadedInFrameHelper = mTestHelperBridge.getOnDocumentLoadedInFrameHelper();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        mWebServer.shutdown();
+        super.tearDown();
+    }
+
+    private String addPageToTestServer(TestWebServer webServer, String httpPath, String html) {
+        List<Pair<String, String>> headers = new ArrayList<Pair<String, String>>();
+        headers.add(Pair.create("Content-Type", "text/html"));
+        headers.add(Pair.create("Cache-Control", "no-store"));
+        return webServer.setResponse(httpPath, html, headers);
+    }
+
+    @SmallTest
+    @Feature({"OnDocumentLoadedInFrame"})
+    public void testOnDocumentLoadedInFrame() throws Throwable {
+        String path = "/test.html";
+        String pageContent = CommonResources.makeHtmlPageFrom("<title>Test</title>",
+                "<div> The title is: Test </div>");
+        final String url = addPageToTestServer(mWebServer, path, pageContent);
+
+        loadUrlSync(url);
+        assertEquals(1, mOnDocumentLoadedInFrameHelper.getFrameId());
+        assertEquals(1, mOnDocumentLoadedInFrameHelper.getCallCount());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
@@ -71,6 +71,20 @@ class TestHelperBridge {
         }
     }
 
+    public class OnDocumentLoadedInFrameHelper extends CallbackHelper {
+        private long mFrameId;
+
+        public long getFrameId() {
+            assert getCallCount() > 0;
+            return mFrameId;
+        }
+
+        public void notifyCalled(long frameId) {
+            mFrameId = frameId;
+            notifyCalled();
+        }
+    }
+
     public class OnLoadStartedHelper extends CallbackHelper {
         private String mUrl;
 
@@ -414,6 +428,7 @@ class TestHelperBridge {
     private final OverrideOrUnhandledKeyEventHelper mOverrideOrUnhandledKeyEventHelper;
     private final OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper;
     private final OnConsoleMessageHelper mOnConsoleMessageHelper;
+    private final OnDocumentLoadedInFrameHelper mOnDocumentLoadedInFrameHelper;
     private final OnReceivedIconHelper mOnReceivedIconHelper;
     private final OnLoadFinishedHelper mOnLoadFinishedHelper;
     private final OnDownloadStartHelper mOnDownloadStartHelper;
@@ -437,6 +452,7 @@ class TestHelperBridge {
         mOverrideOrUnhandledKeyEventHelper = new OverrideOrUnhandledKeyEventHelper();
         mOnCreateWindowRequestedHelper = new OnCreateWindowRequestedHelper();
         mOnConsoleMessageHelper = new OnConsoleMessageHelper();
+        mOnDocumentLoadedInFrameHelper = new OnDocumentLoadedInFrameHelper();
         mOnReceivedIconHelper = new OnReceivedIconHelper();
         mOnLoadFinishedHelper = new OnLoadFinishedHelper();
         mOnDownloadStartHelper = new OnDownloadStartHelper();
@@ -464,6 +480,10 @@ class TestHelperBridge {
 
     public ShouldInterceptLoadRequestHelper getShouldInterceptLoadRequestHelper() {
         return mShouldInterceptLoadRequestHelper;
+    }
+
+    public OnDocumentLoadedInFrameHelper getOnDocumentLoadedInFrameHelper() {
+        return mOnDocumentLoadedInFrameHelper;
     }
 
     public OnLoadStartedHelper getOnLoadStartedHelper() {
@@ -556,6 +576,10 @@ class TestHelperBridge {
         WebResourceResponse response = mShouldInterceptLoadRequestHelper.getReturnValue(url);
         mShouldInterceptLoadRequestHelper.notifyCalled(url);
         return response;
+    }
+
+    public void onDocumentLoadedInFrame(long frameId) {
+        mOnDocumentLoadedInFrameHelper.notifyCalled(frameId);
     }
 
     public void onLoadStarted(String url) {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -156,6 +156,11 @@ public class XWalkViewTestBase
         public void onLoadFinished(XWalkView view, String url) {
             mInnerContentsClient.onLoadFinished(url);
         }
+
+        @Override
+        public void onDocumentLoadedInFrame(XWalkView view, long frameId) {
+            mInnerContentsClient.onDocumentLoadedInFrame(frameId);
+        }
     }
 
     class TestXWalkResourceClient extends TestXWalkResourceClientBase {


### PR DESCRIPTION
Used to notify the client that initial HTML document has been completely loaded and
parsed, without waiting for stylesheets, images, and subframes to finish loading.
This is similar to JavaScript DOMContentLoaded.

BUG=XWALK-4320