### PR TITLE
[Android] Fix the launch screen not working correctly

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkLaunchScreenManager.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkLaunchScreenManager.java
@@ -106,11 +106,6 @@ public class XWalkLaunchScreenManager
                 mLaunchScreenDialog = new Dialog(mLibContext,
                                                  android.R.style.Theme_Holo_Light_NoActionBar);
 
-                int parentVisibility = mActivity.getWindow().getDecorView().getSystemUiVisibility();
-                WindowManager.LayoutParams parentParams = mActivity.getWindow().getAttributes();
-                mLaunchScreenDialog.getWindow().getDecorView().setSystemUiVisibility(parentVisibility);
-                mLaunchScreenDialog.getWindow().setAttributes(parentParams);
-
                 mLaunchScreenDialog.setOnKeyListener(new Dialog.OnKeyListener() {
                     @Override
                     public boolean onKey(DialogInterface arg0, int keyCode,


### PR DESCRIPTION
The launch screen dialog has its own lifecycle. The main Activity's attributes
should not be directly applied to the launch screen dialog. So remove these here.
As to XWALK-4688, if you want to apply custom on xwalk_launch_screen, you need
to call window.screen.show(); in your javascript.

BUG=XWALK-4688, XWALK-4687, XWALK-4261