### PR TITLE
[Android] Change the API version number of onDocumentLoadedInFrame

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -130,7 +130,7 @@ public class XWalkResourceClientInternal {
      * This is similar to JavaScript DOMContentLoaded.
      * @param view the owner XWalkViewInternal instance.
      * @param frameId the loaded and parsed frame.
-     * @since 6.0
+     * @since 5.0
      */
     @XWalkAPI
     public void onDocumentLoadedInFrame(XWalkViewInternal view, long frameId) {


### PR DESCRIPTION
Change the API version number of XWalkResourceClient.onDocumentLoadedInFrame
to 5.0.
BUG=XWALK-4530