### PR TITLE
[Android] Add silent download support in shared mode

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
@@ -67,17 +67,6 @@ class XWalkDialogManager {
                     R.string.startup_not_found_message)));
             setPositiveButton(dialog, downloadText, downloadCommand);
             setNegativeButton(dialog, cancelText, cancelCommand);
-        } else if (status == XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH) {
-            dialog.setTitle(mContext.getString(R.string.startup_architecture_mismatch_title));
-            dialog.setMessage(replaceApplicationName(mContext.getString(
-                    R.string.startup_architecture_mismatch_message)));
-            setPositiveButton(dialog, downloadText, downloadCommand);
-            setNegativeButton(dialog, cancelText, cancelCommand);
-        } else if (status == XWalkLibraryInterface.STATUS_SIGNATURE_CHECK_ERROR) {
-            dialog.setTitle(mContext.getString(R.string.startup_signature_check_error_title));
-            dialog.setMessage(replaceApplicationName(mContext.getString(
-                    R.string.startup_signature_check_error_message)));
-            setNegativeButton(dialog, cancelText, cancelCommand);
         } else if (status == XWalkLibraryInterface.STATUS_OLDER_VERSION) {
             dialog.setTitle(mContext.getString(R.string.startup_older_version_title));
             dialog.setMessage(replaceApplicationName(mContext.getString(
@@ -89,8 +78,19 @@ class XWalkDialogManager {
             dialog.setMessage(replaceApplicationName(mContext.getString(
                     R.string.startup_newer_version_message)));
             setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH) {
+            dialog.setTitle(mContext.getString(R.string.startup_architecture_mismatch_title));
+            dialog.setMessage(replaceApplicationName(mContext.getString(
+                    R.string.startup_architecture_mismatch_message)));
+            setPositiveButton(dialog, downloadText, downloadCommand);
+            setNegativeButton(dialog, cancelText, cancelCommand);
+        } else if (status == XWalkLibraryInterface.STATUS_SIGNATURE_CHECK_ERROR) {
+            dialog.setTitle(mContext.getString(R.string.startup_signature_check_error_title));
+            dialog.setMessage(replaceApplicationName(mContext.getString(
+                    R.string.startup_signature_check_error_message)));
+            setNegativeButton(dialog, cancelText, cancelCommand);
         } else {
-            Assert.fail();
+            Assert.fail("Invalid status for alert dialog " + status);
         }
         showDialog(dialog);
     }

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryDecompressor.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryDecompressor.java
@@ -18,12 +18,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.chromium.base.PathUtils;
-
 import SevenZip.Compression.LZMA.Decoder;
 
 class XWalkLibraryDecompressor {
-    private static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
+    private static final String PRIVATE_LIB_DIR = "xwalkcore";
     private static final String[] MANDATORY_LIBRARIES = { "libxwalkcore.so" };
     private static final String TAG = "XWalkLib";
 
@@ -45,8 +43,7 @@ class XWalkLibraryDecompressor {
     }
 
     public static boolean decompressLibrary(Context context) {
-        PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, context);
-        String lib = PathUtils.getDataDirectory(context.getApplicationContext());
+        String lib = context.getDir(PRIVATE_LIB_DIR, Context.MODE_PRIVATE).toString();
 
         long start = System.currentTimeMillis();
         boolean success = decompress(context, lib);
@@ -55,22 +52,6 @@ class XWalkLibraryDecompressor {
 
         if (success) setLocalVersion(context, XWalkAppVersion.API_VERSION);
         return success;
-    }
-
-    public static boolean loadDecompressedLibrary(Context context) {
-        PathUtils.setPrivateDataDirectorySuffix(PRIVATE_DATA_DIRECTORY_SUFFIX, context);
-        String lib = PathUtils.getDataDirectory(context.getApplicationContext());
-
-        try {
-            for (String library : MANDATORY_LIBRARIES) {
-                System.load(lib + "/" + library);
-            }
-        } catch (UnsatisfiedLinkError e) {
-            Log.d(TAG, "Failed to load decompressed library");
-            return false;
-        }
-
-        return true;
     }
 
     private static boolean decompress(Context context, String libDir) {

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryInterface.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryInterface.java
@@ -24,22 +24,27 @@ interface XWalkLibraryInterface {
     public static final int STATUS_NOT_FOUND = 2;
 
     /**
-     * Mismatch of CPU Architecture for the Crosswalk Runtime.
-     */
-    public static final int STATUS_ARCHITECTURE_MISMATCH = 3;
-
-    /**
-     * The Crosswalk signature verification failed.
-     */
-    public static final int STATUS_SIGNATURE_CHECK_ERROR = 4;
-
-    /**
      * The version of the Crosswalk runtime is older than the application.
      */
-    public static final int STATUS_OLDER_VERSION = 5;
+    public static final int STATUS_OLDER_VERSION = 3;
 
     /**
      * The version of the Crosswalk runtime is newer than the application.
      */
-    public static final int STATUS_NEWER_VERSION = 6;
+    public static final int STATUS_NEWER_VERSION = 4;
+
+    /**
+     * The components of Crosswalk Runtime are not completed.
+     */
+    public static final int STATUS_INCOMPLETE_LIBRARY = 5;
+
+    /**
+     * Mismatch of CPU Architecture for the Crosswalk Runtime.
+     */
+    public static final int STATUS_ARCHITECTURE_MISMATCH = 6;
+
+    /**
+     * The Crosswalk signature verification failed.
+     */
+    public static final int STATUS_SIGNATURE_CHECK_ERROR = 7;
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -6,30 +6,48 @@ package org.xwalk.core;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.os.Handler;
 import android.util.Log;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+import junit.framework.Assert;
 
 import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
 
 /**
  * <p><code>XWalkUpdater</code> is a follow-up solution for {@link XWalkInitializer} in case the
- * initialization has failed. The users of {@link XWalkActivity} don't need to use this class.</p>
+ * initialization failed. The users of {@link XWalkActivity} don't need to use this class.</p>
  *
  * <p><code>XWalkUpdater</code> helps to donwload the Crosswalk runtime and displays dialogs to
  * interact with the user. By default, it will navigate to the Crosswalk runtime's page on the
  * default application store, subsequent process will be up to the user. If the developer specified
  * the download URL of the Crosswalk runtime, it will launch the download manager to fetch the APK.
- * To specify the download URL, insert a meta-data element with the name "xwalk_apk_url" inside the
+ * To specify the download URL, insert a meta-data element named "xwalk_apk_url" inside the
  * application tag in the Android manifest.
  *
  * <pre>
- * &lt;application android:name="org.xwalk.core.XWalkApplication"&gt;
+ * &lt;application&gt;
  *     &lt;meta-data android:name="xwalk_apk_url" android:value="http://host/XWalkRuntimeLib.apk" /&gt;
+ * &lt;/application&gt;
  * </pre>
  *
  * <p>After the proper Crosswalk runtime is downloaded and installed, the user will return to
@@ -44,29 +62,46 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  *         implements XWalkInitializer.XWalkInitListener, XWalkUpdater.XWalkUpdateListener {
  *     XWalkUpdater mXWalkUpdater;
  *
- *     ......
- *
  *     &#64;Override
  *     protected void onResume() {
  *         super.onResume();
  *
- *         // Try to initialize again when the user completed updating and returned to current
+ *         // Try to initialize again when the user completed update and returned to current
  *         // activity. The initAsync() will do nothing if the initialization has already been
- *         // completed successfully.
+ *         // completed successfully or previous update dialog is still being displayed.
  *         mXWalkInitializer.initAsync();
  *     }
  *
  *     &#64;Override
  *     public void onXWalkInitFailed() {
  *         if (mXWalkUpdater == null) mXWalkUpdater = new mXWalkUpdater(this, this);
- *
- *         // The updater won't be launched if previous update dialog is showing.
  *         mXWalkUpdater.updateXWalkRuntime();
+ *     }
+ *
+ *     ......
+ *
+ *     &#64;Override
+ *     public void onXWalkUpdateStarted() {
+ *         // Download manager started to download the APK file.
+ *         // Nothing particular to do here.
  *     }
  *
  *     &#64;Override
  *     public void onXWalkUpdateCancelled() {
- *         // Perform error handling here
+ *         // The user clicked the "Cancel" button during download.
+ *         // Perform error handling here.
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkUpdateFailed() {
+ *         // There will be an alert dialog to guide the user.
+ *         // Nothing particular to do here.
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkUpdateCompleted() {
+ *         // The app will jump into the installer.
+ *         // Nothing particular to do here.
  *     }
  * }
  * </pre>
@@ -80,6 +115,29 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  * &lt;uses-permission android:name="android.permission.INTERNET" /&gt;
  * &lt;uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /&gt;
  * </pre>
+ *
+ *
+ * <p>If you grant following permission further, the download doesn't show in the notifications.</p>
+ *
+ * <pre>
+ * &lt;uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" /&gt;
+ * </pre>
+ *
+ * <p><code>There is another experimental way to update the Crosswalk runtime. The app is still
+ * bundled with xwalk_shared_library and the Crosswalk runtime APK must be specified via meta-data
+ * "xwalk_apk_url". At the first startup, the Crosswalk runtime APK will be downloaded in background
+ * silently without interrupting foreground interactions and the downloaded APK will not be installed
+ * as the normal application. Instead, the downloaded runtime APK will be used as a plugin. To enable
+ * this approach, you need to insert a meta-data named "xwalk_silent_download" into the application tag
+ * in the AndroidManifest.xml</p>
+ *
+ * <p>For example:</p>
+ *
+ * <pre>
+ * &lt;application&gt;
+ *     &lt;meta-data android:name="xwalk_silent_download" android:value="enable" /&gt;
+ * &lt;/application&gt;
+ * </pre>
  */
 
 public class XWalkUpdater {
@@ -92,17 +150,36 @@ public class XWalkUpdater {
          * update or the download (from the specified URL) is cancelled
          */
         public void onXWalkUpdateCancelled();
+
+        public void onXWalkUpdateStarted();
+        public void onXWalkUpdateFailed();
+        public void onXWalkUpdateCompleted();
     }
 
     private static final String XWALK_APK_MARKET_URL = "market://details?id=org.xwalk.core";
-    private static final String TAG = "XWalkActivity";
+
+    private static final String META_XWALK_APK_URL = "xwalk_apk_url";
+    private static final String META_XWALK_SILENT_DOWNLOAD = "xwalk_silent_download";
+
+    private static final String PRIVATE_LIB_DIR = "xwalkcorelib";
+
+    private static final String[] XWALK_LIB_RESOURCES = {
+        "libxwalkcore.so",
+        "icudtl.dat",
+        "xwalk.pak",
+        "classes.dex",
+    };
+    private static final String[] XWALK_LIB_APK = { "XWalkRuntimeLib.apk" };
+
+    private static final String TAG = "XWalkLib";
 
     private XWalkUpdateListener mUpdateListener;
     private Activity mActivity;
     private XWalkDialogManager mDialogManager;
+    private boolean mIsDownloading;
+    private String mXWalkApkUrl;
     private Runnable mDownloadCommand;
     private Runnable mCancelCommand;
-    private String mXWalkApkUrl;
 
     /**
      * Create XWalkUpdater for single activity
@@ -114,11 +191,10 @@ public class XWalkUpdater {
         this(listener, activity, new XWalkDialogManager(activity));
     }
 
-    XWalkUpdater(XWalkUpdateListener listener, Activity activity,
-            XWalkDialogManager dialogManager) {
+    XWalkUpdater(XWalkUpdateListener listener, Activity activity, XWalkDialogManager manager) {
         mUpdateListener = listener;
         mActivity = activity;
-        mDialogManager = dialogManager;
+        mDialogManager = manager;
 
         mDownloadCommand = new Runnable() {
             @Override
@@ -133,30 +209,6 @@ public class XWalkUpdater {
                 mUpdateListener.onXWalkUpdateCancelled();
             }
         };
-    }
-
-    /**
-     * Update the Crosswalk runtime. There are 2 ways to download the Crosswalk runtime: from the
-     * play store or the specified URL. It will download from the play store if the download URL is
-     * not specified. To specify the download URL, insert a meta-data element with the name
-     * "xwalk_apk_url" inside the application tag in the Android manifest.
-     *
-     * <p>Please try to initialize by {@link XWalkInitializer} first and only invoke this method
-     * when the initialization failed. This method must be invoked on the UI thread.
-     *
-     * @return True if the updater is launched, false if is in updating, or the Crosswalk runtime
-     *         doesn't need to be updated, or the Crosswalk runtime has not been initialized yet.
-     */
-    public boolean updateXWalkRuntime() {
-        if (mDialogManager.isShowingDialog()) return false;
-
-        int status = XWalkLibraryLoader.getLibraryStatus();
-        if (status == XWalkLibraryInterface.STATUS_PENDING ||
-                status == XWalkLibraryInterface.STATUS_MATCH) return false;
-
-        Log.d(TAG, "Update the Crosswalk runtime with status " + status);
-        mDialogManager.showInitializationError(status, mCancelCommand, mDownloadCommand);
-        return true;
     }
 
     /**
@@ -180,10 +232,63 @@ public class XWalkUpdater {
         mXWalkApkUrl = url;
     }
 
+    /**
+     * Update the Crosswalk runtime. There are 2 ways to download the Crosswalk runtime: from the
+     * play store or the specified URL. It will download from the play store if the download URL is
+     * not specified. To specify the download URL, insert a meta-data element with the name
+     * "xwalk_apk_url" inside the application tag in the Android manifest.
+     *
+     * <p>Please try to initialize by {@link XWalkInitializer} first and only invoke this method
+     * when the initialization failed. This method must be invoked on the UI thread.
+     *
+     * @return True if the updater is launched, false if is in updating, or the Crosswalk runtime
+     *         doesn't need to be updated, or the Crosswalk runtime has not been initialized yet.
+     */
+    public boolean updateXWalkRuntime() {
+        if (mIsDownloading || mDialogManager.isShowingDialog()) return false;
+
+        int status = XWalkLibraryLoader.getLibraryStatus();
+        if (status == XWalkLibraryInterface.STATUS_PENDING ||
+                status == XWalkLibraryInterface.STATUS_MATCH) return false;
+
+        if (isDownloadMode()) {
+            if (mXWalkApkUrl == null) {
+                mXWalkApkUrl = getAppMetaData(META_XWALK_APK_URL);
+                if (mXWalkApkUrl == null) {
+                    Log.e(TAG, "Please specify xwalk_apk_url in meta-data");
+                    Assert.fail();
+                }
+                Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
+            }
+            XWalkLibraryLoader.startDownload(new BackgroundListener(), mActivity, mXWalkApkUrl);
+        } else {
+            Log.d(TAG, "Update the Crosswalk runtime with status " + status);
+            mDialogManager.showInitializationError(status, mCancelCommand, mDownloadCommand);
+        }
+        return true;
+    }
+
+    private boolean isDownloadMode() {
+        String silentDownload = getAppMetaData(META_XWALK_SILENT_DOWNLOAD);
+        if (silentDownload != null && silentDownload.equalsIgnoreCase("enable")) {
+            Log.i(TAG, "Running in silent download mode");
+            return true;
+        }
+        return false;
+    }
+
     private void downloadXWalkApk() {
-        String downloadUrl = getXWalkApkUrl();
-        if (!downloadUrl.isEmpty()) {
-            XWalkLibraryLoader.startDownload(new XWalkLibraryListener(), mActivity, downloadUrl);
+        // The download url is defined by the meta-data element with the name "xwalk_apk_url"
+        // inside the application tag in the Android manifest. It can also be specified via
+        // the option --xwalk-apk-url of the script make_apk.
+        if (mXWalkApkUrl == null) {
+            mXWalkApkUrl = getAppMetaData(META_XWALK_APK_URL);
+            if (mXWalkApkUrl == null) mXWalkApkUrl = "";
+            Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
+        }
+
+        if (!mXWalkApkUrl.isEmpty()) {
+            XWalkLibraryLoader.startDownload(new ForegroundListener(), mActivity, mXWalkApkUrl);
             return;
         }
 
@@ -199,26 +304,50 @@ public class XWalkUpdater {
         }
     }
 
-    private String getXWalkApkUrl() {
-        if (mXWalkApkUrl != null) return mXWalkApkUrl;
-
-        // The download url is defined by the meta-data element with the name "xwalk_apk_url"
-        // inside the application tag in the Android manifest. It can also be specified via
-        // the option --xwalk-apk-url of the script make_apk.
-        try {
-            PackageManager packageManager = mActivity.getPackageManager();
-            ApplicationInfo appInfo = packageManager.getApplicationInfo(
-                    mActivity.getPackageName(), PackageManager.GET_META_DATA);
-            mXWalkApkUrl = appInfo.metaData.getString("xwalk_apk_url");
-        } catch (NameNotFoundException | NullPointerException e) {
-        }
-
-        if (mXWalkApkUrl == null) mXWalkApkUrl = "";
-        Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
-        return mXWalkApkUrl;
+    /**
+     * Cancel the download of the Crosswalk library.
+     *
+     * @return True if the download is canclled, false otherwise.
+     */
+    public boolean cancelLibraryUpdate() {
+        return XWalkLibraryLoader.cancelDownload();
     }
 
-    private class XWalkLibraryListener implements DownloadListener {
+    private boolean installLibraries(String fileName) {
+        String libDir = mActivity.getDir(PRIVATE_LIB_DIR, Context.MODE_PRIVATE).toString();
+        try {
+            ZipFile zipFile = new ZipFile(fileName);
+            for (String resource : XWALK_LIB_RESOURCES) {
+                String entryName;
+                String dest = libDir + File.separator + resource;
+                if (resource.substring(resource.length() - 2).equals("so")) {
+                    if(Build.CPU_ABI.equalsIgnoreCase("armeabi")) {
+                        // We build armeabi-v7a native lib for both armeabi & armeabi-v7a
+                        entryName = "lib" + File.separator + "armeabi-v7a" +
+                                File.separator + resource;
+                    } else {
+                        entryName = "lib" + File.separator + Build.CPU_ABI +
+                                File.separator + resource;
+                    }
+                } else if (resource.substring(resource.length() - 3).equals("dat") ||
+                        resource.substring(resource.length() - 3).equals("pak")) {
+                    entryName = "assets" + File.separator + resource;
+                } else {
+                    entryName = resource;
+                }
+                Log.d(TAG, "unzip " + entryName);
+                ZipEntry entry = zipFile.getEntry(entryName);
+                copy(zipFile.getInputStream(entry), new FileOutputStream(dest));
+            }
+        } catch (IOException e) {
+            Log.d(TAG, e.getLocalizedMessage());
+            return false;
+        }
+
+        return true;
+    }
+
+    private class ForegroundListener implements DownloadListener {
         @Override
         public void onDownloadStarted() {
             mDialogManager.showDownloadProgress(new Runnable() {
@@ -227,6 +356,8 @@ public class XWalkUpdater {
                     XWalkLibraryLoader.cancelDownload();
                 }
             });
+
+            mUpdateListener.onXWalkUpdateStarted();
         }
 
         @Override
@@ -240,19 +371,75 @@ public class XWalkUpdater {
         }
 
         @Override
+        public void onDownloadFailed(int status, int error) {
+            mDialogManager.dismissDialog();
+            mDialogManager.showDownloadError(status, error, mCancelCommand, mDownloadCommand);
+            mUpdateListener.onXWalkUpdateFailed();
+        }
+
+        @Override
         public void onDownloadCompleted(Uri uri) {
             mDialogManager.dismissDialog();
+            mUpdateListener.onXWalkUpdateCompleted();
 
             Log.d(TAG, "Install the Crosswalk runtime: " + uri.toString());
             Intent install = new Intent(Intent.ACTION_VIEW);
             install.setDataAndType(uri, "application/vnd.android.package-archive");
             mActivity.startActivity(install);
         }
+    }
+
+    private class BackgroundListener implements DownloadListener {
+        @Override
+        public void onDownloadStarted() {
+            mIsDownloading = true;
+            mUpdateListener.onXWalkUpdateStarted();
+        }
+
+        @Override
+        public void onDownloadUpdated(int percentage) {
+        }
+
+        @Override
+        public void onDownloadCancelled() {
+            mIsDownloading = false;
+            mUpdateListener.onXWalkUpdateCancelled();
+        }
 
         @Override
         public void onDownloadFailed(int status, int error) {
-            mDialogManager.dismissDialog();
-            mDialogManager.showDownloadError(status, error, mCancelCommand, mDownloadCommand);
+            mIsDownloading = false;
+            mUpdateListener.onXWalkUpdateFailed();
         }
+
+        @Override
+        public void onDownloadCompleted(Uri uri) {
+            if(!installLibraries(uri.getPath())) Assert.fail();
+
+            mIsDownloading = false;
+            mUpdateListener.onXWalkUpdateCompleted();
+        }
+    }
+
+    private String getAppMetaData(String name) {
+        try {
+            PackageManager packageManager = mActivity.getPackageManager();
+            ApplicationInfo appInfo = packageManager.getApplicationInfo(
+                    mActivity.getPackageName(), PackageManager.GET_META_DATA);
+            return appInfo.metaData.getString(name);
+        } catch (NameNotFoundException | NullPointerException e) {
+        }
+        return null;
+    }
+
+    private void copy(InputStream input, OutputStream output) throws IOException {
+        byte[] buffer = new byte[4096];
+        int len = 0;
+        while ((len = input.read(buffer)) >= 0) {
+            output.write(buffer, 0, len);
+        }
+
+        input.close();
+        output.close();
     }
 }

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -140,7 +140,6 @@
       'dependencies': [
         'xwalk_core_reflection_layer_java_gen',
         'xwalk_app_strings',
-        '../content/content.gyp:content_java',
         'third_party/lzma_sdk/lzma_sdk_android.gyp:lzma_sdk_java',
       ],
       'variables': {


### PR DESCRIPTION
Shared mode APK can be configured to download the runtime APK in
background silently via a meta-data element "xwalk_silent_download"
in AndroidManifest.xml.

The downloaded runtime APK will be not installed as a normal application
instead, its core components (libxwalkcore.so, classes.dex, xwalk.pak
and icudtl.dat) will be extracted to application's private data
directory and the core library will be loaded as a plugin.