### PR TITLE
[Android] Simplify the resource interception code in XWalkViewDelegate.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.lang.StringBuilder;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,6 +18,8 @@ import android.content.res.AssetManager;
 import android.content.res.Resources.NotFoundException;
 import android.os.Build;
 import android.util.Log;
+
+import junit.framework.Assert;
 
 import org.chromium.base.CommandLine;
 import org.chromium.base.JNINamespace;
@@ -36,9 +39,11 @@ class XWalkViewDelegate {
     private static boolean sLibraryLoaded = false;
     private static boolean sRunningOnIA = true;
     private static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
+
+    // TODO(rakuco,lincsoon): This list is also in generate_xwalk_core_library.py.
+    // We should remove it from one of the places to avoid duplication.
     private static final String[] MANDATORY_PAKS = {
             "xwalk.pak",
-            "en-US.pak",
             "icudtl.dat",
             // Please refer to XWALK-3516, disable v8 use external startup data,
             // reopen it if needed later.
@@ -51,6 +56,7 @@ class XWalkViewDelegate {
     };
     private static final String TAG = "XWalkViewDelegate";
     private static final String XWALK_RESOURCES_LIST_RES_NAME = "xwalk_resources_list";
+    private static final String XWALK_PAK_NAME = "xwalk.pak";
 
     private static final String COMMAND_LINE_FILE = "xwalk-command-line";
 
@@ -86,10 +92,14 @@ class XWalkViewDelegate {
     public static void init(Context bridgeContext, Context context) {
         loadXWalkLibrary(bridgeContext);
 
-        if (bridgeContext == null) {
-            init(context);
-        } else {
-            init(new MixedContext(bridgeContext, context));
+        try {
+            if (bridgeContext == null) {
+                init(context);
+            } else {
+                init(new MixedContext(bridgeContext, context));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -130,7 +140,7 @@ class XWalkViewDelegate {
         sLibraryLoaded = true;
     }
 
-    private static void init(final Context context) {
+    private static void init(final Context context) throws IOException {
         if (sInitialized) return;
 
         PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, context);
@@ -147,76 +157,10 @@ class XWalkViewDelegate {
         }
 
         ResourceExtractor.setMandatoryPaksToExtract(MANDATORY_PAKS);
-        int resListResId = context.getResources().getIdentifier(
-                XWALK_RESOURCES_LIST_RES_NAME, "array", context.getClass().getPackage().getName());
-        if (resListResId == 0) {
-            resListResId = context.getResources().getIdentifier(
-                    XWALK_RESOURCES_LIST_RES_NAME, "array", context.getPackageName());
-        }
-        final int resourcesListResId = resListResId;
-        final AssetManager assets = context.getAssets();
-        if (!context.getPackageName().equals(context.getApplicationContext().getPackageName()) ||
-                resourcesListResId != 0) {
-            // For shared mode, assets are in library package.
-            // For embedding API usage, assets are in res/raw.
-            ResourceExtractor.setResourceIntercepter(new ResourceIntercepter() {
-
-                @Override
-                public Set<String> getInterceptableResourceList() {
-                    Set<String> resourcesList = new HashSet<String>();
-                    if (!context.getPackageName().equals(
-                            context.getApplicationContext().getPackageName())) {
-                        try {
-                            for (String resource : assets.list("")) {
-                                resourcesList.add(resource);
-                            }
-                        } catch (IOException e){}
-                    }
-                    if (resourcesListResId != 0) {
-                        try {
-                            String[] resources = context.getResources().getStringArray(resourcesListResId);
-                            for (String resource : resources) {
-                                resourcesList.add(resource);
-                            }
-                        } catch (NotFoundException e) {
-                            Log.w(TAG, "R.array." + XWALK_RESOURCES_LIST_RES_NAME + " can't be found.");
-                        }
-                    }
-                    return resourcesList;
-                }
-
-                @Override
-                public InputStream interceptLoadingForResource(String resource) {
-                    if (!context.getPackageName().equals(
-                            context.getApplicationContext().getPackageName())) {
-                        try {
-                            InputStream fromAsset = context.getAssets().open(resource);
-                            if (fromAsset != null) return fromAsset;
-                        } catch (IOException e) {
-                            Log.w(TAG, resource + " can't be found in assets.");
-                        }
-                    }
-
-                    if (resourcesListResId != 0) {
-                        String resourceName = resource.split("\\.")[0];
-                        int resId = context.getResources().getIdentifier(
-                                resourceName, "raw", context.getClass().getPackage().getName());
-                        if (resId == 0) {
-                            resId = context.getResources().getIdentifier(
-                                    resourceName, "raw", context.getPackageName());
-                        }
-                        try {
-                            if (resId != 0) return context.getResources().openRawResource(resId);
-                        } catch (NotFoundException e) {
-                            Log.w(TAG, "R.raw." + resourceName + " can't be found.");
-                        }
-                    }
-
-                    return null;
-                }
-            });
-        }
         ResourceExtractor.setExtractImplicitLocaleForTesting(false);
+
+        setupResourceInterceptor(context);
+
         // Use MixedContext to initialize the ResourceExtractor, as the pak file
         // is in the library apk if in shared apk mode.
         ResourceExtractor.get(context);
@@ -252,6 +196,89 @@ class XWalkViewDelegate {
                 }
             }
         });
+    }
+
+    /**
+     * Plugs an instance of ResourceExtractor.ResourceIntercepter() into ResourceExtractor.
+     *
+     * It is responsible for loading resources from the right locations depending on whether
+     * Crosswalk is being used in shared or embedded mode.
+     */
+    private static void setupResourceInterceptor(final Context context) throws IOException {
+        final boolean isSharedMode =
+                !context.getPackageName().equals(context.getApplicationContext().getPackageName());
+
+        // The test APKs (XWalkCoreShell, XWalkCoreInternalShell etc) are different from normal
+        // Crosswalk apps: even though they use Crosswalk in embedded mode, the resources are stored
+        // in assets/ with the rest of the app's assets.
+        // XWalkRuntimeClientShell is the only exception, as it uses Crosswalk in shared mode.
+        final boolean isTestApk =
+                !isSharedMode && Arrays.asList(context.getAssets().list("")).contains(XWALK_PAK_NAME);
+
+        Set<String> interceptableResources = new HashSet<String>();
+        if (isSharedMode || isTestApk) {
+            for (String resource : MANDATORY_PAKS) {
+                interceptableResources.add(resource);
+            }
+        } else {
+            int resourceListId = getResourceId(context, XWALK_RESOURCES_LIST_RES_NAME, "array");
+            try {
+                final String[] crosswalkResources = context.getResources().getStringArray(resourceListId);
+                for (String resource : crosswalkResources) {
+                    interceptableResources.add(resource);
+                }
+            } catch (NotFoundException e) {
+                Assert.fail("R.array." + XWALK_RESOURCES_LIST_RES_NAME + " can't be found.");
+            }
+        }
+
+        // For getInterceptableResourceList(), which needs a final value.
+        final Set<String> finalInterceptableResources = interceptableResources;
+
+        // For shared mode, assets are in library package.
+        // For embedded mode, assets are in res/raw.
+        ResourceExtractor.setResourceIntercepter(new ResourceIntercepter() {
+            @Override
+            public Set<String> getInterceptableResourceList() {
+                return finalInterceptableResources;
+            }
+
+            @Override
+            public InputStream interceptLoadingForResource(String resource) {
+                if (isSharedMode || isTestApk) {
+                    try {
+                        return context.getAssets().open(resource);
+                    } catch (IOException e) {
+                        Assert.fail(resource + " can't be found in assets.");
+                    }
+                } else {
+                    String resourceName = resource.split("\\.")[0];
+                    int resourceId = getResourceId(context, resourceName, "raw");
+                    try {
+                        return context.getResources().openRawResource(resourceId);
+                    } catch (NotFoundException e) {
+                        Assert.fail("R.raw." + resourceName + " can't be found.");
+                    }
+                }
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Returns a resource identifier for a given resource name and type.
+     *
+     * Basically a wrapper around Resources.getIdentifier() that also works with applications that
+     * change their package name at build time (see XWALK-3569).
+     */
+    private static int getResourceId(final Context context, final String resourceName, final String resourceType) {
+        int resourceId = context.getResources().getIdentifier(
+                resourceName, resourceType, context.getClass().getPackage().getName());
+        if (resourceId == 0) {
+            resourceId = context.getResources().getIdentifier(
+                    resourceName, resourceType, context.getPackageName());
+        }
+        return resourceId;
     }
 
     public static boolean isRunningOnIA() {


### PR DESCRIPTION
There are two related changes in this patch with the same goal of paving the way for the M45 rebase, where the upstream code handling the loading of Android resources has changed. Most of what we had to do there also applies to M44, so the patch is being landed in master in order to make it clear in the commit history what is being done and why.

1. Make the code easier to understand.
   * Set up the resource interception infrastructure in a separate
     function.
   * Also have a separate function for determining a resource ID after
     XWALK-3469 made the code a bit harder to follow.
   * Have variables with clear names such as `isSharedMode` and
     `isTestApk` to indicate our intents and what is being checked. We
     were previously relying on package name checks or ID comparisons
     that did not make any sense to anyone who was not already familiar
     with the code base.
   * Add more comments to the code to indicate what we are doing.
2. Functional changes.
   * Stop conditionally calling setResourceIntercepter(). The previous
     check basically skipped our test APKs. Since intercepting resources
     there does not cause any harm, do so to make the code easier to
     both write and understand.
   * Remove "en-US.pak" from the list of mandatory PAK files. It has
     never actually existed in our Android builds, and since we now use
     `MANDATORY_PAK_FILES` to determine which resources need to be
     intercepted, we cannot have a non-existent file there as we would
     end up trying to open it.

Most of the code was actually written by @lincsoon in pull request #3220, I only picked as much as I could into master.

Related to: XWALK-4755
