### PR TITLE
To disable Web Speech

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -28,9 +28,15 @@
       ['disable_web_audio==1', {
         'defines': ['DISABLE_WEB_AUDIO=1'],
       }],
+
       ['disable_web_video==1', {
         'defines': ['DISABLE_WEB_VIDEO=1'],
       }],
+
+      ['disable_speech==1', {
+        'defines': ['DISABLE_SPEECH'],
+      }],
+
       ['tizen==1', {
         'defines': ['OS_TIZEN=1'],
       }],

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -44,6 +44,9 @@ sys.path.insert(1, os.path.join(chrome_src, 'third_party', 'liblouis'))
 sys.path.insert(1, os.path.join(chrome_src, 'third_party', 'WebKit',
     'Source', 'build', 'scripts'))
 
+sys.path.insert(1, os.path.join(chrome_src, 'third_party', 'WebKit',
+    'Source', 'modules'))
+
 # On Windows, Psyco shortens warm runs of build/gyp_chromium by about
 # 20 seconds on a z600 machine with 12 GB of RAM, from 90 down to 70
 # seconds.  Conversely, memory usage of build/gyp_chromium with Psyco
@@ -379,12 +382,23 @@ if __name__ == '__main__':
     args.append('-Duse_minimum_resources=0')
     # Enable buildin extension by default.
     args.append('-Ddisable_builtin_extensions=0')
-    # Disable Web Video by default.
+    # Enable Web Video by default.
     args.append('-Ddisable_web_video=0')
+    # Enable webspeech by default
+    args.append('-Ddisable_speech=0')
 
   if not use_analyzer:
     print 'Updating projects from gyp files...'
     sys.stdout.flush()
+
+  disable_speech = 0
+  for arg in args:
+    if arg == '-Ddisable_speech=1':
+      disable_speech = 1
+
+  # Synthesize the 'third_party/WebKit/Source/modules/modules.gypi'
+  from modules_gypi_generator import  generate_modules_gypi
+  generate_modules_gypi(disable_speech)
 
   # Off we go...
   gyp_rc = gyp.main(args)

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -338,10 +338,12 @@ void XWalkContentBrowserClient::ResourceDispatcherHostCreated() {
 }
 #endif
 
+#ifndef DISABLE_SPEECH
 content::SpeechRecognitionManagerDelegate*
     XWalkContentBrowserClient::CreateSpeechRecognitionManagerDelegate() {
   return new xwalk::XWalkSpeechRecognitionManagerDelegate();
 }
+#endif
 
 #if !defined(OS_ANDROID)
 bool XWalkContentBrowserClient::CanCreateWindow(const GURL& opener_url,

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -91,8 +91,10 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
       const base::Callback<void(bool)>& callback, // NOLINT
       content::CertificateRequestResultType* result) override;
 
+#ifndef DISABLE_SPEECH
   content::SpeechRecognitionManagerDelegate*
       CreateSpeechRecognitionManagerDelegate() override;
+#endif
 
   content::PlatformNotificationService* GetPlatformNotificationService()
       override;

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -327,8 +327,16 @@
             'runtime/browser/devtools/remote_debugging_server.h',
             'runtime/browser/devtools/xwalk_devtools_delegate.cc',
             'runtime/browser/devtools/xwalk_devtools_delegate.h',
+          ]
+         }],
+
+        ['disable_speech==1', {
+          'sources!': [
+            'runtime/browser/speech/speech_recognition_manager_delegate.cc',
+            'runtime/browser/speech/speech_recognition_manager_delegate.h',
           ],
         }],
+
         ['tizen==1', {
           'dependencies': [
             '../content/app/resources/content_resources.gyp:content_resources',


### PR DESCRIPTION
To disable Web Speech

With build flag "-Ddisable_speech=1" binary size is reduced by 0.11M.

Due to syntax limitation of gyp, import 'modules_gypi_generator.py'
to synthesize the 'third_party/WebKit/Source/modules/modules.gypi'
directly to exclude the disabled '*.idl' files.
