### PR TITLE
[Android] Fix the out of memory issue.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkLaunchScreenManager.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkLaunchScreenManager.java
@@ -100,7 +100,12 @@ public class XWalkLaunchScreenManager
                 int bgResId = mActivity.getResources().getIdentifier(
                         "launchscreen_bg", "drawable", mActivity.getPackageName());
                 if (bgResId == 0) return;
-                Drawable bgDrawable = mActivity.getResources().getDrawable(bgResId);
+                Drawable bgDrawable = null;
+                try {
+                    bgDrawable = mActivity.getResources().getDrawable(bgResId);
+                } catch (OutOfMemoryError e) {
+                    e.printStackTrace();
+                }
                 if (bgDrawable == null) return;
 
                 mLaunchScreenDialog = new Dialog(mLibContext,


### PR DESCRIPTION
If the background image was set with large resolution, it will be
crashed when "getDrawable()" on some devices.
Catch the OOM error to avoid crash.

BUG=XWALK-4778