### PR TITLE
[Android] Fix the javascript was not executed issue.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -313,6 +313,11 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
 
         mIsHidden = false;
         mContent = new XWalkContent(context, attrs, this);
+        // If XWalkView was created in onXWalkReady(), and the activity which owns
+        // XWalkView was destroyed, pauseTimers() will be invoked. Reentry the activity,
+        // resumeTimers() will not be invoked since onResume() was invoked before
+        // XWalkView creation. So to invoke resumeTimers() explicitly here.
+        mContent.resumeTimers();
         addView(mContent,
                 new FrameLayout.LayoutParams(
                         FrameLayout.LayoutParams.MATCH_PARENT,


### PR DESCRIPTION
Sometimes XWalkView was created in onXWalkReady(), if the activity which
owns XWalkView was destroyed, pauseTimers() will be invoked, then
JavaScript timer was also paused. Reentry this activity, the
resumeTimers() was not called since XWalkView creation was later than
onResume().
Invoke resumeTimers() explicitly when XWalkView was created.

BUG=XWALK-4676