### PR TITLE
DEPS.xwalk: Roll chromium-crosswalk (ecadc9->1021d6)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'ecadc9f25c767bb05ed7513d47864b0015772090'
+chromium_crosswalk_rev = '1021d6640d06558bdf664a2ca958cd17511e7b72'
 v8_crosswalk_rev = 'af82ca6ca297677b03c6a9be952633b5b1b28b5a'
 ozone_wayland_rev = '81e4b41be7511971011c7ced9c70131713d7541e'
 


### PR DESCRIPTION
1021d6 [Backport] Rather than dropping stale navigations, resurrect the navigation entry.
f19d78 [Backport] Don't discard navigations.

BUG=XWALK-4378