### PR TITLE
[Android] Fix the test case crash issue on runtime client.

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -142,4 +142,8 @@ public abstract class XWalkRuntimeActivityBase extends XWalkActivity {
         mUseAnimatableView = value;
     }
 
+    @Override
+    public boolean isXWalkReady() {
+        return super.isXWalkReady();
+    }
 }

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientTestGeneric.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientTestGeneric.java
@@ -9,6 +9,9 @@ import android.app.Activity;
 import android.content.Context;
 import android.test.ActivityInstrumentationTestCase2;
 
+import java.util.Timer;
+import java.util.TimerTask;
+
 import org.xwalk.app.runtime.XWalkRuntimeView;
 import org.xwalk.app.XWalkRuntimeActivityBase;
 import org.xwalk.test.util.XWalkRuntimeClientTestUtilBase.PageStatusCallback;
@@ -17,12 +20,20 @@ public class XWalkRuntimeClientTestGeneric<T extends XWalkRuntimeActivityBase>
         extends ActivityInstrumentationTestCase2<T> {
     private XWalkRuntimeView mRuntimeView;
     XWalkRuntimeClientTestUtilBase mTestUtil;
+    private Timer mTimer = new Timer();
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+        waitForXWalkReady();
+    }
 
+    public void waitForXWalkReady() throws Exception {
         final XWalkRuntimeActivityBase activity = getActivity();
+        while(!activity.isXWalkReady()) {
+            waitForTimerFinish(200);
+        }
+
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
@@ -36,6 +47,31 @@ public class XWalkRuntimeClientTestGeneric<T extends XWalkRuntimeActivityBase>
                 postSetUp();
             }
         });
+    }
+
+    public void waitForTimerFinish(int timer) throws Exception {
+        Object notify = new Object();
+        synchronized (notify) {
+            NotifyTask testTask = new NotifyTask(notify);
+            mTimer.schedule(testTask, timer);
+            notify.wait();
+        }
+    }
+
+    public class NotifyTask extends TimerTask {
+        private Object mObj;
+
+        public NotifyTask(Object obj) {
+            super();
+            mObj = obj;
+        }
+
+        @Override
+        public void run() {
+            synchronized (mObj) {
+                mObj.notify();
+            }
+        }
     }
 
     public void postSetUp() {


### PR DESCRIPTION
The test case was executed when xwalk was not ready, so the runtime view
sometimes was null. This patch is to wait for the xwalk ready then execute
test case.

BUG=XWALK-4549