### PR TITLE
[RemoteDebugging] To fix EnableRemoteDebugging bug

### DIFF
--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -176,7 +176,7 @@ void XWalkRunner::EnableRemoteDebugging(int port) {
   if (port > 0 && port < 65535) {
     if (remote_debugging_server_.get() &&
         remote_debugging_server_.get()->port() == port)
-      remote_debugging_server_.reset();
+      return;
     remote_debugging_server_.reset(
         new RemoteDebuggingServer(browser_context(),
             local_ip, port, std::string()));


### PR DESCRIPTION
To fix EnableRemoteDebugging bug. 

When EnableRemoteDebugging was called with same port number, 
remote_debugging_server was stopped, because it was deleted by reset()

It does not seem to intended code. 
If already remote_debugging_server was created with same port, 
It should just return