### PR TITLE
Work around Skia performance regression

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -105,6 +105,15 @@ hooks = [
     ],
     'pattern': '.',
     'name': 'upstream_revision'
+  },
+  {
+    'action': [
+      'python',
+      'src/xwalk/tools/patch_skia.py',
+      'src/xwalk/packaging/skia-perf-regression-copy-surface-as-draw.patch'
+     ],
+     'pattern': '.',
+     'name': 'patch_skia_regression'
   }
 ]
 

--- a/packaging/skia-perf-regression-copy-surface-as-draw.patch
+++ b/packaging/skia-perf-regression-copy-surface-as-draw.patch
@@ -1,0 +1,30 @@
+From 775d171e308090831ed999aa0dc395b5b27d675d Mon Sep 17 00:00:00 2001
+From: Qiankun Miao <qiankun.miao@intel.com>
+Date: Fri, 26 Jun 2015 16:08:19 +0800
+Subject: [PATCH] Use a fallback draw instead of CopyTexSubImage for
+ copySurface
+
+This is a workaroud for CrossWalk 14. Skia upstream already fixed this
+issue. When CrossWalk rolls that fix, this workaroud should be removed.
+---
+ src/gpu/GrDrawTarget.cpp | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/src/gpu/GrDrawTarget.cpp b/src/gpu/GrDrawTarget.cpp
+index 420f9ea..c582f1b 100644
+--- a/src/gpu/GrDrawTarget.cpp
++++ b/src/gpu/GrDrawTarget.cpp
+@@ -941,10 +941,6 @@ bool GrDrawTarget::copySurface(GrSurface* dst,
+         return true;
+     }
+
+-    if (this->onCopySurface(dst, src, clippedSrcRect, clippedDstPoint)) {
+-        return true;
+-    }
+-
+     GrRenderTarget* rt = dst->asRenderTarget();
+     GrTexture* tex = src->asTexture();
+
+--
+2.4.0
+

--- a/tools/patch_skia.py
+++ b/tools/patch_skia.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 Intel Corp. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+patch_skia.py -- Apply patches to skia when running gclient.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def main():
+  tools_dir = os.path.dirname(os.path.abspath(__file__))
+  xwalk_dir = os.path.dirname(tools_dir)
+  # tools_dir should be at src/xwalk/tools/patch_skia.py
+  # so src is at tools_dir/../../../
+  src_dir = os.path.dirname(xwalk_dir)
+  root_dir = os.path.dirname(src_dir)
+  third_party_dir = os.path.join(src_dir, 'third_party')
+  skia_dir = os.path.join(third_party_dir, 'skia')
+  patch_dir = os.path.join(root_dir, sys.argv[1])
+
+  output = subprocess.call(["git", "reset", "--hard"], cwd=skia_dir)
+  if output != 0:
+    return output
+
+  return subprocess.call(["git", "apply", patch_dir], cwd=skia_dir)
+
+if __name__ == '__main__':
+  sys.exit(main())
+


### PR DESCRIPTION
A Skia CL (https://codereview.chromium.org/607993002 ) made CrossWalk
regress on some devices such as Galaxy S3. Upstream proposed a CL to fix
the performance regression in
https://codereview.chromium.org/1161063003. Alexis backported upstream's
fix to CrossWalk master in
https://github.com/crosswalk-project/crosswalk/pull/3096. But it's hard
to backport to CrossWalk 14 due to many dependency issues in Skia
repo. Not only the real fix is needed to backport but also other
dependent CLs are needed to backport. So I propose to revert the origin
Skia CL which introduced the regression as a workaroud for CrossWalk 14.

Before the regressed CL, Skia use a fallback draw as the first choice
for surface copy.  In this CL I remove other copy methods before the
fallback draw. This is the same logic as before. Also upstream's fix did
the same thing: https://codereview.chromium.org/1161063003. With this
CL, performance of CrossWalk is back. For a test case (propaganda: a
game from community), it can achieve 55FPS compared to previous
5FPS.