### PR TITLE
[Android] Expose onTouchEvent to XWalkView

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -22,6 +22,7 @@ import android.util.Log;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
+import android.view.MotionEvent;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 import android.widget.FrameLayout;
@@ -646,6 +647,10 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
 
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         return mContentView.onCreateInputConnectionSuper(outAttrs);
+    }
+
+    public boolean onTouchEvent(MotionEvent event) {
+        return mContentViewCore.onTouchEvent(event);
     }
 
     //--------------------------------------------------------------------------------------------

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
@@ -8,14 +8,18 @@ package org.xwalk.core.internal;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
+import android.view.MotionEvent;
+import android.view.View;
 
 import org.chromium.content.browser.ContentView;
 import org.chromium.content.browser.ContentViewCore;
 
 public class XWalkContentView extends ContentView {
+    private static final String TAG = "XWalkContentView";
     private XWalkViewInternal mXWalkView;
 
     XWalkContentView(Context context, ContentViewCore cvc, XWalkViewInternal xwView) {
@@ -77,4 +81,14 @@ public class XWalkContentView extends ContentView {
     public boolean performLongClick(){
         return mXWalkView.performLongClickDelegate();
     }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        // Give XWalkView a chance to handle touch event
+        if(mXWalkView.onTouchEventDelegate(event)) {
+            return true;
+        }
+        return mContentViewCore.onTouchEvent(event);
+    }
+
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -24,6 +24,7 @@ import android.view.SurfaceView;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
+import android.view.MotionEvent;
 import android.webkit.ValueCallback;
 import android.widget.FrameLayout;
 
@@ -1258,4 +1259,19 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     public boolean performLongClickDelegate(){
         return false;
     }
+
+    @XWalkAPI(delegate = true,
+              preWrapperLines = {"return onTouchEvent(event);"})
+    public boolean onTouchEventDelegate(MotionEvent event){
+        return false;
+    }
+
+    // Usually super.onTouchEvent is called within XWalkView.onTouchEvent override
+    // This is used as our default touch event handler.
+    @Override
+    @XWalkAPI
+    public boolean onTouchEvent(MotionEvent event) {
+        return mContent.onTouchEvent(event);
+    }
+
 }


### PR DESCRIPTION
Expose onTouchEvent to XWalkView so that developer can override
XWalkView.onTouchEvent to intercept touch event. Usually super.onTouchEvent
is called within onTouchEvent override method so we keep a default
onTouchEvent override in XWalkView to connect to the default touch event
handler within ContentViewCore.

BUG=XWALK-4879