### PR TITLE
[Android] Fixed building error

### DIFF
--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -311,7 +311,7 @@
       'target_name': 'xwalk_shared_library',
       'type': 'none',
       'dependencies': [
-        'xwalk_core_library_java_app_part',
+        'xwalk_core_library_java',
       ],
       'actions': [
         {


### PR DESCRIPTION
Build entire java libraries before generate xwalk_shared_library

BUG=XWALK-4746

(cherry picked from commit f8a31199a3ba1af8dfb72f0a08fe8a9f9a4a00de that
 was mistakenly committed directly to the crosswalk-14 branch)