### PR TITLE
[Android] Add support disabling copy/paste in XWalkView

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkAPI.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkAPI.java
@@ -8,6 +8,7 @@ public @interface XWalkAPI {
     boolean reservable() default false;
     boolean noInstance() default false;
     boolean isConst() default false;
+    boolean delegate() default false;
     Class<?> extendClass() default Object.class;
     String[] preWrapperLines() default {};
     String[] postWrapperLines() default {};

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
@@ -72,4 +72,9 @@ public class XWalkContentView extends ContentView {
             return super.getAccessibilityNodeProvider();
         }
     }
+
+    @Override
+    public boolean performLongClick(){
+        return mXWalkView.onPerformLongClick();
+    }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1182,4 +1182,14 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     public ContentViewCore getXWalkContentForTest() {
         return mContent.getContentViewCoreForTest();
     }
+
+    // This is used to call back to XWalkView's performLongClick() so that developer can
+    // override performLongClick() or setOnLongClickListener to disable copy/paste
+    // action bar.
+    @XWalkAPI(delegate = true,
+        preWrapperLines = {
+                  "return performLongClick();"})
+    public boolean onPerformLongClick(){
+	return false;
+    }
 }

--- a/tools/reflection_generator/wrapper_generator.py
+++ b/tools/reflection_generator/wrapper_generator.py
@@ -263,7 +263,7 @@ coreWrapper.getBridgeObject(constructorParams.get(i)));
     if (ref_methods_string != ''):
       ref_methods_string += "\n"
     for method in self._java_data.methods:
-      if method.is_constructor or method.is_static or method.is_abstract:
+      if method.is_constructor or method.is_static or method.is_abstract or method.is_delegate:
         continue
       value = { 'METHOD_DECLARE_NAME': method._method_declare_name,
                 'METHOD': method.method_name,


### PR DESCRIPTION
Delegate ContentView's performLongClick() to XWalkView so that developer
can override XWalkView's performLongClick() or setOnLongClickListener() to
disable copy/paste action bar.
A new annotation XWalkAPI.delegate is used to ensure that the callback
from XWalkViewInternal to XWalkView is one-way and the actual implementation
of callback in XWalkView side is specified via XWalkAPI.preWrapperLines.

BUG=XWALK-4786