### PR TITLE
[Android] Implement the text zoom API.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -79,6 +79,7 @@ public class XWalkSettingsInternal {
 
     private static final int MINIMUM_FONT_SIZE = 1;
     private static final int MAXIMUM_FONT_SIZE = 72;
+    private int mDefaultFontSize = 16;
 
     private boolean mAutoCompleteEnabled = true;
 
@@ -825,6 +826,43 @@ public class XWalkSettingsInternal {
     public int getTextZoom() {
         synchronized (mXWalkSettingsLock) {
             return mTextSizePercent;
+        }
+    }
+
+    private int clipFontSize(int size) {
+        if (size < MINIMUM_FONT_SIZE) {
+            return MINIMUM_FONT_SIZE;
+        } else if (size > MAXIMUM_FONT_SIZE) {
+            return MAXIMUM_FONT_SIZE;
+        }
+        return size;
+    }
+
+    /**
+     * Sets the default font size. The default is 16.
+     * @param size non-negative integer between 1 and 72.
+     *             Any number outside the specified range will be pinned.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void setDefaultFontSize(int size) {
+        synchronized (mXWalkSettingsLock) {
+            size = clipFontSize(size);
+            if (mDefaultFontSize == size) return;
+            mDefaultFontSize = size;
+            mEventHandler.updateWebkitPreferencesLocked();
+        }
+    }
+
+    /**
+     * Gets the default font size.
+     * @return a non-negative integer between 1 and 72.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public int getDefaultFontSize() {
+        synchronized (mXWalkSettingsLock) {
+            return mDefaultFontSize;
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -80,6 +80,7 @@ public class XWalkSettingsInternal {
     private static final int MINIMUM_FONT_SIZE = 1;
     private static final int MAXIMUM_FONT_SIZE = 72;
     private int mDefaultFontSize = 16;
+    private int mDefaultFixedFontSize = 13;
 
     private boolean mAutoCompleteEnabled = true;
 
@@ -863,6 +864,34 @@ public class XWalkSettingsInternal {
     public int getDefaultFontSize() {
         synchronized (mXWalkSettingsLock) {
             return mDefaultFontSize;
+        }
+    }
+
+    /**
+     * Sets the default fixed font size. The default is 16.
+     * @param size a non-negative integer between 1 and 72.
+     *             Any number outside the specified range will be pinned.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void setDefaultFixedFontSize(int size) {
+        synchronized (mXWalkSettingsLock) {
+            size = clipFontSize(size);
+            if (mDefaultFixedFontSize == size) return;
+            mDefaultFixedFontSize = size;
+            mEventHandler.updateWebkitPreferencesLocked();
+        }
+    }
+
+    /**
+     * Gets the default fixed font size.
+     * @return a non-negative integer between 1 and 72.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public int getDefaultFixedFontSize() {
+        synchronized (mXWalkSettingsLock) {
+            return mDefaultFixedFontSize;
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -84,6 +84,7 @@ public class XWalkSettingsInternal {
 
     private float mInitialPageScalePercent = 0;
     private double mDIPScale = 1.0;
+    private int mTextSizePercent = 100;
 
     static class LazyDefaultUserAgent{
         private static final String sInstance = nativeGetDefaultUserAgent();
@@ -799,6 +800,32 @@ public class XWalkSettingsInternal {
     private boolean getPasswordEchoEnabledLocked() {
         assert Thread.holdsLock(mXWalkSettingsLock);
         return mPasswordEchoEnabled;
+    }
+
+    /**
+     * Sets the text zoom of the page in percent. The default is 100.
+     * @param textZoom the text zoom in percent.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void setTextZoom(final int textZoom) {
+        synchronized (mXWalkSettingsLock) {
+            if (mTextSizePercent == textZoom) return;
+            mTextSizePercent = textZoom;
+            mEventHandler.updateWebkitPreferencesLocked();
+        }
+    }
+
+    /**
+     * Gets the text zoom of the page in percent.
+     * @return the text zoom of the page in percent.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public int getTextZoom() {
+        synchronized (mXWalkSettingsLock) {
+            return mTextSizePercent;
+        }
     }
 
     private native long nativeInit(WebContents webContents);

--- a/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc
+++ b/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc
@@ -175,4 +175,10 @@ void XWalkRenderViewHostExt::SetBackgroundColor(SkColor c) {
   Send(new XWalkViewMsg_SetBackgroundColor(web_contents()->GetRoutingID(), c));
 }
 
+void XWalkRenderViewHostExt::SetTextZoomFactor(float factor) {
+  DCHECK(CalledOnValidThread());
+  Send(new XWalkViewMsg_SetTextZoomFactor(web_contents()->GetRoutingID(),
+      factor));
+}
+
 }  // namespace xwalk

--- a/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h
+++ b/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h
@@ -67,6 +67,9 @@ class XWalkRenderViewHostExt : public content::WebContentsObserver,
   // Sets the white list for Cross-Origin access.
   void SetOriginAccessWhitelist(const std::string& base_url,
                                 const std::string& permissions);
+  // Sets the zoom factor for text only. Used in layout modes other than
+  // Text Autosizing.
+  void SetTextZoomFactor(float factor);
 
  private:
   // content::WebContentsObserver implementation.

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -76,6 +76,8 @@ struct XWalkSettings::FieldIds {
         GetFieldID(env, clazz, "mTextSizePercent", "I");
     default_font_size =
         GetFieldID(env, clazz, "mDefaultFontSize", "I");
+    default_fixed_font_size =
+        GetFieldID(env, clazz, "mDefaultFixedFontSize", "I");
   }
 
   // Field ids
@@ -94,6 +96,7 @@ struct XWalkSettings::FieldIds {
   jfieldID default_video_poster_url;
   jfieldID text_size_percent;
   jfieldID default_font_size;
+  jfieldID default_fixed_font_size;
 };
 
 XWalkSettings::XWalkSettings(JNIEnv* env,
@@ -239,6 +242,10 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
 
   int font_size = env->GetIntField(obj, field_ids_->default_font_size);
   prefs.default_font_size = font_size;
+
+  int fixed_font_size = env->GetIntField(obj,
+      field_ids_->default_fixed_font_size);
+  prefs.default_fixed_font_size = fixed_font_size;
 
   render_view_host->UpdateWebkitPreferences(prefs);
 }

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -72,6 +72,8 @@ struct XWalkSettings::FieldIds {
         GetFieldID(env, clazz, "mMediaPlaybackRequiresUserGesture", "Z");
     default_video_poster_url =
         GetFieldID(env, clazz, "mDefaultVideoPosterURL", kStringClassName);
+    text_size_percent =
+        GetFieldID(env, clazz, "mTextSizePercent", "I");
   }
 
   // Field ids
@@ -88,6 +90,7 @@ struct XWalkSettings::FieldIds {
   jfieldID use_wide_viewport;
   jfieldID media_playback_requires_user_gesture;
   jfieldID default_video_poster_url;
+  jfieldID text_size_percent;
 };
 
 XWalkSettings::XWalkSettings(JNIEnv* env,
@@ -219,6 +222,17 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
           env->GetObjectField(obj, field_ids_->default_video_poster_url)));
   prefs.default_video_poster_url = str.obj() ?
       GURL(ConvertJavaStringToUTF8(str)) : GURL();
+
+  int text_size_percent = env->GetIntField(obj, field_ids_->text_size_percent);
+  if (prefs.text_autosizing_enabled) {
+    prefs.font_scale_factor = text_size_percent / 100.0f;
+    prefs.force_enable_zoom = text_size_percent >= 130;
+    // Use the default zoom factor value when Text Autosizer is turned on.
+    render_view_host_ext->SetTextZoomFactor(1);
+  } else {
+    prefs.force_enable_zoom = false;
+    render_view_host_ext->SetTextZoomFactor(text_size_percent / 100.0f);
+  }
 
   render_view_host->UpdateWebkitPreferences(prefs);
 }

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -74,6 +74,8 @@ struct XWalkSettings::FieldIds {
         GetFieldID(env, clazz, "mDefaultVideoPosterURL", kStringClassName);
     text_size_percent =
         GetFieldID(env, clazz, "mTextSizePercent", "I");
+    default_font_size =
+        GetFieldID(env, clazz, "mDefaultFontSize", "I");
   }
 
   // Field ids
@@ -91,6 +93,7 @@ struct XWalkSettings::FieldIds {
   jfieldID media_playback_requires_user_gesture;
   jfieldID default_video_poster_url;
   jfieldID text_size_percent;
+  jfieldID default_font_size;
 };
 
 XWalkSettings::XWalkSettings(JNIEnv* env,
@@ -233,6 +236,9 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
     prefs.force_enable_zoom = false;
     render_view_host_ext->SetTextZoomFactor(text_size_percent / 100.0f);
   }
+
+  int font_size = env->GetIntField(obj, field_ids_->default_font_size);
+  prefs.default_font_size = font_size;
 
   render_view_host->UpdateWebkitPreferences(prefs);
 }

--- a/runtime/common/android/xwalk_render_view_messages.h
+++ b/runtime/common/android/xwalk_render_view_messages.h
@@ -89,6 +89,10 @@ IPC_MESSAGE_CONTROL2(XWalkViewMsg_SetOriginAccessWhitelist, // NOLINT(*)
 IPC_MESSAGE_ROUTED1(XWalkViewMsg_SetBackgroundColor, // NOLINT(*)
                     SkColor)
 
+// Set the text zoom factor
+IPC_MESSAGE_ROUTED1(XWalkViewMsg_SetTextZoomFactor, // NOLINT(*)
+                    float)
+
 //-----------------------------------------------------------------------------
 // RenderView messages
 // These are messages sent from the renderer to the browser process.

--- a/runtime/renderer/android/xwalk_render_view_ext.cc
+++ b/runtime/renderer/android/xwalk_render_view_ext.cc
@@ -149,6 +149,7 @@ bool XWalkRenderViewExt::OnMessageReceived(const IPC::Message& message) {
                         OnResetScrollAndScaleState)
     IPC_MESSAGE_HANDLER(XWalkViewMsg_SetInitialPageScale, OnSetInitialPageScale)
     IPC_MESSAGE_HANDLER(XWalkViewMsg_SetBackgroundColor, OnSetBackgroundColor)
+    IPC_MESSAGE_HANDLER(XWalkViewMsg_SetTextZoomFactor, OnSetTextZoomFactor)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
   return handled;
@@ -265,6 +266,14 @@ void XWalkRenderViewExt::OnSetBackgroundColor(SkColor c) {
   if (!render_view() || !render_view()->GetWebView())
     return;
   render_view()->GetWebView()->setBaseBackgroundColor(c);
+}
+
+void XWalkRenderViewExt::OnSetTextZoomFactor(float zoom_factor) {
+  if (!render_view() || !render_view()->GetWebView())
+    return;
+  // Hide selection and autofill popups.
+  render_view()->GetWebView()->hidePopups();
+  render_view()->GetWebView()->setTextZoomFactor(zoom_factor);
 }
 
 }  // namespace xwalk

--- a/runtime/renderer/android/xwalk_render_view_ext.h
+++ b/runtime/renderer/android/xwalk_render_view_ext.h
@@ -51,6 +51,8 @@ class XWalkRenderViewExt : public content::RenderViewObserver {
 
   void OnSetBackgroundColor(SkColor c);
 
+  void OnSetTextZoomFactor(float zoom_factor);
+
   float page_scale_factor_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRenderViewExt);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/DefaultFixedFontSizeTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/DefaultFixedFontSizeTest.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+import org.xwalk.core.XWalkSettings;
+
+/**
+ * Test suite for setDefaultFixedFontSize(), getDefaultFixedFontSize().
+ */
+public class DefaultFixedFontSizeTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @SmallTest
+    @Feature({"setDefaultFixedFontSize(), getDefaultFixedFontSize()"})
+    public void testAccessDefaultFixedFontSize() throws Throwable {
+        XWalkSettings settings = getXWalkSettingsOnUiThreadByXWalkView(getXWalkView());
+        int defaultSize = settings.getDefaultFixedFontSize();
+        assertTrue(defaultSize > 0);
+        settings.setDefaultFixedFontSize(1000);
+        int maxSize = settings.getDefaultFixedFontSize();
+        assertTrue(maxSize > defaultSize);
+        settings.setDefaultFixedFontSize(-10);
+        int minSize = settings.getDefaultFixedFontSize();
+        assertTrue(minSize > 0);
+        assertTrue(minSize < maxSize);
+        settings.setDefaultFixedFontSize(10);
+        assertEquals(10, settings.getDefaultFixedFontSize());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/DefaultFontSizeTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/DefaultFontSizeTest.java
@@ -1,0 +1,93 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+import org.xwalk.core.XWalkSettings;
+import org.xwalk.core.XWalkView;
+
+/**
+ * Test suite for setDefaultFontSize(), getDefaultFontSize().
+ */
+public class DefaultFontSizeTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    class XWalkSettingsDefaultFontSizeTestHelper extends XWalkSettingsTestHelper<Integer> {
+        TestHelperBridge mBridge;
+        XWalkView mView;
+
+        XWalkSettingsDefaultFontSizeTestHelper(XWalkView view,
+                TestHelperBridge bridge) throws Throwable {
+            super(view);
+            mView = view;
+            mBridge = bridge;
+        }
+
+        @Override
+        protected Integer getAlteredValue() {
+            return 42;
+        }
+
+        @Override
+        protected Integer getInitialValue() {
+            return 16;
+        }
+
+        @Override
+        protected Integer getCurrentValue() {
+            return mXWalkSettingsForHelper.getDefaultFontSize();
+        }
+
+        @Override
+        protected void setCurrentValue(Integer value) {
+            mXWalkSettingsForHelper.setDefaultFontSize(value);
+        }
+
+        @Override
+        protected void doEnsureSettingHasValue(Integer value) throws Throwable {
+            loadDataSyncWithXWalkView(getData(), mView, mBridge);
+            assertEquals(value.toString() + "px", getTitleOnUiThreadByContent(mView));
+        }
+
+        private String getData() {
+            return "<html><body onload=\"document.title = "
+                    + "getComputedStyle(document.body).getPropertyValue('font-size');\">"
+                    + "</body></html>";
+        }
+    }
+
+    @SmallTest
+    @Feature({"setDefaultFontSize(), getDefaultFontSize()"})
+    public void testDefaultFontSizeWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsDefaultFontSizeTestHelper(views.getView0(), views.getBridge0()),
+                new XWalkSettingsDefaultFontSizeTestHelper(views.getView1(), views.getBridge1()));
+    }
+
+    @SmallTest
+    @Feature({"setDefaultFontSize(), getDefaultFontSize()"})
+    public void testAccessDefaultFontSize() throws Throwable {
+        XWalkSettings settings = getXWalkSettingsOnUiThreadByXWalkView(getXWalkView());
+        int defaultSize = settings.getDefaultFontSize();
+        assertTrue(defaultSize > 0);
+        settings.setDefaultFontSize(1000);
+        int maxSize = settings.getDefaultFontSize();
+        assertTrue(maxSize > defaultSize);
+        settings.setDefaultFontSize(-10);
+        int minSize = settings.getDefaultFontSize();
+        assertTrue(minSize > 0);
+        assertTrue(minSize < maxSize);
+        settings.setDefaultFontSize(10);
+        assertEquals(10, settings.getDefaultFontSize());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TextZoomTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TextZoomTest.java
@@ -1,0 +1,171 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.ui.gfx.DeviceDisplayInfo;
+import org.xwalk.core.XWalkView;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Test suite for setTextZoom(), getTextZoom().
+ */
+public class TextZoomTest extends XWalkViewTestBase {
+    private final String TAG = "TextZoomTest";
+    private static final float MAXIMUM_SCALE = 2.0f;
+    private final float mPageMinimumScale = 0.5f;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    // This class provides helper methods for testing of settings related to
+    // the text autosizing feature.
+    abstract class XWalkSettingsTextAutosizingTestHelper<T> extends XWalkSettingsTestHelper<T> {
+        protected static final float PARAGRAPH_FONT_SIZE = 14.0f;
+        private boolean mNeedToWaitForFontSizeChange;
+        private float mOldFontSize;
+        XWalkView mView;
+        TestHelperBridge mBridge;
+
+        XWalkSettingsTextAutosizingTestHelper(XWalkView view,
+                TestHelperBridge bridge) throws Throwable {
+            super(view);
+            mNeedToWaitForFontSizeChange = false;
+            mView = view;
+            mBridge = bridge;
+            loadDataSyncWithXWalkView(getData(), view, bridge);
+        }
+
+        @Override
+        protected void setCurrentValue(T value) throws Throwable {
+            mNeedToWaitForFontSizeChange = false;
+            if (value != getCurrentValue()) {
+                mOldFontSize = getActualFontSize();
+                mNeedToWaitForFontSizeChange = true;
+            }
+        }
+
+        protected float getActualFontSize() throws Throwable {
+            if (!mNeedToWaitForFontSizeChange) {
+                executeJavaScriptAndWaitForResultByXWalkView(
+                        "setTitleToActualFontSize()", mView, mBridge);
+            } else {
+                final float oldFontSize = mOldFontSize;
+                poll(new Callable<Boolean>() {
+                    @Override
+                    public Boolean call() throws Exception {
+                        executeJavaScriptAndWaitForResultByXWalkView(
+                                "setTitleToActualFontSize()", mView, mBridge);
+                        float newFontSize = Float.parseFloat(getTitleOnUiThreadByContent(mView));
+                        return newFontSize != oldFontSize;
+                    }
+                });
+                mNeedToWaitForFontSizeChange = false;
+            }
+            return Float.parseFloat(getTitleOnUiThreadByContent(mView));
+        }
+
+        protected String getData() {
+            DeviceDisplayInfo deviceInfo = DeviceDisplayInfo.create(mView.getContext());
+            int displayWidth = (int) (deviceInfo.getDisplayWidth() / deviceInfo.getDIPScale());
+            int layoutWidth = (int) (displayWidth * 2.5f); // Use 2.5 as autosizing layout tests do.
+            StringBuilder sb = new StringBuilder();
+            sb.append("<html>"
+                    + "<head>"
+                    + "<meta name=\"viewport\" content=\"width=" + layoutWidth + "\">"
+                    + "<style>"
+                    + "body { width: " + layoutWidth + "px; margin: 0; overflow-y: hidden; }"
+                    + "</style>"
+                    + "<script>"
+                    + "function setTitleToActualFontSize() {"
+                    // parseFloat is used to trim out the "px" suffix.
+                    + "  document.title = parseFloat(getComputedStyle("
+                    + "    document.getElementById('par')).getPropertyValue('font-size'));"
+                    + "}</script></head>"
+                    + "<body>"
+                    + "<p id=\"par\" style=\"font-size:");
+            sb.append(PARAGRAPH_FONT_SIZE);
+            sb.append("px;\">");
+            // Make the paragraph wide enough for being processed by the font autosizer.
+            for (int i = 0; i < 500; i++) {
+                sb.append("Hello, World! ");
+            }
+            sb.append("</p></body></html>");
+            return sb.toString();
+        }
+    }
+
+    class XWalkSettingsTextZoomAutosizingTestHelper
+            extends XWalkSettingsTextAutosizingTestHelper<Integer> {
+        private static final int INITIAL_TEXT_ZOOM = 100;
+        private final float mInitialActualFontSize;
+        private final XWalkView mView;
+
+        XWalkSettingsTextZoomAutosizingTestHelper(XWalkView view,
+                TestHelperBridge bridge) throws Throwable {
+            super(view, bridge);
+            mView = view;
+            mInitialActualFontSize = getActualFontSize();
+        }
+
+        @Override
+        protected Integer getAlteredValue() {
+            return INITIAL_TEXT_ZOOM * 2;
+        }
+
+        @Override
+        protected Integer getInitialValue() {
+            return INITIAL_TEXT_ZOOM;
+        }
+
+        @Override
+        protected Integer getCurrentValue() {
+            try {
+                return getTextZoomOnUiThreadByXWalkView(mView);
+            } catch (Exception e) {
+                Log.e(TAG, "getCurrentValue e=" + e);
+                return -1;
+            }
+        }
+
+        @Override
+        protected void setCurrentValue(Integer value) throws Throwable {
+            super.setCurrentValue(value);
+            setTextZoomOnUiThreadByXWalkView(value, mView);
+        }
+
+        @Override
+        protected void doEnsureSettingHasValue(Integer value) throws Throwable {
+            final float actualFontSize = getActualFontSize();
+            // Ensure that actual vs. initial font size ratio is similar to actual vs. initial
+            // text zoom values ratio.
+            final float ratiosDelta = Math.abs(
+                    (actualFontSize / mInitialActualFontSize)
+                    - (value / (float) INITIAL_TEXT_ZOOM));
+            assertTrue(
+                    "|(" + actualFontSize + " / " + mInitialActualFontSize + ") - ("
+                    + value + " / " + INITIAL_TEXT_ZOOM + ")| = " + ratiosDelta,
+                    ratiosDelta <= 0.2f);
+        }
+    }
+
+    @SmallTest
+    @Feature({"setTextZoom(), getTextZoom()"})
+    public void testTextZoom() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsTextZoomAutosizingTestHelper(views.getView0(), 
+                        views.getBridge0()),
+                new XWalkSettingsTextZoomAutosizingTestHelper(views.getView1(),
+                        views.getBridge1()));
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -35,6 +35,7 @@ import org.xwalk.core.XWalkJavascriptResult;
 import org.xwalk.core.XWalkNavigationHistory;
 import org.xwalk.core.XWalkNavigationItem;
 import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkSettings;
 import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkWebResourceRequest;
@@ -747,5 +748,241 @@ public class XWalkViewTestBase
                 return targetScale == getScaleFactor();
             }
         });
