### PR TITLE
Roll GYP forward so it supports compiling managed code on Windows.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -50,6 +50,10 @@ solutions = [
       'src/v8':
         crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
 
+      # Temporary roll GYP forward so we can have support to compile managed code on Windows.
+      'src/tools/gyp':
+        'https://chromium.googlesource.com/external/gyp.git@1f374df95de1c0a125485496e8d23d36303a93fd',
+
       # Include OpenCL header files for WebCL support, target version 1.2.
       'src/third_party/khronos/CL':
         crosswalk_git + '/khronos-cl-api-1.2.git@6f4be98d10f03ce2b12c769cd9835c73a441c00f',


### PR DESCRIPTION
This is in preparation of landing the dotnet extensions for Crosswalk
on Windows. At some point GYP will naturally roll into Chromium
so we may get it around M47.

GYP CL : https://codereview.chromium.org/1331463002