### PR TITLE
[Android] Implement the feature to change cache path.

### DIFF
--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -109,8 +109,11 @@ XWalkBrowserContext::CreateZoomLevelDelegate(
 base::FilePath XWalkBrowserContext::GetPath() const {
   base::FilePath result;
 #if defined(OS_ANDROID)
-  CHECK(PathService::Get(base::DIR_ANDROID_APP_DATA, &result));
   base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kUserDataDir))
+    result = cmd_line->GetSwitchValuePath(switches::kUserDataDir);
+  if (result.empty())
+    CHECK(PathService::Get(base::DIR_ANDROID_APP_DATA, &result));
   if (cmd_line->HasSwitch(switches::kXWalkProfileName))
     result = result.Append(
         cmd_line->GetSwitchValuePath(switches::kXWalkProfileName));

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -52,4 +52,8 @@ const char kPpapiFlashPath[] = "ppapi-flash-path";
 const char kPpapiFlashVersion[] = "ppapi-flash-version";
 #endif
 
+// Specifies the user data directory, which is where the browser will look for
+// all of its state.
+const char kUserDataDir[] = "user-data-dir";
+
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -29,6 +29,8 @@ extern const char kPpapiFlashPath[];
 extern const char kPpapiFlashVersion[];
 #endif
 
+extern const char kUserDataDir[];
+
 }  // namespace switches
 
 #endif  // XWALK_RUNTIME_COMMON_XWALK_SWITCHES_H_


### PR DESCRIPTION
This patch is to add the function to change cache path by adding switch
to command line.
If the user data directory was specified in command line, use this path
instead of the default.

BUG=XWALK-2030