### PR TITLE
[Android] Add new API - doUpdateVisitedHistory()

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -233,6 +233,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void doUpdateVisitedHistory(String url, boolean isReload) {
+        mXWalkResourceClient.doUpdateVisitedHistory(mXWalkView, url, isReload);
     }
 
     @Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -298,4 +298,18 @@ public class XWalkResourceClientInternal {
             ClientCertRequestInternal handler) {
         handler.cancel();
     }
+
+    /**
+     * Notify the host application to update its visited links database.
+     *
+     * @param view The XWalkView that is initiating the callback.
+     * @param url The url being visited.
+     * @param isReload True if this url is being reloaded.
+     *
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void doUpdateVisitedHistory(XWalkViewInternal view, String url,
+            boolean isReload) {
+    }
 }


### PR DESCRIPTION
Add XWalkResourceClient.doUpdateVisitedHistory() to notify the host
application to update its visited links database.

BUG=XWALK-4739