### PR TITLE
[Tools] Pass "--ignore_locks" to gclient sync when fetching deps.

### DIFF
--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -46,6 +46,7 @@ class DepsFetcher(object):
   def DoGclientSyncForChromium(self):
     gclient_cmd = ['gclient', 'sync', '--verbose', '--reset',
                    '--force', '--with_branch_heads',
+                   '--ignore_locks',
                    '--delete_unversioned_trees']
     gclient_cmd.append('--gclientfile=%s' %
                        os.path.basename(self._new_gclient_file))


### PR DESCRIPTION
Fetching Crosswalk on Android with git caches is currently broken when
calling `gclient sync` without `-j1`, as two different entries in
Chromium's DEPS use the same repository and when multiple gclient jobs
are running in parallel more than one can try locking the same
repository cache at the same time. This has been reported upstream as
[http://crbug.com/516347](bug 516347).

This does not seem to affect the build.chromium.org slaves because they
all call `gclient sync` with `--ignore_locks`, so there is no
possibility of lock contention. Despite the scary name, the option looks
safe enough for our bots to use as well.

BUG=XWALK-4882