### PR TITLE
Fix XWalkExtensionsV8ToolsTest.V8ToolsWorks asserting in debug.

### DIFF
--- a/extensions/renderer/xwalk_v8tools_module.cc
+++ b/extensions/renderer/xwalk_v8tools_module.cc
@@ -50,8 +50,6 @@ void LifecycleTrackerCleanup(
   }
 
   v8::Handle<v8::Context> context = v8::Context::New(isolate);
-  blink::WebScopedMicrotaskSuppression suppression;
-
   v8::TryCatch try_catch;
   v8::Handle<v8::Function>::Cast(function)->Call(context->Global(), 0, NULL);
   if (try_catch.HasCaught())


### PR DESCRIPTION
The tests seemed to be blocked while forcing gc() in JavaScript
however it turns out that the test actually trigger an ASSERT while
calling blink::WebScopedMicrotaskSuppression suppression;

The documentation of WebScopedMicrotaskSuppression explains that you need
to stack allocate this object if you call a script context that will not
cause author script to run and the call is made on the context directly.
We do this in various places in the extension code for this particular
reason. The correct usage of WebScopedMicrotaskSuppression is enforced
in debug with various ASSERTs helping to figure out if you did the right
thing.

In the case of V8ToolsWorks, WebScopedMicrotaskSuppression was triggering
an ASSERT regarding the recursion. In our test code we have some
facilities to catch up when v8 object are destroyed (we use it to test
that objects are correctly garbage collected, for example in sysapps).
The problem is that when we enter LifecycleTrackerCleanup() we have
already entered into a recursion meaning ScriptForbiddenScope::enter()
was already called. It explains why WebScopedMicrotaskSuppression
assert as it verifies that we haven't entered in a "ScriptForbiddenScope"
already. The assert indicates that we are doing an erronous usage of
WebScopedMicrotaskSuppression and that we don't need it at all. The actual
call of to increment the current scoping is in V8GCController::majorGCPrologue
which is triggered when you call gc() in JavaScript. The assert and the
documentation tell us that we can remove the stack allocation of
WebScopedMicrotaskSuppression.

The ASSERT was probably there since day one but nobody actually build
Crosswalk in debug which explains why nobody bothered fixing it. As
a nice side effect it also fix the sysapp browser tests because they
were also enforcing gc().