### PR TITLE
[Android] Enable widevine support

### DIFF
--- a/runtime/DEPS
+++ b/runtime/DEPS
@@ -19,5 +19,7 @@ include_rules = [
   "+jni",
   "+components/web_contents_delegate_android",
   "+components/navigation_interception",
+  "+components/cdm/browser",
+  "+components/cdm/renderer",
   "+cc/base/switches.h"
 ]

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -55,6 +55,7 @@
 #include "base/android/locale_utils.h"
 #include "base/android/path_utils.h"
 #include "base/base_paths_android.h"
+#include "components/cdm/browser/cdm_message_filter_android.h"
 #include "xwalk/runtime/browser/android/xwalk_cookie_access_policy.h"
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
 #include "xwalk/runtime/browser/android/xwalk_web_contents_view_delegate.h"
@@ -202,6 +203,9 @@ void XWalkContentBrowserClient::RenderProcessWillLaunch(
 #endif
   xwalk_runner_->OnRenderProcessWillLaunch(host);
   host->AddFilter(new XWalkRenderMessageFilter);
+#if defined(OS_ANDROID)
+  host->AddFilter(new cdm::CdmMessageFilterAndroid());
+#endif
 }
 
 content::MediaObserver* XWalkContentBrowserClient::GetMediaObserver() {

--- a/runtime/browser/xwalk_permission_manager.cc
+++ b/runtime/browser/xwalk_permission_manager.cc
@@ -55,9 +55,11 @@ void XWalkPermissionManager::RequestPermission(
       callback.Run(content::PERMISSION_STATUS_DENIED);
 #endif
       break;
+    case content::PermissionType::PROTECTED_MEDIA_IDENTIFIER:
+      callback.Run(content::PERMISSION_STATUS_GRANTED);
+      break;
     case content::PermissionType::MIDI_SYSEX:
     case content::PermissionType::NOTIFICATIONS:
-    case content::PermissionType::PROTECTED_MEDIA_IDENTIFIER:
     case content::PermissionType::PUSH_MESSAGING:
       NOTIMPLEMENTED() << "RequestPermission is not implemented for "
                        << static_cast<int>(permission);
@@ -83,6 +85,7 @@ void XWalkPermissionManager::CancelPermissionRequest(
 #endif
       break;
     case content::PermissionType::PROTECTED_MEDIA_IDENTIFIER:
+      break;
     case content::PermissionType::MIDI_SYSEX:
     case content::PermissionType::NOTIFICATIONS:
     case content::PermissionType::PUSH_MESSAGING:
@@ -105,6 +108,9 @@ content::PermissionStatus XWalkPermissionManager::GetPermissionStatus(
     content::PermissionType permission,
     const GURL& requesting_origin,
     const GURL& embedding_origin) {
+  if (permission == content::PermissionType::PROTECTED_MEDIA_IDENTIFIER)
+    return content::PERMISSION_STATUS_GRANTED;
+
   return content::PERMISSION_STATUS_DENIED;
 }
 

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -30,6 +30,7 @@
 #include "xwalk/runtime/renderer/pepper/pepper_helper.h"
 
 #if defined(OS_ANDROID)
+#include "components/cdm/renderer/android_key_systems.h"
 #include "xwalk/runtime/browser/android/net/url_constants.h"
 #include "xwalk/runtime/renderer/android/xwalk_permission_client.h"
 #include "xwalk/runtime/renderer/android/xwalk_render_process_observer.h"
@@ -296,6 +297,13 @@ void XWalkContentRendererClient::GetNavigationErrorStrings(
   if (error_description) {
     *error_description = LocalizedError::GetErrorDetails(error, is_post);
   }
+}
+
+void XWalkContentRendererClient::AddKeySystems(
+    std::vector<media::KeySystemInfo>* key_systems) {
+#if defined(OS_ANDROID)
+  cdm::AddAndroidWidevine(key_systems);
+#endif  // defined(OS_ANDROID)
 }
 
 }  // namespace xwalk

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -7,12 +7,14 @@
 #define XWALK_RUNTIME_RENDERER_XWALK_CONTENT_RENDERER_CLIENT_H_
 
 #include <string>
+#include <vector>
 
 #include "base/compiler_specific.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/files/file.h"
 #include "base/strings/string16.h"
 #include "content/public/renderer/content_renderer_client.h"
+#include "media/base/key_system_info.h"
 #include "ui/base/page_transition_types.h"
 #include "xwalk/extensions/renderer/xwalk_extension_renderer_controller.h"
 #if defined(OS_ANDROID)
@@ -58,6 +60,8 @@ class XWalkContentRendererClient
                        const GURL& url,
                        const GURL& first_party_for_cookies,
                        GURL* new_url) override;
+
+  void AddKeySystems(std::vector<media::KeySystemInfo>* key_systems) override;
 
  protected:
   scoped_ptr<XWalkRenderProcessObserver> xwalk_render_process_observer_;

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -39,6 +39,7 @@
         '../components/components.gyp:autofill_content_browser',
         '../components/components.gyp:autofill_content_renderer',
         '../components/components.gyp:autofill_core_browser',
+        '../components/components.gyp:cdm_renderer',
         '../components/components.gyp:devtools_http_handler',
         '../components/components.gyp:user_prefs',
         '../components/components.gyp:visitedlink_browser',
@@ -359,6 +360,7 @@
         }],
         ['OS=="android"',{
           'dependencies':[
+            '../components/components.gyp:cdm_browser',
             'xwalk_core_jar_jni',
             'xwalk_core_native_jni',
           ],

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -10,6 +10,8 @@
       'android_unmangled_name': 1,
       'dependencies': [
         '../components/components.gyp:auto_login_parser',
+        '../components/components.gyp:cdm_browser',
+        '../components/components.gyp:cdm_renderer',
         '../components/components.gyp:navigation_interception',
         '../components/components.gyp:visitedlink_browser',
         '../components/components.gyp:visitedlink_renderer',


### PR DESCRIPTION
Currently, crosswalk only support clearkey CDM, but doesn't support
widevine CDM. This PR will enable it in crosswalk for android.

The spec can refer https://w3c.github.io/encrypted-media/.

The steps to verify this feature:
Add "enable_widevine=1" to the GYP_DEFINES. Then run gyp and build.
The following link is for DRM testing. If 'com.widevine.alpha' keySystem
is not supported, the below video won't play.
http://shaka-player-demo.appspot.com/?dash;asset=assets/car_segmenttemplate.mpd