### PR TITLE
gyp: Make xwalk_runtime depend on xwalk_pak.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -70,6 +70,7 @@
         '../v8/tools/gyp/v8.gyp:v8',
         'generate_upstream_blink_version',
         'xwalk_application_lib',
+        'xwalk_pak',
         'xwalk_resources',
         'extensions/extensions.gyp:xwalk_extensions',
         'sysapps/sysapps.gyp:sysapps',
@@ -709,7 +710,6 @@
       'defines!': ['CONTENT_IMPLEMENTATION'],
       'dependencies': [
         'xwalk_runtime',
-        'xwalk_pak',
       ],
       'include_dirs': [
         '..',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -21,7 +21,6 @@
         'xwalk_core_extensions_native_jni',
         'xwalk_core_jar_jni',
         'xwalk_core_native_jni',
-        'xwalk_pak',
         'xwalk_runtime',
       ],
       'include_dirs': [


### PR DESCRIPTION
The runtime code actually needs xwalk.pak to be present to work. This is
evident when building a target like xwalk_extensions_browsertest from
scratch -- it depends on xwalk_runtime, but not xwalk_pak, and tests
InternalExtensionTest.InternalExtension and
XWalkExtensionsIFrameTest.CrossContextsReferenceShouldNotCrash were
failing when xwalk.pak was absent.

BUG=XWALK-4776