### PR TITLE
[Android] Deprecate XWalkApplication

### DIFF
--- a/app/android/app_hello_world/AndroidManifest.xml
+++ b/app/android/app_hello_world/AndroidManifest.xml
@@ -9,7 +9,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.app.hello.world">
 
-    <application android:name="org.xwalk.core.XWalkApplication"
+    <application
         android:label="XWalkAppHelloWorld" android:hardwareAccelerated="true"
         android:icon="@drawable/crosswalk">
         <activity android:name="org.xwalk.app.hello.world.HelloWorldActivity"

--- a/app/android/app_template/AndroidManifest.xml
+++ b/app/android/app_template/AndroidManifest.xml
@@ -10,7 +10,7 @@
     package="org.xwalk.app.template"
     android:installLocation="auto">
 
-    <application android:name="org.xwalk.core.XWalkApplication"
+    <application
         android:label="XWalkAppTemplate" android:hardwareAccelerated="true"
         android:icon="@drawable/crosswalk">
         <activity android:name="org.xwalk.app.template.AppTemplateActivity"

--- a/app/android/runtime_client_embedded_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_embedded_shell/AndroidManifest.xml
@@ -9,7 +9,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.runtime.client.embedded.shell">
 
-    <application android:name="org.xwalk.core.XWalkApplication"
+    <application
         android:label="XWalkRuntimeClientEmbeddedShell" android:hardwareAccelerated="true">
         <activity android:name="org.xwalk.runtime.client.embedded.shell.XWalkRuntimeClientEmbeddedShellActivity"
             android:theme="@android:style/Theme.Holo.Light.NoActionBar"

--- a/app/android/runtime_client_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_shell/AndroidManifest.xml
@@ -9,7 +9,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.runtime.client.shell">
 
-    <application android:name="org.xwalk.core.XWalkApplication"
+    <application
         android:label="XWalkRuntimeClientShell" android:hardwareAccelerated="true">
         <activity android:name="org.xwalk.runtime.client.shell.XWalkRuntimeClientShellActivity"
             android:theme="@android:style/Theme.Holo.Light.NoActionBar"

--- a/app/tools/android/test_data/extensions/adextension/AndroidManifest.xml
+++ b/app/tools/android/test_data/extensions/adextension/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:name="org.xwalk.core.XWalkApplication">
+    <application>
         <meta-data android:name="com.google.android.gms.version" android:value="_GOOGLE_PLAY_SERVICES_LIB_VERSION_"/>
     </application>
 </manifest>

--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -249,24 +249,18 @@ def CopyResources(project_source, out_dir, out_project_dir, shared):
   # Since there might be some resource files with same names from
   # different folders like ui_java, content_java and others,
   # it's necessary to rename some files to avoid overridding.
-  if shared:
-    res_to_copy = [
-        # zip file list
-        'xwalk_app_strings.zip',
-        'xwalk_core_java.zip'
-    ]
-  else:
-    res_to_copy = [
-        # zip file list
-        'content_java.zip',
-        'content_strings_grd.zip',
-        'ui_java.zip',
-        'ui_strings_grd.zip',
-        'web_contents_delegate_android_java.zip',
-        'xwalk_core_internal_java.zip',
-        'xwalk_core_strings.zip',
-        'xwalk_app_strings.zip'
-    ]
+  res_to_copy = [
+      # zip file list
+      'content_java.zip',
+      'content_strings_grd.zip',
+      'ui_java.zip',
+      'ui_strings_grd.zip',
+      'web_contents_delegate_android_java.zip',
+      'xwalk_core_internal_java.zip',
+      'xwalk_core_java.zip',
+      'xwalk_core_strings.zip',
+      'xwalk_app_strings.zip'
+  ]
 
   for res_zip in res_to_copy:
     zip_file = os.path.join(out_dir, 'res.java', res_zip)

--- a/build/android/generate_xwalk_core_library_aar.py
+++ b/build/android/generate_xwalk_core_library_aar.py
@@ -34,8 +34,8 @@ def main():
         'AndroidManifest.xml'), 'AndroidManifest.xml'),
       (os.path.join(options.target, 'xwalk_shared_library', 'libs',
         'xwalk_core_library_java_app_part.jar'), 'classes.jar'),
