### PR TITLE
Fix crash issue when app control event was invoked

### DIFF
--- a/application/browser/application_system_tizen.cc
+++ b/application/browser/application_system_tizen.cc
@@ -118,8 +118,10 @@ void application_event_cb(app_event event, void* data, bundle* b) {
 
       Application* app =
           app_service_tizen->LaunchFromAppID(app_id, encoded_bundle);
-      LOG(INFO) << "Application launched with id: " << app->id();
-      handler_data->current_app = static_cast<ApplicationTizen*>(app);
+      if (app) {
+        LOG(INFO) << "Application launched with id: " << app->id();
+        handler_data->current_app = static_cast<ApplicationTizen*>(app);
+      }
       break;
     }
     case AE_LOWMEM_POST:


### PR DESCRIPTION
LaunchFromAppID could returning the NULL pointer.
but it does not checked before used