### PR TITLE
Implement .NET external extension system.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -42,6 +42,10 @@ solutions = [
       'src/v8':
         crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
 
+      # Temporary roll GYP forward so we can have support to compile managed code on Windows.
+      'src/tools/gyp':
+        'https://chromium.googlesource.com/external/gyp.git@1f374df95de1c0a125485496e8d23d36303a93fd',
+
       # Include OpenCL header files for WebCL support, target version 1.2.
       'src/third_party/khronos/CL':
         crosswalk_git + '/khronos-cl-api-1.2.git@6f4be98d10f03ce2b12c769cd9835c73a441c00f',

--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -114,12 +114,18 @@ bool XWalkExtensionProcessHost::Delegate::OnRegisterPermissions(
 XWalkExtensionProcessHost::XWalkExtensionProcessHost(
     content::RenderProcessHost* render_process_host,
     const base::FilePath& external_extensions_path,
+#if defined (OS_WIN)
+    const base::FilePath& dotnet_extensions_path,
+#endif
     XWalkExtensionProcessHost::Delegate* delegate,
     scoped_ptr<base::ValueMap> runtime_variables)
     : ep_rp_channel_handle_(""),
       render_process_host_(render_process_host),
       render_process_message_filter_(new RenderProcessMessageFilter(this)),
       external_extensions_path_(external_extensions_path),
+#if defined (OS_WIN)
+      dotnet_extensions_path_(dotnet_extensions_path),
+#endif
       is_extension_process_channel_ready_(false),
       delegate_(delegate),
       runtime_variables_(runtime_variables.Pass()) {
@@ -196,6 +202,10 @@ void XWalkExtensionProcessHost::StartProcess() {
       &runtime_variables_lv);
   Send(new XWalkExtensionProcessMsg_RegisterExtensions(
         external_extensions_path_, runtime_variables_lv));
+#if defined (OS_WIN)
+  Send(new XWalkExtensionProcessMsg_RegisterDotNetExtensions(
+        dotnet_extensions_path_, runtime_variables_lv));
+#endif
 }
 
 void XWalkExtensionProcessHost::StopProcess() {

--- a/extensions/browser/xwalk_extension_process_host.h
+++ b/extensions/browser/xwalk_extension_process_host.h
@@ -53,6 +53,9 @@ class XWalkExtensionProcessHost
 
   XWalkExtensionProcessHost(content::RenderProcessHost* render_process_host,
                             const base::FilePath& external_extensions_path,
+#if defined (OS_WIN)
+                            const base::FilePath& dotnet_extensions_path,
+#endif
                             XWalkExtensionProcessHost::Delegate* delegate,
                             scoped_ptr<base::ValueMap> runtime_variables);
   ~XWalkExtensionProcessHost() override;
@@ -101,6 +104,9 @@ class XWalkExtensionProcessHost
   scoped_refptr<RenderProcessMessageFilter> render_process_message_filter_;
 
   base::FilePath external_extensions_path_;
+#if defined (OS_WIN)
+  base::FilePath dotnet_extensions_path_;
+#endif
 
   bool is_extension_process_channel_ready_;
 

--- a/extensions/browser/xwalk_extension_service.h
+++ b/extensions/browser/xwalk_extension_service.h
@@ -61,6 +61,10 @@ class XWalkExtensionService : public content::NotificationObserver,
 
   void RegisterExternalExtensionsForPath(const base::FilePath& path);
 
+#if defined(OS_WIN)
+  void RegisterDotNetExtensionsForPath(const base::FilePath& path);
+#endif
+
   // To be called when a new RenderProcessHost is created, will plug the
   // extension system to that render process. See
   // XWalkContentBrowserClient::RenderProcessWillLaunch().
@@ -88,6 +92,9 @@ class XWalkExtensionService : public content::NotificationObserver,
       const CreateExtensionsCallback& callback);
 
   static void SetExternalExtensionsPathForTesting(const base::FilePath& path);
+#if defined(OS_WIN)
+  static void SetDotNetExtensionsPathForTesting(const base::FilePath& path);
+#endif
 
  private:
   void OnRenderProcessHostCreatedInternal(
@@ -137,6 +144,9 @@ class XWalkExtensionService : public content::NotificationObserver,
   Delegate* delegate_;
 
   base::FilePath external_extensions_path_;
+#if defined(OS_WIN)
+  base::FilePath dotnet_extensions_path_;
+#endif
 
   typedef std::map<int, XWalkExtensionData*> RenderProcessToExtensionDataMap;
   RenderProcessToExtensionDataMap extension_data_map_;

--- a/extensions/common/win/xwalk_dotnet_bridge.cc
+++ b/extensions/common/win/xwalk_dotnet_bridge.cc
@@ -1,0 +1,289 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/common/win/xwalk_dotnet_bridge.h"
+
+#include <Objbase.h>
+#include <vcclr.h>
+
+#include <iostream>
+#include <string>
+
+using namespace System; // NOLINT
+using namespace System::Reflection; // NOLINT
+using namespace Runtime::InteropServices; // NOLINT
+
+namespace xwalk {
+namespace extensions {
+
+static void MarshalString(String^ input, std::string* output) {
+  const char* chars = reinterpret_cast<const char*>(
+      Marshal::StringToHGlobalAnsi(input).ToPointer());
+  *output = chars;
+  Marshal::FreeHGlobal(IntPtr((void*)chars)); //NOLINT
+}
+
+public ref class Bridge : public Object {
+ public:
+  Bridge(XWalkDotNetBridge* bridge)
+    : bridge_(bridge),
+      instance_(0) {}
+  void setNativeInstance(void* instance) {
+    instance_ = instance;
+  }
+  void PostMessageToJS(String^ message) {
+    std::string message_to_js;
+    MarshalString(message, &message_to_js);
+    bridge_->PostMessageToInstance(instance_, message_to_js);
+  }
+  void SendSyncReply(String^ message) {
+    std::string message_to_js;
+    MarshalString(message, &message_to_js);
+    bridge_->SetSyncReply(instance_, message_to_js);
+  }
+ private:
+  XWalkDotNetBridge* bridge_;
+  void* instance_;
+};
+
+XWalkDotNetBridge::XWalkDotNetBridge(
+    void* extension, const std::wstring& library_path)
+    : extension_(extension),
+      library_path_(library_path),
+      initialized_(false),
+      extension_dotnet_(0),
+      set_name_callback_(0),
+      set_javacript_api_callback_(0) {}
+
+XWalkDotNetBridge::~XWalkDotNetBridge() {
+  if (extension_dotnet_) {
+    gcroot<Object^> *extension_object_ptr =
+        static_cast<gcroot<Object^>*>(extension_dotnet_);
+    delete extension_object_ptr;
+    extension_dotnet_ = 0;
+  }
+  if (extension_assembly_) {
+    gcroot<Assembly^> *extension_assembly_ptr =
+        static_cast<gcroot<Assembly^>*>(extension_assembly_);
+    delete extension_assembly_ptr;
+    extension_assembly_ = 0;
+  }
+}
+
+bool XWalkDotNetBridge::Initialize() {
+  if (initialized_)
+    return true;
+  try {
+    String^ path = gcnew String(library_path_.c_str());
+    Assembly^ extension_assembly = Assembly::LoadFrom(path);
+    gcroot<Assembly^> *extension_assembly_ptr =
+        new gcroot<Assembly^>(extension_assembly);
+    extension_assembly_ = static_cast<void*>(extension_assembly_ptr);
+    // Figure out if the XWalkExtension class is present.
+    Type^ extension_type =
+        extension_assembly->GetType("xwalk.XWalkExtension", true);
+    if (!extension_type) {
+      std::cerr << "Error loading extension "
+                << library_path_.c_str()
+                << "': XWalkExtension class is not defined";
+      return false;
+    }
+    ConstructorInfo^ extension_constructor =
+        extension_type->GetConstructor(Type::EmptyTypes);
+    if (!extension_constructor) {
+      std::cerr << "Error loading extension " << library_path_.c_str()
+                << "': XWalkExtension constructor is not defined";
+      return false;
+    }
+
+    MethodInfo^ extension_name_method =
+        extension_type->GetMethod("ExtensionName");
+    if (!extension_name_method) {
+      std::cerr << "Error loading extension " << library_path_.c_str()
+                << "': ExtensionName method is not defined";
+      return false;
+    }
+
+    MethodInfo^ extension_api_method =
+        extension_type->GetMethod("ExtensionAPI");
+    if (!extension_api_method) {
+      std::cerr << "Error loading extension " << library_path_.c_str()
+                << "': ExtensionAPI method is not defined";
+      return false;
+    }
+
+    Object^ extension_object =
+        extension_constructor->Invoke(gcnew array<Object^>(0){});
+    gcroot<Object^> *extension_object_ptr =
+        new gcroot<Object^>(extension_object);
+    extension_dotnet_ = static_cast<void*>(extension_object_ptr);
+
+    Object^ extension_name_clr =
+        extension_name_method->Invoke(extension_object,
+                                      gcnew array<Object^>(0){});
+    if (extension_name_clr->GetType() != String::typeid) {
+      std::cerr << "Error loading extension " << library_path_.c_str()
+                << "': ExtensionName return type is not valid";
+      return false;
+    }
+    std::string extension_name;
+    MarshalString(extension_name_clr->ToString(), &extension_name);
+    set_name_callback_(extension_, extension_name);
+
+    Object^ api_clr = extension_api_method->Invoke(extension_object,
+                                                   gcnew array<Object^>(0){});
+    if (api_clr->GetType() != String::typeid) {
+      std::cerr << "Error loading extension " << library_path_.c_str()
+                << "': ExtensionAPI return type is not valid";
+      return false;
+    }
+    std::string api;
+    MarshalString(api_clr->ToString(), &api);
+    set_javacript_api_callback_(extension_, api);
+
+    initialized_ = true;
+    return true;
+  }
+  catch (Exception^ e) {
+    std::string message;
+    MarshalString(e->ToString(), &message);
+    std::cerr << "Error loading extension " << library_path_.c_str()
+              << "': " << message;
+    return false;
+  }
+}
+
+void XWalkDotNetBridge::set_name_callback(set_name_callback_func callback) {
+  set_name_callback_ = callback;
+}
+
+void XWalkDotNetBridge::set_javascript_api_callback(
+    set_javacript_api_callback_func callback) {
+  set_javacript_api_callback_ = callback;
+}
+
+void XWalkDotNetBridge::set_post_message_callback(
+    post_message_callback_func callback) {
+  post_message_callback_ = callback;
+}
+
+void XWalkDotNetBridge::set_set_sync_reply_callback(
+  set_sync_reply_callback_func callback) {
+  set_sync_reply_callback_ = callback;
+}
+
+void* XWalkDotNetBridge::CreateInstance(void* native_instance) {
+  if (!initialized_)
+    return 0;
+  try {
+    gcroot<Assembly^> *extension_assembly_ptr =
+        static_cast<gcroot<Assembly^>*>(extension_assembly_);
+    Type^ extension_instance_type =
+        ((Assembly^)*extension_assembly_ptr)->GetType(
+            "xwalk.XWalkExtensionInstance", true);
+    if (!extension_instance_type) {
+      std::cerr << "Error creating .NET extension instance "
+                << library_path_.c_str()
+                << "': XWalkExtensionInstance class is not defined";
+      return 0;
+    }
+
+    array<Type^>^types = gcnew array<Type^>(1);
+    types[0] = Object::typeid;
+    ConstructorInfo^ extension_instance_constructor =
+        extension_instance_type->GetConstructor(types);
+    if (!extension_instance_constructor) {
+      std::cerr << "Error loading extension instance " << library_path_.c_str()
+                << "': XWalkExtensionInstance constructor is not defined";
+      return 0;
+    }
+
+    array<Type^>^types_string = gcnew array<Type^>(1);
+    types_string[0] = String::typeid;
+    MethodInfo^ handle_sync_message_method =
+        extension_instance_type->GetMethod("HandleSyncMessage", types_string);
+    if (!handle_sync_message_method) {
+      std::cerr << "Error loading extension instance " << library_path_.c_str()
+                << "': HandleSyncMessage is not defined or has"
+                << " an incorrect prototype";
+      return 0;
+    }
+
+    MethodInfo^ handle_message_method =
+        extension_instance_type->GetMethod("HandleMessage", types_string);
+    if (!handle_message_method) {
+      std::cerr << "Error loading extension instance " << library_path_.c_str()
+                << "': HandleMessage is not defined or has"
+                << " an incorrect prototype";
+      return 0;
+    }
+
+    Bridge^ callback = gcnew Bridge(this);
+    Object^ extension_instance_object =
+        extension_instance_constructor->Invoke(
+            gcnew array<Object^>(1){ callback });
+    gcroot<Object^> *extension_instance_object_ptr =
+        new gcroot<Object^>(extension_instance_object);
+    void* extension_instance_dotnet =
+        static_cast<void*>(extension_instance_object_ptr);
+    callback->setNativeInstance(native_instance);
+    return extension_instance_dotnet;
+  }
+  catch (Exception^ e) {
+    std::string message;
+    MarshalString(e->ToString(), &message);
+    std::cerr << "Error creating extension instance"
+              << library_path_.c_str() << "': " << message;
+    return 0;
+  }
+}
+
+void XWalkDotNetBridge::HandleMessage(void* instance,
+                                      const std::string& message) {
+  String^ message_str = gcnew String(message.c_str());
+  gcroot<Object^> *instance_object_ptr =
+      static_cast<gcroot<Object^>*>(instance);
+  Type^ extension_instance_type = ((Object^)*instance_object_ptr)->GetType();
+  MethodInfo^ handle_message_method =
+      extension_instance_type->GetMethod("HandleMessage");
+  if (!handle_message_method) {
+    std::cerr << "Error invoking HandleMessage on extension instance "
+              << library_path_.c_str()
+              << "': HandleMessage method is not defined";
+    return;
+  }
+  Object^ returnValue = handle_message_method->Invoke(
+      ((Object^)*instance_object_ptr), gcnew array<Object^>(1){ message_str });
+}
+
+void XWalkDotNetBridge::HandleSyncMessage(void* instance,
+                                          const std::string& message) {
+  String^ message_str = gcnew String(message.c_str());
+  gcroot<Object^> *instance_object_ptr =
+      static_cast<gcroot<Object^>*>(instance);
+  Type^ extension_instance_type = ((Object^)*instance_object_ptr)->GetType();
+  MethodInfo^ handle_sync_message_method =
+      extension_instance_type->GetMethod("HandleSyncMessage");
+  if (!handle_sync_message_method) {
+    std::cerr << "Error invoking HandleSyncMessage on extension instance "
+              << library_path_.c_str()
+              << "': HandleMessage method is not defined";
+    return;
+  }
+  Object^ returnValue = handle_sync_message_method->Invoke(
+      ((Object^)*instance_object_ptr), gcnew array<Object^>(1){ message_str });
+}
+
+void XWalkDotNetBridge::PostMessageToInstance(void* instance,
+                                              const std::string& message) {
+  post_message_callback_(instance, message);
+}
+
+void XWalkDotNetBridge::SetSyncReply(void* instance,
+                                     const std::string& message) {
+  set_sync_reply_callback_(instance, message);
+}
+
+}  // namespace extensions
+}  // namespace xwalk

--- a/extensions/common/win/xwalk_dotnet_bridge.h
+++ b/extensions/common/win/xwalk_dotnet_bridge.h
@@ -1,0 +1,135 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_BRIDGE_H_
+#define XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_BRIDGE_H_
+
+#ifdef DOTNET_BRIDGE_IMPLEMENTATION
+#define DOTNET_BRIDGE_EXPORT __declspec(dllexport)
+#else
+#define DOTNET_BRIDGE_EXPORT __declspec(dllimport)
+#endif
+
+#include <memory>
+#include <string>
+
+#include "base/macros.h"
+
+namespace xwalk {
+namespace extensions {
+
+typedef void(*set_name_callback_func)(void*, const std::string&);
+typedef void(*set_javacript_api_callback_func)(void*, const std::string&);
+typedef void(*post_message_callback_func)(void*, const std::string&);
+typedef void(*set_sync_reply_callback_func)(void*, const std::string&);
+
+class XWalkDotNetBridge {
+ public:
+  XWalkDotNetBridge(void* extension, const std::wstring& library_path);
+  ~XWalkDotNetBridge();
+
+  bool Initialize();
+  void* CreateInstance(void* native_instance);
+  void HandleMessage(void* instance, const std::string& message);
+  void HandleSyncMessage(void* instance, const std::string& message);
+  void PostMessageToInstance(void* instance, const std::string& message);
+  void SetSyncReply(void* instance, const std::string& message);
+
+  void set_name_callback(set_name_callback_func);
+  void set_javascript_api_callback(set_javacript_api_callback_func);
+  void set_post_message_callback(post_message_callback_func);
+  void set_set_sync_reply_callback(set_sync_reply_callback_func);
+
+ private:
+  void* extension_;
+  std::wstring library_path_;
+  bool initialized_;
+  void* extension_dotnet_;
+  void* extension_assembly_;
+  set_name_callback_func set_name_callback_;
+  set_javacript_api_callback_func set_javacript_api_callback_;
+  post_message_callback_func post_message_callback_;
+  set_sync_reply_callback_func set_sync_reply_callback_;
+  DISALLOW_COPY_AND_ASSIGN(XWalkDotNetBridge);
+};
+
+extern "C" DOTNET_BRIDGE_EXPORT void* CreateDotNetBridge(
+  void* extension, const std::wstring& library_path_) {
+  return new XWalkDotNetBridge(extension, library_path_);
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT void ReleaseDotNetBridge(void* bridge) {
+  if (!bridge)
+    return;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  delete bridge_obj;
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT bool InitializeBridge(void* bridge) {
+  if (!bridge)
+    return false;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  return bridge_obj->Initialize();
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT void* CreateDotNetInstance(
+  void* bridge, void* native_instance) {
+  if (!bridge)
+    return 0;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  return bridge_obj->CreateInstance(native_instance);
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT void HandleMessage(
+  void* bridge, void* instance, const std::string& message) {
+  if (!bridge)
+    return;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  return bridge_obj->HandleMessage(instance, message);
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT void HandleSyncMessage(
+  void* bridge, void* instance, const std::string& message) {
+  if (!bridge)
+    return;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  return bridge_obj->HandleSyncMessage(instance, message);
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT void set_name_callback(
+  void* bridge, set_name_callback_func func) {
+  if (!bridge)
+    return;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  bridge_obj->set_name_callback(func);
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT void set_javascript_api_callback(
+  void* bridge, set_javacript_api_callback_func func) {
+  if (!bridge)
+    return;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  bridge_obj->set_javascript_api_callback(func);
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT void set_post_message_callback(
+  void* bridge, post_message_callback_func func) {
+  if (!bridge)
+    return;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  bridge_obj->set_post_message_callback(func);
+}
+
+extern "C" DOTNET_BRIDGE_EXPORT void set_set_sync_reply_callback(
+  void* bridge, set_sync_reply_callback_func func) {
+  if (!bridge)
+    return;
+  XWalkDotNetBridge* bridge_obj = reinterpret_cast<XWalkDotNetBridge*>(bridge);
+  bridge_obj->set_set_sync_reply_callback(func);
+}
+
+}  // namespace extensions
+}  // namespace xwalk
+
+#endif  // XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_BRIDGE_H_

--- a/extensions/common/win/xwalk_dotnet_extension.cc
+++ b/extensions/common/win/xwalk_dotnet_extension.cc
@@ -1,0 +1,114 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/common/win/xwalk_dotnet_extension.h"
+
+#include <vector>
+
+#include "base/logging.h"
+#include "xwalk/extensions/common/win/xwalk_dotnet_instance.h"
+
+namespace {
+  typedef void(*set_name_callback_func)(void*, const std::string&);
+  typedef void(*set_javacript_api_callback_func)(void*, const std::string&);
+  typedef void* (CALLBACK* CreateDotNetBridge)(void*, const std::wstring&);
+  typedef void (CALLBACK* ReleaseDotNetBridge)(void*);
+  typedef bool (CALLBACK* InitializeBridge)(void*);
+  typedef void (CALLBACK* set_name_callback)(void*, set_name_callback_func);
+  typedef void (CALLBACK* set_javascript_api_callback)(
+    void*, set_javacript_api_callback_func);
+}  // anonymous namespace
+
+namespace xwalk {
+namespace extensions {
+
+XWalkDotNetExtension::XWalkDotNetExtension(const base::FilePath& path)
+  : library_path_(path),
+    bridge_(0),
+    initialized_(false) {
+  dotnet_bridge_handle_ = LoadLibrary(L"xwalk_dotnet_bridge.dll");
+  if (!dotnet_bridge_handle_) {
+    LOG(WARNING) << "Could not find the .NET bridge, no .NET extensions"
+      << "are going load.";
+      return;
+  }
+
+  CreateDotNetBridge create_dotnet_ptr =
+    (CreateDotNetBridge)GetProcAddress(dotnet_bridge_handle_,
+                                       "CreateDotNetBridge");
+  if (!create_dotnet_ptr)
+    return;
+
+  bridge_ = create_dotnet_ptr(this, library_path_.value());
+
+  set_name_callback set_name_callback_ptr =
+    (set_name_callback)GetProcAddress(dotnet_bridge_handle_,
+                                       "set_name_callback");
+  set_name_callback_ptr(bridge_, &SetNameCallback);
+
+  set_javascript_api_callback set_javascript_api_callback_ptr =
+    (set_javascript_api_callback)GetProcAddress(dotnet_bridge_handle_,
+    "set_javascript_api_callback");
+  set_javascript_api_callback_ptr(bridge_, &SetJavascriptAPICallback);
+}
+
+XWalkDotNetExtension::~XWalkDotNetExtension() {
+  if (!initialized_)
+    return;
+
+  if (dotnet_bridge_handle_) {
+    ReleaseDotNetBridge release_dotnet_ptr =
+      (ReleaseDotNetBridge)GetProcAddress(dotnet_bridge_handle_,
+      "ReleaseDotNetBridge");
+    release_dotnet_ptr(bridge_);
+    FreeLibrary(dotnet_bridge_handle_);
+  }
+}
+
+bool XWalkDotNetExtension::Initialize() {
+  if (initialized_)
+    return true;
+
+  if (!bridge_)
+    return false;
+
+  InitializeBridge initialize_bridge_ptr =
+    (InitializeBridge)GetProcAddress(dotnet_bridge_handle_,
+    "InitializeBridge");
+
+  if (!initialize_bridge_ptr(bridge_))
+    return false;
+
+  initialized_ = true;
+  return true;
+}
+
+XWalkExtensionInstance* XWalkDotNetExtension::CreateInstance() {
+  return new XWalkDotNetInstance(this);
+}
+
+void XWalkDotNetExtension::SetNameCallback(
+    void* extension, const std::string& name) {
+  if (!extension)
+    return;
+
+  xwalk::extensions::XWalkDotNetExtension* ext =
+    reinterpret_cast<xwalk::extensions::XWalkDotNetExtension*>(extension);
+  if (ext)
+    ext->set_name(name);
+}
+
+void XWalkDotNetExtension::SetJavascriptAPICallback(
+    void* extension, const std::string& api) {
+  if (!extension)
+    return;
+
+  xwalk::extensions::XWalkDotNetExtension* ext =
+    reinterpret_cast<xwalk::extensions::XWalkDotNetExtension*>(extension);
+  if (ext)
+    ext->set_javascript_api(api);
+}
+
+}  // namespace extensions
+}  // namespace xwalk

--- a/extensions/common/win/xwalk_dotnet_extension.h
+++ b/extensions/common/win/xwalk_dotnet_extension.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_EXTENSION_H_
+#define XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_EXTENSION_H_
+
+
+#include <string>
+#include "base/files/file_path.h"
+#include "base/values.h"
+#include "base/scoped_native_library.h"
+#include "xwalk/extensions/common/xwalk_extension.h"
+
+namespace base {
+class FilePath;
+};
+
+namespace xwalk {
+namespace extensions {
+
+class XWalkDotNetBridge;
+
+// XWalkDotNetExtension implements an XWalkExtension backed by a shared
+// library implemented in .NET with few defined entry points.
+class XWalkDotNetExtension : public XWalkExtension {
+ public:
+  explicit XWalkDotNetExtension(const base::FilePath& path);
+
+  ~XWalkDotNetExtension();
+
+  bool Initialize();
+
+  void* GetBridge() const { return bridge_; }
+  HINSTANCE GetBridgeHandle()  { return dotnet_bridge_handle_; }
+
+  void set_runtime_variables(const base::ValueMap& runtime_variables) {
+    runtime_variables_ = runtime_variables;
+  }
+
+ protected:
+  // XWalkExtension implementation.
+  XWalkExtensionInstance* CreateInstance() override;
+
+ private:
+  // Variables from the browser process. Usually things like currently-running
+  // application ID.
+  base::ValueMap runtime_variables_;
+
+  static void SetNameCallback(void* extension, const std::string& name);
+  static void SetJavascriptAPICallback(
+    void* extension, const std::string& api);
+
+  base::FilePath library_path_;
+  HINSTANCE dotnet_bridge_handle_;
+  void* bridge_;
+
+  bool initialized_;
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkDotNetExtension);
+};
+
+}  // namespace extensions
+}  // namespace xwalk
+
+#endif  // XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_EXTENSION_H_

--- a/extensions/common/win/xwalk_dotnet_extension_unittest.cc
+++ b/extensions/common/win/xwalk_dotnet_extension_unittest.cc
@@ -1,0 +1,116 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/common/win/xwalk_dotnet_extension.h"
+#include "xwalk/extensions/common/win/xwalk_dotnet_instance.h"
+#include "xwalk/extensions/test/xwalk_extensions_test_base.h"
+
+#include "base/basictypes.h"
+#include "base/files/file_path.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using namespace xwalk::extensions;  // NOLINT
+
+class TestExtension : public XWalkDotNetExtension {
+ public:
+  explicit TestExtension(const base::FilePath& path)
+    : XWalkDotNetExtension(path) {
+  }
+  XWalkDotNetInstance* CreateDotNetInstance() {
+    return static_cast<XWalkDotNetInstance*>(CreateInstance());
+  }
+};
+
+TEST(XWalkDotNetExtensionTest, InvalidExtensions) {
+  base::FilePath test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("echo_extension/echo_extension.dll"));
+  TestExtension* valid_extension = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(valid_extension->Initialize());
+  EXPECT_TRUE(valid_extension->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_1/invalid_extension_1.dll"));
+  TestExtension* invalid_extension_1 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_1->Initialize());
+  EXPECT_FALSE(invalid_extension_1->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_2/invalid_extension_2.dll"));
+  TestExtension* invalid_extension_2 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_2->Initialize());
+  EXPECT_FALSE(invalid_extension_2->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_3/invalid_extension_3.dll"));
+  TestExtension* invalid_extension_3 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_3->Initialize());
+  EXPECT_FALSE(invalid_extension_3->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_4/invalid_extension_4.dll"));
+  TestExtension* invalid_extension_4 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_4->Initialize());
+  EXPECT_FALSE(invalid_extension_4->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_5/invalid_extension_5.dll"));
+  TestExtension* invalid_extension_5 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_5->Initialize());
+  EXPECT_FALSE(invalid_extension_5->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_6/invalid_extension_6.dll"));
+  TestExtension* invalid_extension_6 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_6->Initialize());
+  EXPECT_FALSE(invalid_extension_6->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_7/invalid_extension_7.dll"));
+  TestExtension* invalid_extension_7 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_7->Initialize());
+  EXPECT_FALSE(invalid_extension_7->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_8/invalid_extension_8.dll"));
+  TestExtension* invalid_extension_8 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_8->Initialize());
+  EXPECT_FALSE(invalid_extension_8->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_9/invalid_extension_9.dll"));
+  TestExtension* invalid_extension_9 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_9->Initialize());
+  EXPECT_FALSE(invalid_extension_9->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_10/invalid_extension_10.dll"));
+  TestExtension* invalid_extension_10 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_10->Initialize());
+  EXPECT_FALSE(invalid_extension_10->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_11/invalid_extension_11.dll"));
+  TestExtension* invalid_extension_11 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_11->Initialize());
+  EXPECT_FALSE(invalid_extension_11->CreateDotNetInstance()->isValid());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_12/invalid_extension_12.dll"));
+  TestExtension* invalid_extension_12 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_12->Initialize());
+  EXPECT_FALSE(invalid_extension_12->CreateDotNetInstance()->isValid());
+}

--- a/extensions/common/win/xwalk_dotnet_instance.cc
+++ b/extensions/common/win/xwalk_dotnet_instance.cc
@@ -1,0 +1,102 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/common/win/xwalk_dotnet_instance.h"
+
+#include <vector>
+
+#include "base/logging.h"
+#include "xwalk/extensions/common/win/xwalk_dotnet_extension.h"
+
+namespace {
+
+typedef void(*post_message_callback_func)(void*, const std::string&);
+typedef void(*set_sync_reply_callback_func)(void*, const std::string&);
+typedef void (CALLBACK* set_post_message_callback)(
+  void*, post_message_callback_func);
+typedef void (CALLBACK* set_set_sync_reply_callback)(
+  void*, set_sync_reply_callback_func);
+typedef void* (CALLBACK* CreateDotNetInstance)(void*, void*);
+typedef void* (CALLBACK* HandleMessageType)(void*, void*, const std::string&);
+typedef void* (CALLBACK* HandleSyncMessageType)(
+  void*, void*, const std::string&);
+
+}  // namespace
+
+namespace xwalk {
+namespace extensions {
+
+XWalkDotNetInstance::XWalkDotNetInstance(
+  XWalkDotNetExtension* extension) : extension_(extension) {
+  CreateDotNetInstance create_instance_ptr =
+      (CreateDotNetInstance)GetProcAddress(extension_->GetBridgeHandle(),
+      "CreateDotNetInstance");
+  instance_dotnet_ = create_instance_ptr(extension_->GetBridge(), this);
+
+  set_post_message_callback set_post_message_callback_ptr =
+      (set_post_message_callback)GetProcAddress(extension_->GetBridgeHandle(),
+      "set_post_message_callback");
+  set_post_message_callback_ptr(
+      extension_->GetBridge(), &PostMessageToJSCallback);
+
+  set_set_sync_reply_callback set_set_sync_reply_callback_ptr =
+      (set_set_sync_reply_callback)GetProcAddress(extension_->GetBridgeHandle(),
+      "set_set_sync_reply_callback");
+  set_set_sync_reply_callback_ptr(extension_->GetBridge(), &SetSyncReply);
+}
+
+XWalkDotNetInstance::~XWalkDotNetInstance() {
+}
+
+void XWalkDotNetInstance::HandleMessage(scoped_ptr<base::Value> msg) {
+  if (!instance_dotnet_)
+    return;
+  std::string string_msg;
+  if (!msg->GetAsString(&string_msg)) {
+    LOG(WARNING) << "Failed to retrieve the message's value.";
+    return;
+  }
+  HandleMessageType handle_message_ptr =
+      (HandleMessageType)GetProcAddress(extension_->GetBridgeHandle(),
+      "HandleMessage");
+  handle_message_ptr(extension_->GetBridge(), instance_dotnet_, string_msg);
+}
+
+void XWalkDotNetInstance::HandleSyncMessage(scoped_ptr<base::Value> msg) {
+  if (!instance_dotnet_)
+    return;
+  std::string string_msg;
+  if (!msg->GetAsString(&string_msg)) {
+    LOG(WARNING) << "Failed to retrieve the message's value.";
+    return;
+  }
+
+  HandleSyncMessageType handle_message_ptr =
+      (HandleSyncMessageType)GetProcAddress(extension_->GetBridgeHandle(),
+      "HandleSyncMessage");
+  handle_message_ptr(extension_->GetBridge(), instance_dotnet_, string_msg);
+}
+
+void XWalkDotNetInstance::PostMessageToJSCallback(
+    void* instance, const std::string& message) {
+  if (!instance)
+    return;
+    XWalkDotNetInstance* inst =
+        reinterpret_cast<XWalkDotNetInstance*>(instance);
+    inst->PostMessageToJS(scoped_ptr<base::Value>(
+        new base::StringValue(message)));
+}
+
+void XWalkDotNetInstance::SetSyncReply(
+    void* instance, const std::string& message) {
+  if (!instance)
+    return;
+  XWalkDotNetInstance* inst =
+      reinterpret_cast<XWalkDotNetInstance*>(instance);
+  inst->SendSyncReplyToJS(scoped_ptr<base::Value>(
+      new base::StringValue(message)));
+}
+
+}  // namespace extensions
+}  // namespace xwalk

--- a/extensions/common/win/xwalk_dotnet_instance.h
+++ b/extensions/common/win/xwalk_dotnet_instance.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_INSTANCE_H_
+#define XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_INSTANCE_H_
+
+#include "xwalk/extensions/common/xwalk_extension.h"
+
+#include <string>
+
+namespace xwalk {
+namespace extensions {
+
+class XWalkDotNetExtension;
+
+class XWalkDotNetInstance : public XWalkExtensionInstance {
+ public:
+  explicit XWalkDotNetInstance(XWalkDotNetExtension* extension);
+  ~XWalkDotNetInstance() override;
+  bool isValid() const { return instance_dotnet_ && extension_; }
+ private:
+  // XWalkExtensionInstance implementation.
+  void HandleMessage(scoped_ptr<base::Value> msg) override;
+  void HandleSyncMessage(scoped_ptr<base::Value> msg) override;
+  static void PostMessageToJSCallback(
+    void* instance, const std::string& message);
+  static void SetSyncReply(void* instance, const std::string& message);
+
+  friend class XWalkDotNetExtensionTest;
+  XWalkDotNetExtension* extension_;
+  void* instance_dotnet_;
+  DISALLOW_COPY_AND_ASSIGN(XWalkDotNetInstance);
+};
+
+}  // namespace extensions
+}  // namespace xwalk
+
+#endif  // XWALK_EXTENSIONS_COMMON_WIN_XWALK_DOTNET_INSTANCE_H_

--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -30,6 +30,12 @@ IPC_MESSAGE_CONTROL2(XWalkExtensionProcessMsg_RegisterExtensions,  // NOLINT(*)
                      base::FilePath /* extensions path */,
                      base::ListValue /* browser variables */)
 
+#if defined (OS_WIN) // NOLINT
+IPC_MESSAGE_CONTROL2(XWalkExtensionProcessMsg_RegisterDotNetExtensions, // NOLINT(*)
+                     base::FilePath /* extensions path */,
+                     base::ListValue /* browser variables */)
+#endif // NOLINT
+
 // This implies that extensions are all loaded and Extension Process
 // is ready to be used.
 IPC_MESSAGE_CONTROL1(XWalkExtensionProcessHostMsg_RenderProcessChannelCreated, // NOLINT(*)

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -122,6 +122,12 @@ class XWalkExtensionServer : public IPC::Listener,
   XWalkExtension::PermissionsDelegate* permissions_delegate_;
 };
 
+#if defined(OS_WIN)
+std::vector<std::string> RegisterDotNetExtensionsInDirectory(
+  XWalkExtensionServer* server, const base::FilePath& dir,
+  scoped_ptr<base::ValueMap> runtime_variables);
+#endif
+
 std::vector<std::string> RegisterExternalExtensionsInDirectory(
     XWalkExtensionServer* server, const base::FilePath& dir,
     scoped_ptr<base::ValueMap> runtime_variables);

--- a/extensions/common/xwalk_extension_switches.cc
+++ b/extensions/common/xwalk_extension_switches.cc
@@ -19,6 +19,9 @@ const char kXWalkExtensionProcess[] = "xwalk-extension-process";
 // Specifies where XWalk will look for external extensions.
 const char kXWalkExternalExtensionsPath[] = "external-extensions-path";
 
+// Specifies where XWalk will look for dotnet extensions.
+const char kXWalkDotNetExtensionsPath[] = "dotnet-extensions-path";
+
 // The contents of this flag are prepended to the extension command line.
 // Useful values might be "valgrind" or "xterm -e gdb --args".
 const char kXWalkExtensionCmdPrefix[] = "xwalk-extension-cmd-prefix";

--- a/extensions/common/xwalk_extension_switches.h
+++ b/extensions/common/xwalk_extension_switches.h
@@ -11,6 +11,7 @@ namespace switches {
 extern const char kXWalkDisableExtensionProcess[];
 extern const char kXWalkExtensionProcess[];
 extern const char kXWalkExternalExtensionsPath[];
+extern const char kXWalkDotNetExtensionsPath[];
 extern const char kXWalkExtensionCmdPrefix[];
 extern const char kXWalkDisableExtensions[];
 

--- a/extensions/dotnet_bridge.gyp
+++ b/extensions/dotnet_bridge.gyp
@@ -1,0 +1,41 @@
+{
+    # This is needed so that /RTC1 and /MTx are not added to the
+    # compilation command line (it's not compatible with /clr)
+    'target_defaults': {
+      'variables': {
+        'win_release_RuntimeChecks': '0',
+        'win_debug_RuntimeChecks': '0',
+        'win_release_RuntimeLibrary': '2', # 2 = /MD (nondebug DLL)
+        'win_debug_RuntimeLibrary': '3',   # 3 = /MDd (debug DLL)
+      },
+    },
+    'targets': [
+      {
+          'target_name': 'dotnet_bridge',
+          'type': 'none',
+          'dependencies': [
+            'xwalk_dotnet_bridge'
+          ],
+      },
+      {
+        'target_name': 'xwalk_dotnet_bridge',
+        'type': 'shared_library',
+        'sources': [
+          'common/win/xwalk_dotnet_bridge.cc',
+          'common/win/xwalk_dotnet_bridge.h',
+        ],
+        'defines': [
+          'DOTNET_BRIDGE_IMPLEMENTATION',
+        ],
+        'include_dirs': [
+          '../../',
+        ],
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'RuntimeTypeInfo': 'true',
+            'CompileAsManaged':'true',
+          }
+        },
+     },
+   ],
+}

--- a/extensions/dotnet_extension_sample.gyp
+++ b/extensions/dotnet_extension_sample.gyp
@@ -1,0 +1,278 @@
+{
+  'targets': [
+    {
+      'target_name': 'dotnet_echo_extension',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_echo_extension',
+          'inputs': [
+            'test/win/echo_extension/XWalkExtension.cs',
+            'test/win/echo_extension/XWalkExtensionInstance.cs',
+          ],
+          'outputs': [
+            'echo_extension.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/echo_extension',
+                     '--project', 'echo_extension/echo_extension.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_1',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_1',
+          'inputs': [
+            'test/win/invalid_extension_1/Bla.cs'
+          ],
+          'outputs': [
+            'invalid_extension_1.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_1',
+                     '--project', 'invalid_extension_1/invalid_extension_1.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_2',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_2',
+          'inputs': [
+            'test/win/invalid_extension_2/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_2.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_2',
+                     '--project', 'invalid_extension_2/invalid_extension_2.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_3',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_3',
+          'inputs': [
+            'test/win/invalid_extension_3/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_3.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_3',
+                     '--project', 'invalid_extension_3/invalid_extension_3.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_4',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_4',
+          'inputs': [
+            'test/win/invalid_extension_4/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_4.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_4',
+                     '--project', 'invalid_extension_4/invalid_extension_4.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_5',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_5',
+          'inputs': [
+            'test/win/invalid_extension_5/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_5.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_5',
+                     '--project', 'invalid_extension_5/invalid_extension_5.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_6',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_6',
+          'inputs': [
+            'test/win/invalid_extension_6/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_6.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_6',
+                     '--project', 'invalid_extension_6/invalid_extension_6.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_7',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_7',
+          'inputs': [
+            'test/win/invalid_extension_7/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_7.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_7',
+                     '--project', 'invalid_extension_7/invalid_extension_7.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_8',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_8',
+          'inputs': [
+            'test/win/invalid_extension_8/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_8.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_8',
+                     '--project', 'invalid_extension_8/invalid_extension_8.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_9',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_9',
+          'inputs': [
+            'test/win/invalid_extension_9/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_9.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_9',
+                     '--project', 'invalid_extension_9/invalid_extension_9.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_10',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_10',
+          'inputs': [
+            'test/win/invalid_extension_10/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_10.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_10',
+                     '--project', 'invalid_extension_10/invalid_extension_10.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_11',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_11',
+          'inputs': [
+            'test/win/invalid_extension_11/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_11.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_11',
+                     '--project', 'invalid_extension_11/invalid_extension_11.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_12',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_12',
+          'inputs': [
+            'test/win/invalid_extension_12/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_12.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_12',
+                     '--project', 'invalid_extension_12/invalid_extension_12.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/extensions/extension_process/xwalk_extension_process.h
+++ b/extensions/extension_process/xwalk_extension_process.h
@@ -57,6 +57,11 @@ class XWalkExtensionProcess : public IPC::Listener,
   void OnRegisterExtensions(const base::FilePath& extension_path,
                             const base::ListValue& browser_variables);
 
+#if defined (OS_WIN)
+  void OnRegisterDotNetExtensions(const base::FilePath& extension_path,
+                                  const base::ListValue& browser_variables);
+#endif
+
   void CreateBrowserProcessChannel(const IPC::ChannelHandle& channel_handle);
 
   void CreateRenderProcessChannel();

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -69,6 +69,16 @@
         'renderer/xwalk_v8tools_module.cc',
         'renderer/xwalk_v8tools_module.h',
       ],
+      'conditions': [
+        ['OS=="win"', {
+          'sources': [
+              'common/win/xwalk_dotnet_extension.cc',
+              'common/win/xwalk_dotnet_extension.h',
+              'common/win/xwalk_dotnet_instance.cc',
+              'common/win/xwalk_dotnet_instance.h',
+            ],
+        }],
+      ],
     },
   ],
 }

--- a/extensions/extensions_tests.gyp
+++ b/extensions/extensions_tests.gyp
@@ -61,4 +61,57 @@
       ],
     },
   ],
+  'conditions': [
+    ['OS=="win"', {
+      'targets': [
+        {
+          'target_name': 'xwalk_dotnet_extensions_browsertest',
+          'type': 'executable',
+          'dependencies': [
+            '../../base/base.gyp:base',
+            '../../content/content.gyp:content_browser',
+            '../../content/content_shell_and_tests.gyp:test_support_content',
+            '../../net/net.gyp:net',
+            '../../skia/skia.gyp:skia',
+            '../../testing/gtest.gyp:gtest',
+            '../test/base/base.gyp:xwalk_test_base',
+            '../xwalk.gyp:xwalk_runtime',
+            'dotnet_extension_sample.gyp:*',
+            'extensions.gyp:xwalk_extensions',
+            'extensions_resources.gyp:xwalk_extensions_resources',
+          ],
+          'defines': [
+            'HAS_OUT_OF_PROC_TEST_RUNNER',
+          ],
+          'sources': [
+            'test/win/xwalk_dotnet_extensions_browsertest.cc',
+            'test/xwalk_extensions_test_base.cc',
+            'test/xwalk_extensions_test_base.h',
+          ],
+        },
+        {
+          'target_name': 'xwalk_dotnet_extensions_unittest',
+          'type': 'executable',
+          'dependencies': [
+           '../../base/base.gyp:base',
+            '../../content/content.gyp:content_browser',
+            '../../content/content_shell_and_tests.gyp:test_support_content',
+            '../../net/net.gyp:net',
+            '../../skia/skia.gyp:skia',
+            '../../testing/gtest.gyp:gtest',
+            '../test/base/base.gyp:xwalk_test_base',
+            '../xwalk.gyp:xwalk_runtime',
+            'dotnet_extension_sample.gyp:*',
+            'extensions.gyp:xwalk_extensions',
+            'extensions_resources.gyp:xwalk_extensions_resources',
+          ],
+          'sources': [
+            'common/win/xwalk_dotnet_extension_unittest.cc',
+            'test/xwalk_extensions_test_base.cc',
+            'test/xwalk_extensions_test_base.h',
+          ],
+        },
+      ],
+    }],
+  ],
 }

--- a/extensions/test/win/echo_extension/XWalkExtension.cs
+++ b/extensions/test/win/echo_extension/XWalkExtension.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+    return "echo";
+  }
+
+  public String ExtensionAPI() {
+    return
+      @"var echoListener = null;
+        extension.setMessageListener(function(msg) {
+          if (echoListener instanceof Function) {
+            echoListener(msg);
+          };
+        });
+        exports.echo = function(msg, callback) {
+          echoListener = callback;
+          extension.postMessage(msg);
+        };
+        exports.syncEcho = function(msg) {
+          return extension.internal.sendSyncMessage(msg);
+        };";
+  }
+}
+}

--- a/extensions/test/win/echo_extension/XWalkExtensionInstance.cs
+++ b/extensions/test/win/echo_extension/XWalkExtensionInstance.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(dynamic native) {
+    native_ = native;
+  }
+
+  public void HandleMessage(String message) {
+    native_.PostMessageToJS(message);
+  }
+  public void HandleSyncMessage(String message) {
+    native_.SendSyncReply(message);
+  }
+  private dynamic native_;
+}
+}

--- a/extensions/test/win/echo_extension/echo_extension.csproj
+++ b/extensions/test/win/echo_extension/echo_extension.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>echo_extension</RootNamespace>
+    <AssemblyName>echo_extension</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_1/Bla.cs
+++ b/extensions/test/win/invalid_extension_1/Bla.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace invalid
+{
+public class Foo
+{
+  public Foo() {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_1/invalid_extension_1.csproj
+++ b/extensions/test/win/invalid_extension_1/invalid_extension_1.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_1</RootNamespace>
+    <AssemblyName>invalid_extension_1</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Bla.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_10/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_10/XWalkExtension.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+    public String ExtensionName() {
+        return "foo";
+    }
+    public String ExtensionAPI() {
+        return "foo";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_10/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_10/XWalkExtensionInstance.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace xwalk
+{
+  public class XWalkExtensionInstance
+  {
+    public XWalkExtensionInstance(dynamic native)
+    {
+    }
+    public void HandleSyncMessage(String message)
+    {
+    }
+  }
+}

--- a/extensions/test/win/invalid_extension_10/invalid_extension_10.csproj
+++ b/extensions/test/win/invalid_extension_10/invalid_extension_10.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_10</RootNamespace>
+    <AssemblyName>invalid_extension_10</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_11/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_11/XWalkExtension.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+    return "echo";
+  }
+
+  public String ExtensionAPI() {
+    return
+      @"var echoListener = null;
+      extension.setMessageListener(function(msg) {
+        if (echoListener instanceof Function) {
+          echoListener(msg);
+        };
+      });
+      exports.echo = function(msg, callback) {
+        echoListener = callback;
+        extension.postMessage(msg);
+      };
+      exports.syncEcho = function(msg) {
+        return extension.internal.sendSyncMessage(msg);
+      };";
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_11/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_11/XWalkExtensionInstance.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace xwalk
+{
+  public class XWalkExtensionInstance
+  {
+    public XWalkExtensionInstance(dynamic native)
+    {
+    }
+    public void HandleMessage(int message)
+    {
+    }
+    public void HandleSyncMessage(int message)
+    {
+    }
+  }
+}

--- a/extensions/test/win/invalid_extension_11/invalid_extension_11.csproj
+++ b/extensions/test/win/invalid_extension_11/invalid_extension_11.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_11</RootNamespace>
+    <AssemblyName>invalid_extension_11</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_12/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_12/XWalkExtension.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension {
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+    return "echo";
+  }
+
+  public String ExtensionAPI() {
+    return
+      @"var echoListener = null;
+      extension.setMessageListener(function(msg) {
+        if (echoListener instanceof Function) {
+          echoListener(msg);
+        };
+      });
+      exports.echo = function(msg, callback) {
+        echoListener = callback;
+        extension.postMessage(msg);
+      };
+      exports.syncEcho = function(msg) {
+        return extension.internal.sendSyncMessage(msg);
+      };";
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_12/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_12/XWalkExtensionInstance.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace xwalk
+{
+  public class XWalkExtensionInstance
+  {
+    public XWalkExtensionInstance(dynamic native)
+    {
+    }
+    public void HandleMessage(int message)
+    {
+    }
+    public void HandleSyncMessage(String message)
+    {
+    }
+  }
+}

--- a/extensions/test/win/invalid_extension_12/invalid_extension_12.csproj
+++ b/extensions/test/win/invalid_extension_12/invalid_extension_12.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_12</RootNamespace>
+    <AssemblyName>invalid_extension_12</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_2/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_2/XWalkExtension.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension(String invalidConstructor) {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_2/invalid_extension_2.csproj
+++ b/extensions/test/win/invalid_extension_2/invalid_extension_2.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_2</RootNamespace>
+    <AssemblyName>invalid_extension_2</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_3/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_3/XWalkExtension.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_3/invalid_extension_3.csproj
+++ b/extensions/test/win/invalid_extension_3/invalid_extension_3.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_3</RootNamespace>
+    <AssemblyName>invalid_extension_3</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_4/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_4/XWalkExtension.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+    public String ExtensionName() {
+        return "test";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_4/invalid_extension_4.csproj
+++ b/extensions/test/win/invalid_extension_4/invalid_extension_4.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_4</RootNamespace>
+    <AssemblyName>invalid_extension_4</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_5/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_5/XWalkExtension.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+
+    public int ExtensionName() {
+        return 3;
+    }
+    public String ExtensionAPI() {
+        return "foo";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_5/invalid_extension_5.csproj
+++ b/extensions/test/win/invalid_extension_5/invalid_extension_5.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_5</RootNamespace>
+    <AssemblyName>invalid_extension_5</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_6/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_6/XWalkExtension.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+    public String ExtensionName() {
+        return "foo";
+    }
+    public int ExtensionAPI() {
+        return 3;
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_6/invalid_extension_6.csproj
+++ b/extensions/test/win/invalid_extension_6/invalid_extension_6.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_6</RootNamespace>
+    <AssemblyName>invalid_extension_6</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_7/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_7/XWalkExtension.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace xwalk
+{
+    public class XWalkExtension
+    {
+        public XWalkExtension()
+        {}
+      
+        public String ExtensionName()
+        {
+            return "foo";
+        }
+        public String ExtensionAPI()
+        {
+            return "foo";
+        }
+    }
+}

--- a/extensions/test/win/invalid_extension_7/invalid_extension_7.csproj
+++ b/extensions/test/win/invalid_extension_7/invalid_extension_7.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_7</RootNamespace>
+    <AssemblyName>invalid_extension_7</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_8/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_8/XWalkExtension.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+
+    public String ExtensionName() {
+        return "foo";
+    }
+    public String ExtensionAPI() {
+        return "foo";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_8/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_8/XWalkExtensionInstance.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace xwalk
+{
+  public class XWalkExtensionInstance
+  {
+    public XWalkExtensionInstance(int native)
+    {
+    }
+   }
+}

--- a/extensions/test/win/invalid_extension_8/invalid_extension_8.csproj
+++ b/extensions/test/win/invalid_extension_8/invalid_extension_8.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_8</RootNamespace>
+    <AssemblyName>invalid_extension_8</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_9/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_9/XWalkExtension.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+    public String ExtensionName() {
+        return "foo";
+    }
+    public String ExtensionAPI() {
+        return "foo";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_9/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_9/XWalkExtensionInstance.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace xwalk
+{
+  public class XWalkExtensionInstance
+  {
+    public XWalkExtensionInstance(dynamic native)
+    {
+    }
+  }
+}

--- a/extensions/test/win/invalid_extension_9/invalid_extension_9.csproj
+++ b/extensions/test/win/invalid_extension_9/invalid_extension_9.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_9</RootNamespace>
+    <AssemblyName>invalid_extension_9</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/xwalk_dotnet_extensions_browsertest.cc
+++ b/extensions/test/win/xwalk_dotnet_extensions_browsertest.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2015  Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/native_library.h"
+#include "base/path_service.h"
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/extensions/common/win/xwalk_dotnet_extension.h"
+#include "xwalk/extensions/browser/xwalk_extension_service.h"
+#include "xwalk/extensions/test/xwalk_extensions_test_base.h"
+#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/test/base/xwalk_test_utils.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
+
+using namespace xwalk::extensions;  // NOLINT
+using xwalk::extensions::XWalkExtensionService;
+using xwalk::Runtime;
+
+const char* kEchoAPI =
+"var echoListener = null;"
+"extension.setMessageListener(function(msg) {"
+"  if (echoListener instanceof Function) {"
+"    echoListener(msg);"
+"  };"
+"});"
+"exports.echo = function(msg, callback) {"
+"  echoListener = callback;"
+"  extension.postMessage(msg);"
+"};"
+"exports.syncEcho = function(msg) {"
+"  return extension.internal.sendSyncMessage(msg);"
+"};";
+
+class DotNetExtensionTest : public XWalkExtensionsTestBase {
+ public:
+  void SetUp() override {
+    XWalkExtensionService::SetDotNetExtensionsPathForTesting(
+      GetDotNetExtensionTestPath(FILE_PATH_LITERAL("echo_extension")));
+    XWalkExtensionsTestBase::SetUp();
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(DotNetExtensionTest, DotNetExtension) {
+  Runtime* runtime = CreateRuntime();
+  GURL url = GetExtensionsTestURL(base::FilePath(),
+    base::FilePath().AppendASCII("echo.html"));
+  content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+  xwalk_test_utils::NavigateToURL(runtime, url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}
+
+IN_PROC_BROWSER_TEST_F(DotNetExtensionTest, DotNetExtensionSync) {
+  Runtime* runtime = CreateRuntime();
+  GURL url = GetExtensionsTestURL(
+    base::FilePath(),
+    base::FilePath().AppendASCII("sync_echo.html"));
+  content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+  xwalk_test_utils::NavigateToURL(runtime, url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}

--- a/extensions/test/xwalk_extensions_test_base.cc
+++ b/extensions/test/xwalk_extensions_test_base.cc
@@ -58,3 +58,16 @@ base::FilePath GetExternalExtensionTestPath(
                   .Append(test);
   return extension_dir;
 }
+
+#if defined(OS_WIN)
+base::FilePath GetDotNetExtensionTestPath(
+  const base::FilePath::CharType test[]) {
+  base::FilePath extension_dir;
+  PathService::Get(base::DIR_EXE, &extension_dir);
+  extension_dir = extension_dir
+    .Append(FILE_PATH_LITERAL("tests"))
+    .Append(FILE_PATH_LITERAL("dotnet_extension"))
+    .Append(test);
+  return extension_dir;
+}
+#endif

--- a/extensions/test/xwalk_extensions_test_base.h
+++ b/extensions/test/xwalk_extensions_test_base.h
@@ -25,6 +25,10 @@ GURL GetExtensionsTestURL(const base::FilePath& dir,
 
 base::FilePath GetExternalExtensionTestPath(
     const base::FilePath::CharType test[]);
+#if defined(OS_WIN)
+base::FilePath GetDotNetExtensionTestPath(
+    const base::FilePath::CharType test[]);
+#endif
 
 const base::string16 kPassString = base::ASCIIToUTF16("Pass");
 const base::string16 kFailString = base::ASCIIToUTF16("Fail");

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -61,6 +61,9 @@ class XWalkBrowserMainParts : public content::BrowserMainParts {
       extensions::XWalkExtensionVector* extensions);
 
  protected:
+#if defined(OS_WIN)
+  void RegisterDotNetExtensions();
+#endif
   void RegisterExternalExtensions();
 
   XWalkRunner* xwalk_runner_;

--- a/tools/msbuild_dotnet.py
+++ b/tools/msbuild_dotnet.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 Intel Corp. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+msbuild_dotnet.py -- Invoke MSBuild for .NET project.
+"""
+
+import logging
+import optparse
+import os
+import subprocess
+import sys
+
+
+def LaunchMSBuild(options):
+  if not options.output_dir:
+    print('You must specify the output-dir')
+    return 1
+  if not options.project:
+    print('You have not specified the project you want to build')
+    return 1
+  if not options.build_type:
+    print('You have not specified the build-type')
+    return 1
+
+  output_dir = os.path.abspath(options.output_dir)
+  tools_dir = os.path.dirname(os.path.abspath(__file__))
+  xwalk_dir = os.path.dirname(tools_dir)
+  extensions_dir = os.path.join(xwalk_dir, 'extensions')
+  extensions_test_dir = os.path.join(extensions_dir, 'test')
+  extensions_win_test_dir = os.path.join(extensions_test_dir,
+                                         'win' + os.path.sep)
+
+  output = subprocess.call(['msbuild', extensions_win_test_dir
+      + options.project, '/p:Platform=AnyCPU,Configuration='
+      + options.build_type + ',OutDir=' + output_dir
+      + ',BaseIntermediateOutputPath=' + output_dir + os.path.sep],
+      cwd=extensions_win_test_dir)
+  if output != 0:
+    return output
+
+def main():
+  option_parser = optparse.OptionParser()
+  option_parser.add_option('--output-dir',
+                           help='Set the output dir for MSBuild.')
+  option_parser.add_option('--project',
+                           help='The project to build with MSBuild.')
+  option_parser.add_option('--build-type',
+                           help='The type of build : Release/Debug.')
+  options, _ = option_parser.parse_args()
+  LaunchMSBuild(options)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -759,6 +759,7 @@
         ['OS == "win"', {
           'dependencies': [
             '../sandbox/sandbox.gyp:sandbox',
+            'extensions/dotnet_bridge.gyp:dotnet_bridge'
           ],
         }],  # OS=="win"
         ['OS=="mac"', {

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -11,6 +11,14 @@
         'sysapps/sysapps_tests.gyp:xwalk_sysapps_browsertest',
         'sysapps/sysapps_tests.gyp:xwalk_sysapps_unittest',
       ],
+      'conditions': [
+        ['OS=="win"', {
+          'dependencies': [
+            'extensions/extensions_tests.gyp:xwalk_dotnet_extensions_browsertest',
+            'extensions/extensions_tests.gyp:xwalk_dotnet_extensions_unittest',
+          ],
+        }],
+      ],
     },
     {
       'target_name': 'xwalk_unittest',


### PR DESCRIPTION
This commit adds support to load external .NET extensions
for 3rd party developers.

You can specify the path of the extensions to load using
--dotnet-extensions-path=/path/ .

The extensions are expected to be a .DLL constructed with
Visual Studio as a C# Library (and thus multiarch).
This library needs to contains two classes XWalkExtension and
XWalkExtensionInstance which are going to be invoked by Crosswalk
to load the extensions and call the various methods on each instances
to make communication between .NET and JS. .NET extensions are a bit
higher level than our C or C++ extensions because the .NET extension
system will automatically call the constructors in .NET when needed :
e.g. creating the XWalkExtension instance and then create the various
XWalkExtensionInstance instances. This is following inspiration of
what's inside tizen-extension-crosswalk common/ directory which is used
to abstract the low levelness to who write t-e-c extensions.

```
 _______       _______       ______________
| xwalk | <-> | bridge| <-> |.NET extension|
|_______|     |_______|     |______________|
```

The bridge is loaded dynamically (and not linked to Crosswalk
final executable) because the bridge is compiled with /clr support
which make it incompatible with linking with static builds of Crosswalk
(built with /MT).

One bridge instance is used by each extension and it is responsible to load
the .NET extension, verify using .NET reflection that the entry points
(e.g. XWalkExtension constructor, XWalkInstance handleMessage method...)
are present and that the .NET extension can be used. It then handles the
communication back and forth with Crosswalk and the extension.

One implementation detail worth to note is the usage of the dynamic parameter
in XWalkExtensionInstance, this pointer is used to communicate back from
.NET to C++/XWalk and the fact is dynamic is to hide implementation
details to the 3rd party developer which should only care about calling
the right functions on it. If they don't exists, there will be a runtime
error showing up. It makes using the system very simple (nothing to
include, nothing to import).

Please note that we don't support all the features of the extension
system at the moment, for example you can't add multiple entry points
in JS, and you can't have access to the runtime variables inside the
extension. These features can be added in a following patch.

This commit also roll GYP forward so we can compile passing /clr as
a compiler paramenter. It will probably be not needed by the next
rebase.

Part of the feature work I've added a bunch of tests which
actually build .NET extensions and test the overall system (thus
the .csproj files checked in). There is a little script to invoke
msbuild so it builds the DLL in .NET (GYP doesn't know about that).