### PR TITLE
Spell "destroy" correctly in several places in the code base.

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/JsStubGenerator.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/JsStubGenerator.java
@@ -141,15 +141,15 @@ public class JsStubGenerator {
         return (new String[] {result, staticResult}); 
     }
 
-    String destoryBindingObject(ReflectionHelper targetReflect) {
-        String result = "exports.destory = function() {\n";
+    String destroyBindingObject(ReflectionHelper targetReflect) {
+        String result = "exports.destroy = function() {\n";
         Map<String, MemberInfo> members = targetReflect.getMembers();
         for (String key : members.keySet()) {
             result += "delete exports[\"" + key + "\"];\n";
         }
-        result += "helper.destory();\n";
+        result += "helper.destroy();\n";
         result += "delete exports[\"__stubHelper\"];\n";
-        result += "delete exports[\"destory\"];\n";
+        result += "delete exports[\"destroy\"];\n";
         result += "};";
         return result; 
     }
@@ -247,7 +247,7 @@ public class JsStubGenerator {
 
         String protoStr = String.format(
                 "function %s(exports, helper){\n" + "%s\n" + "%s\n" + "}\n",
-                protoFunc, classStr[0], destoryBindingObject(targetReflect));
+                protoFunc, classStr[0], destroyBindingObject(targetReflect));
 
         String self = String.format(
                 "function %s(%s) {\n" +

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkCoreExtensionBridge.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkCoreExtensionBridge.java
@@ -37,8 +37,8 @@ class XWalkCoreExtensionBridge extends XWalkExtension implements XWalkRuntimeExt
     }
 
     @Override
-    public void onInstanceDestoryed(int instanceID) {
-        mExtension.onInstanceDestoryed(instanceID);
+    public void onInstanceDestroyed(int instanceID) {
+        mExtension.onInstanceDestroyed(instanceID);
     }
 
     public void onDestroy() {

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionBindingObject.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionBindingObject.java
@@ -25,9 +25,9 @@ public class XWalkExtensionBindingObject {
     }
 
     /*
-     * Called when this binding object is destoryed by JS.
+     * Called when this binding object is destroyed by JS.
      */
-    public void onJsDestoryed() {}
+    public void onJsDestroyed() {}
 
     /*
      * Called when this object is binded with JS.

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionBindingObjectStore.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionBindingObjectStore.java
@@ -39,7 +39,7 @@ public class XWalkExtensionBindingObjectStore {
 
     public XWalkExtensionBindingObject removeBindingObject(int objectId) {
        XWalkExtensionBindingObject obj = bindingObjects.remove(objectId);
-       if (obj != null) obj.onJsDestoryed();
+       if (obj != null) obj.onJsDestroyed();
 
        return obj;
     }

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkExtensionClient.java
@@ -155,9 +155,9 @@ public class XWalkExtensionClient {
     }
 
     /**
-     * Called when a extension instance is destoryed.
+     * Called when a extension instance is destroyed.
      */
-    public void onInstanceDestoryed(int instanceID) {
+    public void onInstanceDestroyed(int instanceID) {
         instanceStores.remove(instanceID);
     }
 

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkRuntimeExtensionBridge.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkRuntimeExtensionBridge.java
@@ -41,11 +41,11 @@ interface XWalkRuntimeExtensionBridge {
     public void onInstanceCreated(int instanceId);
 
     /**
-     * Called when a extension instance is destoryed.
+     * Called when a extension instance is destroyed.
      *
      * @param instanceId The extension instance id.
      */
-    public void onInstanceDestoryed(int instanceId);
+    public void onInstanceDestroyed(int instanceId);
 
     /**
      * Handle the message from JavaScript side to native side.

--- a/app/tools/android/test_data/entry/constructor-jsStub.html
+++ b/app/tools/android/test_data/entry/constructor-jsStub.html
@@ -42,7 +42,7 @@
 
         console.log("---------------------Testcase 5-------------------");
         console.log("Delete p2");
-        p2.destory();
+        p2.destroy();
         delete p2;
         setTimeout(function(){
             console.log("Person number:" + jsStub.person.getPersonNumber());

--- a/app/tools/android/test_data/extensions/constructorJsStubGen/src/com/example/jsStub/Person.java
+++ b/app/tools/android/test_data/extensions/constructorJsStubGen/src/com/example/jsStub/Person.java
@@ -17,7 +17,7 @@ class Person extends XWalkExtensionBindingObject {
     int personId;
     int age;
 
-    public void onJsDestoryed() {
+    public void onJsDestroyed() {
         ((PersonExtension)extensionClient).onRemoveBindingObject(this);
     }
     

--- a/extensions/android/java/src/org/xwalk/core/internal/extensions/XWalkExtensionAndroid.java
+++ b/extensions/android/java/src/org/xwalk/core/internal/extensions/XWalkExtensionAndroid.java
@@ -60,7 +60,7 @@ public abstract class XWalkExtensionAndroid {
     public void onInstanceCreated(int instanceID) {}
 
     @CalledByNative
-    public void onInstanceDestoryed(int instanceID) {}
+    public void onInstanceDestroyed(int instanceID) {}
 
     @CalledByNative
     public abstract void onMessage(int instanceID, String message);

--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -152,10 +152,10 @@ XWalkExtensionAndroidInstance::~XWalkExtensionAndroidInstance() {
   JNIEnv* env = base::android::AttachCurrentThread();
   ScopedJavaLocalRef<jobject> obj = java_ref_.get(env);
   if (obj.is_null()) {
-    LOG(ERROR) << "No valid Java object to notice instance destoryed.";
+    LOG(ERROR) << "No valid Java object to notice instance destroyed.";
     return;
   }
-  Java_XWalkExtensionAndroid_onInstanceDestoryed(
+  Java_XWalkExtensionAndroid_onInstanceDestroyed(
       env, obj.obj(), id_);
 }
 

--- a/extensions/renderer/xwalk_js_stub_wrapper.js
+++ b/extensions/renderer/xwalk_js_stub_wrapper.js
@@ -177,7 +177,7 @@ jsStub.create = function(base) {
 jsStub.getHelper = function(base, rootStub) {
   if (!(base.__stubHelper instanceof jsStub)) {
     Object.defineProperty(base, "__stubHelper", {
-      // TODO: set to false if find good way to do clear destory.
+      // TODO: set to false if find good way to do clear destroy.
       "configurable": true,
       "enumerable": false,
       "value":new jsStub(base, rootStub) 
@@ -261,7 +261,7 @@ jsStub.prototype = {
       channel.postMessage(msg);
     };
   },
-  "destory": function() {
+  "destroy": function() {
     var objId = this.objectId;
     var msg = {
       cmd: "jsObjectCollected",
@@ -281,7 +281,7 @@ jsStub.prototype = {
     delete this.getNativeProperty;
     delete this.setNativeProperty;
     delete this.invokeCallback;;
-    delete this.destory;
+    delete this.destroy;
   },
   "getNativeProperty": function(name) {
     return this.sendSyncMessage({
@@ -337,7 +337,7 @@ jsStub.defineProperty = function(obj, prop, writable) {
   helper.properties[prop] = helper.getNativeProperty(prop);
 
   var desc = {
-    // TODO: set to false if find good way to do clear destory.
+    // TODO: set to false if find good way to do clear destroy.
     'configurable': true,
     'enumerable': true,
     'get': function() {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkExtensionInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkExtensionInternal.java
@@ -73,12 +73,12 @@ public abstract class XWalkExtensionInternal extends XWalkExtensionAndroid {
     public void onInstanceCreated(int instanceID) {}
 
     /**
-     * Notify the extension that an instance is destoryed.
+     * Notify the extension that an instance is destroyed.
      * @param instanceID the id of instance.
      * @since 15.45
      */
     @XWalkAPI
-    public void onInstanceDestoryed(int instanceID) {}
+    public void onInstanceDestroyed(int instanceID) {}
 
     /**
      * Notify the extension that the async message is received.


### PR DESCRIPTION
"Destroy" was being spelled "destory" in a lot of places, from comments
to variables to method names.