### PR TITLE
Add 'Optimize for size, Os' compile option

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -376,6 +376,8 @@ if __name__ == '__main__':
     args.append('-Ddisable_web_video=1')
     # Disable webspeech by default
     args.append('-Ddisable_speech=1')
+    # Enable "Optimize for size, Os" compile option by default
+    args.append('-Duse_optimize_for_size_compile_option=1')
 
   if not use_analyzer:
     print 'Updating projects from gyp files...'


### PR DESCRIPTION
Modules like Base,Skia,cc,V8 use "increase size for speed" to
run faster.In Lite we prefer to decrease size.

With lzma, 677K binary size reduced for embedded_shell.apk
Without lzma, 820K binary size reduced.

Slight performance downgrade found,it is an acceptable balance.