### PR TITLE
[Android] Implement XWalkView background color in manifest

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -46,6 +46,12 @@ const char kLaunchScreenPortrait[] =
     "launch_screen.portrait";
 const char kLaunchScreenReadyWhen[] =
     "launch_screen.ready_when";
+const char kView[] = "view";
+const char kViewBackgroundColor[] = "view.background_color";
+
+// XWalk View Manifest extensions:
+const char kXWalkView[] = "xwalk_view";
+const char kXWalkViewBackgroundColor[] = "xwalk_view.background_color";
 
 // XWalk W3C Manifest (XPK) extensions:
 

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -45,6 +45,12 @@ namespace application_manifest_keys {
   extern const char kLaunchScreenLandscape[];
   extern const char kLaunchScreenPortrait[];
   extern const char kLaunchScreenReadyWhen[];
+  extern const char kView[];
+  extern const char kViewBackgroundColor[];
+
+  // XWalk View extensions:
+  extern const char kXWalkView[];
+  extern const char kXWalkViewBackgroundColor[];
 
   // XWalk extensions:
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -450,6 +450,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         return ((color >> 24) & 0xFF) == 0xFF;
     }
 
+    @CalledByNative
     public void setBackgroundColor(final int color) {
         if (mNativeContent == 0) return;
         if (mIsLoaded == false) {

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -19,6 +19,7 @@
 #include "base/path_service.h"
 #include "base/pickle.h"
 #include "base/prefs/pref_service.h"
+#include "base/strings/string_number_conversions.h"
 #include "components/autofill/content/browser/content_autofill_driver_factory.h"
 #include "components/autofill/core/browser/autofill_manager.h"
 #include "components/navigation_interception/intercept_navigation_delegate.h"
@@ -467,6 +468,22 @@ jboolean XWalkContent::SetManifest(JNIEnv* env,
     // No need to display launch screen, load the url directly.
     Java_XWalkContent_onGetUrlFromManifest(env, obj, url_buffer.obj());
   }
+  std::string view_background_color;
+  ManifestGetString(manifest,
+                    keys::kXWalkViewBackgroundColor,
+                    keys::kViewBackgroundColor,
+                    &view_background_color);
+
+  if (view_background_color.empty())
+    return true;
+  unsigned int view_background_color_int = 0;
+  if (!base::HexStringToUInt(view_background_color.substr(1),
+      &view_background_color_int)) {
+    LOG(ERROR) << "Background color format error! Valid background color"
+               "should be(Alpha Red Green Blue): #ff01abcd";
+    return false;
+  }
+  Java_XWalkContent_setBackgroundColor(env, obj, view_background_color_int);
   return true;
 }
 


### PR DESCRIPTION
Add xwalk_view.background_color in manifest. This supports set XWalkView's
background color in manifest.json. This can also avoid white screen on start.
Set XWalkView's background color in manifest.json:
  "xwalk_view": {
    "background_color": "#ff01abcd"
  }
Note: Color is in Alpha/Red/Green/Blue order.
BUG=XWALK-4809,XWALK-4963