### PR TITLE
Roll Chromium 44.0.2403.81.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,8 +17,8 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'aa27a06ed316c2a8a77ef256acc7c367de781fdf'
-v8_crosswalk_rev = 'fec24d2b62fc69c84c9ad12310ef257e53225042'
+chromium_crosswalk_rev = '05bf1798ede0a2e1278c47219eed769ce8398058'
+v8_crosswalk_rev = '113df1898786636dcc444644a1e2d54031c0d666'
 ozone_wayland_rev = '81e4b41be7511971011c7ced9c70131713d7541e'
 
 # |blink_crosswalk_rev| specifies the SHA1 hash of the blink-crosswalk commit
@@ -27,8 +27,8 @@ ozone_wayland_rev = '81e4b41be7511971011c7ced9c70131713d7541e'
 # the blink-crosswalk repository, so that the devtools code can use it to fetch
 # assets from Chromium's servers with a revision that exists there. We need an
 # SVN revision while Blink is still in SVN.
-blink_crosswalk_rev = '410929b00299e3bf00eb4d0c966f850a137393ec'
-blink_upstream_rev = '197137'
+blink_crosswalk_rev = '8a5b095d16177fa3ddd907b91337a52f9437dbb9'
+blink_upstream_rev = '198430'
 
 crosswalk_git = 'https://github.com/crosswalk-project'
 ozone_wayland_git = 'https://github.com/01org'
