### PR TITLE
Stop referencing ffmpegsumo and fix usage of libffpeg.so.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -6,10 +6,6 @@
     'use_webui_file_picker%': 0,
     'disable_bundled_extensions%': 0,
 
-    # Build FFMPEG as a shared library. The default since M44 is building it as
-    # a static library. We do not want to do that for now, see XWALK-4574.
-    'ffmpeg_component%': 'shared_library',
-
     'conditions': [
       ['OS=="android"', {
         # Enable WebCL by default on android.
@@ -17,6 +13,13 @@
         'v8_use_external_startup_data%': 0,
       }, {
         'enable_webcl%': 0,
+      }],
+      ['OS=="linux"', {
+        # Since M44, ffmpeg is built as a static library by default. On Linux,
+        # keep the previous behavior or building it as a shared library while
+        # we figure out if it makes sense to switch to a static library by
+        # default.
+        'ffmpeg_component%': 'shared_library',
       }],
     ],
   },

--- a/packaging/crosswalk-libs.spec
+++ b/packaging/crosswalk-libs.spec
@@ -237,7 +237,6 @@ rm -f src/out/Release/lib/libxwalk_backend_lib.so
 install -d %{buildroot}%{_libdir}/xwalk/lib
 install -m 0644 -p -D src/out/Release/lib/*.so %{buildroot}%{_libdir}/xwalk/lib/
 install -m 0644 -p -D src/out/Release/icudtl.dat %{buildroot}%{_libdir}/xwalk/icudtl.dat
-install -m 0644 -p -D src/out/Release/libffmpegsumo.so %{buildroot}%{_libdir}/xwalk/libffmpegsumo.so
 install -m 0644 -p -D src/out/Release/natives_blob.bin %{buildroot}%{_libdir}/xwalk/natives_blob.bin
 install -m 0644 -p -D src/out/Release/snapshot_blob.bin %{buildroot}%{_libdir}/xwalk/snapshot_blob.bin
 
@@ -245,7 +244,6 @@ install -m 0644 -p -D src/out/Release/snapshot_blob.bin %{buildroot}%{_libdir}/x
 %manifest crosswalk-libs.manifest
 %{_libdir}/xwalk/icudtl.dat
 %{_libdir}/xwalk/lib/lib*.so
-%{_libdir}/xwalk/libffmpegsumo.so
 %if ! %{_disable_nacl}
 %{_libdir}/xwalk/nacl_bootstrap_raw
 %{_libdir}/xwalk/nacl_helper

--- a/tools/build/linux/FILES.cfg
+++ b/tools/build/linux/FILES.cfg
@@ -35,8 +35,4 @@ FILES = [
     'filename': 'xwalk.pak',
     'buildtype': ['dev', 'official'],
   },
-  {
-    'filename': 'libffmpegsumo.so',
-    'buildtype': ['dev'],
-  },
 ]

--- a/tools/build/win/FILES.cfg
+++ b/tools/build/win/FILES.cfg
@@ -38,10 +38,6 @@ FILES = [
     'buildtype': ['dev', 'official'],
   },
   {
-    'filename': 'ffmpegsumo.dll',
-    'buildtype': ['dev'],
-  },
-  {
     'filename': 'icudt.dll',
     'buildtype': ['dev', 'official'],
   },
@@ -61,11 +57,6 @@ FILES = [
   {
     'filename': 'xwalk.exe.pdb',
     'buildtype': ['dev', 'official'],
-    'archive': 'xwalk-win32-syms.zip',
-  },
-  {
-    'filename': 'ffmpegsumo.dll.pdb',
-    'buildtype': ['dev'],
     'archive': 'xwalk-win32-syms.zip',
   },
   {

--- a/tools/installer/common/installer.include
+++ b/tools/installer/common/installer.include
@@ -172,7 +172,10 @@ stage_install_common() {
   done
 
   # ffmpeg libs
-  install -m 644 -s "${BUILDDIR}/libffmpegsumo.so" "${STAGEDIR}/${INSTALLDIR}/"
+  if [ -f "${BUILDDIR}/lib/libffmpeg.so" ]; then
+      install -m 755 -d "${STAGEDIR}/${INSTALLDIR}/lib/"
+      install -m 644 -s "${BUILDDIR}/lib/libffmpeg.so" "${STAGEDIR}/${INSTALLDIR}/lib/"
+  fi
 
   # launcher script and symlink
   process_template "${BUILDDIR}/installer/common/wrapper" \

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -880,15 +880,6 @@
             'runtime/app/xwalk_content_main.cc',
             'runtime/app/xwalk_content_main.h',
           ],
-          'copies': [
-            {
-              # Copy FFmpeg binaries for audio/video support.
-              'destination': '<(PRODUCT_DIR)/$(CONTENTS_FOLDER_PATH)/Libraries',
-              'files': [
-                '<(PRODUCT_DIR)/ffmpegsumo.so',
-              ],
-            },
-          ],
           'conditions': [
             ['enable_webrtc==1', {
               'variables': {

--- a/xwalk_installer.gypi
+++ b/xwalk_installer.gypi
@@ -22,7 +22,6 @@
         ],
         'packaging_files_binaries': [
           '<(PRODUCT_DIR)/xwalk',
-          '<(PRODUCT_DIR)/libffmpegsumo.so',
 
           # Commented out for the time being because non-Ozone Linux builds
           # depend on the gtk2ui target in src/chrome, which can cause
@@ -35,6 +34,11 @@
         'deb_cmd': ['<@(flock_bash)', '<(deb_build)', '-o' '<(PRODUCT_DIR)',
                     '-b', '<(PRODUCT_DIR)', '-a', '<(target_arch)'],
         'conditions': [
+          ['ffmpeg_component=="shared_library"', {
+            'packaging_files_binaries': [
+              '<(PRODUCT_DIR)/lib/libffmpeg.so',
+            ],
+          }],
           ['target_arch=="ia32"', {
             'deb_arch': 'i386',
             'packaging_files_common': [


### PR DESCRIPTION
This is a follow-up to f5be8735 ("Roll Chromium 44.0.2403.81").

That version of Chromium M44 includes changes in Chromium's version of
ffmpeg that got rid of the ffmpegsumo library: there is only
`libffmpeg.so` now, and it is a regular library.

In practice, this means the following changes had to be made for a build
from scratch to work again:

* References to `libffmpegsumo.so` in Tizen's spec files have been
  dropped. `libffmpeg.so` is built in `lib/` and does not need special
  treatment.
* References to `libffmegsumo.so` in the Debian packaging files have also
  been dropped. This was a bit more intricate than the above, as some
  code in `build.sh` had to be moved to `do_package()` because even though
  the Debian packages are built with `component=static_library` the
  `ffmpeg_component` variable is set to `shared_library`.
  Consequently, when we called `dpkg-shlibdeps` in the xwalk binary in
  `${BUILDDIR}` it had a dependency on lib/libffmpeg.so and this resulted
  in a lot of warnings like this:
  ```
  dpkg-shlibdeps: warning: $ORIGIN is used in RPATH of
  /path/to/out/Release/xwalk and the corresponding directory could not
  be identified due to lack of DEBIAN sub-directory in the root of
  package's build tree
  ```
  We now do the staging first so that the `DEBIAN` directory exists and call
  `dpkg-shlibdeps` on the staged binary instead of the one in the build
  directory.
* We build ffmpeg as a shared library only on Linux instead of all
  platforms. Building ffmpeg as a shared library on Windows and OS X is
  not completely tested anymore I think, and it was not clear whether
  the gyp code that copies ffmpeg to the Crosswalk Framework on Mac is
  supposed to work with libffmpeg.so instead of `libffmpegsumo.so`.

BUG=XWALK-3705
BUG=XWALK-4574