### PR TITLE
[Android] Optimizing layout hierarchy of XWalkView

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -55,11 +55,12 @@ import org.chromium.ui.gfx.DeviceDisplayInfo;
  * This class is the implementation class for XWalkViewInternal by calling internal
  * various classes.
  */
-class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyValueChangeListener {
+class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     private static String TAG = "XWalkContent";
     private static Class<? extends Annotation> javascriptInterfaceClass = null;
 
     private ContentViewCore mContentViewCore;
+    private Context mViewContext;
     private XWalkContentView mContentView;
     private ContentViewRenderView mContentViewRenderView;
     private ActivityWindowAndroid mWindow;
@@ -101,10 +102,9 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
     private CleanupReference mCleanupReference;
 
     public XWalkContent(Context context, AttributeSet attrs, XWalkViewInternal xwView) {
-        super(context, attrs);
-
         // Initialize the WebContensDelegate.
         mXWalkView = xwView;
+        mViewContext = mXWalkView.getContext();
         mContentsClientBridge = new XWalkContentsClientBridge(mXWalkView);
         mXWalkContentsDelegateAdapter = new XWalkWebContentsDelegateAdapter(
             mContentsClientBridge);
@@ -137,16 +137,16 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
                 XWalkPreferencesInternal.ANIMATABLE_XWALK_VIEW);
         CompositingSurfaceType surfaceType =
                 animated ? CompositingSurfaceType.TEXTURE_VIEW : CompositingSurfaceType.SURFACE_VIEW;
-        mContentViewRenderView = new ContentViewRenderView(getContext(), surfaceType) {
+        mContentViewRenderView = new ContentViewRenderView(mViewContext, surfaceType) {
             protected void onReadyToRender() {
                 // Anything depending on the underlying Surface readiness should
                 // be placed here.
             }
         };
         mContentViewRenderView.onNativeLibraryLoaded(mWindow);
-        mLaunchScreenManager = new XWalkLaunchScreenManager(getContext(), mXWalkView);
+        mLaunchScreenManager = new XWalkLaunchScreenManager(mViewContext, mXWalkView);
         mContentViewRenderView.registerFirstRenderedFrameListener(mLaunchScreenManager);
-        addView(mContentViewRenderView, new FrameLayout.LayoutParams(
+        mXWalkView.addView(mContentViewRenderView, new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
                 FrameLayout.LayoutParams.MATCH_PARENT));
 
@@ -159,12 +159,12 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         WebContents webContents = nativeGetWebContents(mNativeContent);
 
         // Initialize ContentView.
-        mContentViewCore = new ContentViewCore(getContext());
-        mContentView = new XWalkContentView(getContext(), mContentViewCore, mXWalkView);
+        mContentViewCore = new ContentViewCore(mViewContext);
+        mContentView = new XWalkContentView(mViewContext, mContentViewCore, mXWalkView);
         mContentViewCore.initialize(mContentView, mContentView, webContents, mWindow);
         mWebContents = mContentViewCore.getWebContents();
         mNavigationController = mWebContents.getNavigationController();
-        addView(mContentView, new FrameLayout.LayoutParams(
+        mXWalkView.addView(mContentView, new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
                 FrameLayout.LayoutParams.MATCH_PARENT));
         mContentViewCore.setContentViewClient(mContentsClientBridge);
@@ -173,7 +173,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         mContentsClientBridge.installWebContentsObserver(mWebContents);
 
         // Set DIP scale.
-        mContentsClientBridge.setDIPScale(DeviceDisplayInfo.create(getContext()).getDIPScale());
+        mContentsClientBridge.setDIPScale(DeviceDisplayInfo.create(mViewContext).getDIPScale());
 
         mContentViewCore.setDownloadDelegate(mContentsClientBridge);
 
@@ -181,7 +181,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         // the members mAllowUniversalAccessFromFileURLs and mAllowFileAccessFromFileURLs
         // won't be changed from false to true at the same time in the constructor of
         // XWalkSettings class.
-        mSettings = new XWalkSettings(getContext(), webContents, false);
+        mSettings = new XWalkSettings(mViewContext, webContents, false);
         // Enable AllowFileAccessFromFileURLs, so that files under file:// path could be
         // loaded by XMLHttpRequest.
         mSettings.setAllowFileAccessFromFileURLs(true);
@@ -439,7 +439,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
     public void setBackgroundColor(final int color) {
         if (mNativeContent == 0) return;
         if (mIsLoaded == false) {
-            post(new Runnable() {
+            mXWalkView.post(new Runnable() {
                 @Override
                 public void run() {
                     setBackgroundColor(color);
@@ -601,8 +601,8 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         // Reset existing notification service in order to destruct it.
         setNotificationService(null);
         // Remove its children used for page rendering from view hierarchy.
-        removeView(mContentView);
-        removeView(mContentViewRenderView);
+        mXWalkView.removeView(mContentView);
+        mXWalkView.removeView(mContentViewRenderView);
         mContentViewRenderView.setCurrentContentViewCore(null);
 
         // Destroy the native resources.
@@ -618,7 +618,6 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         return nativeGetRoutingID(mNativeContent);
     }
 
-    @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         return mContentView.onCreateInputConnectionSuper(outAttrs);
     }
@@ -734,7 +733,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
     public void enableRemoteDebugging() {
         // Chrome looks for "devtools_remote" pattern in the name of a unix domain socket
         // to identify a debugging page
-        final String socketName = getContext().getApplicationContext().getPackageName() + "_devtools_remote";
+        final String socketName = mViewContext.getApplicationContext().getPackageName() + "_devtools_remote";
         if (mDevToolsServer == null) {
             mDevToolsServer = new XWalkDevToolsServer(socketName);
             mDevToolsServer.setRemoteDebuggingEnabled(

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -313,17 +313,12 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
 
         mIsHidden = false;
         mContent = new XWalkContent(context, attrs, this);
+
         // If XWalkView was created in onXWalkReady(), and the activity which owns
         // XWalkView was destroyed, pauseTimers() will be invoked. Reentry the activity,
         // resumeTimers() will not be invoked since onResume() was invoked before
         // XWalkView creation. So to invoke resumeTimers() explicitly here.
         mContent.resumeTimers();
-        addView(mContent,
-                new FrameLayout.LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT));
-
-
         // Set default XWalkClientImpl.
         setXWalkClient(new XWalkClient(this));
         // Set default XWalkWebChromeClient and DownloadListener. The default actions


### PR DESCRIPTION
Decouple XWalkContent from FrameLayout, this can reduce the XWalkView's 4 level view hierarchy to
to 3.
BUG=XWALK-4760