### PR TITLE
Add code to build Debian desktop packages.

### DIFF
--- a/tools/installer/common/crosswalk.info
+++ b/tools/installer/common/crosswalk.info
@@ -1,0 +1,27 @@
+# Copyright (c) 2009 The Chromium Authors. All rights reserved.
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# This file provides common configuration information for building
+# Crosswalk packages for various platforms.
+
+# Base name of the package.
+PACKAGE="crosswalk"
+
+# Filename of the main executable (for generating launcher scripts, etc.)
+PROGNAME="xwalk"
+
+# Base directory for package installation.
+INSTALLDIR="/opt/crosswalk-project"
+
+# Brief package description.
+SHORTDESC="Runtime for hosted and packaged apps"
+
+# Detailed package description.
+FULLDESC="The Crosswalk Project is an HTML5 application runtime, built on open source foundations, which extends the web platform with new capabilities."
+
+# Package maintainer information.
+MAINTNAME="Crosswalk Project"
+MAINTMAIL="crosswalk-dev@lists.crosswalk-project.org"
+PRODUCTURL="https://crosswalk-project.org/"

--- a/tools/installer/common/generate-changelog.sh
+++ b/tools/installer/common/generate-changelog.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Generates a list of changes since the last version revision commit bump for
+# later consumption by, for example, the packaging system for Linux distros.
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $1 <output file>"
+    exit 2
+fi
+
+SCRIPTDIR=$(readlink -f "$(dirname "$0")")
+REPOROOT=$(readlink -f "${SCRIPTDIR}/../../..")
+
+if [ ! -d ${REPOROOT}/.git ]; then
+    echo "Not in a git checkout. Not generating commit log for packaging."
+    exit 0
+fi
+
+export GIT_DIR=${REPOROOT}/.git
+
+last_bump_rev=`git log -1 --author='Crosswalk Release Engineering' --format='%H'`
+if [ -z "${last_bump_rev}" ]; then
+    echo "It looks like there has never been a version bump commit before."
+    echo "Are you in src/xwalk?"
+    exit 1
+fi
+
+OUTPUT=`readlink -f $1`
+git log --no-merges --reverse --format='%s' $last_bump_rev.. > $OUTPUT

