### PR TITLE
crosswalk-14: Track OpenCL headers from our git repository.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -52,8 +52,7 @@ solutions = [
 
       # Include OpenCL header files for WebCL support, target version 1.2.
       'src/third_party/khronos/CL':
-        'https://cvs.khronos.org/svn/repos/registry/trunk/public/cl/api/1.2@'
-           '28150',
+        crosswalk_git + '/khronos-cl-api-1.2.git@6f4be98d10f03ce2b12c769cd9835c73a441c00f',
 
       # These directories are not relevant to Crosswalk and can be safely ignored
       # in a checkout. It avoids creating additional directories outside src/ that


### PR DESCRIPTION
**I do not intend to make a new Crosswalk 14 release because of this commit. My intention with it is to make sure all the branches we currently support and work on use OpenCL from git so we can remove the SVN references and instructions from the website**

Stop tracking OpenCL headers from Khronos's SVN repository and use our
git mirror on GitHub instead.

The OpenCL headers were the only Crosswalk dependency that required
Subversion, which meant that additional programs were required to check
out Crosswalk, and more settings had to be tuned for people behind
corporate proxies.

Discussed in:
https://lists.crosswalk-project.org/pipermail/crosswalk-dev/2015-August/003039.html

(cherry picked from commit 109990fca57094d545ca58b55814cefe77e8191d)