### PR TITLE
Delete the reduplicate 'Mobile' user agent

### DIFF
--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -124,11 +124,7 @@ std::string GetProduct() {
 
 std::string GetUserAgent() {
   std::string product = GetProduct();
-#if (defined(OS_TIZEN_MOBILE) || defined(OS_ANDROID))
-  product += " Mobile Crosswalk/" XWALK_VERSION;
-#else
   product += " Crosswalk/" XWALK_VERSION;
-#endif
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kUseMobileUserAgent))
     product += " Mobile";


### PR DESCRIPTION
Sencha Touch did not determined correct device type on tablet devices
by match the keyword of 'Mobile' in user agent.
There is 'Mobile' in the user agent before 'Safari' by default when
we load xwalk shell on a phone, we don't need add the 'Mobile' again
before 'Crosswalk'.
Original commit is fa1b87549450d1b2fcaee048b9acf5891deb3aa5.

BUG=XWALK-4318