--- a/tools/installer/common/installer.include
+++ b/tools/installer/common/installer.include
@@ -1,0 +1,183 @@
+# Recursively replace @@include@@ template variables with the referenced file,
+# and write the resulting text to stdout.
+process_template_includes() {
+  INCSTACK+="$1->"
+  # Includes are relative to the file that does the include.
+  INCDIR=$(dirname $1)
+  # Clear IFS so 'read' doesn't trim whitespace
+  local OLDIFS="$IFS"
+  IFS=''
+  while read -r LINE
+  do
+    INCLINE=$(sed -e '/^[[:space:]]*@@include@@/!d' <<<$LINE)
+    if [ -n "$INCLINE" ]; then
+      INCFILE=$(echo $INCLINE | sed -e "s#@@include@@\(.*\)#\1#")
+      # Simple filename match to detect cyclic includes.
+      CYCLE=$(sed -e "\#$INCFILE#"'!d' <<<$INCSTACK)
+      if [ "$CYCLE" ]; then
+        echo "ERROR: Possible cyclic include detected." 1>&2
+        echo "$INCSTACK$INCFILE" 1>&2
+        exit 1
+      fi
+      if [ ! -r "$INCDIR/$INCFILE" ]; then
+        echo "ERROR: Couldn't read include file: $INCDIR/$INCFILE" 1>&2
+        exit 1
+      fi
+      process_template_includes "$INCDIR/$INCFILE"
+    else
+      echo "$LINE"
+    fi
+  done < "$1"
+  IFS="$OLDIFS"
+  INCSTACK=${INCSTACK%"$1->"}
+}
+
+# Replace template variables (@@VARNAME@@) in the given template file. If a
+# second argument is given, save the processed text to that filename, otherwise
+# modify the template file in place.
+process_template() (
+  # Don't worry if some of these substitution variables aren't set.
+  # Note that this function is run in a sub-shell so we don't leak this
+  # setting, since we still want unbound variables to be an error elsewhere.
+  set +u
+
+  local TMPLIN="$1"
+  if [ -z "$2" ]; then
+    local TMPLOUT="$TMPLIN"
+  else
+    local TMPLOUT="$2"
+  fi
+  # Process includes first so included text also gets substitutions.
+  TMPLINCL="$(process_template_includes "$TMPLIN")"
+  sed \
+    -e "s#@@PACKAGE@@#${PACKAGE}#g" \
+    -e "s#@@PACKAGE_FILENAME@@#${PACKAGE_FILENAME}#g" \
+    -e "s#@@PROGNAME@@#${PROGNAME}#g" \
+    -e "s#@@CHANNEL@@#${CHANNEL}#g" \
+    -e "s#@@COMPANY_FULLNAME@@#${COMPANY_FULLNAME}#g" \
+    -e "s#@@VERSION@@#${VERSION}#g" \
+    -e "s#@@PACKAGE_RELEASE@@#${PACKAGE_RELEASE}#g" \
+    -e "s#@@VERSIONFULL@@#${VERSIONFULL}#g" \
+    -e "s#@@INSTALLDIR@@#${INSTALLDIR}#g" \
+    -e "s#@@BUILDDIR@@#${BUILDDIR}#g" \
+    -e "s#@@STAGEDIR@@#${STAGEDIR}#g" \
+    -e "s#@@SCRIPTDIR@@#${SCRIPTDIR}#g" \
+    -e "s#@@MENUNAME@@#${MENUNAME}#g" \
+    -e "s#@@PRODUCTURL@@#${PRODUCTURL}#g" \
+    -e "s#@@PREDEPENDS@@#${PREDEPENDS}#g" \
+    -e "s#@@DEPENDS@@#${DEPENDS}#g" \
+    -e "s#@@PROVIDES@@#${PROVIDES}#g" \
+    -e "s#@@REPLACES@@#${REPLACES}#g" \
+    -e "s#@@CONFLICTS@@#${CONFLICTS}#g" \
+    -e "s#@@ARCHITECTURE@@#${ARCHITECTURE}#g" \
+    -e "s#@@MAINTNAME@@#${MAINTNAME}#g" \
+    -e "s#@@MAINTMAIL@@#${MAINTMAIL}#g" \
+    -e "s#@@REPOCONFIG@@#${REPOCONFIG}#g" \
+    -e "s#@@SSLREPOCONFIG@@#${SSLREPOCONFIG}#g" \
+    -e "s#@@SHORTDESC@@#${SHORTDESC}#g" \
+    -e "s#@@FULLDESC@@#${FULLDESC}#g" \
+    -e "s#@@DEFAULT_FLAGS@@#${DEFAULT_FLAGS:-}#g" \
+    -e "s#@@SXS_USER_DATA_DIR@@#${SXS_USER_DATA_DIR:-}#g" \
+    -e "s#@@USR_BIN_SYMLINK_NAME@@#${USR_BIN_SYMLINK_NAME:-}#g" \
+    > "$TMPLOUT" <<< "$TMPLINCL"
+)
+
+# Setup the installation directory hierachy in the package staging area.
+prep_staging_common() {
+  install -m 755 -d "${STAGEDIR}/${INSTALLDIR}" \
+    "${STAGEDIR}/usr/bin"
+}
+
+get_version_info() {
+  source "${BUILDDIR}/installer/VERSION"
+  VERSION="${MAJOR}.${MINOR}.${BUILD}.${PATCH}"
+
+  # Crosswalk-specific code to determine whether we are building a canary or
+  # beta package. In short, if the current patch version is > 0, this is a beta
+  # build, otherwise it is a canary.
+  if [ "${PATCH}" -gt 0 ]; then
+      CHANNEL="beta"
+  else
+      CHANNEL="canary"
+  fi
+
+  # TODO(phajdan.jr): Provide a mechanism to pass a different package
+  # release number if needed. The meaning of it is to bump it for
+  # packaging-only changes while the underlying software has the same version.
+  # This corresponds to the Release field in RPM spec files and debian_revision
+  # component of the Version field for DEB control file.
+  # Generally with Chrome's fast release cycle it'd be more hassle to try
+  # to bump this number between releases.
+  PACKAGE_RELEASE="1"
+}
+
+stage_install_common() {
+  echo "Staging common install files in '${STAGEDIR}'..."
+
+  # TODO(mmoss) This assumes we built the static binaries. To support shared
+  # builds, we probably want an install target in scons so it can give us all
+  # the right files. See also:
+  # http://code.google.com/p/chromium/issues/detail?id=4451
+  #
+  # app
+  # We need to add the debug link so gdb knows to look for the symbols.
+  DEBUGFILE="${BUILDDIR}/${PROGNAME}.debug"
+  STRIPPEDFILE="${BUILDDIR}/${PROGNAME}.stripped"
+  "${BUILDDIR}/installer/common/eu-strip" -o "${STRIPPEDFILE}" -f "${DEBUGFILE}" "${BUILDDIR}/${PROGNAME}"
+  install -m 755 "${STRIPPEDFILE}" "${STAGEDIR}/${INSTALLDIR}/${PROGNAME}"
+  rm "${DEBUGFILE}" "${STRIPPEDFILE}"
+
+  # resources
+  install -m 644 "${BUILDDIR}/"*.pak "${STAGEDIR}/${INSTALLDIR}/"
+
+  # ICU data file; only necessary when icu_use_data_file_flag is set to 1
+  # in build/common.gypi.
+  install -m 644 "${BUILDDIR}/icudtl.dat" "${STAGEDIR}/${INSTALLDIR}/"
+
+  # V8 snapshot files; only necessary when v8_use_external_startup_data is
+  # set to 1 in build/common.gypi.
+  if [ -f "${BUILDDIR}/natives_blob.bin" ]; then
+    install -m 644 "${BUILDDIR}/natives_blob.bin" "${STAGEDIR}/${INSTALLDIR}/"
+    install -m 644 "${BUILDDIR}/snapshot_blob.bin" "${STAGEDIR}/${INSTALLDIR}/"
+  fi
+
+  # l10n paks
+  cp -a "${BUILDDIR}/locales" "${STAGEDIR}/${INSTALLDIR}/"
+  find "${STAGEDIR}/${INSTALLDIR}/locales" -type f -exec chmod 644 '{}' \;
+  find "${STAGEDIR}/${INSTALLDIR}/locales" -type d -exec chmod 755 '{}' \;
+
+  # nacl_helper and nacl_helper_bootstrap
+  # Don't use "-s" (strip) because this runs binutils "strip", which
+  # mangles the special ELF program headers of nacl_helper_bootstrap.
+  # Explicitly use eu-strip instead, because it doesn't have that problem.
+  for file in nacl_helper nacl_helper_bootstrap; do
+    buildfile="${BUILDDIR}/${file}"
+    if [ -f "${buildfile}" ]; then
+      strippedfile="${buildfile}.stripped"
+      debugfile="${buildfile}.debug"
+      "${BUILDDIR}/installer/common/eu-strip" -o "${strippedfile}" -f "${debugfile}" "${buildfile}"
+      install -m 755 "${strippedfile}" "${STAGEDIR}/${INSTALLDIR}/${file}"
+    fi
+  done
+  # Don't use "-s" (strip) because this would use the Linux toolchain to
+  # strip the NaCl binary, which has the potential to break it.  It
+  # certainly resets the OSABI and ABIVERSION fields to non-NaCl values,
+  # although the NaCl IRT loader doesn't care about these fields.  In any
+  # case, the IRT binaries are already stripped by NaCl's build process.
+  for filename in ${BUILDDIR}/nacl_irt_*.nexe; do
+    # Re-check the filename in case globbing matched nothing.
+    if [ -f "$filename" ]; then
+      install -m 644 "$filename" "${STAGEDIR}/${INSTALLDIR}/`basename "$filename"`"
+    fi
+  done
+
+  # ffmpeg libs
+  install -m 644 -s "${BUILDDIR}/libffmpegsumo.so" "${STAGEDIR}/${INSTALLDIR}/"
+
+  # launcher script and symlink
+  process_template "${BUILDDIR}/installer/common/wrapper" \
+    "${STAGEDIR}/${INSTALLDIR}/${PACKAGE}"
+  chmod 755 "${STAGEDIR}/${INSTALLDIR}/${PACKAGE}"
+  ln -snf "${INSTALLDIR}/${PACKAGE}" \
+    "${STAGEDIR}/usr/bin/${USR_BIN_SYMLINK_NAME}"
+}

