### PR TITLE
[Android] Aggressively flush to disk

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -129,6 +129,11 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
 
   command_line->AppendSwitch(switches::kEnableViewportMeta);
 
+  // WebView does not (yet) save Chromium data during shutdown, so add setting
+  // for Chrome to aggressively persist DOM Storage to minimize data loss.
+  // http://crbug.com/479767
+  command_line->AppendSwitch(switches::kEnableAggressiveDOMStorageFlushing);
+
   XWalkBrowserMainParts::PreMainMessageLoopStart();
 
   startup_url_ = GURL();


### PR DESCRIPTION
WebView does not (yet) save Chromium data during shutdown, so add setting
to aggressively persist DOM Storage to minimize data loss.
http://crbug.com/479767.
Relative commit is https://github.com/crosswalk-project/chromium-crosswalk/commit/5eba2222bb5e2f70618d3fa3017d19a91504e823.

BUG=XWALK-4260