### PR TITLE
[Android] Crosswalk Cocos2d optimization

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -354,6 +354,7 @@ if __name__ == '__main__':
     args.append('-Duse_minimum_resources=1')
     args.append('-Duse_lzma=1')
     args.append('-Ddisable_builtin_extensions=1')
+    args.append('-Denable_cocos2d=0')
 
   if not use_analyzer:
     print 'Updating projects from gyp files...'

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -238,6 +238,14 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     private static void init(Context context, Activity activity) {
         if (sInitialized) return;
 
+        try {
+            Class cocos2dHelper = Class.forName("org.cocos2dx.lib.Cocos2dxHelper");
+            Method method = cocos2dHelper.getMethod("init", new Class[]{Context.class});
+            method.invoke(null, activity);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         XWalkViewDelegate.loadXWalkLibrary(null);
 
         // Initialize the ActivityStatus. This is needed and used by many internal

--- a/runtime/app/android/xwalk_entry_point.cc
+++ b/runtime/app/android/xwalk_entry_point.cc
@@ -10,6 +10,9 @@
 #include "content/public/app/content_main_delegate.h"
 #include "xwalk/runtime/app/android/xwalk_jni_registrar.h"
 #include "xwalk/runtime/app/android/xwalk_main_delegate_android.h"
+#if defined(USE_COCOS2D)
+#include "third_party/WebKit/Source/core/cocos2d/cocos2dx/platform/android/blinkjni/Cocos2dxJniHelper.h"
+#endif
 
 // This is called by the VM when the shared library is first loaded.
 JNI_EXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
@@ -22,6 +25,11 @@ JNI_EXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   if (!xwalk::RegisterJni(env))
     return -1;
+
+  #if defined(USE_COCOS2D)
+  if (!cocos2d::RegisterCocos2dJni(env))
+    return -1;
+  #endif
 
   content::SetContentMainDelegate(new xwalk::XWalkMainDelegateAndroid());
 

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -38,6 +38,9 @@
             'cleanup_icu_data',
           ],
         }],
+        ['enable_cocos2d==1', {
+          'defines': ['USE_COCOS2D'],
+        }],
       ],
     },
     {
@@ -185,6 +188,11 @@
         'generated_src_dirs': [
           '<(reflection_java_dir)/wrapper',
         ],
+        'conditions': [
+          ['enable_cocos2d==1', {
+            'input_jars_paths': ['<(PRODUCT_DIR)/lib.java/cocos2d_blink_java.jar']
+          }],
+        ]        
       },
       'includes': ['../build/java.gypi']
     },

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -31,6 +31,11 @@
         ],
         'xwalk_core_jar': '<(PRODUCT_DIR)/lib.java/xwalk_core_library_java_app_part.jar',
         'docs': '<(PRODUCT_DIR)/xwalk_core_library_docs',
+        'conditions': [
+          ['enable_cocos2d==1', {
+            'input_jars_paths': ['<(PRODUCT_DIR)/lib.java/cocos2d_blink_java.jar']
+          }],
+        ]
       },
       'actions': [
         {


### PR DESCRIPTION
Add build flag & cocos2d init code to support cocos2d optimization
Disabled cocos2d build by default.
Enable it with build flags change in gyp_xwalk:
args.append('-Denable_webrtc=0') => args.append('-Denable_webrtc=1')
args.append('-Duse_lzma=1') => args.append('-Duse_lzma=0')
args.append('-Denable_cocos2d=0') => args.append('-Denable_cocos2d=1')