### PR TITLE
Fix dangling pointer in xwalk extension code.

### DIFF
--- a/extensions/browser/xwalk_extension_data.cc
+++ b/extensions/browser/xwalk_extension_data.cc
@@ -14,8 +14,7 @@ namespace xwalk {
 namespace extensions {
 
 XWalkExtensionData::XWalkExtensionData()
-    : in_process_message_filter_(NULL),
-      extension_thread_(NULL),
+    : extension_thread_(NULL),
       render_process_host_(NULL) {}
 
 XWalkExtensionData::~XWalkExtensionData() {

--- a/extensions/browser/xwalk_extension_data.h
+++ b/extensions/browser/xwalk_extension_data.h
@@ -35,10 +35,6 @@ class XWalkExtensionData {
     return in_process_ui_thread_server_.get();
   }
 
-  ExtensionServerMessageFilter* in_process_message_filter() {
-    return in_process_message_filter_;
-  }
-
   scoped_ptr<XWalkExtensionProcessHost> extension_process_host() {
     return extension_process_host_.Pass();
   }
@@ -57,12 +53,6 @@ class XWalkExtensionData {
     in_process_ui_thread_server_.reset(server.release());
   }
 
-  // We don't take the ownership of the filter because filters are owned by
-  // the IPC Channel they are filtering.
-  void set_in_process_message_filter(ExtensionServerMessageFilter* filter) {
-    in_process_message_filter_ = filter;
-  }
-
   void set_extension_process_host(scoped_ptr<XWalkExtensionProcessHost> host) {
     extension_process_host_.reset(host.release());
   }
@@ -79,9 +69,6 @@ class XWalkExtensionData {
   // Extension servers living on their respective threads.
   scoped_ptr<XWalkExtensionServer> in_process_extension_thread_server_;
   scoped_ptr<XWalkExtensionServer> in_process_ui_thread_server_;
-
-  // This object lives on the IO-thread.
-  ExtensionServerMessageFilter* in_process_message_filter_;
 
   // This object lives on the IO-thread.
   scoped_ptr<XWalkExtensionProcessHost> extension_process_host_;


### PR DESCRIPTION
 At the time we reach OnRenderProcessHostClosed the IPC messaging filters are already deleted because the IPC Channel has been closed. We do not need to invalidate the ExtensionServerMessageFilter instance because it's already deleted (and the various overloads of MessageFilter are going to invalidate it) and we should not remove from the current channel because it's been already deleted (removing it will cause its deletion). In fact we do not need to hold a reference of that message filter as it's own by the IPC channel and will be deleted.

BUG=XWALK-4295