### PR TITLE
[Windows][Extensions]Fix render process crash when sending data

### DIFF
--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -117,7 +117,7 @@ class XWalkExtensionServer : public IPC::Listener,
   typedef std::set<std::string> ExtensionSymbolsSet;
   ExtensionSymbolsSet extension_symbols_;
 
-  base::ProcessHandle renderer_process_handle_;
+  int32 renderer_process_pid_;
 
   XWalkExtension::PermissionsDelegate* permissions_delegate_;
 };

--- a/extensions/test/data/bulk_data_transmission.html
+++ b/extensions/test/data/bulk_data_transmission.html
@@ -47,15 +47,6 @@ var readableSize = function(size) {
   return size + suffix;
 }
 
-var requestDataAsync = function(size) {
-  bulkData.requestBulkDataAsync(size, function(msg) {
-      var message = document.createElement('p');
-      message.innerText = 'Requested '
-        + readableSize(msg.length) + ' data chunk asynchronously';
-      divAsync.appendChild(message);
-    });
-}
-
 var startPow = 1;
 var maxPow = 26; // 26 is 64MB, which is the limit of IPC post message
 var repeatTimes = 1;
@@ -64,10 +55,15 @@ var index = startPow * repeatTimes;
 
 function runTestCase() {
   return new Promise(function(resolve) {
-      var size = Math.pow(2, Math.floor(index / repeatTimes));
-      requestDataAsync(size);
+    var size = Math.pow(2, Math.floor(index / repeatTimes));
+    bulkData.requestBulkDataAsync(size, function (msg) {
+      var message = document.createElement('p');
+      message.innerText = 'Received '
+        + readableSize(msg.length) + ' data chunk asynchronously';
+      divAsync.appendChild(message);
       resolve();
-    }).then(function() {
+    });
+  }).then(function () {
       ++index;
       if (index == (maxPow + 1) * repeatTimes) {
         document.title = "Pass";
@@ -76,7 +72,7 @@ function runTestCase() {
       runTestCase();
     }, function(e) {
       console.error(e);
-      document.title = "Fail";
+      document.title = "Fail" + e;
     });
 };
 runTestCase();

--- a/extensions/test/external_extension.cc
+++ b/extensions/test/external_extension.cc
@@ -24,6 +24,16 @@ class ExternalExtensionTest : public XWalkExtensionsTestBase {
   }
 };
 
+class BulkExtensionTest : public XWalkExtensionsTestBase {
+ public:
+  void SetUp() override {
+    XWalkExtensionService::SetExternalExtensionsPathForTesting(
+      GetExternalExtensionTestPath(
+        FILE_PATH_LITERAL("bulk_data_transmission")));
+    XWalkExtensionsTestBase::SetUp();
+  }
+};
+
 class RuntimeInterfaceTest : public XWalkExtensionsTestBase {
  public:
   void SetUp() override {
@@ -121,4 +131,14 @@ IN_PROC_BROWSER_TEST_F(MultipleEntryPointsExtension, ReplacementObjectIsUsed) {
   title_watcher.AlsoWaitForTitle(kFailString);
   xwalk_test_utils::NavigateToURL(runtime, url);
   EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}
+
+IN_PROC_BROWSER_TEST_F(BulkExtensionTest, BulkDataExtension) {
+Runtime* runtime = CreateRuntime();
+GURL url = GetExtensionsTestURL(base::FilePath(),
+base::FilePath().AppendASCII("bulk_data_transmission.html"));
+content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
+title_watcher.AlsoWaitForTitle(kFailString);
+xwalk_test_utils::NavigateToURL(runtime, url);
+EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
 }

--- a/extensions/test/xwalk_extensions_browsertest.cc
+++ b/extensions/test/xwalk_extensions_browsertest.cc
@@ -107,45 +107,6 @@ class ExtensionWithInvalidName : public XWalkExtension {
 
 bool ExtensionWithInvalidName::s_instance_was_created = false;
 
-static const char* kBulkDataAPI = "var bulkDataListener = null;"
-""
-"extension.setMessageListener(function(msg) {"
-"  if (bulkDataListener instanceof Function) {"
-"    bulkDataListener(msg);"
-"  };"
-"});"
-""
-"exports.requestBulkDataAsync = function(power, callback) {"
-"  bulkDataListener = callback;"
-"  extension.postMessage(power.toString());"
-"};";
-
-class BulkDataContext : public XWalkExtensionInstance {
- public:
-  BulkDataContext() {
-  }
-  void HandleMessage(scoped_ptr<base::Value> msg) override {
-    std::string message;
-    msg->GetAsString(&message);
-    int size = atoi(message.c_str());
-    std::string data_chunk(size, 'p');
-    scoped_ptr<base::Value> data(new base::StringValue(data_chunk));
-    PostMessageToJS(data.Pass());
-  }
-};
-
-class BulkDataExtension : public XWalkExtension {
- public:
-  BulkDataExtension() : XWalkExtension() {
-    set_name("bulkData");
-    set_javascript_api(kBulkDataAPI);
-  }
-
-  XWalkExtensionInstance* CreateInstance() override {
-    return new BulkDataContext();
-  }
-};
-
 }  // namespace
 
 class XWalkExtensionsTest : public XWalkExtensionsTestBase {
@@ -154,7 +115,6 @@ class XWalkExtensionsTest : public XWalkExtensionsTestBase {
       XWalkExtensionVector* extensions) override {
     extensions->push_back(new EchoExtension);
     extensions->push_back(new ExtensionWithInvalidName);
-    extensions->push_back(new BulkDataExtension);
   }
 };
 
@@ -205,16 +165,6 @@ IN_PROC_BROWSER_TEST_F(XWalkExtensionsDelayedTest, EchoExtensionSync) {
   GURL url = GetExtensionsTestURL(base::FilePath(),
                                   base::FilePath().AppendASCII(
                                       "sync_echo.html"));
-  content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
-  title_watcher.AlsoWaitForTitle(kFailString);
-  xwalk_test_utils::NavigateToURL(runtime, url);
-  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
-}
-
-IN_PROC_BROWSER_TEST_F(XWalkExtensionsTest, BulkDataExtension) {
-  Runtime* runtime = CreateRuntime();
-  GURL url = GetExtensionsTestURL(base::FilePath(),
-      base::FilePath().AppendASCII("bulk_data_transmission.html"));
   content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
   title_watcher.AlsoWaitForTitle(kFailString);
   xwalk_test_utils::NavigateToURL(runtime, url);


### PR DESCRIPTION
from native to JS using the shared memory handle.

This is the second fix for this bug. The previous fix uncovered this
one.

The crash was because the memory handle we send to the extension process
was null. The fact it was null is because on Windows it was failing to
share the handle of the shared memory between the render process and
the extension process. GiveReadOnlyToProcess was failing inside
windows specific code, more exactly in DuplicateHandle, a win API
which was returning an error code of 6. 6 means the handle we're passing
is invalid. Turns out that while we store the renderer process handle
earlier (so we can share the data between the two), the open() call
on the process is too early. It seems like Windows can't work with this
handle unless the process is open right before. Moving the open() call
to the last moment (by storing the PID instead of the handle) doesn't
fully work (we don't fail with error 6 but with 5 which means there
is not enough privileges to open/share with that process). We therefore
open it with extra privileges which means we can share data between
the two. I also added a LOG and an early return when sharing the handle
doesn't work, after all it means it's functionally broken.

While investigating this issue it turns out that the automatic test was
broken because it was always reporting "Pass" even if the actual message
passing with data handle was broken. The fix consists of moving it from
a regular extension test to a true external extension test. The second
part is also making sure we don't report "Pass" until we received all
the messages back from the native extension. If we don't receive one
the test will time out. I've decided to address it in this patch so that
I don't need to fix the test, then disable it to land that patch and
re-enable it again.

It turns out that the fix made the test to fail on Linux (running the test
into a regular xwalk instance was working fine) because the process
couldn't be opened. After debbuging it turns out that the test was
run in a in mode where the extensions are not created the same way as
an external extension (created as in process). This will make our code
for sharing memory to fail because there is no multi-process involved.
The test never worked but the code worked, it was discovered together
with this patch.