### PR TITLE
[Android] Initialize NetworkChangeNotifier after loadXWalkLibrary

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -29,6 +29,7 @@ import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.base.library_loader.ProcessInitException;
 import org.chromium.content.browser.BrowserStartupController;
 import org.chromium.content.browser.DeviceUtils;
+import org.chromium.net.NetworkChangeNotifier;
 
 @JNINamespace("xwalk")
 class XWalkViewDelegate {
@@ -91,6 +92,14 @@ class XWalkViewDelegate {
         } else {
             init(new MixedContext(bridgeContext, context));
         }
+        initNetworkChangeNotifier(context);
+    }
+
+    private static void initNetworkChangeNotifier(Context context) {
+        // Auto detect network connectivity state.
+        // setAutoDetectConnectivityState() need to be called before activity started.
+        NetworkChangeNotifier.init(context);
+        NetworkChangeNotifier.setAutoDetectConnectivityState(true);
     }
 
     public static void loadXWalkLibrary(Context context) throws UnsatisfiedLinkError {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -41,7 +41,6 @@ import org.chromium.base.ApplicationStatus.ActivityStateListener;
 import org.chromium.base.ApplicationStatusManager;
 import org.chromium.base.CommandLine;
 import org.chromium.content.browser.ContentViewCore;
-import org.chromium.net.NetworkChangeNotifier;
 
 import org.xwalk.core.internal.extension.BuiltinXWalkExtensions;
 
@@ -263,11 +262,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         // Initialize the ActivityStatus. This is needed and used by many internal
         // features such as location provider to listen to activity status.
         ApplicationStatusManager.init(activity.getApplication());
-
-        // Auto detect network connectivity state.
-        // setAutoDetectConnectivityState() need to be called before activity started.
-        NetworkChangeNotifier.init(activity);
-        NetworkChangeNotifier.setAutoDetectConnectivityState(true);
 
         // We will miss activity onCreate() status in ApplicationStatusManager,
         // informActivityStarted() will simulate these callbacks.


### PR DESCRIPTION
Follow the design of chrome for android, initialize NetworkChangeNotifier after loadXWalkLibrary.

BUG=XWALK-4514