--- a/tools/installer/common/wrapper
+++ b/tools/installer/common/wrapper
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright (c) 2011 The Chromium Authors. All rights reserved.
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+THIS="`readlink -f "$0"`"
+HERE="`dirname "${THIS}"`"
+
+# Always use our versions of ffmpeg libs.
+# This also makes RPMs find the compatibly-named library symlinks.
+if [[ -n "$LD_LIBRARY_PATH" ]]; then
+  LD_LIBRARY_PATH="$HERE:$HERE/lib:$LD_LIBRARY_PATH"
+else
+  LD_LIBRARY_PATH="$HERE:$HERE/lib"
+fi
+export LD_LIBRARY_PATH
+
+# Sanitize std{in,out,err} because they'll be shared with untrusted child
+# processes (http://crbug.com/376567).
+exec < /dev/null
+exec > >(exec cat)
+exec 2> >(exec cat >&2)
+
+exec -a "$0" "$HERE/@@PROGNAME@@" @@DEFAULT_FLAGS@@ "$@"

--- a/tools/installer/debian/build.sh
+++ b/tools/installer/debian/build.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+#
+# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file is a tuned-down version of the scripts used to build Chrome Debian
+# packages. See src/chrome/installer/linux/debian for the original.
+
+set -e
+set -o pipefail
+if [ "$VERBOSE" ]; then
+  set -x
+fi
+set -u
+
+# Create the Debian changelog file needed by dpkg-gencontrol.
+# There is some sed/awk trickery involved to get the git commit log formatted
+# and appended to the regular list of changes.
+gen_changelog() {
+  rm -f "${DEB_CHANGELOG}"
+  process_template "${SCRIPTDIR}/changelog.template" "${DEB_CHANGELOG}"
+
+  # Add a line so debchange can update the timestamp and have one changelog
+  # line, then use sed to add a summary of the changes since the last version
+  # bump.
+  debchange -a --nomultimaint -m --changelog "${DEB_CHANGELOG}" \
+            "New release."
+  if [ -f "${BUILDDIR}/installer/changes.txt" ]; then
+      local formatted_changes=`awk '{printf "    - %s\\\\\n",$0}' ${BUILDDIR}/installer/changes.txt`
+      sed -i '/New release/{n;c\
+'"${formatted_changes}"'
+
+}' ${DEB_CHANGELOG}
+  fi
+
+  GZLOG="${STAGEDIR}/usr/share/doc/${PACKAGE}/changelog.Debian.gz"
+  mkdir -p "$(dirname "${GZLOG}")"
+  gzip -9 -c "${DEB_CHANGELOG}" > "${GZLOG}"
+  chmod 644 "${GZLOG}"
+}
+
+# Create the Debian control file needed by dpkg-deb.
+gen_control() {
+  dpkg-gencontrol -v"${VERSIONFULL}" -c"${DEB_CONTROL}" -l"${DEB_CHANGELOG}" \
+  -f"${DEB_FILES}" -p"${PACKAGE}" -P"${STAGEDIR}" \
+  -O > "${STAGEDIR}/DEBIAN/control"
+  rm -f "${DEB_CONTROL}"
+}
+
+# Setup the installation directory hierachy in the package staging area.
+prep_staging_debian() {
+  prep_staging_common
+  install -m 755 -d "${STAGEDIR}/DEBIAN" \
+    "${STAGEDIR}/usr/share/doc/${PACKAGE}"
+}
+
+# Put the package contents in the staging area.
+stage_install_debian() {
+  local USR_BIN_SYMLINK_NAME="xwalk"
+
+  prep_staging_debian
+  stage_install_common
+}
+
+# Actually generate the package file.
+do_package() {
+  echo "Packaging ${ARCHITECTURE}..."
+  PREDEPENDS="$COMMON_PREDEPS"
+  DEPENDS="${COMMON_DEPS}"
+  REPLACES=""
+  CONFLICTS=""
+  PROVIDES=""
+  gen_changelog
+  process_template "${SCRIPTDIR}/control.template" "${DEB_CONTROL}"
+  export DEB_HOST_ARCH="${ARCHITECTURE}"
+  if [ -f "${DEB_CONTROL}" ]; then
+    gen_control
+  fi
+  fakeroot dpkg-deb -Zxz -z9 -b "${STAGEDIR}" .
+}
+
+# Remove temporary files and unwanted packaging output.
+cleanup() {
+  echo "Cleaning..."
+  rm -rf "${STAGEDIR}"
+  rm -rf "${TMPFILEDIR}"
+}
+
+usage() {
+  echo "usage: $(basename $0) [-a target_arch] [-o 'dir'] "
+  echo "                      [-b 'dir']"
+  echo "-a arch    package architecture (ia32 or x64)"
+  echo "-o dir     package output directory [${OUTPUTDIR}]"
+  echo "-b dir     build input directory    [${BUILDDIR}]"
+  echo "-h         this help message"
+}
+
+process_opts() {
+  while getopts ":o:b:c:a:h" OPTNAME
+  do
+    case $OPTNAME in
+      o )
+        OUTPUTDIR=$(readlink -f "${OPTARG}")
+        mkdir -p "${OUTPUTDIR}"
+        ;;
+      b )
+        BUILDDIR=$(readlink -f "${OPTARG}")
+        ;;
+      a )
+        TARGETARCH="$OPTARG"
+        ;;
+      h )
+        usage
+        exit 0
+        ;;
+      \: )
+        echo "'-$OPTARG' needs an argument."
+        usage
+        exit 1
+        ;;
+      * )
+        echo "invalid command-line option: $OPTARG"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+}
+
+#=========
+# MAIN
+#=========
+
+SCRIPTDIR=$(readlink -f "$(dirname "$0")")
+OUTPUTDIR="${PWD}"
+STAGEDIR=$(mktemp -d -t deb.build.XXXXXX) || exit 1
+TMPFILEDIR=$(mktemp -d -t deb.tmp.XXXXXX) || exit 1
+DEB_CHANGELOG="${TMPFILEDIR}/changelog"
+DEB_FILES="${TMPFILEDIR}/files"
+DEB_CONTROL="${TMPFILEDIR}/control"
+# Default target architecture to same as build host.
+if [ "$(uname -m)" = "x86_64" ]; then
+  TARGETARCH="x64"
+else
+  TARGETARCH="ia32"
+fi
+
+# call cleanup() on exit
+trap cleanup 0
+process_opts "$@"
+BUILDDIR=${BUILDDIR:=$(readlink -f "${SCRIPTDIR}/../../../../out/Release")}
+
+source ${BUILDDIR}/installer/common/installer.include
+
+get_version_info
+VERSIONFULL="${VERSION}-${PACKAGE_RELEASE}"
+
+source ${BUILDDIR}/installer/common/crosswalk.info
+
+# Some Debian packaging tools want these set.
+export DEBFULLNAME="${MAINTNAME}"
+export DEBEMAIL="${MAINTMAIL}"
+
+# We'd like to eliminate more of these deps by relying on the 'lsb' package, but
+# that brings in tons of unnecessary stuff, like an mta and rpm. Until that full
+# 'lsb' package is installed by default on DEB distros, we'll have to stick with
+# the LSB sub-packages, to avoid pulling in all that stuff that's not installed
+# by default.
+
+# Need a dummy debian/control file for dpkg-shlibdeps.
+DUMMY_STAGING_DIR="${TMPFILEDIR}/dummy_staging"
+mkdir "$DUMMY_STAGING_DIR"
+cd "$DUMMY_STAGING_DIR"
+mkdir debian
+touch debian/control
+
+# Generate the dependencies,
+# TODO(mmoss): This is a workaround for a problem where dpkg-shlibdeps was
+# resolving deps using some of our build output shlibs (i.e.
+# out/Release/lib.target/libfreetype.so.6), and was then failing with:
+#   dpkg-shlibdeps: error: no dependency information found for ...
+# It's not clear if we ever want to look in LD_LIBRARY_PATH to resolve deps,
+# but it seems that we don't currently, so this is the most expediant fix.
+SAVE_LDLP=${LD_LIBRARY_PATH:-}
+unset LD_LIBRARY_PATH
+DPKG_SHLIB_DEPS=$(dpkg-shlibdeps -O "$BUILDDIR/${PROGNAME}" | \
+  sed 's/^shlibs:Depends=//')
+if [ -n "$SAVE_LDLP" ]; then
+  LD_LIBRARY_PATH=$SAVE_LDLP
+fi
+
+rm -rf "$DUMMY_STAGING_DIR"
+
+# Additional dependencies not in the dpkg-shlibdeps output.
+# - Pull a more recent version of NSS than required by runtime linking, for
+#   security and stability updates in NSS.
+ADDITION_DEPS="ca-certificates, libnss3 (>= 3.14.3), lsb-base (>=3.2), \
+    xdg-utils (>= 1.0.2)"
+
+# Fix-up libnspr dependency due to renaming in Ubuntu (the old package still
+# exists, but it was moved to "universe" repository, which isn't installed by
+# default).
+DPKG_SHLIB_DEPS=$(sed \
+    's/\(libnspr4-0d ([^)]*)\), /\1 | libnspr4 (>= 4.9.5-0ubuntu0), /g' \
+    <<< $DPKG_SHLIB_DEPS)
+
+COMMON_DEPS="${DPKG_SHLIB_DEPS}, ${ADDITION_DEPS}"
+COMMON_PREDEPS="dpkg (>= 1.14.0)"
+
+# Make everything happen in the OUTPUTDIR.
+cd "${OUTPUTDIR}"
+
+case "$TARGETARCH" in
+  ia32 )
+    export ARCHITECTURE="i386"
+    stage_install_debian
+    ;;
+  x64 )
+    export ARCHITECTURE="amd64"
+    stage_install_debian
+    ;;
+  * )
+    echo
+    echo "ERROR: Don't know how to build DEBs for '$TARGETARCH'."
+    echo
+    exit 1
+    ;;
+esac
+
+do_package

