### PR TITLE
[Tizen] Remove support for pausing and resuming the JS engine.

### DIFF
--- a/application/browser/application_system_tizen.cc
+++ b/application/browser/application_system_tizen.cc
@@ -79,20 +79,14 @@ void application_event_cb(app_event event, void* data, bundle* b) {
   switch (event) {
     case AE_UNKNOWN:
     case AE_CREATE:
+    case AE_PAUSE:
+    case AE_RESUME:
       break;
     case AE_TERMINATE:
       if (handler_data->current_app) {
         handler_data->current_app->Terminate();
         delete handler_data;
       }
-      break;
-    case AE_PAUSE:
-      if (handler_data->current_app)
-        handler_data->current_app->Suspend();
-      break;
-    case AE_RESUME:
-      if (handler_data->current_app)
-        handler_data->current_app->Resume();
       break;
     case AE_RESET: {
       const std::string& app_id = handler_data->app_id;

--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -146,11 +146,11 @@ class ScreenOrientationDelegateTizen :
 ApplicationTizen::ApplicationTizen(
     scoped_refptr<ApplicationData> data,
     XWalkBrowserContext* browser_context)
-    : Application(data, browser_context),
+    : Application(data, browser_context)
 #if defined(OS_TIZEN_MOBILE)
-      root_window_(NULL),
+      , root_window_(NULL)
 #endif
-      is_suspended_(false) {
+      {
   ui::PlatformEventSource::GetInstance()->AddPlatformEventObserver(this);
   cookie_manager_ = scoped_ptr<CookieManager>(
       new CookieManager(id(), browser_context_));
@@ -261,44 +261,6 @@ base::FilePath ApplicationTizen::GetSplashScreenPath() {
     return data()->path().Append(FILE_PATH_LITERAL(ss_info->src()));
   }
   return base::FilePath();
-}
-
-bool ApplicationTizen::CanBeSuspended() const {
-  if (TizenSettingInfo* setting = static_cast<TizenSettingInfo*>(
-          data()->GetManifestData(widget_keys::kTizenSettingKey))) {
-    return !setting->background_support_enabled();
-  }
-  return true;
-}
-
-void ApplicationTizen::Suspend() {
-  if (is_suspended_ || !CanBeSuspended())
-    return;
-
-  DCHECK(render_process_host_);
-  render_process_host_->Send(new ViewMsg_SuspendJSEngine(true));
-
-  DCHECK(!runtimes_.empty());
-  for (auto it = runtimes_.begin(); it != runtimes_.end(); ++it) {
-    if ((*it)->web_contents())
-      (*it)->web_contents()->WasHidden();
-  }
-  is_suspended_ = true;
-}
-
-void ApplicationTizen::Resume() {
-  if (!is_suspended_ || !CanBeSuspended())
-    return;
-
-  DCHECK(render_process_host_);
-  render_process_host_->Send(new ViewMsg_SuspendJSEngine(false));
-
-  DCHECK(!runtimes_.empty());
-  for (auto it = runtimes_.begin(); it != runtimes_.end(); ++it) {
-    if ((*it)->web_contents())
-      (*it)->web_contents()->WasShown();
-  }
-  is_suspended_ = false;
 }
 
 void ApplicationTizen::WillProcessEvent(const ui::PlatformEvent& event) {}

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -25,8 +25,6 @@ class ApplicationTizen :  // NOLINT
   ~ApplicationTizen() override;
   void Hide();
   void Show();
-  void Suspend();
-  void Resume();
 
   void RemoveAllCookies();
   void SetUserAgentString(const std::string& user_agent_string);
@@ -50,13 +48,11 @@ class ApplicationTizen :  // NOLINT
 
   void WillProcessEvent(const ui::PlatformEvent& event) override;
   void DidProcessEvent(const ui::PlatformEvent& event) override;
-  bool CanBeSuspended() const;
 
 #if defined(OS_TIZEN_MOBILE)
   NativeAppWindow* root_window_;
 #endif
   scoped_ptr<CookieManager> cookie_manager_;
-  bool is_suspended_;
 };
 
 inline ApplicationTizen* ToApplicationTizen(Application* app) {

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -126,7 +126,6 @@ const char kAllowNavigationKey[] = "widget.allow-navigation.#text";
 const char kCSPReportOnlyKey[] =
     "widget.content-security-policy-report-only.#text";
 const char kTizenSettingKey[] = "widget.setting";
-const char kTizenBackgroundSupportKey[] = "widget.setting.@background-support";
 const char kTizenContextMenuKey[] = "widget.setting.@context-menu";
 const char kTizenHardwareKey[] = "widget.setting.@hwkey-event";
 const char kTizenEncryptionKey[] = "widget.setting.@encryption";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -107,7 +107,6 @@ namespace application_widget_keys {
   extern const char kAllowNavigationKey[];
   extern const char kCSPReportOnlyKey[];
   extern const char kTizenSettingKey[];
-  extern const char kTizenBackgroundSupportKey[];
   extern const char kTizenContextMenuKey[];
   extern const char kTizenHardwareKey[];
   extern const char kTizenEncryptionKey[];

--- a/application/common/manifest_handlers/tizen_setting_handler.cc
+++ b/application/common/manifest_handlers/tizen_setting_handler.cc
@@ -19,8 +19,7 @@ namespace application {
 
 TizenSettingInfo::TizenSettingInfo()
     : hwkey_enabled_(true),
-      screen_orientation_(PORTRAIT),
-      background_support_enabled_(false) {}
+      screen_orientation_(PORTRAIT) {}
 
 TizenSettingInfo::~TizenSettingInfo() {}
 
@@ -53,10 +52,6 @@ bool TizenSettingHandler::Parse(scoped_refptr<ApplicationData> application,
   std::string context_menu;
   manifest->GetString(keys::kTizenContextMenuKey, &context_menu);
   app_info->set_context_menu_enabled(context_menu != "disable");
-
-  std::string background_support;
-  manifest->GetString(keys::kTizenBackgroundSupportKey, &background_support);
-  app_info->set_background_support_enabled(background_support == "enable");
 
   application->SetManifestData(keys::kTizenSettingKey,
                                app_info.release());
@@ -102,15 +97,6 @@ bool TizenSettingHandler::Validate(
     *error = std::string("The context-menu value must be 'enable'/'disable', "
                          "or not specified in configuration file.");
     return false;
-  }
-  std::string background_support;
-  manifest->GetString(keys::kTizenBackgroundSupportKey, &background_support);
-  if (!background_support.empty() &&
-      background_support != "enable" &&
-      background_support != "disable") {
-    *error = std::string("The background-support value must be"
-                         "'enable'/'disable', or not specified in configuration"
-                         "file.");
   }
   return true;
 }

--- a/application/common/manifest_handlers/tizen_setting_handler.h
+++ b/application/common/manifest_handlers/tizen_setting_handler.h
@@ -43,19 +43,11 @@ class TizenSettingInfo : public ApplicationData::ManifestData {
   }
   bool context_menu_enabled() const { return context_menu_enabled_; }
 
-  void set_background_support_enabled(bool enabled) {
-    background_support_enabled_ = enabled;
-  }
-  bool background_support_enabled() const {
-    return background_support_enabled_;
-  }
-
  private:
   bool hwkey_enabled_;
   ScreenOrientation screen_orientation_;
   bool encryption_enabled_;
   bool context_menu_enabled_;
-  bool background_support_enabled_;
 };
 
 class TizenSettingHandler : public ManifestHandler {

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -42,9 +42,6 @@ IPC_MESSAGE_CONTROL2(ViewMsg_EnableSecurityMode,    // NOLINT
                      xwalk::application::ApplicationSecurityPolicy::SecurityMode
                      /* security mode */)
 
-IPC_MESSAGE_CONTROL1(ViewMsg_SuspendJSEngine,  // NOLINT
-                     bool /* is suspend */)
-
 #if defined(OS_TIZEN)
 IPC_MESSAGE_CONTROL1(ViewMsg_UserAgentStringChanged,  // NOLINT
                      std::string /*new user agent string*/)

--- a/runtime/renderer/xwalk_render_process_observer_generic.cc
+++ b/runtime/renderer/xwalk_render_process_observer_generic.cc
@@ -5,8 +5,7 @@
 
 #include "xwalk/runtime/renderer/xwalk_render_process_observer_generic.h"
 
-#include "content/renderer/render_thread_impl.h"
-#include "content/renderer/renderer_blink_platform_impl.h"
+#include "content/public/renderer/render_thread.h"
 #include "ipc/ipc_message_macros.h"
 #include "third_party/WebKit/public/web/WebSecurityOrigin.h"
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
@@ -44,7 +43,6 @@ void XWalkRenderProcessObserver::AddAccessWhiteListEntry(
 
 XWalkRenderProcessObserver::XWalkRenderProcessObserver()
     : is_blink_initialized_(false),
-      is_suspended_(false),
       security_mode_(application::ApplicationSecurityPolicy::NoSecurity) {
 }
 
@@ -57,7 +55,6 @@ bool XWalkRenderProcessObserver::OnControlMessageReceived(
   IPC_BEGIN_MESSAGE_MAP(XWalkRenderProcessObserver, message)
     IPC_MESSAGE_HANDLER(ViewMsg_SetAccessWhiteList, OnSetAccessWhiteList)
     IPC_MESSAGE_HANDLER(ViewMsg_EnableSecurityMode, OnEnableSecurityMode)
-    IPC_MESSAGE_HANDLER(ViewMsg_SuspendJSEngine, OnSuspendJSEngine)
 #if defined(OS_TIZEN)
     IPC_MESSAGE_HANDLER(ViewMsg_UserAgentStringChanged, OnUserAgentChanged)
 #endif
@@ -93,18 +90,6 @@ void XWalkRenderProcessObserver::OnEnableSecurityMode(
     application::ApplicationSecurityPolicy::SecurityMode mode) {
   app_url_ = url;
   security_mode_ = mode;
-}
-
-void XWalkRenderProcessObserver::OnSuspendJSEngine(bool is_suspend) {
-  if (is_suspend == is_suspended_)
-    return;
-  content::RenderThreadImpl* thread = content::RenderThreadImpl::current();
-  thread->EnsureWebKitInitialized();
-  if (is_suspend)
-    thread->blink_platform_impl()->SuspendSharedTimer();
-  else
-    thread->blink_platform_impl()->ResumeSharedTimer();
-  is_suspended_ = is_suspend;
 }
 
 #if defined(OS_TIZEN)

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -56,7 +56,6 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
   void OnEnableSecurityMode(
       const GURL& url,
       application::ApplicationSecurityPolicy::SecurityMode mode);
-  void OnSuspendJSEngine(bool is_pause);
 #if defined(OS_TIZEN)
   void OnUserAgentChanged(const std::string& userAgentString);
   std::string overriden_user_agent_;
@@ -66,7 +65,6 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
                                bool allow_subdomains);
 
   bool is_blink_initialized_;
-  bool is_suspended_;
   application::ApplicationSecurityPolicy::SecurityMode security_mode_;
   GURL app_url_;
   ScopedVector<AccessWhitelistItem> access_whitelist_;


### PR DESCRIPTION
This (manually) reverts the following commits:
* 94d0859a0920b991d4294e8ab8969e61bc734888 ([Tizen][Runtime] Enable pause/resume web application JS engine)
* 3bf14f044e46f9ebe772b004a34c33eb75c201f9 ([Tizen] Enable background-support attribute in settings element)
* 01be04ccda9da53680a8e723278aa6eb5d068e41 ([Tizen] Use appcore RESET event as application starting point)

All the code relied upon suspending Blink's shared timer, which has been
removed in M45 -- see upstream bug 463143 for all related commits and
rationale.

Prepare for M45 by removing the code separately so that the change is
more visible and easier to revert in the future should we ever implement
support for it differently.

BUG=XWALK-1148
BUG=XWALK-1497
BUG=XWALK-1498
BUG=XWALK-2779