### PR TITLE
[Android]Support css meta theme-color on Android Lollipop+(5.0+).

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -51,6 +51,11 @@ abstract class XWalkContentsClient extends ContentViewClient {
         }
 
         @Override
+        public void didChangeThemeColor(int color) {
+            onDidChangeThemeColor(color);
+        }
+
+        @Override
         public void didStopLoading(String url) {
             onPageFinished(url);
         }
@@ -163,6 +168,8 @@ abstract class XWalkContentsClient extends ContentViewClient {
     protected abstract boolean onCreateWindow(boolean isDialog, boolean isUserGesture);
 
     protected abstract void onCloseWindow();
+
+    public abstract void onDidChangeThemeColor(int color);
 
     public abstract void onReceivedIcon(Bitmap bitmap);
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -238,6 +238,13 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
+    public void onDidChangeThemeColor(int color) {
+        if (isOwnerActivityRunning()) {
+            mXWalkUIClient.onDidChangeThemeColor(mXWalkView,color);
+        }
+    }
+
+    @Override
     public void onResourceLoadStarted(String url) {
         if (isOwnerActivityRunning()) {
             mXWalkResourceClient.onLoadStarted(mXWalkView, url);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -15,9 +15,12 @@ import android.os.Build.VERSION_CODES;
 import android.os.Message;
 import android.view.KeyEvent;
 import android.view.View;
+import android.view.Window;
 import android.view.WindowManager;
 import android.webkit.ValueCallback;
 import android.widget.EditText;
+
+import org.chromium.base.ApiCompatibilityUtils;
 
 /**
  * This class notifies the embedder UI events/callbacks.
@@ -91,6 +94,15 @@ public class XWalkUIClientInternal {
     public boolean onCreateWindowRequested(XWalkViewInternal view, InitiateByInternal initiator,
             ValueCallback<XWalkViewInternal> callback) {
         return false;
+    }
+
+    /**
+     * Called when the theme color is changed. This works only on Android Lollipop+(5.0+).
+     * @param color the new color in RGB format.
+     */
+    public void onDidChangeThemeColor(XWalkViewInternal view, int color) {
+        if (view == null || view.getActivity() == null) return;
+        ApiCompatibilityUtils.setStatusBarColor(view.getActivity(),color);
     }
 
     /**


### PR DESCRIPTION
For Android version older than 5.0, this doesn't work.
BUG=XWALK-4305.

(cherry picked from commit 94d6666c7f863c8ddb1bddb08e51e435d616050c)