### PR TITLE
[Android] Encode the data by base64 to load that as a data: URL

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.WindowManager;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.util.Base64;
 import android.util.Log;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
@@ -227,8 +228,18 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
             if (content == null || content.isEmpty()) {
                 params = new LoadUrlParams(url);
             } else {
-                params = LoadUrlParams.createLoadDataParamsWithBaseUrl(
-                        content, "text/html", false, url, null);
+                // When loading data with a non-data: base URL, the classic XWalkView would effectively
+                // "dump" that string of data into the XWalkView without going through regular URL
+                // loading steps such as decoding URL-encoded entities. We achieve this same behavior by
+                // base64 encoding the data that is passed here and then loading that as a data: URL.
+                try {
+                    params = LoadUrlParams.createLoadDataParamsWithBaseUrl(
+                            Base64.encodeToString(content.getBytes("utf-8"),
+                            Base64.DEFAULT), "text/html", true, url, null, "utf-8");
+                } catch (java.io.UnsupportedEncodingException e) {
+                    Log.w(TAG, "Unable to load data string " + content, e);
+                    return;
+                }
             }
             params.setOverrideUserAgent(UserAgentOverrideOption.TRUE);
             mNavigationController.loadUrl(params);

--- a/test/android/util/src/org/xwalk/test/util/XWalkTestUtilBase.java
+++ b/test/android/util/src/org/xwalk/test/util/XWalkTestUtilBase.java
@@ -75,8 +75,7 @@ public class XWalkTestUtilBase<T> {
     }
 
     public void loadAssetFile(String fileName) throws Exception {
-        //The content of "Data URI scheme" should be escaped when data type is "text/html".
-        String fileContent = Uri.encode(getFileContent(fileName));
+        String fileContent = getFileContent(fileName);
         loadDataSync(fileContent, "text/html", false);
     }
 


### PR DESCRIPTION
The data type of "text/html" can be parsed, so doesn't need be escaped before
loading.

BUG=XWALK-3571