@@ -54,6 +54,14 @@ solutions = [
       'src/third_party/khronos/CL':
         'https://cvs.khronos.org/svn/repos/registry/trunk/public/cl/api/1.2@'
            '28150',
+
+      # Temporarily roll ffmpeg forward.
+      # We need commit 408c4b08 which introduces the |ffmpeg_component|
+      # variable so that we can continue building ffmpeg as a shared library
+      # for the time being (see https://crrev.com/1141703002 and
+      # https://groups.google.com/a/chromium.org/d/msg/chromium-packagers/R5rcZXWxBEQ/B6k0zzmJbvcJ.
+      'src/third_party/ffmpeg':
+         'https://chromium.googlesource.com/chromium/third_party/ffmpeg.git@408c4b08fab5cbaa284847f8c573fe939cada87c',
 
       # These directories are not relevant to Crosswalk and can be safely ignored
       # in a checkout. It avoids creating additional directories outside src/ that

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -5,6 +5,11 @@
     'enable_murphy%': 0,
     'use_webui_file_picker%': 0,
     'disable_bundled_extensions%': 0,
+
+    # Build FFMPEG as a shared library. The default since M44 is building it as
+    # a static library. We do not want to do that for now, see XWALK-4574.
+    'ffmpeg_component%': 'shared_library',
+
     'conditions': [
       ['OS=="android"', {
         # Enable WebCL by default on android.

--- a/packaging/crosswalk-do-not-build-several-chromium-dependencies.patch
+++ b/packaging/crosswalk-do-not-build-several-chromium-dependencies.patch
@@ -658,114 +658,34 @@ BUG=XWALK-2571
              'includes': [ '../build/common_defines.gypi', ],
 --- src/third_party/ffmpeg/ffmpeg.gyp
 +++ src/third_party/ffmpeg/ffmpeg.gyp
-@@ -150,6 +150,12 @@
-       'targets': [
-         {
-           'target_name': 'ffmpegsumo',
-+          'type': 'none',
-+          # No 'link_settings', ffmpegsumo is a 'loadable_module'.
-+        },
-+
-+        {
-+          'target_name': 'ffmpegsumo_original',
-           'type': 'loadable_module',
-           'sources': [
-             '<@(c_sources)',
-@@ -429,6 +435,61 @@
-   'targets': [
-     {
-       'target_name': 'ffmpeg',
-+      'type': 'none',
-+      'link_settings': {
-+        'libraries': [
-+          '-lffmpeg',
-+        ],
-+      },
-+      'direct_dependent_settings': {
-+        'defines': [
-+          '__STDC_CONSTANT_MACROS',  # FFmpeg uses INT64_C.
-+        ],
-+        'include_dirs': [
-+          '<(output_root)',
-+          '../..',  # The chromium 'src' directory.
-+          '<(platform_config_root)',
-+          '.',
-+        ],
-+      },
-+      'variables': {
-+        'outfile_type': 'posix_stubs',
-+        'stubs_filename_root': 'ffmpeg_stubs',
-+        'project_path': 'third_party/ffmpeg',
-+        'intermediate_dir': '<(INTERMEDIATE_DIR)',
-+        'output_root': '<(SHARED_INTERMEDIATE_DIR)/ffmpeg',
-+        'platform_config_root': 'chromium/config/<(ffmpeg_branding)/<(os_config)/<(ffmpeg_config)'
-+      },
-+      'actions': [
-+        {
-+          'action_name': 'generate_stubs',
-+          'inputs': [
-+            '<(generate_stubs_script)',
-+            '<(extra_header)',
-+            '<@(sig_files)',
-+          ],
-+          'outputs': [
-+            '<(intermediate_dir)/<(stubs_filename_root).cc',
-+            '<(output_root)/<(project_path)/<(stubs_filename_root).h',
-+          ],
-+          'action': ['python',
-+                     '<(generate_stubs_script)',
-+                     '-i', '<(intermediate_dir)',
-+                     '-o', '<(output_root)/<(project_path)',
-+                     '-t', '<(outfile_type)',
-+                     '-e', '<(extra_header)',
-+                     '-s', '<(stubs_filename_root)',
-+                     '-p', '<(project_path)',
-+                     '<@(_inputs)',
-+          ],
-+          'process_outputs_as_sources': 1,
-+          'message': 'Generating FFmpeg stubs for dynamic loading',
-+        },
+@@ -168,6 +168,27 @@
+ 
+   'targets': [{
+     'target_name': 'ffmpeg',
++    'type': 'none',
++    'link_settings': {
++      'libraries': [
++        '-lffmpeg',
 +      ],
 +    },
++    'variables': {
++      # Path to platform configuration files.
++      'platform_config_root': 'chromium/config/<(ffmpeg_branding)/<(os_config)/<(ffmpeg_config)',
++    },
++    'direct_dependent_settings': {
++      'include_dirs': [
++        '../..',  # The chromium 'src' directory.
++        '<(platform_config_root)',
++        '.',
++      ],
++    },
++  },
 +
-+    {
-+      'target_name': 'ffmpeg_original',
-       'sources': [
-         # Files needed for stub generation rules.
-         '<@(sig_files)',
-@@ -536,32 +597,6 @@
-               '.',
-             ],
-           },
--          'actions': [
--            {
--              'action_name': 'generate_stubs',
--              'inputs': [
--                '<(generate_stubs_script)',
--                '<(extra_header)',
--                '<@(sig_files)',
--              ],
--              'outputs': [
--                '<(intermediate_dir)/<(stubs_filename_root).cc',
--                '<(output_root)/<(project_path)/<(stubs_filename_root).h',
--              ],
--              'action': ['python',
--                         '<(generate_stubs_script)',
--                         '-i', '<(intermediate_dir)',
--                         '-o', '<(output_root)/<(project_path)',
--                         '-t', '<(outfile_type)',
--                         '-e', '<(extra_header)',
--                         '-s', '<(stubs_filename_root)',
--                         '-p', '<(project_path)',
--                         '<@(_inputs)',
--              ],
--              'process_outputs_as_sources': 1,
--              'message': 'Generating FFmpeg stubs for dynamic loading',
--            },
--          ],
-           'conditions': [
-             # Linux/Solaris need libdl for dlopen() and friends.
-             ['OS == "linux" or OS == "solaris"', {
++  {
++    'target_name': 'ffmpeg_original',
+     'type': '<(ffmpeg_component)',
+     'variables': {
+       # Path to platform configuration files.
 --- src/third_party/icu/icu.gyp
 +++ src/third_party/icu/icu.gyp
 @@ -171,6 +171,37 @@

--- a/sysapps/common/sysapps_manager_unittest.cc
+++ b/sysapps/common/sysapps_manager_unittest.cc
@@ -30,7 +30,7 @@ namespace {
 class XWalkSysAppsManagerTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    media::InitializeMediaLibraryForTesting();
+    media::InitializeMediaLibrary();
 
     // We need to make sure the resource bundle is up because
     // the extensions we instantiate on this test depend on it.

--- a/sysapps/device_capabilities/av_codecs_provider_ffmpeg.cc
+++ b/sysapps/device_capabilities/av_codecs_provider_ffmpeg.cc
@@ -19,9 +19,7 @@ namespace xwalk {
 namespace sysapps {
 
 AVCodecsProviderFFmpeg::AVCodecsProviderFFmpeg() {
-  base::FilePath media_path;
-  PathService::Get(content::DIR_MEDIA_LIBS, &media_path);
-  media::InitializeMediaLibrary(media_path);
+  media::InitializeMediaLibrary();
   media::FFmpegGlue::InitializeFFmpeg();
 }
 

--- a/sysapps/device_capabilities/av_codecs_provider_unittest.cc
+++ b/sysapps/device_capabilities/av_codecs_provider_unittest.cc
@@ -18,7 +18,7 @@ using xwalk::jsapi::device_capabilities::SystemAVCodecs;
 using xwalk::sysapps::AVCodecsProvider;
 
 TEST(XWalkSysAppsDeviceCapabilitiesTest, AVCodecsProvider) {
-  media::InitializeMediaLibraryForTesting();
+  media::InitializeMediaLibrary();
   xwalk::sysapps::SysAppsManager manager;
 
   AVCodecsProvider* provider(manager.GetAVCodecsProvider());


### PR DESCRIPTION
This is the latest Linux beta release so far. Thanks to Olli Raula for
starting the work.

FFMPEG had to be temporarily rolled forward so that we can continue
building it as a shared library for the time being.
See https://codereview.chromium.org/1141703002 and
https://codereview.chromium.org/1198653005/ for more information.

A few commits in chromium-crosswalk were also dropped because of this
change, as the code which loaded additional ffmpeg libraries via
--proprietary-codec-lib-path does not work anymore. Users wishing to
provide a different ffmpeg version with additional codecs now need to
replace the version built by Crosswalk instead of adding it alongside
the existing library.

Related to: XWALK-3705
Related to: XWALK-4574