### PR TITLE
[Android] Backport patch to export XWalkCookieManager

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
@@ -7,18 +7,20 @@ package org.xwalk.core.internal;
 import org.chromium.base.JNINamespace;
 
 /**
- * XWalkCookieManager manages cookies according to RFC2109 spec.
+ * XWalkCookieManagerInternal manages cookies according to RFC2109 spec.
  *
  * Methods in this class are thread safe.
  *
  * @hide
  */
 @JNINamespace("xwalk")
-public final class XWalkCookieManager {
+@XWalkAPI(createExternally = true)
+public class XWalkCookieManagerInternal {
     /**
      * Control whether cookie is enabled or disabled
      * @param accept TRUE if accept cookie
      */
+    @XWalkAPI
     public void setAcceptCookie(boolean accept) {
         nativeSetAcceptCookie(accept);
     }
@@ -27,6 +29,7 @@ public final class XWalkCookieManager {
      * Return whether cookie is enabled
      * @return TRUE if accept cookie
      */
+    @XWalkAPI
     public boolean acceptCookie() {
         return nativeAcceptCookie();
     }
@@ -38,6 +41,7 @@ public final class XWalkCookieManager {
      * @param url The url which cookie is set for
      * @param value The value for set-cookie: in http response header
      */
+    @XWalkAPI
     public void setCookie(final String url, final String value) {
         nativeSetCookie(url, value);
     }
@@ -48,6 +52,7 @@ public final class XWalkCookieManager {
      * @param url The url needs cookie
      * @return The cookies in the format of NAME=VALUE [; NAME=VALUE]
      */
+    @XWalkAPI
     public String getCookie(final String url) {
         String cookie = nativeGetCookie(url.toString());
         // Return null if the string is empty to match legacy behavior
@@ -57,6 +62,7 @@ public final class XWalkCookieManager {
     /**
      * Remove all session cookies, which are cookies without expiration date
      */
+    @XWalkAPI
     public void removeSessionCookie() {
         nativeRemoveSessionCookie();
     }
@@ -64,6 +70,7 @@ public final class XWalkCookieManager {
     /**
      * Remove all cookies
      */
+    @XWalkAPI
     public void removeAllCookie() {
         nativeRemoveAllCookie();
     }
@@ -71,6 +78,7 @@ public final class XWalkCookieManager {
     /**
      *  Return true if there are stored cookies.
      */
+    @XWalkAPI
     public boolean hasCookies() {
         return nativeHasCookies();
     }
@@ -78,10 +86,12 @@ public final class XWalkCookieManager {
     /**
      * Remove all expired cookies
      */
+    @XWalkAPI
     public void removeExpiredCookie() {
         nativeRemoveExpiredCookie();
     }
 
+    @XWalkAPI
     public void flushCookieStore() {
         nativeFlushCookieStore();
     }
@@ -89,6 +99,7 @@ public final class XWalkCookieManager {
     /**
      * Whether cookies are accepted for file scheme URLs.
      */
+    @XWalkAPI
     public boolean allowFileSchemeCookies() {
         return nativeAllowFileSchemeCookies();
     }
@@ -103,6 +114,7 @@ public final class XWalkCookieManager {
      * Note that calls to this method will have no effect if made after a
      * WebView or CookieManager instance has been created.
      */
+    @XWalkAPI
     public void setAcceptFileSchemeCookies(boolean accept) {
         nativeSetAcceptFileSchemeCookies(accept);
     }

--- a/runtime/browser/android/cookie_manager.cc
+++ b/runtime/browser/android/cookie_manager.cc
@@ -19,7 +19,7 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/url_constants.h"
-#include "jni/XWalkCookieManager_jni.h"
+#include "jni/XWalkCookieManagerInternal_jni.h"
 #include "net/cookies/cookie_monster.h"
 #include "net/cookies/cookie_options.h"
 #include "net/url_request/url_request_context.h"

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkCookieManager;
+import org.xwalk.core.internal.XWalkCookieManagerInternal;
 import org.xwalk.core.internal.XWalkClient;
 
 /**
@@ -32,13 +32,13 @@ import org.xwalk.core.internal.XWalkClient;
  */
 public class CookieManagerTest extends XWalkViewTestBase {
 
-    private XWalkCookieManager mCookieManager = null;
+    private XWalkCookieManagerInternal mCookieManager = null;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
 
-        mCookieManager = new XWalkCookieManager();
+        mCookieManager = new XWalkCookieManagerInternal();
     }
 
     @SmallTest

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -16,6 +16,7 @@ from wrapper_generator import WrapperGenerator
 
 # Classes list that have to generate bridge and wrap code.
 CLASSES_TO_BE_PROCESS = [
+  'XWalkCookieManagerInternal',
   'XWalkExtensionInternal',
   'XWalkViewInternal',
   'XWalkUIClientInternal',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -146,7 +146,7 @@
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsIoThreadClient.java',
-        'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManager.java',
+        'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDevToolsServer.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandler.java',
         'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPathHelper.java',


### PR DESCRIPTION
Expose XWalkCookieManager to developer, Change the name of XWalkCookieManager
to XWalkCookieManagerInternal for generating wrapper and bridge of the class.

(cherry picked from commit c5504aa8376b80fd51877815ec69e85679f91ec7)

Conflicts:
	tools/reflection_generator/reflection_generator.py