### PR TITLE
[Android]Support external extensions written in C++ on Android

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkRuntimeExtensionManager.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/XWalkRuntimeExtensionManager.java
@@ -24,6 +24,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import org.xwalk.core.XWalkNativeExtensionLoader;
+
 /**
  * This internal class acts a manager to manage extensions.
  */
@@ -37,11 +39,13 @@ public class XWalkRuntimeExtensionManager implements XWalkExtensionContextClient
     private final HashMap<String, XWalkRuntimeExtensionBridge> mExtensions = new HashMap<String, XWalkRuntimeExtensionBridge>();
     // This variable is to set whether to load external extensions. The default is true.
     private boolean mLoadExternalExtensions;
+    private final XWalkNativeExtensionLoader mNativeExtensionLoader;
 
     public XWalkRuntimeExtensionManager(Context context, Activity activity) {
         mContext = context;
         mActivity = activity;
         mLoadExternalExtensions = true;
+        mNativeExtensionLoader = new XWalkNativeExtensionLoader();
     }
 
     @Override
@@ -138,6 +142,14 @@ public class XWalkRuntimeExtensionManager implements XWalkExtensionContextClient
 
     private void loadExternalExtensions() {
         if (!mLoadExternalExtensions) return;
+
+        // If there is a native external extension, register the path. The
+        // extensions under the path will be loaded automatically when the
+        // native service starts.
+        String path = "/data/data/" + mActivity.getPackageName() + "/lib";
+        File libraryDir = new File(path);
+        if (libraryDir.listFiles().length > 0)
+            mNativeExtensionLoader.registerNativeExtensionsInPath(path);
 
         // Read extensions-config.json and create external extensions.
         String configFileContent;

--- a/extensions/android/java/src/org/xwalk/core/internal/extensions/XWalkNativeExtensionLoaderAndroid.java
+++ b/extensions/android/java/src/org/xwalk/core/internal/extensions/XWalkNativeExtensionLoaderAndroid.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal.extensions;
+
+import org.chromium.base.JNINamespace;
+
+@JNINamespace("xwalk::extensions")
+public abstract class XWalkNativeExtensionLoaderAndroid {
+    public void registerNativeExtensionsInPath(String path) {
+        nativeRegisterExtensionInPath(path);
+    }
+
+    private static native void nativeRegisterExtensionInPath(String path);
+}

--- a/extensions/common/android/xwalk_native_extension_loader_android.cc
+++ b/extensions/common/android/xwalk_native_extension_loader_android.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2015 Intel Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/common/android/xwalk_native_extension_loader_android.h"
+
+#include <string>
+
+#include "jni/XWalkNativeExtensionLoaderAndroid_jni.h"
+#include "xwalk/runtime/browser/xwalk_browser_main_parts_android.h"
+#include "xwalk/runtime/browser/xwalk_content_browser_client.h"
+
+namespace xwalk {
+namespace extensions {
+
+void RegisterExtensionInPath(JNIEnv* env, jclass jcaller, jstring path) {
+  const char *str = env->GetStringUTFChars(path, 0);
+  xwalk::XWalkBrowserMainPartsAndroid* main_parts =
+      ToAndroidMainParts(XWalkContentBrowserClient::Get()->main_parts());
+  main_parts->RegisterExtensionInPath(str);
+  env->ReleaseStringUTFChars(path, str);
+}
+
+bool RegisterXWalkNativeExtensionLoaderAndroid(JNIEnv* env) {
+  return RegisterNativesImpl(env);
+}
+
+}  // namespace extensions
+}  // namespace xwalk

--- a/extensions/common/android/xwalk_native_extension_loader_android.h
+++ b/extensions/common/android/xwalk_native_extension_loader_android.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2015 Intel Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_COMMON_ANDROID_XWALK_NATIVE_EXTENSION_LOADER_ANDROID_H_
+#define XWALK_EXTENSIONS_COMMON_ANDROID_XWALK_NATIVE_EXTENSION_LOADER_ANDROID_H_
+
+#include <jni.h>
+
+namespace xwalk {
+namespace extensions {
+
+bool RegisterXWalkNativeExtensionLoaderAndroid(JNIEnv* env);
+
+}  // namespace extensions
+}  // namespace xwalk
+
+#endif  // XWALK_EXTENSIONS_COMMON_ANDROID_XWALK_NATIVE_EXTENSION_LOADER_ANDROID_H_

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -25,6 +25,8 @@
         'browser/xwalk_extension_service.h',
         'common/android/xwalk_extension_android.cc',
         'common/android/xwalk_extension_android.h',
+        'common/android/xwalk_native_extension_loader_android.cc',
+        'common/android/xwalk_native_extension_loader_android.h',
         'common/xwalk_extension.cc',
         'common/xwalk_extension.h',
         'common/xwalk_extension_messages.cc',

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNativeExtensionLoaderInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNativeExtensionLoaderInternal.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+import org.xwalk.core.internal.extensions.XWalkNativeExtensionLoaderAndroid;
+
+@XWalkAPI
+public class XWalkNativeExtensionLoaderInternal extends XWalkNativeExtensionLoaderAndroid {
+    /**
+     * register path of native extensions.
+     * @param path the path of the extension.
+     */
+    @XWalkAPI
+    public void registerNativeExtensionsInPath(String path) {
+        super.registerNativeExtensionsInPath(path);
+    }
+}

--- a/runtime/app/android/xwalk_jni_registrar.cc
+++ b/runtime/app/android/xwalk_jni_registrar.cc
@@ -10,6 +10,7 @@
 #include "components/web_contents_delegate_android/component_jni_registrar.h"
 #include "net/android/net_jni_registrar.h"
 #include "xwalk/extensions/common/android/xwalk_extension_android.h"
+#include "xwalk/extensions/common/android/xwalk_native_extension_loader_android.h"
 #include "xwalk/runtime/browser/android/cookie_manager.h"
 #include "xwalk/runtime/browser/android/intercepted_request_data_impl.h"
 #include "xwalk/runtime/browser/android/net/android_protocol_handler.h"
@@ -46,6 +47,8 @@ static base::android::RegistrationMethod kXWalkRegisteredMethods[] = {
   { "XWalkDevToolsServer", RegisterXWalkDevToolsServer },
   { "XWalkExtensionAndroid", extensions::RegisterXWalkExtensionAndroid },
   { "XWalkHttpAuthHandler", RegisterXWalkHttpAuthHandler },
+  { "XWalkNativeExtensionLoaderAndroid",
+      extensions::RegisterXWalkNativeExtensionLoaderAndroid },
   { "XWalkPathHelper", RegisterXWalkPathHelper },
   { "XWalkSettings", RegisterXWalkSettings },
   { "XWalkViewDelegate", RegisterXWalkViewDelegate },

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -259,4 +259,10 @@ XWalkExtension* XWalkBrowserMainPartsAndroid::LookupExtension(
   return NULL;
 }
 
+void XWalkBrowserMainPartsAndroid::RegisterExtensionInPath(
+    const std::string& path) {
+  extension_service_->RegisterExternalExtensionsForPath(
+      base::FilePath(path));
+}
+
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_main_parts_android.h
+++ b/runtime/browser/xwalk_browser_main_parts_android.h
@@ -41,6 +41,8 @@ class XWalkBrowserMainPartsAndroid : public XWalkBrowserMainParts {
   // already registered. Returns NULL if no such extension exists.
   extensions::XWalkExtension* LookupExtension(const std::string& name);
 
+  void RegisterExtensionInPath(const std::string& path);
+
  private:
   extensions::XWalkExtensionVector extensions_;
   scoped_refptr<net::CookieStore> cookie_store_;

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/NativeExternalExtensionTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/NativeExternalExtensionTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.runtime.client.shell.XWalkRuntimeClientShellActivity;
+import org.xwalk.test.util.RuntimeClientApiTestBase;
+
+/**
+ * Test suite for testing native external extensions.
+ */
+public class NativeExternalExtensionTest extends XWalkRuntimeClientTestBase {
+
+    @SmallTest
+    @Feature({"NativeExternalExtension"})
+    public void testNativeExternalExtension() throws Throwable {
+        RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(
+                        getTestUtil(), this);
+        helper.testNativeExternalExtension();
+    }
+}

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/NativeExternalExtensionTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/NativeExternalExtensionTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime.client.embedded.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import org.chromium.base.test.util.Feature;
+import org.xwalk.runtime.client.embedded.shell.XWalkRuntimeClientEmbeddedShellActivity;
+import org.xwalk.test.util.RuntimeClientApiTestBase;
+
+/**
+ * Test suite for testing native external extensions.
+ */
+public class NativeExternalExtensionTest extends XWalkRuntimeClientTestBase {
+
+    @SmallTest
+    @Feature({"NativeExternalExtension"})
+    public void testNativeExternalExtension() throws Throwable {
+        RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
+                new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(
+                        getTestUtil(), this);
+        helper.testNativeExternalExtension();
+    }
+}

--- a/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
+++ b/test/android/util/runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java
@@ -322,6 +322,12 @@ public class RuntimeClientApiTestBase<T extends Activity> {
         });
     }
 
+    // For native external extension mechanism.
+    public void testNativeExternalExtension() throws Throwable {
+        String title = mTestUtil.loadAssetFileAndWaitForTitle("echo.html");
+        mTestCase.assertEquals("Pass", title);
+    }
+
     // For internal extension implementation of Messaging.
     public void testMessaging() throws Throwable {
         String title = mTestUtil.loadAssetFileAndWaitForTitle("messaging_mini.html");

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -27,6 +27,7 @@ CLASSES_TO_BE_PROCESS = [
     'XWalkPreferencesInternal',
     'XWalkNavigationItemInternal',
     'XWalkNavigationHistoryInternal',
+    'XWalkNativeExtensionLoaderInternal',
     'XWalkJavascriptResultHandlerInternal',
     'XWalkJavascriptResultInternal',
     'ClientCertRequestHandlerInternal',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -210,6 +210,7 @@
       },
       'sources': [
         'extensions/android/java/src/org/xwalk/core/internal/extensions/XWalkExtensionAndroid.java',
+        'extensions/android/java/src/org/xwalk/core/internal/extensions/XWalkNativeExtensionLoaderAndroid.java',
       ],
       'includes': ['../build/jni_generator.gypi'],
     },

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -246,6 +246,7 @@
       'target_name': 'xwalk_runtime_client_shell_apk',
       'type': 'none',
       'dependencies': [
+        'extensions/external_extension_sample.gyp:echo_extension',
         'xwalk_app_runtime_java',
         'xwalk_runtime_client_test_utils_java',
       ],
@@ -254,6 +255,10 @@
         'java_in_dir': 'app/android/runtime_client_shell',
         'resource_dir': 'app/android/runtime_client_shell/res',
         'is_test_apk': 1,
+        'native_lib_target': 'libxwalkdummy',
+        'additional_bundled_libs': [
+          '<(PRODUCT_DIR)/lib/libecho_extension.>(android_product_extension)',
+        ],
         'additional_input_paths': [
           '<(PRODUCT_DIR)/runtime_client_shell/assets/extensions-config.json',
           '<(PRODUCT_DIR)/runtime_client_shell/assets/index.html',
@@ -309,11 +314,12 @@
       'target_name': 'xwalk_runtime_client_embedded_shell_apk',
       'type': 'none',
       'dependencies': [
+        'extensions/external_extension_sample.gyp:echo_extension',
+        'libxwalkdummy',
         'xwalk_app_runtime_java',
         'xwalk_core_internal_java',
         'xwalk_runtime_client_embedded_shell_apk_pak',
         'xwalk_runtime_client_test_utils_java',
-        'libxwalkdummy',
       ],
       'variables': {
         'apk_name': 'XWalkRuntimeClientEmbeddedShell',
@@ -321,6 +327,7 @@
         'resource_dir': 'app/android/runtime_client_embedded_shell/res',
         'native_lib_target': 'libxwalkdummy',
         'additional_bundled_libs': [
+          '<(PRODUCT_DIR)/lib/libecho_extension.>(android_product_extension)',
           '<(PRODUCT_DIR)/lib/libxwalkcore.>(android_product_extension)',
         ],
         'additional_input_paths': [
@@ -352,6 +359,10 @@
         'asset_location': '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets',
       },
       'copies': [
+        {
+          'destination': '<(PRODUCT_DIR)/lib',
+          'files': ['<(PRODUCT_DIR)/tests/extension/echo_extension/libecho_extension.>(android_product_extension)'],
+        },
         {
           'destination': '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets',
           'files': [
@@ -437,6 +448,7 @@
           '<(PRODUCT_DIR)/runtime_client_test/assets/contacts.html',
           '<(PRODUCT_DIR)/runtime_client_test/assets/device_capabilities.html',
           '<(PRODUCT_DIR)/runtime_client_test/assets/displayAvailableTest.html',
+          '<(PRODUCT_DIR)/runtime_client_test/assets/echo.html',
           '<(PRODUCT_DIR)/runtime_client_test/assets/echo_java.html',
           '<(PRODUCT_DIR)/runtime_client_test/assets/echo_sync_java.html',
           '<(PRODUCT_DIR)/runtime_client_test/assets/messaging_mini.html',
@@ -450,6 +462,7 @@
         {
           'destination': '<(PRODUCT_DIR)/runtime_client_test/assets',
           'files': [
+            'extensions/test/data/echo.html',
             'test/android/data/contacts.html',
             'test/android/data/device_capabilities.html',
             'test/android/data/displayAvailableTest.html',
@@ -492,6 +505,7 @@
           '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/contacts.html',
           '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/device_capabilities.html',
           '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/displayAvailableTest.html',
+          '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/echo.html',
           '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/echo_java.html',
           '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/echo_sync_java.html',
           '<(PRODUCT_DIR)/runtime_client_embedded_test/assets/messaging_mini.html',
@@ -505,6 +519,7 @@
         {
           'destination': '<(PRODUCT_DIR)/runtime_client_embedded_test/assets',
           'files': [
+            'extensions/test/data/echo.html',
             'test/android/data/contacts.html',
             'test/android/data/device_capabilities.html',
             'test/android/data/displayAvailableTest.html',

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -25,6 +25,7 @@
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkExtension.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkHttpAuthHandler.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkJavascriptResult.java',
+          '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkNativeExtensionLoader.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkNavigationHistory.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkNavigationItem.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkPreferences.java',


### PR DESCRIPTION
Before this patch, Crosswalk only supports the extensions written in
Java.

With this patch, Crosswalk can load native C++ extensions by calling a
Java API, which will tell the aboslute location to the XWalkExtensionService.
Then when the extension service starts, it will load the extension from
the proper path. To achieve this purpose, add a new option
"--native-extensions" for make_apk.py. By setting it to the location of
the folder, which contains the c++ extension library, the make_apk will
pack them into the final APK file.

Also, this patch creates two unit tests for native external extensions
for runtime client, including shared/embedded modes.

BUG=XWALK-4749