### PR TITLE
[Android] Fix the error that the screen flashes at startup

### DIFF
--- a/app/android/app_template/res/values-v14/theme.xml
+++ b/app/android/app_template/res/values-v14/theme.xml
@@ -8,8 +8,9 @@ found in the LICENSE file.
 
 <resources>
     <!-- Application theme. -->
+    <color name="white">#FFFFFFFF</color>
     <style name="AppTheme" parent="@android:style/Theme.Holo.Light.NoActionBar">
         <item name="android:windowFullscreen">false</item>
-        <item name="android:windowBackground">@null</item>
+        <item name="android:windowBackground">@color/white</item>
     </style>
 </resources>

--- a/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
+++ b/app/android/app_template/src/org/xwalk/app/template/AppTemplateActivity.java
@@ -38,7 +38,6 @@ public class AppTemplateActivity extends XWalkRuntimeActivityBase {
     @Override
     protected void didTryLoadRuntimeView(View runtimeView) {
         if (runtimeView != null) {
-            setContentView(runtimeView);
             getRuntimeView().loadAppFromUrl("file:///android_asset/www/index.html");
         } else {
             TextView msgText = new TextView(this);

--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -30,11 +30,19 @@ public abstract class XWalkRuntimeActivityBase extends XWalkActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        tryLoadRuntimeView();
     }
 
     @Override
     public void onXWalkReady() {
-        tryLoadRuntimeView();
+        // XWalkPreferences.ENABLE_EXTENSIONS
+        if (XWalkPreferences.getValue("enable-extensions")) {
+                // Enable xwalk extension mechanism and start load extensions here.
+                // Note that it has to be after above initialization.
+            mExtensionManager = new XWalkRuntimeExtensionManager(getApplicationContext(), this);
+            mExtensionManager.loadExtensions();
+        }
+        didTryLoadRuntimeView(mRuntimeView);
         // TODO(sunlin): In shared mode, mRuntimeView.onCreate() will be
         // called after onResume(). Currently, there is no impact because
         // both of onCreate and onResume in XWalkRuntimeView is empty.
@@ -99,17 +107,10 @@ public abstract class XWalkRuntimeActivityBase extends XWalkActivity {
             } else {
                 XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, false);
             }
-            // XWalkPreferences.ENABLE_EXTENSIONS
-            if (XWalkPreferences.getValue("enable-extensions")) {
-                // Enable xwalk extension mechanism and start load extensions here.
-                // Note that it has to be after above initialization.
-                mExtensionManager = new XWalkRuntimeExtensionManager(getApplicationContext(), this);
-                mExtensionManager.loadExtensions();
-            }
+            setContentView(mRuntimeView);
         } catch (Exception e) {
             handleException(e);
         }
-        didTryLoadRuntimeView(mRuntimeView);
     }
 
     public XWalkRuntimeView getRuntimeView() {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -20,6 +20,7 @@ import android.provider.MediaStore;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.SurfaceView;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
@@ -185,17 +186,29 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     @XWalkAPI
     public static final int RELOAD_IGNORE_CACHE = 1;
 
+    // The moment when the XWalkViewBridge is added to the XWalkView, the screen flashes black. The
+    // reason is when the SurfaceView appears in the window the fist time, it requests the window's
+    // parameters changing by calling IWindowSession.relayout(). But if the window already has
+    // appropriate parameters, it will not refresh all the window's stuff and the screen will not
+    // blink. So we add a 0px SurfaceView at first. This will recreate the window before the
+    // activity is shown on the screen, and when the actual XWalkViewBridge is added, it will just
+    // continue to use the window with current parameters. The temporary SurfaceView can be removed
+    // at last.
     /**
      * Constructs a new XWalkView with a Context object.
      * @param context a Context object used to access application assets.
      * @since 6.0
      */
     @XWalkAPI(preWrapperLines = {
-                  "        super(${param1}, null);"},
+                  "        super(${param1}, null);",
+                  "        SurfaceView surfaceView = new SurfaceView(${param1});",
+                  "        surfaceView.setLayoutParams(new ViewGroup.LayoutParams(0, 0));",
+                  "        addView(surfaceView);"},
               postWrapperLines = {
                   "        addView((FrameLayout)bridge, new FrameLayout.LayoutParams(",
                   "                FrameLayout.LayoutParams.MATCH_PARENT,",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT));"})
+                  "                FrameLayout.LayoutParams.MATCH_PARENT));",
+                  "        removeViewAt(0);"})
     public XWalkViewInternal(Context context) {
         super(context, null);
 
@@ -214,11 +227,15 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * @since 1.0
      */
     @XWalkAPI(preWrapperLines = {
-                  "        super(${param1}, ${param2});"},
+                  "        super(${param1}, ${param2});",
+                  "        SurfaceView surfaceView = new SurfaceView(${param1});",
+                  "        surfaceView.setLayoutParams(new ViewGroup.LayoutParams(0, 0));",
+                  "        addView(surfaceView);"},
               postWrapperLines = {
                   "        addView((FrameLayout)bridge, new FrameLayout.LayoutParams(",
                   "                FrameLayout.LayoutParams.MATCH_PARENT,",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT));"})
+                  "                FrameLayout.LayoutParams.MATCH_PARENT));",
+                  "        removeViewAt(0);"})
     public XWalkViewInternal(Context context, AttributeSet attrs) {
         super(context, attrs);
 
@@ -238,11 +255,15 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * @since 1.0
      */
     @XWalkAPI(preWrapperLines = {
-                  "        super(${param1}, null);"},
+                  "        super(${param1}, null);",
+                  "        SurfaceView surfaceView = new SurfaceView(${param1});",
+                  "        surfaceView.setLayoutParams(new ViewGroup.LayoutParams(0, 0));",
+                  "        addView(surfaceView);"},
               postWrapperLines = {
                   "        addView((FrameLayout)bridge, new FrameLayout.LayoutParams(",
                   "                FrameLayout.LayoutParams.MATCH_PARENT,",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT));"})
+                  "                FrameLayout.LayoutParams.MATCH_PARENT));",
+                  "        removeViewAt(0);"})
     public XWalkViewInternal(Context context, Activity activity) {
         super(context, null);
 


### PR DESCRIPTION
The moment when the XWalkViewBridge is added to the XWalkView, the
screen flashes black. The reason is when the SurfaceView appears
in the window the fist time, it requests the window's parameters
changing by calling IWindowSession.relayout(). But if the window
already has appropriate parameters, it will not refresh all the
window's stuff and the screen will not blink. So we add a 0px
SurfaceView at first. This will recreate the window before the
activity is shown on the screen, and when the actual XWalkViewBridge
is added, it will just continue to use the window with current
parameters. The temporary SurfaceView can be removed at last.

BUG=XWALK-4966