### PR TITLE
[Android] Fix the issue about hangonman doesn't display cloud backgroud.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -472,6 +472,8 @@ def Execution(options, app_info):
     ant_cmd.extend(['-Dkey.store.password=%s' % key_code])
   if key_alias_code:
     ant_cmd.extend(['-Dkey.alias.password=%s' % key_alias_code])
+  ignore_properties = "!.svn:!.git:.*:!CVS:!thumbs.db:!picasa.ini:!*.scc:*~"
+  ant_cmd.extend(['-Daapt.ignore.assets=%s' % ignore_properties])
 
   cmd_display = ' '.join([str(item) for item in ant_cmd])
   if options.verbose:


### PR DESCRIPTION
The android project default ignores files starting with an "_" when building.
Override the default in ant.properties to include all files when package
resources.

BUG=XWALK-2223