### PR TITLE
[Android] Update the accept languages in http request header.

### DIFF
--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -146,8 +146,14 @@ void XWalkContent::UpdateRendererPreferences() {
       web_contents_->GetMutableRendererPrefs();
   PrefService* pref_service =
       user_prefs::UserPrefs::Get(XWalkBrowserContext::GetDefault());
-  prefs->accept_languages = pref_service->GetString("intl.accept_languages");
+  const std::string accept_languages =
+      pref_service->GetString("intl.accept_languages");
+  prefs->accept_languages = accept_languages;
   web_contents_->GetRenderViewHost()->SyncRendererPrefs();
+  XWalkBrowserContext* browser_context =
+      XWalkRunner::GetInstance()->browser_context();
+  CHECK(browser_context);
+  browser_context->UpdateAcceptLanguages(accept_languages);
 }
 
 void XWalkContent::CreateUserPrefServiceIfNecessary(

--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -292,4 +292,14 @@ net::HostResolver* RuntimeURLRequestContextGetter::host_resolver() {
   return url_request_context_->host_resolver();
 }
 
+#if defined(OS_ANDROID)
+void RuntimeURLRequestContextGetter::UpdateAcceptLanguages(
+    const std::string& accept_languages) {
+  if (!storage_)
+    return;
+  storage_->set_http_user_agent_settings(new net::StaticHttpUserAgentSettings(
+      accept_languages, xwalk::GetUserAgent()));
+}
+#endif
+
 }  // namespace xwalk

--- a/runtime/browser/runtime_url_request_context_getter.h
+++ b/runtime/browser/runtime_url_request_context_getter.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_RUNTIME_BROWSER_RUNTIME_URL_REQUEST_CONTEXT_GETTER_H_
 #define XWALK_RUNTIME_BROWSER_RUNTIME_URL_REQUEST_CONTEXT_GETTER_H_
 
+#include <string>
+
 #include "base/compiler_specific.h"
 #include "base/files/file_path.h"
 #include "base/memory/ref_counted.h"
@@ -44,6 +46,9 @@ class RuntimeURLRequestContextGetter : public net::URLRequestContextGetter {
       GetNetworkTaskRunner() const override;
 
   net::HostResolver* host_resolver();
+  #if defined(OS_ANDROID)
+  void UpdateAcceptLanguages(const std::string& accept_languages);
+  #endif
 
  private:
   ~RuntimeURLRequestContextGetter() override;

--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -368,6 +368,15 @@ void XWalkBrowserContext::CreateUserPrefServiceIfNecessary() {
 
   user_prefs::UserPrefs::Set(this, user_pref_service_.get());
 }
+
+void XWalkBrowserContext::UpdateAcceptLanguages(
+    const std::string& accept_languages) {
+  RuntimeURLRequestContextGetter* url_request_context_getter =
+      url_request_getter_.get();
+  if (!url_request_context_getter)
+    return;
+  url_request_context_getter->UpdateAcceptLanguages(accept_languages);
+}
 #endif
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_context.h
+++ b/runtime/browser/xwalk_browser_context.h
@@ -106,6 +106,8 @@ class XWalkBrowserContext
       const scoped_refptr<URLEnumerator>& enumerator) override;
 
   void CreateUserPrefServiceIfNecessary();
+
+  void UpdateAcceptLanguages(const std::string& accept_languages);
 #endif
 
  private:


### PR DESCRIPTION
In http request header, the accept languages was set by default
value, e.g. "en-us,en", user cann't modify it, this patch is to
update the accept languages when user invoke the embedding API.
Http request header was created before the embedding API invoked,
so the accept languages could noly be updated.

BUG=XWALK-3463