### PR TITLE
[Android] Implement the embedding API for clearFormData().

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -825,6 +825,17 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
      * @see android.webkit.WebView#clearFormData()
      */
     public void hideAutofillPopup() {
+        if (mNativeContent == 0) return;
+        if (mIsLoaded == false) {
+            mXWalkView.post(new Runnable() {
+                @Override
+                public void run() {
+                    hideAutofillPopup();
+                }
+            });
+            return;
+        }
+
         if (mXWalkAutofillClient != null) {
             mXWalkAutofillClient.hideAutofillPopup();
         }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1000,6 +1000,20 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         mContent.setZOrderOnTop(onTop);
     }
 
+    /**
+     * Removes the autocomplete popup from the currently focused form field, if present.
+     * Note this only affects the display of the autocomplete popup, it does not remove
+     * any saved form data from this WebView's store.
+     * This is a poorly named method, but we keep it for historical reasons.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void clearFormData() {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.hideAutofillPopup();
+    }
+
     // Below methods are for test shell and instrumentation tests.
     /**
      * @hide


### PR DESCRIPTION
This patch is to implement clearFormData(), this API removes the
autocomplete popup from the currently focused form field, if present.
It does not remove any saved form data from this WebView's store.

BUG=XWALK-4243