--- a/tools/installer/debian/changelog.template
+++ b/tools/installer/debian/changelog.template
@@ -1,0 +1,4 @@
+@@PACKAGE@@ (@@VERSIONFULL@@) @@CHANNEL@@; urgency=low
+
+
+ -- @@MAINTNAME@@ <@@MAINTMAIL@@>  Tue, 03 Feb 2009 14:54:35 -0800

--- a/tools/installer/debian/control.template
+++ b/tools/installer/debian/control.template
@@ -1,0 +1,16 @@
+Source: @@PACKAGE@@
+Section: web
+Priority: optional
+Maintainer: @@MAINTNAME@@ <@@MAINTMAIL@@>
+Build-Depends: dpkg-dev, devscripts, fakeroot, xz-utils
+Standards-Version: 3.8.0
+
+Package: @@PACKAGE@@
+Provides: @@PROVIDES@@
+Replaces: @@REPLACES@@
+Conflicts: @@CONFLICTS@@
+Pre-Depends: @@PREDEPENDS@@
+Depends: @@DEPENDS@@
+Architecture: @@ARCHITECTURE@@
+Description: @@SHORTDESC@@
+ @@FULLDESC@@

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -20,6 +20,7 @@
   'includes' : [
     'xwalk_tests.gypi',
     'application/xwalk_application.gypi',
+    'xwalk_installer.gypi',
   ],
   'targets': [
     {

--- a/xwalk_installer.gypi
+++ b/xwalk_installer.gypi
@@ -1,0 +1,118 @@
+# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Much simplified version of the code in src/chrome/chrome_installer.gypi.
+
+{
+  'conditions': [
+    ['OS=="linux"', {
+      'variables': {
+        'packaging_files_common': [
+          'tools/installer/common/crosswalk.info',
+          'tools/installer/common/generate-changelog.sh',
+          'tools/installer/common/installer.include',
+          'tools/installer/common/wrapper',
+        ],
+        'packaging_files_deb': [
+          'tools/installer/debian/build.sh',
+          'tools/installer/debian/changelog.template',
+          'tools/installer/debian/control.template',
+        ],
+        'packaging_files_binaries': [
+          '<(PRODUCT_DIR)/xwalk',
+          '<(PRODUCT_DIR)/libffmpegsumo.so',
+          '<(PRODUCT_DIR)/locales/en-US.pak',
+        ],
+        'flock_bash': ['flock', '--', '/tmp/linux_package_lock', 'bash'],
+        'deb_build': '<(PRODUCT_DIR)/installer/debian/build.sh',
+        'deb_cmd': ['<@(flock_bash)', '<(deb_build)', '-o' '<(PRODUCT_DIR)',
+                    '-b', '<(PRODUCT_DIR)', '-a', '<(target_arch)'],
+        'conditions': [
+          ['target_arch=="ia32"', {
+            'deb_arch': 'i386',
+            'packaging_files_common': [
+              '<(DEPTH)/build/linux/bin/eu-strip',
+            ],
+          }],
+          ['target_arch=="x64"', {
+            'deb_arch': 'amd64',
+            'packaging_files_common': [
+              '<!(which eu-strip)',
+            ],
+          }],
+        ],
+      },
+      'targets': [
+        {
+          'target_name': 'xwalk_installer_linux_prepare',
+          'type': 'none',
+          # Add these files to the build output so the build archives will be
+          # "hermetic" for packaging.
+          'copies': [
+            {
+              'destination': '<(PRODUCT_DIR)/installer/debian/',
+              'files': [
+                '<@(packaging_files_deb)',
+              ]
+            },
+            {
+              'destination': '<(PRODUCT_DIR)/installer/common/',
+              'files': [
+                '<@(packaging_files_common)',
+              ]
+            },
+            {
+              'destination': '<(PRODUCT_DIR)/installer/',
+              'files': [
+                '<(DEPTH)/xwalk/VERSION',
+              ]
+            },
+          ],
+          'actions': [
+            {
+              'action_name': 'generate_changelog_from_git',
+              'inputs': [
+                '<(DEPTH)/xwalk/tools/installer/common/generate-changelog.sh',
+              ],
+              'outputs': [
+                '<(PRODUCT_DIR)/installer/changes.txt',
+              ],
+              'action': [
+                'bash',
+                '<(DEPTH)/xwalk/tools/installer/common/generate-changelog.sh',
+                '<@(_outputs)',
+              ],
+            }
+          ],
+        },
+        {
+          'target_name': 'xwalk_installer_linux_debian',
+          'suppress_wildcard': 1,
+          'type': 'none',
+          'dependencies': [
+            'xwalk',
+            'xwalk_installer_linux_prepare',
+          ],
+          'actions': [
+            {
+              'action_name': 'deb_packages',
+              'process_outputs_as_sources': 1,
+              'inputs': [
+                '<(deb_build)',
+                '<@(packaging_files_binaries)',
+                '<@(packaging_files_common)',
+                '<@(packaging_files_deb)',
+              ],
+              'outputs': [
+                '<(PRODUCT_DIR)/crosswalk-<(xwalk_version)-1_<(deb_arch).deb',
+              ],
+              'action': [ '<@(deb_cmd)', ],
+            },
+          ],
+        },
+      ],
+    }],
+  ],
+}


### PR DESCRIPTION
This work is still experimental, so here be dragons!

The whole patch is inspired by the code in Chromium itself in
`src/chrome/installer/linux` that is used to generate RPMs and Debian
packages.

Consequently, this means that at least for now we are not following
Debian's best practices:
- We do not build from a source tarball; instead, the new gyp target
  `xwalk_installer_linux_debian` creates a package out of the files
  generated by the `xwalk` target.
- To achieve that, we make some fairly low-level calls to `dpkg-deb`
  directly.

We may revisit the way we create packages in the future; for now, this
is the quickest way to start having Debian packages and also saves us
some work if/when we decide to ship NaCl's support files, as we do not
need to care about downloading all the toolchain tarball files ourselves
since it is done by `gclient runhooks'.

TODO items:
- Have a `copyright` file.
- Consider whether we should install into `/usr` directly.
- Possibly switch to a more standard Debian packaging workflow.
- Ship NaCl's support files.

Related bug: XWALK-4374