### PR TITLE
[Android] Deliver onCreateInputConnection to XWalkView

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -19,6 +19,8 @@ import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 import android.widget.FrameLayout;
@@ -57,7 +59,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
     private static Class<? extends Annotation> javascriptInterfaceClass = null;
 
     private ContentViewCore mContentViewCore;
-    private ContentView mContentView;
+    private XWalkContentView mContentView;
     private ContentViewRenderView mContentViewRenderView;
     private ActivityWindowAndroid mWindow;
     private XWalkDevToolsServer mDevToolsServer;
@@ -156,7 +158,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
 
         // Initialize ContentView.
         mContentViewCore = new ContentViewCore(getContext());
-        mContentView = ContentView.newInstance(getContext(), mContentViewCore);
+        mContentView = new XWalkContentView(getContext(), mContentViewCore, mXWalkView);
         mContentViewCore.initialize(mContentView, mContentView, webContents, mWindow);
         mWebContents = mContentViewCore.getWebContents();
         mNavigationController = mWebContents.getNavigationController();
@@ -608,6 +610,11 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
 
     public int getRoutingID() {
         return nativeGetRoutingID(mNativeContent);
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        return mContentView.onCreateInputConnectionSuper(outAttrs);
     }
 
     //--------------------------------------------------------------------------------------------

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
@@ -1,0 +1,75 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.accessibility.AccessibilityNodeProvider;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+
+import org.chromium.content.browser.ContentView;
+import org.chromium.content.browser.ContentViewCore;
+
+public class XWalkContentView extends ContentView {
+    private XWalkViewInternal mXWalkView;
+
+    XWalkContentView(Context context, ContentViewCore cvc, XWalkViewInternal xwView) {
+        super(context, cvc);
+        mXWalkView = xwView;
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        return mXWalkView.onCreateInputConnection(outAttrs);
+    }
+
+    public InputConnection onCreateInputConnectionSuper(EditorInfo outAttrs) {
+        return super.onCreateInputConnection(outAttrs);
+    }
+
+    @Override
+    public boolean performAccessibilityAction(int action, Bundle arguments) {
+        // Originally, we obtain a ContentView instance through ContentView.newInstance().
+        // The method newInstance will return ContentView or JellyBeanContentView
+        // respectively according to the sdk version like below:
+        // public static ContentView newInstance(Context context, ContentViewCore cvc) {
+        //     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+        //         return new ContentView(context, cvc);
+        //     } else {
+        //         return new JellyBeanContentView(context, cvc);
+        //     }
+        // }
+        // Now we use XWalkContentView uniformly, so this is a substitute for it.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            return super.performAccessibilityAction(action, arguments);
+        }
+
+        // Copy code from JellyBeanContentView because the class is not public
+        if (mContentViewCore.supportsAccessibilityAction(action)) {
+            return mContentViewCore.performAccessibilityAction(action, arguments);
+        }
+
+        return super.performAccessibilityAction(action, arguments);
+    }
+
+    @Override
+    public AccessibilityNodeProvider getAccessibilityNodeProvider() {
+        // Ditto
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            return super.getAccessibilityNodeProvider();
+        }
+
+        // Copy code from JellyBeanContentView because the class is not public
+        AccessibilityNodeProvider provider = mContentViewCore.getAccessibilityNodeProvider();
+        if (provider != null) {
+            return provider;
+        } else {
+            return super.getAccessibilityNodeProvider();
+        }
+    }
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -21,6 +21,8 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 import android.webkit.ValueCallback;
 import android.widget.FrameLayout;
 
@@ -877,6 +879,18 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         if (mContent == null) return false;
         checkThreadSafety();
         return mContent.canZoomOut();
+    }
+
+    /**
+     * Create a new InputConnection for and InputMethod to interact with the view.
+     * The default implementation returns the InputConnection created by ContentView
+     * @param outAttrs Fill in with attribute information about the connection
+     * @return the new InputConnection
+     * @since 5.0
+     */
+    @XWalkAPI
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        return mContent.onCreateInputConnection(outAttrs);
     }
 
     /**


### PR DESCRIPTION
onCreateInputConnection is never called even if override it on
XWalkView. Because the view get callbacked is the descendant
ContentView, but not the XWalkView which the user holds.
So pass the callback to the parent view step by step and finally
it can reach to the XWalkView.

BUG=XWALK-3024
(cherry picked from commit 7cdb86c3ed540b291def245922812ccdca26c475)