### PR TITLE
Debian packaging: stop depending on locales/en-US.pak.

### DIFF
--- a/xwalk_installer.gypi
+++ b/xwalk_installer.gypi
@@ -23,7 +23,12 @@
         'packaging_files_binaries': [
           '<(PRODUCT_DIR)/xwalk',
           '<(PRODUCT_DIR)/libffmpegsumo.so',
-          '<(PRODUCT_DIR)/locales/en-US.pak',
+
+          # Commented out for the time being because non-Ozone Linux builds
+          # depend on the gtk2ui target in src/chrome, which can cause
+          # Chromium's language files to overwrite Crosswalk's in the directory
+          # below. Remove once we stop depending on the gtk2ui target.
+          # '<(PRODUCT_DIR)/locales/en-US.pak',
         ],
         'flock_bash': ['flock', '--', '/tmp/linux_package_lock', 'bash'],
         'deb_build': '<(PRODUCT_DIR)/installer/debian/build.sh',


### PR DESCRIPTION
Depending on that file triggered a nasty and hard to debug build system
issue on non-Ozone Linux builds:
* In this configuration, we depend on the `gtk2ui` gyp target in
  `src/chrome`.
* This target on its turn causes gyp to process
  `src/chrome/chrome_resources.gyp`.
* The `packed_resources` target there, even if not depended upon by any
  target we build, has one `copies` section where it first processes
  Chromium's language files and then copies them to `locale/`.
* This is the same location where we also copy our locale files in the
  `xwalk_strings` target.

This combination of factors caused a race condition where Chromium's
language files could overwrite Crosswalk's and we would then end up with
the wrong PAK files and a UI with no text.

Fix it by just removing the dependency on `locale/en-SU.pak`: it is
already indirectly depended upon via the `xwalk_installer_linux_debian`
target depending on `xwalk`, which depends on `xwalk_strings`. Leave the
entry in gyp commented out though, as once we manage to get rid of the
`gtk2ui` dependency we can start depending on that file again.