### PR TITLE
[Android] Rewrite merge_jars.py.

### DIFF
--- a/build/android/merge_jars.py
+++ b/build/android/merge_jars.py
@@ -5,67 +5,33 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import fnmatch
 import optparse
 import os
 import sys
-import shutil
-import subprocess
 
+GYP_ANDROID_DIR = os.path.join(os.path.dirname(__file__),
+                               os.pardir, os.pardir, os.pardir,
+                               'build',
+                               'android',
+                               'gyp')
+sys.path.append(GYP_ANDROID_DIR)
 
-def GetCommandOutput(command, cwd=None):
-  proc = subprocess.Popen(command, stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT, bufsize=1,
-                          cwd=cwd)
-  output = proc.communicate()[0]
-  result = proc.returncode
-  if result:
-    raise Exception('%s: %s' % (subprocess.list2cmdline(command), output))
-  return output
-
-
-def UnpackJar(jar, classes_dir):
-  jar_cmd = ['jar', 'xvf', os.path.abspath(jar)]
-  GetCommandOutput(jar_cmd, classes_dir)
-
-
-def FindInDirectory(directory, filename_filter):
-  files = []
-  for root, _dirnames, filenames in os.walk(directory):
-    matched_files = fnmatch.filter(filenames, filename_filter)
-    files.extend((os.path.join(root, f) for f in matched_files))
-  return files
-
-
-def DoJar(classes_dir, jar_path):
-  class_files = FindInDirectory(classes_dir, '*.class')
-
-  jar_path = os.path.abspath(jar_path)
-
-  class_files_rel = [os.path.relpath(f, classes_dir) for f in class_files]
-  jar_cmd = ['jar', 'cf0', jar_path] + class_files_rel
-
-  GetCommandOutput(jar_cmd, classes_dir)
+import jar
+from util import build_utils
 
 
 def main():
   parser = optparse.OptionParser()
-  info = ('The folder to place unzipped classes')
-  parser.add_option('--classes-dir', help=info)
-  info = ('The jars to merge')
-  parser.add_option('--jars', help=info)
-  info = ('The output merged jar file')
-  parser.add_option('--jar-path', help=info)
+  parser.add_option('--jars', help='The jars to merge.')
+  parser.add_option('--jar-path', help='The output merged jar file.')
+
   options, _ = parser.parse_args()
 
-  if os.path.isdir(options.classes_dir):
-    shutil.rmtree(options.classes_dir)
-  os.makedirs(options.classes_dir)
+  with build_utils.TempDir() as temp_dir:
+    for jar_file in build_utils.ParseGypList(options.jars):
+      build_utils.ExtractAll(jar_file, path=temp_dir, pattern='*.class')
+    jar.JarDirectory(temp_dir, [], options.jar_path)
 
-  for jar in options.jars.split(' '):
-    UnpackJar(eval(jar), options.classes_dir)
-
-  DoJar(options.classes_dir, options.jar_path)
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -200,7 +200,6 @@
         'xwalk_core_java',
       ],
       'variables': {
-        'classes_dir': '<(PRODUCT_DIR)/<(_target_name)/classes',
         'jar_name': '<(_target_name).jar',
         'jar_final_path': '<(PRODUCT_DIR)/lib.java/<(jar_name)',
       },
@@ -217,7 +216,6 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--classes-dir=<(classes_dir)',
             '--jars=>(input_jars_paths)',
             '--jar-path=<(jar_final_path)',
           ],
@@ -231,7 +229,6 @@
         'xwalk_core_internal_empty_embedder_apk',
       ],
       'variables': {
-        'classes_dir': '<(PRODUCT_DIR)/<(_target_name)/classes',
         'jar_name': '<(_target_name).jar',
         'jar_final_path': '<(PRODUCT_DIR)/lib.java/<(jar_name)',
       },
@@ -248,7 +245,6 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--classes-dir=<(classes_dir)',
             '--jars=>(input_jars_paths)',
             '--jar-path=<(jar_final_path)',
           ],
@@ -263,7 +259,6 @@
         'xwalk_core_library_java_library_part',
       ],
       'variables': {
-        'classes_dir': '<(PRODUCT_DIR)/<(_target_name)/classes',
         'jar_name': '<(_target_name).jar',
         'jar_final_path': '<(PRODUCT_DIR)/lib.java/<(jar_name)',
       },
@@ -280,7 +275,6 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--classes-dir=<(classes_dir)',
             '--jars=>(input_jars_paths)',
             '--jar-path=<(jar_final_path)',
           ],


### PR DESCRIPTION
Almost all the code that was present in the script is also available in
Chromium itself, so it makes no sense to have the uptenth
reimplementation of GetCommandOutput() or calls to jar(1).

Additionally, the handling of the --jars option was broken: it always
assumed that each path would be properly escaped by gyp and could be
eval()ed directly into Python. Not only does calling eval() in this
context make zero sense, but it also fails with targets such as
`android_support_v13_javalib`, which is passed as an absolute path
without escaped shell quotes. This is a problem starting with M45, as
that target is depended upon by `content_java`.

The --classes-dir option is also useless: instead of creating and
cleaning directories inside the build directory, just use a different
temporary directory each time.

The only difference in the generated jar files is the presence of a
temporary directory with an `.empty` file there that comes from the code
in src/build/android/gyp/jar.py. It should not cause any trouble.