### PR TITLE
To disable WebAudio solely.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -25,6 +25,9 @@
       'disable_builtin_extensions%': '<(disable_builtin_extensions)',
     },
     'conditions': [
+      ['disable_web_audio==1', {
+        'defines': ['DISABLE_WEB_AUDIO=1'],
+      }],
       ['tizen==1', {
         'defines': ['OS_TIZEN=1'],
       }],

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -220,7 +220,10 @@ if __name__ == '__main__':
   args = list(set(args))
   delist = []
   ip_media_codecs = False # Default: no third-party codecs be build in.
+  web_audio_enabled = False
   for arg in args:
+    if arg == '-Ddisable_web_audio=0':
+      web_audio_enabled = True
     if arg.startswith('-Dproprietary_codecs') or arg.startswith('-Dffmpeg_branding'):
       continue
     elif arg == '-Dmediacodecs_EULA=1':
@@ -338,10 +341,6 @@ if __name__ == '__main__':
 
   args.extend(['-D', 'gyp_output_dir=' + GetOutputDirectory()])
 
-  # Enable Web Audio by default on Android x86
-  if gyp_vars_dict.get('OS') == 'android':
-    args.append('-Duse_openmax_dl_fft=1')
-
   # Enable Aura by default on all platforms except Android and Mac.
   if gyp_vars_dict.get('OS') != 'android' and sys.platform not in ('darwin',):
     args.append('-Duse_aura=1')
@@ -370,7 +369,12 @@ if __name__ == '__main__':
     # Enable Sync compositor by default
     args.append('-Ddisable_sync_compositor=0')
     # Enable webaudio by default
-    args.append('-Ddisable_webaudio_hrtf=0')
+    if web_audio_enabled:
+      args.append('-Ddisable_webaudio_hrtf=0')
+      args.append('-Duse_openmax_dl_fft=1')
+    else:
+      args.append('-Ddisable_webaudio_hrtf=1')
+      args.append('-Duse_openmax_dl_fft=0')
     # Disable use_minimum_resources by default
     args.append('-Duse_minimum_resources=0')
     # Enable buildin extension by default.


### PR DESCRIPTION
Build with "-Ddisable_web_audio" will reduce size by 0.3M.

Details of patch:
(1) The macro 'DISABLE_WEB_AUDIO' will disable the WebAudio related
    code in 'content' folder.
(2) Set the building flag 'use_openmax_dl_fft' to 0 will disable the
    WebAudio related code for Android in blink eventrually, leveraging
    the macro 'ENABLE_WEB_AUDIO'.