### PR TITLE
[Tizen] Stop depending on the extensions_browser gyp target.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -338,9 +338,6 @@
             '<(DEPTH)/third_party/jsoncpp/jsoncpp.gyp:jsoncpp',
             '../components/components.gyp:web_modal',
             '../components/components.gyp:renderer_context_menu',
-
-            # https://code.google.com/p/chromium/issues/detail?id=449919#c30
-            '../extensions/extensions.gyp:extensions_browser',
           ],
           'sources': [
             'runtime/browser/tizen/xwalk_web_contents_view_delegate.cc',


### PR DESCRIPTION
The dependency was introduced when we moved to M42, as there was a
layering violation that introduced a dependency on extensions/ that we
had to provide ourselves (see comment #30 in http://crbug.com/449919).

This has since been fixed upstream (http://crbug.com/477096), so we can
remove the workaround and get rid of a lot of unnecessary dependencies.