### PR TITLE
[Android] Implement the API to clear cache for single file.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -363,6 +363,20 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         nativeClearCache(mNativeContent, includeDiskFiles);
     }
 
+    public void clearCacheForSingleFile(final String url) {
+        if (mNativeContent == 0) return;
+        if (mIsLoaded == false) {
+            mXWalkView.post(new Runnable() {
+                @Override
+                public void run() {
+                    clearCacheForSingleFile(url);
+                }
+            });
+            return;
+        }
+        nativeClearCacheForSingleFile(mNativeContent, url);
+    }
+
     public void clearHistory() {
         if (mNativeContent == 0) return;
         mNavigationController.clearHistory();
@@ -859,6 +873,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
             XWalkContentsIoThreadClient ioThreadClient,
             InterceptNavigationDelegate navigationInterceptionDelegate);
     private native void nativeClearCache(long nativeXWalkContent, boolean includeDiskFiles);
+    private native void nativeClearCacheForSingleFile(long nativeXWalkContent, String url);
     private native String nativeDevToolsAgentId(long nativeXWalkContent);
     private native String nativeGetVersion(long nativeXWalkContent);
     private native void nativeSetJsOnlineProperty(long nativeXWalkContent, boolean networkUp);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -511,6 +511,19 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     }
 
     /**
+     * Clear the resource cache. Note that it only clear the cache for the specified
+     * url.
+     * @param url indicate which cache will be cleared.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void clearCacheForSingleFile(String url) {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.clearCacheForSingleFile(url);
+    }
+
+    /**
      * Indicate that a HTML element is occupying the whole screen.
      * @return true if any HTML element is occupying the whole screen.
      * @since 1.0

--- a/runtime/browser/android/net_disk_cache_remover.h
+++ b/runtime/browser/android/net_disk_cache_remover.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_RUNTIME_BROWSER_ANDROID_NET_DISK_CACHE_REMOVER_H_
 #define XWALK_RUNTIME_BROWSER_ANDROID_NET_DISK_CACHE_REMOVER_H_
 
+#include <string>
+
 namespace content {
 
 class BrowserContext;
@@ -16,7 +18,8 @@ namespace xwalk {
 // Clear all http disk cache for this renderer. This method is asynchronous and
 // will noop if a previous call has not finished.
 void RemoveHttpDiskCache(content::BrowserContext* browser_context,
-                        int renderer_child_id);
+                         int renderer_child_id,
+                         const std::string& key);
 
 }  // namespace xwalk
 

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -289,7 +289,22 @@ void XWalkContent::ClearCache(
 
   if (include_disk_files) {
     RemoveHttpDiskCache(web_contents_->GetBrowserContext(),
-                        web_contents_->GetRoutingID());
+                        web_contents_->GetRoutingID(),
+                        std::string());
+  }
+}
+
+void XWalkContent::ClearCacheForSingleFile(
+    JNIEnv* env,
+    jobject obj,
+    jstring url) {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+  std::string key = base::android::ConvertJavaStringToUTF8(env, url);
+
+  if (!key.empty()) {
+    RemoveHttpDiskCache(web_contents_->GetBrowserContext(),
+                        web_contents_->GetRoutingID(),
+                        key);
   }
 }
 

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -48,6 +48,7 @@ class XWalkContent {
                     jobject io_thread_client,
                     jobject intercept_navigation_delegate);
   void ClearCache(JNIEnv* env, jobject obj, jboolean include_disk_files);
+  void ClearCacheForSingleFile(JNIEnv* env, jobject obj, jstring url);
   ScopedJavaLocalRef<jstring> DevToolsAgentId(JNIEnv* env, jobject obj);
   void Destroy(JNIEnv* env, jobject obj);
   ScopedJavaLocalRef<jstring> GetVersion(JNIEnv* env, jobject obj);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearCacheForSingleFileTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearCacheForSingleFileTest.java
@@ -1,0 +1,86 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Pair;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.net.test.util.TestWebServer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test suite for clearCacheForSingleFile().
+ */
+public class ClearCacheForSingleFileTest extends XWalkViewTestBase {
+
+    private TestWebServer mWebServer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mWebServer = TestWebServer.start();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        mWebServer.shutdown();
+        super.tearDown();
+    }
+
+    @SmallTest
+    @Feature({"clearCacheForSingleFile"})
+    public void testClearCacheForSingleFile() throws Throwable {
+        final String pagePath = "/clear_cache_test.html";
+        final String otherPagePath = "/clear_other_cache_test.html";
+        List<Pair<String, String>> headers = new ArrayList<Pair<String, String>>();
+        // Set Cache-Control headers to cache this request. One century should be long enough.
+        headers.add(Pair.create("Cache-Control", "max-age=3153600000"));
+        headers.add(Pair.create("Last-Modified", "Mon, 12 May 2014 00:00:00 GMT"));
+        final String pageUrl = mWebServer.setResponse(
+                pagePath, "<html><body>foo</body></html>", headers);
+        final String otherPageUrl = mWebServer.setResponse(
+                otherPagePath, "<html><body>foo</body></html>", headers);
+
+        // First load to populate cache.
+        clearSingleCacheOnUiThread(pageUrl);
+        loadUrlSync(pageUrl);
+        assertEquals(1, mWebServer.getRequestCount(pagePath));
+
+        // Load about:blank so next load is not treated as reload by XWalkView and force
+        // revalidate with the server.
+        loadUrlSync("about:blank");
+
+        // No clearCache call, so should be loaded from cache.
+        loadUrlSync(pageUrl);
+        assertEquals(1, mWebServer.getRequestCount(pagePath));
+
+        loadUrlSync(otherPageUrl);
+        assertEquals(1, mWebServer.getRequestCount(otherPagePath));
+
+        // Same as above.
+        loadUrlSync("about:blank");
+
+        // Clear cache, so should hit server again.
+        clearSingleCacheOnUiThread(pageUrl);
+        loadUrlSync(pageUrl);
+        assertEquals(2, mWebServer.getRequestCount(pagePath));
+
+        // otherPageUrl was not cleared, so should be loaded from cache.
+        loadUrlSync(otherPageUrl);
+        assertEquals(1, mWebServer.getRequestCount(otherPagePath));
+
+        // Same as above.
+        loadUrlSync("about:blank");
+
+        // Do not clear cache, so should be loaded from cache.
+        clearCacheOnUiThread(false);
+        loadUrlSync(pageUrl);
+        assertEquals(2, mWebServer.getRequestCount(pagePath));
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -564,6 +564,15 @@ public class XWalkViewTestBase
         });
     }
 
+    protected void clearSingleCacheOnUiThread(final String url) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.clearCacheForSingleFile(url);
+            }
+        });
+    }
+
     protected String getAPIVersionOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override


### PR DESCRIPTION
This patch is to supply an API to clear partial cache.
User could transfer the url to ClearCacheForSingleFile() to clear the
cache for this url.
Add test case for ClearCacheForSingleFile().

BUG=XWALK-4609