-      (os.path.join(options.target, 'gen', 'xwalk_core_java', 'java_R',
-        'R.txt'), 'R.txt'),
+      (os.path.join(options.target, 'xwalk_core_empty_embedder_apk',
+        'gen', 'R.txt'), 'R.txt'),
     )
     exclude_files = (
       os.path.join(options.target, 'xwalk_shared_library', 'libs',

--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -5,7 +5,6 @@
 package org.xwalk.core;
 
 import android.app.Activity;
-import android.content.res.Resources;
 import android.os.Bundle;
 
 /**
@@ -53,14 +52,7 @@ import android.os.Bundle;
  * }
  * </pre>
  *
- * <p>Besides, you must use {@link XWalkApplication} in the Android manifest if the application is
- * intended to run in shared mode.</p>
- *
- * <pre>
- * &lt;application android:name="org.xwalk.core.XWalkApplication"&gt;
- * </pre>
- *
- * <p>And shared mode also needs following permissions:</p>
+ * <p>Besides, shared mode needs following permissions:</p>
  *
  * <pre>
  * &lt;uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /&gt;
@@ -114,13 +106,5 @@ public abstract class XWalkActivity extends Activity {
     protected void onResume() {
         super.onResume();
         mActivityDelegate.onResume();
-    }
-
-    /**
-     * Returns the Resource instance comes from the application context
-     */
-    @Override
-    public Resources getResources() {
-        return getApplicationContext().getResources();
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkApplication.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkApplication.java
@@ -9,6 +9,8 @@ import android.content.Context;
 import android.content.res.Resources;
 
 /**
+ * This class is deprecated.
+ *
  * XWalkApplication is to support cross package resource loading.
  * It provides method to allow overriding getResources() behavior.
  */

--- a/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
@@ -152,14 +152,6 @@ class XWalkCoreWrapper {
         sInstance = sProvisionalInstance;
         sProvisionalInstance = null;
         sInstance.initXWalkCore();
-
-        if (sInstance.isSharedMode()) {
-            XWalkApplication application = XWalkApplication.getApplication();
-            if (application == null) {
-                Assert.fail("Please use XWalkApplication in the Android manifest for shared mode");
-            }
-            application.addResource(sInstance.mBridgeContext.getResources());
-        }
         Log.d(TAG, "Initialize xwalk core successfully");
     }
 
@@ -194,15 +186,9 @@ class XWalkCoreWrapper {
 
     private void initXWalkView() {
         Log.d(TAG, "Init xwalk view");
-        Object object = mWrapperContext;
-        if (mBridgeContext != null) {
-            ReflectConstructor constructor = new ReflectConstructor(
-                    getBridgeClass("MixedContext"), Context.class, Context.class);
-            object = constructor.newInstance(mBridgeContext, mWrapperContext);
-        }
-
         Class<?> clazz = getBridgeClass("XWalkViewDelegate");
-        new ReflectMethod(clazz, "init", Context.class).invoke(object);
+        ReflectMethod method = new ReflectMethod(clazz, "init", Context.class, Context.class);
+        method.invoke(mBridgeContext, mWrapperContext);
     }
 
     private void initXWalkCore() {

--- a/runtime/android/core/src/org/xwalk/core/XWalkMixedResources.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkMixedResources.java
@@ -12,6 +12,8 @@ import android.graphics.drawable.Drawable;
 import android.util.TypedValue;
 
 /**
+ * This class is deprecated.
+ *
  * XWalkMixedResources is used to combine the resources
  * from two different packages.
  *

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkInternalResources.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkInternalResources.java
@@ -26,6 +26,7 @@ class XWalkInternalResources {
     // Use reflection to iterate over the target class is to avoid hardcode.
     private static void doResetIds(Context context) {
         ClassLoader classLoader = context.getClassLoader();
+        ClassLoader appClassLoader = context.getApplicationContext().getClassLoader();
         for (String resourceClass : INTERNAL_RESOURCE_CLASSES) {
             try {
                 Class<?> internalResource = classLoader.loadClass(resourceClass);
@@ -35,7 +36,7 @@ class XWalkInternalResources {
                     String generatedInnerClassName = innerClazz.getName().replace(
                             resourceClass, GENERATED_RESOURCE_CLASS);
                     try {
-                        generatedInnerClazz = classLoader.loadClass(generatedInnerClassName);
+                        generatedInnerClazz = appClassLoader.loadClass(generatedInnerClassName);
                     } catch (ClassNotFoundException e) {
                         Log.w(TAG, generatedInnerClassName + "is not found.");
                         continue;
@@ -43,7 +44,7 @@ class XWalkInternalResources {
                     Field[] fields = innerClazz.getFields();
                     for (Field field : fields) {
                         // It's final means we are probably not used as library project.
-                        if (Modifier.isFinal(field.getModifiers())) continue;
+                        if (Modifier.isFinal(field.getModifiers())) field.setAccessible(true);
                         try {
                             int value = generatedInnerClazz.getField(field.getName()).getInt(null);
                             field.setInt(null, value);
@@ -57,6 +58,7 @@ class XWalkInternalResources {
                             Log.w(TAG, generatedInnerClazz.getName() + "." +
                                     field.getName() + " is not found.");
                         }
+                        if (Modifier.isFinal(field.getModifiers())) field.setAccessible(false);
                     }
                 }
             } catch (ClassNotFoundException e) {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -83,6 +83,16 @@ class XWalkViewDelegate {
         }
     }
 
+    public static void init(Context bridgeContext, Context context) {
+        loadXWalkLibrary(bridgeContext);
+
+        if (bridgeContext == null) {
+            init(context);
+        } else {
+            init(new MixedContext(bridgeContext, context));
+        }
+    }
+
     public static void loadXWalkLibrary(Context context) throws UnsatisfiedLinkError {
         if (sLibraryLoaded) return;
 
@@ -120,7 +130,7 @@ class XWalkViewDelegate {
         sLibraryLoaded = true;
     }
 
-    public static void init(final Context context) {
+    private static void init(final Context context) {
         if (sInitialized) return;
 
         PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, context);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -186,6 +186,28 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     public static final int RELOAD_IGNORE_CACHE = 1;
 
     /**
+     * Constructs a new XWalkView with a Context object.
+     * @param context a Context object used to access application assets.
+     * @since 6.0
+     */
+    @XWalkAPI(preWrapperLines = {
+                  "        super(${param1}, null);"},
+              postWrapperLines = {
+                  "        addView((FrameLayout)bridge, new FrameLayout.LayoutParams(",
+                  "                FrameLayout.LayoutParams.MATCH_PARENT,",
+                  "                FrameLayout.LayoutParams.MATCH_PARENT));"})
+    public XWalkViewInternal(Context context) {
+        super(context, null);
+
+        checkThreadSafety();
+        mActivity = (Activity) context;
+        mContext = getContext();
+
+        init(getContext(), getActivity());
+        initXWalkContent(mContext, null);
+    }
+
+    /**
      * Constructor for inflating via XML.
      * @param context  a Context object used to access application assets.
      * @param attrs    an AttributeSet passed to our parent.
@@ -198,7 +220,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
                   "                FrameLayout.LayoutParams.MATCH_PARENT,",
                   "                FrameLayout.LayoutParams.MATCH_PARENT));"})
     public XWalkViewInternal(Context context, AttributeSet attrs) {
-        super(convertContext(context), attrs);
+        super(context, attrs);
 
         checkThreadSafety();
         mActivity = (Activity) context;
@@ -222,7 +244,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
                   "                FrameLayout.LayoutParams.MATCH_PARENT,",
                   "                FrameLayout.LayoutParams.MATCH_PARENT));"})
     public XWalkViewInternal(Context context, Activity activity) {
-        super(convertContext(context), null);
+        super(context, null);
 
         checkThreadSafety();
         // Make sure mActivity is initialized before calling 'init' method.
@@ -233,26 +255,10 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         initXWalkContent(mContext, null);
     }
 
-    private static Context convertContext(Context context) {
-        Context ret = context;
-        Context bridgeContext = null;
-        if (XWalkCoreBridge.getInstance() != null) {
-            bridgeContext = XWalkCoreBridge.getInstance().getContext();
-        }
-        if (bridgeContext == null || context == null ||
-                bridgeContext.getPackageName().equals(context.getPackageName())) {
-            // Not acrossing package
-            ret = context;
-        } else {
-            ret = new MixedContext(bridgeContext, context);
-        }
-        return ret;
-    }
-
     private static void init(Context context, Activity activity) {
         if (sInitialized) return;
 
-        XWalkViewDelegate.loadXWalkLibrary(context);
+        XWalkViewDelegate.init(null, activity);
 
         // Initialize the ActivityStatus. This is needed and used by many internal
         // features such as location provider to listen to activity status.
@@ -266,8 +272,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         // We will miss activity onCreate() status in ApplicationStatusManager,
         // informActivityStarted() will simulate these callbacks.
         ApplicationStatusManager.informActivityStarted(activity);
-
-        XWalkViewDelegate.init(context);
 
         sInitialized = true;
     }

--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -9,7 +9,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.core.xwview.shell">
 
-    <application android:name="org.xwalk.core.XWalkApplication"
+    <application
         android:label="XWalkCoreShell" android:hardwareAccelerated="true">
         <activity android:name="org.xwalk.core.xwview.shell.XWalkViewShellActivity"
             android:theme="@android:style/Theme.Holo.Light"

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -18,7 +18,6 @@
         'api_files': [
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/JavascriptInterface.java',
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java',
-          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkApplication.java',
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkInitializer.java',
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkDownloadListener.java',


### PR DESCRIPTION
XWalkApplication's role is to help the app to get resources from the
XWalkRuntimeLib.apk in shared mode, but it also cause the
inconvenience of developers. So we integrate the whole resources to
the app even in shared mode to get rid of this class.