### PR TITLE
[Android] Control library directory from upper level

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
@@ -67,17 +67,6 @@ class XWalkDialogManager {
                     R.string.startup_not_found_message)));
             setPositiveButton(dialog, downloadText, downloadCommand);
             setNegativeButton(dialog, cancelText, cancelCommand);
-        } else if (status == XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH) {
-            dialog.setTitle(mContext.getString(R.string.startup_architecture_mismatch_title));
-            dialog.setMessage(replaceApplicationName(mContext.getString(
-                    R.string.startup_architecture_mismatch_message)));
-            setPositiveButton(dialog, downloadText, downloadCommand);
-            setNegativeButton(dialog, cancelText, cancelCommand);
-        } else if (status == XWalkLibraryInterface.STATUS_SIGNATURE_CHECK_ERROR) {
-            dialog.setTitle(mContext.getString(R.string.startup_signature_check_error_title));
-            dialog.setMessage(replaceApplicationName(mContext.getString(
-                    R.string.startup_signature_check_error_message)));
-            setNegativeButton(dialog, cancelText, cancelCommand);
         } else if (status == XWalkLibraryInterface.STATUS_OLDER_VERSION) {
             dialog.setTitle(mContext.getString(R.string.startup_older_version_title));
             dialog.setMessage(replaceApplicationName(mContext.getString(
@@ -89,8 +78,24 @@ class XWalkDialogManager {
             dialog.setMessage(replaceApplicationName(mContext.getString(
                     R.string.startup_newer_version_message)));
             setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_INCOMPLETE_LIBRARY) {
+            dialog.setTitle(mContext.getString(R.string.startup_incomplete_library_title));
+            dialog.setMessage(replaceApplicationName(mContext.getString(
+                    R.string.startup_incomplete_library_message)));
+            setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH) {
+            dialog.setTitle(mContext.getString(R.string.startup_architecture_mismatch_title));
+            dialog.setMessage(replaceApplicationName(mContext.getString(
+                    R.string.startup_architecture_mismatch_message)));
+            setPositiveButton(dialog, downloadText, downloadCommand);
+            setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_SIGNATURE_CHECK_ERROR) {
+            dialog.setTitle(mContext.getString(R.string.startup_signature_check_error_title));
+            dialog.setMessage(replaceApplicationName(mContext.getString(
+                    R.string.startup_signature_check_error_message)));
+            setNegativeButton(dialog, cancelText, cancelCommand);
         } else {
-            Assert.fail();
+            Assert.fail("Invalid status for alert dialog " + status);
         }
         showDialog(dialog);
     }

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryDecompressor.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryDecompressor.java
@@ -18,12 +18,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.chromium.base.PathUtils;
-
 import SevenZip.Compression.LZMA.Decoder;
 
 class XWalkLibraryDecompressor {
-    private static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
     private static final String[] MANDATORY_LIBRARIES = { "libxwalkcore.so" };
     private static final String TAG = "XWalkLib";
 
@@ -45,32 +42,16 @@ class XWalkLibraryDecompressor {
     }
 
     public static boolean decompressLibrary(Context context) {
-        PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, context);
-        String lib = PathUtils.getDataDirectory(context.getApplicationContext());
+        String libDir = context.getDir(XWalkLibraryInterface.PRIVATE_DATA_DIRECTORY_SUFFIX,
+                Context.MODE_PRIVATE).toString();
 
         long start = System.currentTimeMillis();
-        boolean success = decompress(context, lib);
+        boolean success = decompress(context, libDir);
         long end = System.currentTimeMillis();
         Log.d(TAG, "Decompress library cost: " + (end - start) + " milliseconds.");
 
         if (success) setLocalVersion(context, XWalkAppVersion.API_VERSION);
         return success;
-    }
-
-    public static boolean loadDecompressedLibrary(Context context) {
-        PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, context);
-        String lib = PathUtils.getDataDirectory(context.getApplicationContext());
-
-        try {
-            for (String library : MANDATORY_LIBRARIES) {
-                System.load(lib + "/" + library);
-            }
-        } catch (UnsatisfiedLinkError e) {
-            Log.d(TAG, "Failed to load decompressed library");
-            return false;
-        }
-
-        return true;
     }
 
     private static boolean decompress(Context context, String libDir) {

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryInterface.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryInterface.java
@@ -24,22 +24,29 @@ interface XWalkLibraryInterface {
     public static final int STATUS_NOT_FOUND = 2;
 
     /**
-     * Mismatch of CPU Architecture for the Crosswalk Runtime.
-     */
-    public static final int STATUS_ARCHITECTURE_MISMATCH = 3;
-
-    /**
-     * The Crosswalk signature verification failed.
-     */
-    public static final int STATUS_SIGNATURE_CHECK_ERROR = 4;
-
-    /**
      * The version of the Crosswalk runtime is older than the application.
      */
-    public static final int STATUS_OLDER_VERSION = 5;
+    public static final int STATUS_OLDER_VERSION = 3;
 
     /**
      * The version of the Crosswalk runtime is newer than the application.
      */
-    public static final int STATUS_NEWER_VERSION = 6;
+    public static final int STATUS_NEWER_VERSION = 4;
+
+    /**
+     * Missing certain necessary native library
+     */
+    public static final int STATUS_INCOMPLETE_LIBRARY = 5;
+
+    /**
+     * Mismatch of CPU Architecture for the Crosswalk Runtime.
+     */
+    public static final int STATUS_ARCHITECTURE_MISMATCH = 6;
+
+    /**
+     * The Crosswalk signature verification failed.
+     */
+    public static final int STATUS_SIGNATURE_CHECK_ERROR = 7;
+
+    public static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryLoader.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryLoader.java
@@ -231,15 +231,10 @@ class XWalkLibraryLoader {
 
         @Override
         protected Integer doInBackground(Void... params) {
-            if (!mIsCompressed) return 0;
+            if (!mIsCompressed || mIsDecompressed) return 0;
 
-            if (!mIsDecompressed && !XWalkLibraryDecompressor.decompressLibrary(mContext)) {
-                return 1;
-            }
+            if (!XWalkLibraryDecompressor.decompressLibrary(mContext)) return 1;
 
-            if (!isCancelled() && !XWalkLibraryDecompressor.loadDecompressedLibrary(mContext)) {
-                return 2;
-            }
             return 0;
         }
 

--- a/runtime/android/core/strings/xwalk_app_strings.grd
+++ b/runtime/android/core/strings/xwalk_app_strings.grd
@@ -32,18 +32,6 @@
       <message desc="Startup Not Found Message [CHAR-LIMIT=100]" name="IDS_STARTUP_NOT_FOUND_MESSAGE">
         APP_NAME requires the Crosswalk Project Service to work. Please install it from the app store, then restart APP_NAME.
       </message>
-      <message desc="Startup Architecture Mismatched Title [CHAR-LIMIT=100]" name="IDS_STARTUP_ARCHITECTURE_MISMATCH_TITLE">
-        Mismatch of CPU Architecture for the Crosswalk Project Service
-      </message>
-      <message desc="Startup Architecture Mismatched Message [CHAR-LIMIT=100]" name="IDS_STARTUP_ARCHITECTURE_MISMATCH_MESSAGE">
-        The Crosswalk Project Service must be updated to match the CPU architecture of the device. Please install it from the app store, then restart APP_NAME.
-      </message>
-      <message desc="Startup Signature Check Error Title [CHAR-LIMIT=100]" name="IDS_STARTUP_SIGNATURE_CHECK_ERROR_TITLE">
-        The Crosswalk Project Signature Verification Failed
-      </message>
-      <message desc="Startup Signature Check Error Message [CHAR-LIMIT=100]" name="IDS_STARTUP_SIGNATURE_CHECK_ERROR_MESSAGE">
-        The integrity of the Crosswalk Project Service cannot be verified. Please uninstall it and restart APP_NAME.
-      </message>
       <message desc="Startup Older Version Title [CHAR-LIMIT=100]" name="IDS_STARTUP_OLDER_VERSION_TITLE">
         New Crosswalk Project Service Required
       </message>
@@ -55,6 +43,24 @@
       </message>
       <message desc="Startup Newer Version Message [CHAR-LIMIT=100]" name="IDS_STARTUP_NEWER_VERSION_MESSAGE">
         APP_NAME is not compatible with the installed version of the Crosswalk Project Service.
+      </message>
+      <message desc="Startup Incomplete Library Title [CHAR-LIMIT=100]" name="IDS_STARTUP_INCOMPLETE_LIBRARY_TITLE">
+        Incomplete Crosswalk Project Service
+      </message>
+      <message desc="Startup Incomplete Library Message [CHAR-LIMIT=100]" name="IDS_STARTUP_INCOMPLETE_LIBRARY_MESSAGE">
+        Please repackage APP_NAME.
+      </message>
+      <message desc="Startup Architecture Mismatched Title [CHAR-LIMIT=100]" name="IDS_STARTUP_ARCHITECTURE_MISMATCH_TITLE">
+        Mismatch of CPU Architecture for the Crosswalk Project Service
+      </message>
+      <message desc="Startup Architecture Mismatched Message [CHAR-LIMIT=100]" name="IDS_STARTUP_ARCHITECTURE_MISMATCH_MESSAGE">
+        The Crosswalk Project Service must be updated to match the CPU architecture of the device. Please install it from the app store, then restart APP_NAME.
+      </message>
+      <message desc="Startup Signature Check Error Title [CHAR-LIMIT=100]" name="IDS_STARTUP_SIGNATURE_CHECK_ERROR_TITLE">
+        The Crosswalk Project Signature Verification Failed
+      </message>
+      <message desc="Startup Signature Check Error Message [CHAR-LIMIT=100]" name="IDS_STARTUP_SIGNATURE_CHECK_ERROR_MESSAGE">
+        The integrity of the Crosswalk Project Service cannot be verified. Please uninstall it and restart APP_NAME.
       </message>
       <message desc="Label of Get Crosswalk [CHAR-LIMIT=100]" name="IDS_XWALK_GET_CROSSWALK">
         Get Crosswalk

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -140,7 +140,6 @@
       'dependencies': [
         'xwalk_core_reflection_layer_java_gen',
         'xwalk_app_strings',
-        '../content/content.gyp:content_java',
         'third_party/lzma_sdk/lzma_sdk_android.gyp:lzma_sdk_java',
       ],
       'variables': {


### PR DESCRIPTION
Specify the directory from where the infrastructure loads native
libraries from the package org.xwalk.core instead of
org.xwalk.core.internal. This is to support for the lite mode and future
download mode in which native libraries don't exist in the default
directory.