### PR TITLE
[Android] Move dummy/dummy.cc to a reasonable location, rename.

### DIFF
--- a/runtime/android/dummy_lib/dummy_lib.cc
+++ b/runtime/android/dummy_lib/dummy_lib.cc
@@ -4,6 +4,5 @@
 // found in the LICENSE file.
 
 // a placeholder used by Google Play to recognize architecture.
-void __no_used_dummy_function(void)
-{
+void __unused_dummy_function() {
 }

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -725,7 +725,7 @@
       'target_name': 'libxwalkdummy',
       'type': 'shared_library',
       'sources': [
-        'dummy/dummy.cc',
+        'runtime/android/dummy_lib/dummy_lib.cc',
       ],
     },
   ],


### PR DESCRIPTION
A top-level directory called "dummy" is a terrible choice that confuses
pretty much anyone that looks at it -- there is only a single-line
explanation in the only file there giving a hint that it is something
Android-specific.

Move the directory to runtime/android and call it "dummy_lib" instead;
this way, the association with Android is clear and people can at least
know that it is a library.