### PR TITLE
Revert "Encode the data by base64 to load that as a data: URL"

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -17,7 +17,6 @@ import android.view.View;
 import android.view.WindowManager;
 import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.util.Base64;
 import android.util.Log;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
@@ -228,18 +227,8 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
             if (content == null || content.isEmpty()) {
                 params = new LoadUrlParams(url);
             } else {
-                // When loading data with a non-data: base URL, the classic WebView would effectively
-                // "dump" that string of data into the WebView without going through regular URL
-                // loading steps such as decoding URL-encoded entities. We achieve this same behavior by
-                // base64 encoding the data that is passed here and then loading that as a data: URL.
-                try {
-                    params = LoadUrlParams.createLoadDataParamsWithBaseUrl(
-                            Base64.encodeToString(content.getBytes("utf-8"),
-                            Base64.DEFAULT), "text/html", true, url, null, "utf-8");
-                } catch (java.io.UnsupportedEncodingException e) {
-                    Log.w(TAG, "Unable to load data string " + content, e);
-                    return;
-                }
+                params = LoadUrlParams.createLoadDataParamsWithBaseUrl(
+                        content, "text/html", false, url, null);
             }
             params.setOverrideUserAgent(UserAgentOverrideOption.TRUE);
             mNavigationController.loadUrl(params);


### PR DESCRIPTION
This reverts commit 1907a9c2b7d59765d41efab9c0a2824f8bced4f9.

Reason: broke several Android tests.
- org.xwalk.runtime.client.embedded.test.ContactsTest#testContacts
- org.xwalk.runtime.client.embedded.test.DeviceCapabilitiesTest#testDeviceCapabilities
- org.xwalk.runtime.client.embedded.test.ExternalExtensionTest#testExternalExtensionAsync
- org.xwalk.runtime.client.embedded.test.MessagingTest#testMessaging
- org.xwalk.runtime.client.embedded.test.NativeFileSystemTest#testNativeFileSystem
- org.xwalk.runtime.client.embedded.test.PauseResumeTest#testPauseAndResume
- org.xwalk.runtime.client.embedded.test.PresentationTest#testPresentationDisplayAvailable
- org.xwalk.runtime.client.embedded.test.ScreenOrientationTest#testScreenOrientation
- org.xwalk.runtime.client.embedded.test.ExternalExtensionTest#testExternalExtensionSync
- org.xwalk.runtime.client.test.ContactsTest#testContacts
- org.xwalk.runtime.client.test.DeviceCapabilitiesTest#testDeviceCapabilities
- org.xwalk.runtime.client.test.ExternalExtensionTest#testExternalExtensionAsync
- org.xwalk.runtime.client.test.MessagingTest#testMessaging
- org.xwalk.runtime.client.test.NativeFileSystemTest#testNativeFileSystem
- org.xwalk.runtime.client.test.PauseResumeTest#testPauseAndResume
- org.xwalk.runtime.client.test.PresentationTest#testPresentationDisplayAvailable
- org.xwalk.runtime.client.test.ScreenOrientationTest#testScreenOrientation
- org.xwalk.runtime.client.test.ExternalExtensionTest#testExternalExtensionSync

BUG=XWALK-3571