### PR TITLE
[Android] Aggressively flush to disk

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -134,6 +134,11 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
 
   command_line->AppendSwitch(switches::kEnableViewportMeta);
 
+  // WebView does not (yet) save Chromium data during shutdown, so add setting
+  // for Chrome to aggressively persist DOM Storage to minimize data loss.
+  // http://crbug.com/479767
+  command_line->AppendSwitch(switches::kEnableAggressiveDOMStorageFlushing);
+
   XWalkBrowserMainParts::PreMainMessageLoopStart();
 
   startup_url_ = GURL();


### PR DESCRIPTION
WebView does not (yet) save Chromium data during shutdown, so add setting
to aggressively persist DOM Storage to minimize data loss.
http://crbug.com/479767.
Relative commit is 256bc7c44b79291123ff024ec9a5b4066c3becb9.

BUG=XWALK-4260

(cherry picked from commit 981f35bdf0ed7845c4c7894a473461840f8b1812)