### PR TITLE
[Android] Update XWalkView API usage example

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -154,7 +154,7 @@ import org.xwalk.core.internal.extension.BuiltinXWalkExtensions;
  *
  *       &#64;Override
  *       protected void onCreate(Bundle savedInstanceState) {
- *           mXwalkView = new XWalkViewInternal(this, null);
+ *           mXwalkView = new XWalkViewInternal(this);
  *           setContentView(mXwalkView);
  *           mXwalkView.setResourceClient(new MyResourceClient(mXwalkView));
  *           mXwalkView.setUIClient(new MyUIClient(mXwalkView));


### PR DESCRIPTION
XWalkView has two constructor with two parameters,
so XWalkView(this, null) is ambiguous.

BUG=XWALK-3553