### PR TITLE
Revert "[Android] Support theme-color on Android Lollipop+(5.0+)"

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -51,11 +51,6 @@ abstract class XWalkContentsClient extends ContentViewClient {
         }
 
         @Override
-        public void didChangeThemeColor(int color) {
-            onDidChangeThemeColor(color);
-        }
-
-        @Override
         public void didStopLoading(String url) {
             onPageFinished(url);
         }
@@ -168,8 +163,6 @@ abstract class XWalkContentsClient extends ContentViewClient {
     protected abstract boolean onCreateWindow(boolean isDialog, boolean isUserGesture);
 
     protected abstract void onCloseWindow();
-
-    public abstract void onDidChangeThemeColor(int color);
 
     public abstract void onReceivedIcon(Bitmap bitmap);
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -238,13 +238,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
-    public void onDidChangeThemeColor(int color) {
-        if (isOwnerActivityRunning()) {
-            mXWalkUIClient.onDidChangeThemeColor(mXWalkView,color);
-        }
-    }
-
-    @Override
     public void onResourceLoadStarted(String url) {
         if (isOwnerActivityRunning()) {
             mXWalkResourceClient.onLoadStarted(mXWalkView, url);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -15,12 +15,9 @@ import android.os.Build.VERSION_CODES;
 import android.os.Message;
 import android.view.KeyEvent;
 import android.view.View;
-import android.view.Window;
 import android.view.WindowManager;
 import android.webkit.ValueCallback;
 import android.widget.EditText;
-
-import org.chromium.base.ApiCompatibilityUtils;
 
 /**
  * This class notifies the embedder UI events/callbacks.
@@ -94,15 +91,6 @@ public class XWalkUIClientInternal {
     public boolean onCreateWindowRequested(XWalkViewInternal view, InitiateByInternal initiator,
             ValueCallback<XWalkViewInternal> callback) {
         return false;
-    }
-
-    /**
-     * Called when the theme color is changed. This works only on Android Lollipop+(5.0+).
-     * @param color the new color in RGB format.
-     */
-    public void onDidChangeThemeColor(XWalkViewInternal view, int color) {
-        if (view == null || view.getActivity() == null) return;
-        ApiCompatibilityUtils.setStatusBarColor(view.getActivity().getWindow(),color);
     }
 
     /**


### PR DESCRIPTION
This reverts commit b1ea577cd3152dd3a522955ff5e9634062427cf1.

Reason: broke Crosswalk 14 beta build from scratch.

```
runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java:105: error: method setStatusBarColor in class ApiCompatibilityUtils cannot be applied to given types;
        ApiCompatibilityUtils.setStatusBarColor(view.getActivity().getWindow(),color);
                             ^
  required: Activity,int
  found: Window,int
  reason: actual argument Window cannot be converted to Activity by method invocation conversion
```

BUG=XWALK-4305