### PR TITLE
Remove use of MessageLoopProxy and deprecated MessageLoop APIs.

### DIFF
--- a/extensions/browser/xwalk_extension_function_handler.h
+++ b/extensions/browser/xwalk_extension_function_handler.h
@@ -9,7 +9,7 @@
 #include <string>
 #include "base/bind.h"
 #include "base/memory/weak_ptr.h"
-#include "base/message_loop/message_loop_proxy.h"
+#include "base/message_loop/message_loop.h"
 #include "base/values.h"
 
 namespace xwalk {
@@ -105,7 +105,7 @@ class XWalkExtensionFunctionHandler {
  private:
   static void DispatchResult(
       const base::WeakPtr<XWalkExtensionFunctionHandler>& handler,
-      scoped_refptr<base::MessageLoopProxy> client_task_runner,
+      scoped_refptr<base::SingleThreadTaskRunner> client_task_runner,
       const std::string& callback_id,
       scoped_ptr<base::ListValue> result);
 

--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -358,7 +358,7 @@ void XWalkExtensionService::CreateInProcessExtensionServers(
   }
 
   ExtensionServerMessageFilter* message_filter =
-      new ExtensionServerMessageFilter(extension_thread_.message_loop_proxy(),
+      new ExtensionServerMessageFilter(extension_thread_.task_runner(),
                                        extension_thread_server.get(),
                                        ui_thread_server.get());
 

--- a/extensions/extension_process/xwalk_extension_process.cc
+++ b/extensions/extension_process/xwalk_extension_process.cc
@@ -86,11 +86,11 @@ void XWalkExtensionProcess::CreateBrowserProcessChannel(
             switches::kProcessChannelID);
     browser_process_channel_ = IPC::SyncChannel::Create(
         channel_id, IPC::Channel::MODE_CLIENT, this,
-        io_thread_.message_loop_proxy(), true, &shutdown_event_);
+        io_thread_.task_runner(), true, &shutdown_event_);
   } else {
     browser_process_channel_ = IPC::SyncChannel::Create(
         channel_handle, IPC::Channel::MODE_CLIENT, this,
-        io_thread_.message_loop_proxy(), true, &shutdown_event_);
+        io_thread_.task_runner(), true, &shutdown_event_);
   }
 }
 
@@ -101,7 +101,7 @@ void XWalkExtensionProcess::CreateRenderProcessChannel() {
 
   render_process_channel_ = IPC::SyncChannel::Create(rp_channel_handle_,
       IPC::Channel::MODE_SERVER, &extensions_server_,
-      io_thread_.message_loop_proxy(), true, &shutdown_event_);
+      io_thread_.task_runner(), true, &shutdown_event_);
 
 #if defined(OS_POSIX)
     // On POSIX, pass the server-side file descriptor. We use

--- a/runtime/browser/android/cookie_manager.cc
+++ b/runtime/browser/android/cookie_manager.cc
@@ -13,7 +13,6 @@
 #include "base/bind_helpers.h"
 #include "base/lazy_instance.h"
 #include "base/message_loop/message_loop.h"
-#include "base/message_loop/message_loop_proxy.h"
 #include "base/synchronization/waitable_event.h"
 #include "base/threading/thread_restrictions.h"
 #include "content/public/browser/browser_context.h"

--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -97,7 +97,7 @@ RuntimeURLRequestContextGetter::RuntimeURLRequestContextGetter(
   // the URLRequestContextStorage on the IO thread in GetURLRequestContext().
   proxy_config_service_.reset(
       net::ProxyService::CreateSystemProxyConfigService(
-          io_loop_->message_loop_proxy(), file_loop_->message_loop_proxy()));
+          io_loop_->task_runner(), file_loop_->task_runner()));
 }
 
 RuntimeURLRequestContextGetter::~RuntimeURLRequestContextGetter() {

--- a/tizen/mobile/sensor/tizen_platform_sensor.cc
+++ b/tizen/mobile/sensor/tizen_platform_sensor.cc
@@ -63,7 +63,7 @@ TizenPlatformSensor::~TizenPlatformSensor() {
 bool TizenPlatformSensor::Initialize() {
   // Initialize sensor provider could be time costing. Therefore, we'd better
   // not run it inside browser UI thread.
-  sensor_thread_->message_loop_proxy()->PostTask(
+  sensor_thread_->task_runner()->PostTask(
       FROM_HERE,
       base::Bind(&TizenPlatformSensor::ConnectSensor,
                  base::Unretained(this)));


### PR DESCRIPTION
Chromium is deprecating MessageLoopProxy and moving towards the TaskRunner API instead. [Bug 465354](http://crbug.com/465354) contains more information.

Since we can already do this in M44, do it separately from moving to M45 so that the size of the M45 patch is smaller. Thanks to Olli Raula and Mrunal Kapade for doing the majority of the work.

Most of the changes are mechanic:
* `base::MessageLoopProxy::current()` becomes `base::ThreadTaskRunnerHandle::Get()`.
* `scoped_refptr<base::MessageLoopProxy>` becomes `scoped_refptr<base::SingleThreadTaskRunner>`.
* `base::Thread::message_loop_proxy()` becomes `base::Thread::task_runner()`.

The only noteworthy change is in `XWalkExtensionFunctionHandler`, caused by the fact that `ThreadTaskRunnerHandle::Get()` enforces an assertion that was commented out in `MessageLoopProxy`. This assertion makes sure the call is being performed in a thread with a valid task runner.

That is not the case for XWalkExtensionFunctionHandlerTest's `PostingResultAfterDeletingTheHandler`. Its call to `XWEFH::HandleMessage()` is done without a runner, so we need to check before calling `ThreadTaskRunnerHandle::Get()`. This is similar to Chromium commits afd978c6 ("gpu: Fix webview parent compositor crash in context loss") and 0ad2c54d ("gpu: Remove use of MessageLoopProxy and deprecated MessageLoop APIs").