### PR TITLE
Fix build on Windows.

### DIFF
--- a/runtime/browser/ui/desktop/download_views.cc
+++ b/runtime/browser/ui/desktop/download_views.cc
@@ -194,7 +194,11 @@ DownloadItemView::DownloadItemView(
   item->AddObserver(this);
 
   progress_view_ = new DownloadProgressView();
+#if defined (OS_WIN)
+  progress_view_->SetText(path.BaseName().value());
+#else
   progress_view_->SetText(base::UTF8ToUTF16(path.BaseName().value()));
+#endif
   OnDownloadUpdated(item);
   AddChildView(progress_view_);
 

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -231,6 +231,8 @@
         'runtime/browser/ui/native_app_window_tizen.h',
         'runtime/browser/ui/native_app_window_views.cc',
         'runtime/browser/ui/native_app_window_views.h',
+        'runtime/browser/ui/desktop/download_views.cc',
+        'runtime/browser/ui/desktop/download_views.h',
         'runtime/browser/ui/splash_screen_tizen.cc',
         'runtime/browser/ui/splash_screen_tizen.h',
         'runtime/browser/ui/taskbar_util.h',
@@ -352,6 +354,8 @@
             'runtime/browser/runtime_ui_delegate_desktop.h',
             'runtime/browser/ui/native_app_window_desktop.cc',
             'runtime/browser/ui/native_app_window_desktop.h',
+            'runtime/browser/ui/desktop/download_views.cc',
+            'runtime/browser/ui/desktop/download_views.h',
             'runtime/browser/android/xwalk_web_contents_view_delegate.cc',
             'runtime/browser/android/xwalk_web_contents_view_delegate.h',
           ],
@@ -368,6 +372,8 @@
           'sources!':[
             'runtime/browser/runtime_ui_delegate_desktop.cc',
             'runtime/browser/runtime_ui_delegate_desktop.h',
+            'runtime/browser/ui/desktop/download_views.cc',
+            'runtime/browser/ui/desktop/download_views.h',
             'runtime/browser/ui/native_app_window_desktop.cc',
             'runtime/browser/ui/native_app_window_desktop.h',
             'runtime/renderer/xwalk_render_process_observer_generic.cc',
@@ -399,8 +405,6 @@
           'sources': [
             'runtime/browser/linux/xwalk_notification_manager.cc',
             'runtime/browser/linux/xwalk_notification_manager.h',
-            'runtime/browser/ui/desktop/download_views.cc',
-            'runtime/browser/ui/desktop/download_views.h',
           ]
         }],  # OS=="linux" and tizen!=1
         ['OS=="linux"', {


### PR DESCRIPTION
And most likely on Mac as well.

https://github.com/crosswalk-project/crosswalk/pull/320 broke the
build by using classes not added to the build.

Fix the build by adding the new class from #320 to the build but it's
most likely that the Download feature doesn't yet work on Windows
because there are still code guarded in #ifdef in the original
commit. I've created XWALK-4969 to enable it which shouldn't require
much work.