+    }
+
+    abstract class XWalkSettingsTestHelper<T> {
+        protected final XWalkView mXWalkViewForHelper;
+        protected final XWalkSettings mXWalkSettingsForHelper;
+
+        XWalkSettingsTestHelper(XWalkView view) throws Throwable {
+            mXWalkViewForHelper = view;
+            mXWalkSettingsForHelper = getXWalkSettingsOnUiThreadByXWalkView(view);
+        }
+
+        void ensureSettingHasAlteredValue() throws Throwable {
+            ensureSettingHasValue(getAlteredValue());
+        }
+
+        void ensureSettingHasInitialValue() throws Throwable {
+            ensureSettingHasValue(getInitialValue());
+        }
+
+        void setAlteredSettingValue() throws Throwable {
+            setCurrentValue(getAlteredValue());
+        }
+
+        void setInitialSettingValue() throws Throwable {
+            setCurrentValue(getInitialValue());
+        }
+
+        protected abstract T getAlteredValue();
+
+        protected abstract T getInitialValue();
+
+        protected abstract T getCurrentValue();
+
+        protected abstract void setCurrentValue(T value) throws Throwable;
+
+        protected abstract void doEnsureSettingHasValue(T value) throws Throwable;
+
+        private void ensureSettingHasValue(T value) throws Throwable {
+            assertEquals(value, getCurrentValue());
+            doEnsureSettingHasValue(value);
+        }
+    }
+
+    /**
+     * Verifies the following statements about a setting:
+     *  - initially, the setting has a default value;
+     *  - the setting can be switched to an alternate value and back;
+     *  - switching a setting in the first XWalkView doesn't affect the setting
+     *    state in the second XWalkView and vice versa.
+     *
+     * @param helper0 Test helper for the first XWalkView
+     * @param helper1 Test helper for the second XWalkView
+     * @throws Throwable
+     */
+    protected void runPerViewSettingsTest(XWalkSettingsTestHelper helper0,
+            XWalkSettingsTestHelper helper1) throws Throwable {
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasInitialValue();
+        helper1.setAlteredSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasAlteredValue();
+
+        helper1.setInitialSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper0.setAlteredSettingValue();
+        helper0.ensureSettingHasAlteredValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper0.setInitialSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper0.setAlteredSettingValue();
+        helper0.ensureSettingHasAlteredValue();
+        helper1.ensureSettingHasInitialValue();
+
+        helper1.setAlteredSettingValue();
+        helper0.ensureSettingHasAlteredValue();
+        helper1.ensureSettingHasAlteredValue();
+
+        helper0.setInitialSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasAlteredValue();
+
+        helper1.setInitialSettingValue();
+        helper0.ensureSettingHasInitialValue();
+        helper1.ensureSettingHasInitialValue();
+    }
+
+    protected Integer getTextZoomOnUiThreadByXWalkView(final XWalkView view) throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return view.getSettings().getTextZoom();
+            }
+        });
+    }
+
+    protected void setTextZoomOnUiThreadByXWalkView(final int value,
+            final XWalkView view) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                view.getSettings().setTextZoom(value);
+            }
+        });
+    }
+
+    protected void poll(final Callable<Boolean> callable) throws Exception {
+        assertTrue(CriteriaHelper.pollForCriteria(new Criteria() {
+            @Override
+            public boolean isSatisfied() {
+                try {
+                    return callable.call();
+                } catch (Throwable e) {
+                    Log.e(TAG, "Exception while polling.", e);
+                    return false;
+                }
+            }
+        }, WAIT_TIMEOUT_MS, CHECK_INTERVAL));
+    }
+
+    static class ViewPair {
+        private final XWalkView view0;
+        private final TestHelperBridge bridge0;
+        private final XWalkView view1;
+        private final TestHelperBridge bridge1;
+
+        ViewPair(XWalkView view0, TestHelperBridge bridge0,
+                XWalkView view1, TestHelperBridge bridge1) {
+            this.view0 = view0;
+            this.bridge0 = bridge0;
+            this.view1 = view1;
+            this.bridge1 = bridge1;
+        }
+
+        XWalkView getView0() {
+            return view0;
+        }
+
+        TestHelperBridge getBridge0() {
+            return bridge0;
+        }
+
+        XWalkView getView1() {
+            return view1;
+        }
+
+        TestHelperBridge getBridge1() {
+            return bridge1;
+        }
+    }
+
+    protected ViewPair createViews() throws Throwable {
+        TestHelperBridge helperBridge0 = new TestHelperBridge();
+        TestHelperBridge helperBridge1 = new TestHelperBridge();
+        TestXWalkUIClientBase uiClient0 = new TestXWalkUIClientBase(helperBridge0);
+        TestXWalkUIClientBase uiClient1 = new TestXWalkUIClientBase(helperBridge1);
+        TestXWalkResourceClientBase resourceClient0 =
+                new TestXWalkResourceClientBase(helperBridge0);
+        TestXWalkResourceClientBase resourceClient1 =
+                new TestXWalkResourceClientBase(helperBridge1);
+        ViewPair viewPair =
+                createViewsOnMainSync(helperBridge0, helperBridge1, uiClient0, uiClient1,
+                        resourceClient0, resourceClient1, getActivity());
+
+        return viewPair;
+    }
+
+    protected ViewPair createViewsOnMainSync(final TestHelperBridge helperBridge0,
+                                             final TestHelperBridge helperBridge1,
+                                             final XWalkUIClient uiClient0,
+                                             final XWalkUIClient uiClient1,
+                                             final XWalkResourceClient resourceClient0,
+                                             final XWalkResourceClient resourceClient1,
+                                             final Context context) throws Throwable {
+        final XWalkView walkView0 = createXWalkViewContainerOnMainSync(context,
+                uiClient0, resourceClient0);
+        final XWalkView walkView1 = createXWalkViewContainerOnMainSync(context,
+                uiClient1, resourceClient1);
+        final AtomicReference<ViewPair> viewPair = new AtomicReference<ViewPair>();
+
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                viewPair.set(new ViewPair(walkView0, helperBridge0, walkView1, helperBridge1));
+            }
+        });
+
+        return viewPair.get();
+    }
+
+    protected XWalkSettings getXWalkSettingsOnUiThreadByXWalkView(
+            final XWalkView view) throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<XWalkSettings>() {
+            @Override
+            public XWalkSettings call() throws Exception {
+                return view.getSettings();
+            }
+        });
+    }
+
+    protected void loadDataSyncWithXWalkView(final String data,
+            final XWalkView view, final TestHelperBridge bridge) throws Exception {
+        CallbackHelper pageFinishedHelper = bridge.getOnPageFinishedHelper();
+        int currentCallCount = pageFinishedHelper.getCallCount();
+        loadDataAsyncWithXWalkView(data, view);
+        pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
+    }
+
+    protected void loadDataAsyncWithXWalkView(final String data,
+            final XWalkView view) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                view.load(null, data);
+            }
+        });
+    }
+
+    protected String executeJavaScriptAndWaitForResultByXWalkView(final String code,
+            final XWalkView view, final TestHelperBridge bridge) throws Exception {
+        final TestHelperBridge.OnEvaluateJavaScriptResultHelper helper =
+                bridge.getOnEvaluateJavaScriptResultHelper();
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                helper.evaluateJavascript(view, code);
+            }
+        });
+        helper.waitUntilHasValue();
+        Assert.assertTrue("Failed to retrieve JavaScript evaluation results.", helper.hasValue());
+        return helper.getJsonResultAndClear();
     }
 }


### PR DESCRIPTION
This patch is to implement API for setTextZoom() and getTextZoom().
Adjust test case for reuse.
Add test case for setTextZoom() and getTextZoom().

BUG=XWALK-4994