### PR TITLE
[Android] Fixed building error

### DIFF
--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -311,7 +311,7 @@
       'target_name': 'xwalk_shared_library',
       'type': 'none',
       'dependencies': [
-        'xwalk_core_library_java_app_part',
+        'xwalk_core_library_java',
       ],
       'actions': [
         {


### PR DESCRIPTION
Build entire java libraries before generate xwalk_shared_library

BUG=XWALK-4746