### PR TITLE
[Android] Fix the crash issue for rebase to M44.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
@@ -106,7 +106,8 @@ class XWalkCoreWrapper {
         if (sInstance != null || sReservedObjects != null) return;
 
         Log.d(TAG, "Init embedded mode");
-        XWalkCoreWrapper provisionalInstance = new XWalkCoreWrapper(null, -1);
+        XWalkApplication application = XWalkApplication.getApplication();
+        XWalkCoreWrapper provisionalInstance = new XWalkCoreWrapper(application.getApplicationContext(), -1);
         if (!provisionalInstance.findEmbeddedCore()) {
             Assert.fail("Please extend XWalkActivity for shared mode");
         }
@@ -203,7 +204,8 @@ class XWalkCoreWrapper {
     private boolean checkCoreArchitecture() {
         try {
             Class<?> clazz = getBridgeClass("XWalkViewDelegate");
-            new ReflectMethod(clazz, "loadXWalkLibrary", Context.class).invoke(mBridgeContext);
+            new ReflectMethod(clazz, "loadXWalkLibrary", Context.class,
+                    Context.class).invoke(mBridgeContext, mWrapperContext);
         } catch (RuntimeException e) {
             Log.d(TAG, "Failed to load native library");
             mCoreStatus = XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH;

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -82,7 +82,7 @@ class XWalkViewDelegate {
         }
     }
 
-    public static void loadXWalkLibrary(Context context) throws UnsatisfiedLinkError {
+    public static void loadXWalkLibrary(Context context, Context wrapperContext) throws UnsatisfiedLinkError {
         if (sLibraryLoaded) return;
 
         // If context is null, it's called from wrapper's ReflectionHelper to try
@@ -97,8 +97,12 @@ class XWalkViewDelegate {
                 System.load("/data/data/" + context.getPackageName() + "/lib/" + library);
             }
         }
-
-        PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, context);
+        if (context == null) context = wrapperContext;
+        if (context != null && context.getApplicationContext() != null) {
+            PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, context);
+        } else {
+            PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, wrapperContext);
+        }
         try {
             LibraryLoader libraryLoader = LibraryLoader.get(LibraryProcessType.PROCESS_BROWSER);
             libraryLoader.loadNow(context, true);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -250,7 +250,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     private static void init(Context context, Activity activity) {
         if (sInitialized) return;
 
-        XWalkViewDelegate.loadXWalkLibrary(context);
+        XWalkViewDelegate.loadXWalkLibrary(context, activity);
 
         // Initialize the ActivityStatus. This is needed and used by many internal
         // features such as location provider to listen to activity status.


### PR DESCRIPTION
This patch is to fix the android tests crashed issue when rebase to M44.
Transfer the wrapper context to PathUtils if the bridge context is
invalid.

BUG=XWALK-4323