### PR TITLE
Initialize media query "display-mode" features properly

### DIFF
--- a/application/browser/application.cc
+++ b/application/browser/application.cc
@@ -183,7 +183,7 @@ GURL Application::GetStartURL(Manifest::Type type) const {
 }
 
 template<>
-void Application::GetWindowShowState<Manifest::TYPE_WIDGET>(
+void Application::SetWindowShowState<Manifest::TYPE_WIDGET>(
     NativeAppWindow::CreateParams* params) {
   const Manifest* manifest = data_->GetManifest();
   std::string view_modes_string;
@@ -200,23 +200,23 @@ void Application::GetWindowShowState<Manifest::TYPE_WIDGET>(
 }
 
 template<>
-void Application::GetWindowShowState<Manifest::TYPE_MANIFEST>(
+void Application::SetWindowShowState<Manifest::TYPE_MANIFEST>(
     NativeAppWindow::CreateParams* params) {
   const Manifest* manifest = data_->GetManifest();
   std::string display_string;
 
   // FIXME: As we do not support browser mode, the default fallback will be
   // minimal-ui mode.
-  params->mode = blink::WebDisplayModeMinimalUi;
+  params->display_mode = blink::WebDisplayModeMinimalUi;
   params->state = ui::SHOW_STATE_DEFAULT;
   if (!manifest->GetString(keys::kDisplay, &display_string))
     return;
 
   if (display_string == values::kDisplayModeFullscreen) {
-    params->mode = blink::WebDisplayModeFullscreen;
+    params->display_mode = blink::WebDisplayModeFullscreen;
     params->state = ui::SHOW_STATE_FULLSCREEN;
   } else if (display_string == values::kDisplayModeStandalone) {
-    params->mode = blink::WebDisplayModeStandalone;
+    params->display_mode = blink::WebDisplayModeStandalone;
   }
 }
 
@@ -245,8 +245,8 @@ bool Application::Launch() {
 
   NativeAppWindow::CreateParams params;
   data_->manifest_type() == Manifest::TYPE_WIDGET ?
-      GetWindowShowState<Manifest::TYPE_WIDGET>(&params) :
-      GetWindowShowState<Manifest::TYPE_MANIFEST>(&params);
+      SetWindowShowState<Manifest::TYPE_WIDGET>(&params) :
+      SetWindowShowState<Manifest::TYPE_MANIFEST>(&params);
 
   params.bounds = data_->window_bounds();
   params.minimum_size.set_width(data_->window_min_size().width());

--- a/application/browser/application.h
+++ b/application/browser/application.h
@@ -99,8 +99,6 @@ class Application : public Runtime::Observer,
                      const std::string& permission_name,
                      StoredPermission perm);
   bool CanRequestURL(const GURL& url) const;
-  bool IsFullScreenRequired() const {
-      return window_show_params_.state == ui::SHOW_STATE_FULLSCREEN; }
 
   void set_observer(Observer* observer) { observer_ = observer; }
 
@@ -151,7 +149,7 @@ class Application : public Runtime::Observer,
   // manifest, returns it and the entry point used.
   template <Manifest::Type> GURL GetStartURL() const;
 
-  template <Manifest::Type> void GetWindowShowState(
+  template <Manifest::Type> void SetWindowShowState(
       NativeAppWindow::CreateParams* params);
 
   GURL GetAbsoluteURLFromKey(const std::string& key) const;

--- a/application/browser/application_tizen.cc
+++ b/application/browser/application_tizen.cc
@@ -106,7 +106,7 @@ class ScreenOrientationDelegateTizen :
       LOG(ERROR) << "Invalid app error";
       return false;
     }
-    return app_->IsFullScreenRequired();
+    return ToApplicationTizen(app_.get())->IsFullScreenRequired();
   }
 
   void Lock(content::WebContents* web_contents,

--- a/application/browser/application_tizen.h
+++ b/application/browser/application_tizen.h
@@ -28,6 +28,8 @@ class ApplicationTizen :  // NOLINT
 
   void RemoveAllCookies();
   void SetUserAgentString(const std::string& user_agent_string);
+  bool IsFullScreenRequired() const {
+      return window_show_params_.state == ui::SHOW_STATE_FULLSCREEN; }
 
  protected:
   GURL GetStartURL(Manifest::Type type) const override;

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -170,6 +170,12 @@ bool Runtime::IsFullscreenForTabOrPending(
   return (fullscreen_options_ & FULLSCREEN_FOR_TAB) != 0;
 }
 
+blink::WebDisplayMode Runtime::GetDisplayMode(
+    const content::WebContents* web_contents) const {
+  return (ui_delegate_) ? ui_delegate_->GetDisplayMode()
+                        : blink::WebDisplayModeUndefined;
+}
+
 void Runtime::RequestToLockMouse(content::WebContents* web_contents,
                                  bool user_gesture,
                                  bool last_unlocked_by_target) {

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -111,6 +111,8 @@ class Runtime : public content::WebContentsDelegate,
       content::WebContents* web_contents) override;
   bool IsFullscreenForTabOrPending(
       const content::WebContents* web_contents) const override;
+  blink::WebDisplayMode GetDisplayMode(
+      const content::WebContents* web_contents) const override;
   void RequestToLockMouse(content::WebContents* web_contents,
                           bool user_gesture,
                           bool last_unlocked_by_target) override;

--- a/runtime/browser/runtime_ui_delegate.cc
+++ b/runtime/browser/runtime_ui_delegate.cc
@@ -123,4 +123,10 @@ bool DefaultRuntimeUIDelegate::AddDownloadItem(
   return false;
 }
 
+blink::WebDisplayMode DefaultRuntimeUIDelegate::GetDisplayMode() const {
+  if (window_ && window_->IsFullscreen())
+      return blink::WebDisplayModeFullscreen;
+  return window_params_.display_mode;
+}
+
 }  // namespace xwalk

--- a/runtime/browser/runtime_ui_delegate.h
+++ b/runtime/browser/runtime_ui_delegate.h
@@ -32,6 +32,7 @@ class RuntimeUIDelegate {
   virtual bool AddDownloadItem(content::DownloadItem* download_item,
       const content::DownloadTargetCallback& callback,
       const base::FilePath& suggested_path) = 0;
+  virtual blink::WebDisplayMode GetDisplayMode() const = 0;
 };
 
 // The default implementation displays WebContents in a separate window.
@@ -56,6 +57,7 @@ class DefaultRuntimeUIDelegate : public RuntimeUIDelegate,
   bool AddDownloadItem(content::DownloadItem* download_item,
       const content::DownloadTargetCallback& callback,
       const base::FilePath& suggested_path) override;
+  blink::WebDisplayMode GetDisplayMode() const override;
 
   Runtime* runtime_;
 

--- a/runtime/browser/ui/native_app_window.cc
+++ b/runtime/browser/ui/native_app_window.cc
@@ -13,7 +13,7 @@ NativeAppWindow::CreateParams::CreateParams()
     resizable(true),
     net_wm_pid(0),
     parent(NULL),
-    mode(blink::WebDisplayModeUndefined) {
+    display_mode(blink::WebDisplayModeUndefined) {
 }
 
 NativeAppWindow::CreateParams::~CreateParams() {

--- a/runtime/browser/ui/native_app_window.h
+++ b/runtime/browser/ui/native_app_window.h
@@ -63,8 +63,8 @@ class NativeAppWindow {
     // The absolute path of splash screen.
     // Empty if splash screen is not to be shown.
     base::FilePath splash_screen_path;
-    // The display mode. Currently only used by Linux desktop platform.
-    blink::WebDisplayMode mode;
+    // The display mode. Used on Desktop platforms.
+    blink::WebDisplayMode display_mode;
   };
 
   // Do one time initialization at application startup.

--- a/runtime/browser/ui/native_app_window_desktop.cc
+++ b/runtime/browser/ui/native_app_window_desktop.cc
@@ -89,7 +89,7 @@ NativeAppWindowDesktop::~NativeAppWindowDesktop() {
 void NativeAppWindowDesktop::ViewHierarchyChanged(
     const ViewHierarchyChangedDetails& details) {
   if (details.is_add && details.child == this) {
-    if (create_params().mode == blink::WebDisplayModeMinimalUi)
+    if (create_params().display_mode == blink::WebDisplayModeMinimalUi)
       InitMinimalUI();
     else
       InitStandaloneUI();


### PR DESCRIPTION
The 'Runtime' class overrides 'GetDisplayMode' method (from the base
'content::WebContentsDelegate' class) so that media query "display-mode"
features are initialized properly.