### PR TITLE
Presentation API Reimplementation

### DIFF
--- a/experimental/presentation/presentation_api.js
+++ b/experimental/presentation/presentation_api.js
@@ -6,47 +6,81 @@
 
 var v8toolsNative = requireNative("v8tools");
 
-var DISPLAY_AVAILABLE_CHANGE_EVENT = "displayavailablechange";
+var CHANGE_EVENT = 'change';
+var DEFAULT_SESSION_START_EVENT = 'defaultsessionstart';
 var _listeners = {};
 var _displayAvailable = false;
 var _nextRequestId = 0;
-var _showRequests = {};
+var _sessionRequests = {};
 
 function DOMError(msg) {
   this.name = msg;
 }
 
-function ShowRequest(id, successCallback, errorCallback) {
+function SessionRequest(id, successCallback, errorCallback) {
   this._requestId = id;
   this._successCallback = successCallback;
   this._errorCallback = errorCallback;
 }
 
-/* TODO(hmin): Add Promise support instead of callback approach. */
-function requestShowPresentation(url, successCallback, errorCallback) {
-  if (typeof url !== "string" || typeof successCallback !== "function") {
-    console.error("Invalid parameter for presentation.requestShow!");
-    return;
+function Session(presentationId) {
+  this.id = presentationId;
+
+  this.__defineGetter__('state', function() {
+    return _displayAvailable;
+  });
+  this.__defineSetter__('onmessage', function(callback) {
+    if (callback) {
+      addEventListener("messagetohost", callback);
+    } else {
+      removeEventListener("messagetohost", this.onmessage);
+    }
+  });
+  this.send = function(data) {
+    var message = { "cmd": "SendMessageToRemoteDisplay", "id": this.id, "data": data };
+    extension.postMessage(JSON.stringify(message));
   }
-
-  // errorCallback is optional.
-  if (errorCallback && typeof errorCallback != "function") {
-    console.error("Invalid parameter for presentation.requestShow!");
-    return;
-  }
-
-  var requestId = ++_nextRequestId;
-  var request = new ShowRequest(requestId, successCallback, errorCallback);
-  _showRequests[requestId] = request;
-  // Requested url should be absolute.
-  // If the requested url is relative, we need to combine it with baseUrl to make it absolute.
-  var baseUrl = location.href.substring(0, location.href.lastIndexOf("/")+1);
-
-  var message = { "cmd": "RequestShow", "requestId": requestId, "url": url, "baseUrl": baseUrl };
-  extension.postMessage(JSON.stringify(message));
 }
 
-function addEventListener(name, callback, useCapture /* ignored */) {
+exports.PresentationSession = function(presentationId) {
+  this.id = presentationId;
+
+  this.__defineGetter__('state', function() {
+    return _displayAvailable;
+  });
+  this.__defineSetter__('onmessage', function(callback) {
+    if (callback) {
+      addEventListener("messagetoremote", callback);
+    } else {
+      removeEventListener("messagetoremote", this.onmessage);
+    }
+  });
+  this.send = function(data) {
+    var message = { "cmd": "SendMessageToHostDisplay", "id": this.id, "data": data };
+    extension.postMessage(JSON.stringify(message));
+  }
+}
+
+function Availability() {
+  this.value = false;
+  this.__defineSetter__("on" + CHANGE_EVENT, function(callback) {
+    if (callback) {
+      addEventListener(CHANGE_EVENT, callback);
+    } else {
+      removeEventListener(CHANGE_EVENT, this.onchange);
+    }
+  });
+}
+
+exports.__defineSetter__("on" + DEFAULT_SESSION_START_EVENT, function(callback) {
+    if (callback) {
+      addEventListener(DEFAULT_SESSION_START_EVENT, callback);
+    } else {
+      removeEventListener(DEFAULT_SESSION_START_EVENT, this.ondefaultsessionstart);
+    }
+});
+
+exports.addEventListener = function(name, callback, useCapture /* ignored */) {
   if (typeof name !== "string" || typeof callback !== "function") {
     console.error("Invalid parameter for presentation.addEventListener!");
     return;
@@ -57,7 +91,7 @@ function addEventListener(name, callback, useCapture /* ignored */) {
   _listeners[name].push(callback);
 }
 
-function removeEventListener(name, callback) {
+exports.removeEventListener = function(name, callback) {
   if (typeof name !== "string" || typeof callback !== "function") {
     console.error("Invalid parameter for presentation.removeEventListener!");
     return;
@@ -70,75 +104,114 @@ function removeEventListener(name, callback) {
   }
 }
 
-function handleDisplayAvailableChange(isAvailable) {
+// APIs
+exports.startSession = function(presentationUrl) {
+  return new Promise(function(resolve, reject) {
+    var requestId = ++_nextRequestId;
+    var request = new SessionRequest(requestId, resolve, reject);
+    _sessionRequests[requestId] = request;
+
+    var baseUrl = location.protocol + "//" + location.host;
+    var message = { "cmd": "StartSession", "requestId": requestId, "url": presentationUrl, "baseUrl": baseUrl };
+
+    extension.postMessage(JSON.stringify(message));
+  });
+}
+
+exports.joinSession = function(url, presentationId) {
+  return new Promise(function(resolve, reject) {
+    // TODO: to be implemented.
+    console.warn("TODO: joinSession need to be implemented");
+    reject(null);
+  });
+}
+
+exports.getAvailability = function() {
+  return new Promise(function(resolve, reject) {
+    var res = extension.internal.sendSyncMessage("GetAvailability");
+    var availability = new Availability();
+    availability.value = (res == "true" ? true : false);
+    resolve(availability);
+  });
+}
+
+// Native message handlers
+function handleAvailabilityChange(isAvailable) {
   if (_displayAvailable == isAvailable)
     return;
 
   _displayAvailable = isAvailable;
-  if (!_listeners[DISPLAY_AVAILABLE_CHANGE_EVENT])
+  if (!_listeners[CHANGE_EVENT])
     return;
 
-  var length = _listeners[DISPLAY_AVAILABLE_CHANGE_EVENT].length;
+  var length = _listeners[CHANGE_EVENT].length;
   for (var i = 0; i < length; ++i) {
-    _listeners[DISPLAY_AVAILABLE_CHANGE_EVENT][i].apply(null, null);
+    _listeners[CHANGE_EVENT][i].apply(null, null);
   }
 }
 
-function handleShowSucceeded(requestId, viewId) {
-  var request = _showRequests[requestId];
+function handleSessionStartSucceeded(requestId, viewId) {
+  var request = _sessionRequests[requestId];
   if (request) {
     var view = v8toolsNative.getWindowObject(viewId);
-    request._successCallback.apply(null, [view]);
-    delete _showRequests[requestId];
+    var session = new Session(viewId);
+    request._successCallback.apply(null, [session]);
+    delete _sessionRequests[requestId];
   }
 }
 
-function handleShowFailed(requestId, errorMessage) {
-  var request = _showRequests[requestId];
+function handleSessionStartFailed(requestId, errorMessage) {
+  var request = _sessionRequests[requestId];
   if (request) {
     var error = new DOMError(errorMessage);
     if (request._errorCallback)
       request._errorCallback.apply(null, [error]);
-    delete _showRequests[requestId];
+    delete _sessionRequests[requestId];
   }
+}
+
+function handleDefaultSessionStarted(requestId, viewId) {
+  // TODO: to be implemented.
+  console.warn("TODO: DefaultSesionStarted need to be implemented")
+}
+
+function handleSessionMessageToHostReceived(presentationId, data) {
+  var event = new Event('messagetohost');
+  event.data = data;
+  dispatchEvent(event);
+}
+
+function handleSessionMessageToRemoteReceived(presentationId, data) {
+  var event = new Event('messagetoremote');
+  event.data = data;
+  dispatchEvent(event);
 }
 
 extension.setMessageListener(function(json) {
   var msg = JSON.parse(json);
-  if (msg.cmd == "DisplayAvailableChange") {
+  if (msg.cmd == "AvailabilityChange") {
     /* Using setTimeout here to ensure the error in user-defined event handler
        would be captured in developer tools. */
     setTimeout(function() {
-      handleDisplayAvailableChange(msg.data);
+      handleAvailabilityChange(msg.data);
     }, 0);
-  } else if (msg.cmd == "ShowSucceeded") {
+  } else if (msg.cmd == "SessionStartSucceeded") {
     setTimeout(function() {
-      handleShowSucceeded(msg.requestId, parseInt(msg.data) /* view id */);
+      handleSessionStartSucceeded(msg.requestId, parseInt(msg.data) /* view id */);
     }, 0);
-  } else if (msg.cmd == "ShowFailed") {
+  } else if (msg.cmd == "SessionStartFailed") {
     setTimeout(function() {
-      handleShowFailed(msg.requestId, msg.data /* error message */);
+      handleSessionStartFailed(msg.requestId, msg.data /* error message */);
     }, 0);
+  } else if (msg.cmd == "DefaultSessionStarted") {
+    setTimeout(function() {
+      handleDefaultSessionStarted(msg.requestId, parseInt(msg.data) /* view id */);
+    }, 0);
+  } else if (msg.cmd == "SessionMessageToHostReceived") {
+    handleSessionMessageToHostReceived(msg.presentationId, msg.data);
+  } else if (msg.cmd == "SessionMessageToRemoteReceived") {
+    handleSessionMessageToRemoteReceived(msg.presentationId, msg.data);
   } else {
     console.error("Invalid message : " + msg.cmd);
   }
-})
-
-exports.requestShow = requestShowPresentation;
-exports.addEventListener = addEventListener;
-exports.removeEventListener = removeEventListener;
-exports.__defineSetter__("on" + DISPLAY_AVAILABLE_CHANGE_EVENT,
-  function(callback) {
-    if (callback)
-      addEventListener(DISPLAY_AVAILABLE_CHANGE_EVENT, callback);
-    else
-      removeEventListener(DISPLAY_AVAILABLE_CHANGE_EVENT,
-                          this.ondisplayavailablechange);
-  }
-);
-
-exports.__defineGetter__("displayAvailable", function() {
-  var res = extension.internal.sendSyncMessage("QueryDisplayAvailability");
-  _displayAvailable = (res == "true" ? true : false);
-  return _displayAvailable;
 });

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/XWalkPresentationContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/XWalkPresentationContent.java
@@ -51,10 +51,18 @@ public class XWalkPresentationContent {
                 }
 
                 @Override
+                public void onPageLoadStarted(XWalkViewInternal view, String url) {
+                    mPresentationId = mContentView.getContentID();
+                    String script = "navigator.presentation.session = new navigator.presentation.PresentationSession(";
+                    script += mPresentationId;
+                    script += ");";
+                    view.evaluateJavascript(script, null);
+                }
+
+                @Override
                 public void onPageLoadStopped(
                         XWalkViewInternal view, String url, LoadStatusInternal status) {
                     if (status == LoadStatusInternal.FINISHED) {
-                        mPresentationId = mContentView.getContentID();
                         onContentLoaded();
                     }
                 }


### PR DESCRIPTION
Modified the implementation of Presentation API on Android, according
to the new version of W3C Presentation API Spec:
http://www.w3.org/TR/presentation-api/

The major change of the new implementation is to introduced the
session object, which is responsible for representing a presentation
session, and setup a message channel between host screen and remote
display screen. And the major API (e.g. startSession) returns Promise
object instead of callback functions.

BUG=XWALK-4646