### PR TITLE
[Android] Fix the crash issue when running file transfer.

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/CookieManagerTest.java
@@ -5,7 +5,6 @@
 
 package org.xwalk.core.xwview.test;
 
-import android.graphics.Bitmap;
 import android.test.suitebuilder.annotation.SmallTest;
 import org.chromium.base.test.util.Feature;
 import android.test.MoreAsserts;
@@ -23,22 +22,20 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkCookieManagerInternal;
-import org.xwalk.core.internal.XWalkClient;
+import org.xwalk.core.XWalkCookieManager;
 
 /**
  * Tests for the CookieManager.
  */
 public class CookieManagerTest extends XWalkViewTestBase {
 
-    private XWalkCookieManagerInternal mCookieManager = null;
+    private XWalkCookieManager mCookieManager = null;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
 
-        mCookieManager = new XWalkCookieManagerInternal();
+        mCookieManager = new XWalkCookieManager();
     }
 
     @SmallTest

--- a/tools/reflection_generator/bridge_generator.py
+++ b/tools/reflection_generator/bridge_generator.py
@@ -85,8 +85,21 @@ ${REFLECTION_INIT_SECTION}}
              'BRIDGE_CLASS_NAME': self._java_data.bridge_name}
     return constructor_template.substitute(value)
 
+  def GenerateBridgeDefaultConstructor(self):
+    template = Template("""\
+    public ${NAME}(Object wrapper) {
+        this.wrapper = wrapper;
+        reflectionInit();
+    }
+
+""")
+    value = {'NAME': self._java_data.bridge_name}
+    return template.substitute(value)
+
   def GenerateMethods(self):
     methods_string = ''
+    if self._java_data.need_default_constructor:
+      methods_string += self.GenerateBridgeDefaultConstructor()
     for method in self._java_data.methods:
       methods_string += method.GenerateMethodsStringForBridge()
     return methods_string

--- a/tools/reflection_generator/java_class.py
+++ b/tools/reflection_generator/java_class.py
@@ -85,6 +85,7 @@ class InternalJavaFileData(object):
     self._imports = []
     self._enums = {}
     self._package_name = ''
+    self._need_default_constructor = True
 
   @property
   def class_name(self):
@@ -129,6 +130,10 @@ class InternalJavaFileData(object):
   @property
   def package_name(self):
     return self._package_name
+
+  @property
+  def need_default_constructor(self):
+    return self._need_default_constructor
 
   def GetJavaData(self, clazz):
     return self._class_loader.GetJavaData(clazz)
@@ -212,6 +217,7 @@ class InternalJavaFileData(object):
       create_internally = match.group('create_internally')
       if create_internally == 'true':
         self._class_annotations['createInternally'] = True
+        self._need_default_constructor = False
       elif create_internally == 'false':
         self._class_annotations['createInternally'] = False
 
@@ -230,6 +236,7 @@ class InternalJavaFileData(object):
       no_instance = match.group('no_instance')
       if no_instance == 'true':
         self._class_annotations['noInstance'] = True
+        self._need_default_constructor = False
       elif no_instance == 'false':
         self._class_annotations['noInstance'] = False
 
@@ -275,6 +282,7 @@ class InternalJavaFileData(object):
           method_name, None,
           method_params, method_annotation, method_doc)
       self._methods.append(method)
+      self._need_default_constructor = False
 
     method_re = re.compile(
         '(?P<method_doc>(\n\s*/\*\*.*\n(\s+\*(.)*\n)+\s+\*/\s*)?)\n'

--- a/tools/reflection_generator/wrapper_generator.py
+++ b/tools/reflection_generator/wrapper_generator.py
@@ -160,9 +160,25 @@ ${DOC}
     value = {'CLASS_NAME': self._java_data.wrapper_name};
     return constructor_template.substitute(value)
 
+  def GenerateWrapperDefaultConstructor(self):
+    template = Template("""\
+    public ${NAME}() {
+${WRAP_LINES}
+        reflectionInit();
+    }
+
+""")
+    wrap_string = "        constructorTypes = new ArrayList<Object>();\n"
+    wrap_string += "        constructorParams = new ArrayList<Object>();\n"
+    value = {'NAME': self._java_data.wrapper_name,
+             'WRAP_LINES': wrap_string}
+    return template.substitute(value)
+
   def GenerateMethods(self):
     methods_string = ''
     # Generate method definitions.
+    if self._java_data.need_default_constructor:
+      methods_string += self.GenerateWrapperDefaultConstructor()
     for method in self._java_data.methods:
       methods_string += method.GenerateMethodsStringForWrapper()
     return methods_string


### PR DESCRIPTION
This patch is to fix the crash issue when running file transfer tests in
mobilespeck.
The exposed APIs were not initialized when the explicit constructor was
not existed in the internal java file.
Add the default constructor to call init function.

BUG=XWALK-4667