### PR TITLE
[Android] Fix onReceivedHttpAuthRequest() was not called issue.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java
@@ -12,8 +12,8 @@ import org.chromium.base.annotations.JNINamespace;
  * @hide
  */
 @JNINamespace("xwalk")
-@XWalkAPI(createExternally = true)
-public class XWalkHttpAuthHandlerInternal {
+@XWalkAPI(impl = XWalkHttpAuthInternal.class, createInternally = true)
+public class XWalkHttpAuthHandlerInternal implements XWalkHttpAuthInternal {
 
     private long mNativeXWalkHttpAuthHandler;
     private final boolean mFirstAttempt;
@@ -43,10 +43,16 @@ public class XWalkHttpAuthHandlerInternal {
         return new XWalkHttpAuthHandlerInternal(nativeXWalkAuthHandler, firstAttempt);
     }
 
-    @XWalkAPI
     public XWalkHttpAuthHandlerInternal(long nativeXWalkHttpAuthHandler, boolean firstAttempt) {
         mNativeXWalkHttpAuthHandler = nativeXWalkHttpAuthHandler;
         mFirstAttempt = firstAttempt;
+    }
+
+    // Never use this constructor.
+    // It is only used in XWalkHttpAuthHandlerBridge.
+    XWalkHttpAuthHandlerInternal() {
+        mNativeXWalkHttpAuthHandler = 0;
+        mFirstAttempt = false;
     }
 
     @CalledByNative

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthInternal.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+/**
+ * This interface is used when XWalkResourceClientInternal offers a http auth
+ * request (cancel, proceed) to enable the client to handle the request in their
+ * own way. XWalkResourceClientInternal will offer an object that implements
+ * this interface to the client and when the client has handled the request,
+ * it must either callback with proceed() or cancel() to allow processing to
+ * continue.
+ */
+@XWalkAPI(instance = XWalkHttpAuthHandlerInternal.class)
+public interface XWalkHttpAuthInternal {
+    @XWalkAPI
+    public void proceed(String username, String password);
+
+    @XWalkAPI
+    public void cancel();
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedHttpAuthRequestTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedHttpAuthRequestTest.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package org.xwalk.core.internal.xwview.test;
+package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
 
@@ -12,7 +12,7 @@ import org.chromium.base.test.util.Feature;
 /**
  * Tests for the OnReceivedHttpAuthRequest.
  */
-public class OnReceivedHttpAuthRequestTest extends XWalkViewInternalTestBase {
+public class OnReceivedHttpAuthRequestTest extends XWalkViewTestBase {
     TestHelperBridge.OnReceivedHttpAuthRequestHelper mOnReceivedHttpAuthRequestHelper;
 
     @Override

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
@@ -497,6 +497,20 @@ class TestHelperBridge {
         }
     }
 
+    public class OnReceivedHttpAuthRequestHelper extends CallbackHelper {
+        private String mHost;
+
+        public String getHost() {
+            assert getCallCount() > 0;
+            return mHost;
+        }
+
+        public void notifyCalled(String host) {
+            mHost = host;
+            notifyCalled();
+        }
+    }
+
     private String mChangedTitle;
     private LoadStatus mLoadStatus;
     private final OnPageStartedHelper mOnPageStartedHelper;
@@ -528,6 +542,7 @@ class TestHelperBridge {
     private final OnDownloadStartHelper mOnDownloadStartHelper;
     private final OnReceivedClientCertRequestHelper mOnReceivedClientCertRequestHelper;
     private final OnReceivedResponseHeadersHelper mOnReceivedResponseHeadersHelper;
+    private final OnReceivedHttpAuthRequestHelper mOnReceivedHttpAuthRequestHelper;
 
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -557,6 +572,7 @@ class TestHelperBridge {
         mOnDownloadStartHelper = new OnDownloadStartHelper();
         mOnReceivedClientCertRequestHelper = new OnReceivedClientCertRequestHelper();
         mOnReceivedResponseHeadersHelper = new OnReceivedResponseHeadersHelper();
+        mOnReceivedHttpAuthRequestHelper = new OnReceivedHttpAuthRequestHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -665,6 +681,10 @@ class TestHelperBridge {
 
     public OnReceivedResponseHeadersHelper getOnReceivedResponseHeadersHelper() {
         return mOnReceivedResponseHeadersHelper;
+    }
+
+    public OnReceivedHttpAuthRequestHelper getOnReceivedHttpAuthRequestHelper() {
+        return mOnReceivedHttpAuthRequestHelper;
     }
 
     public void onTitleChanged(String title) {
@@ -787,5 +807,9 @@ class TestHelperBridge {
             XWalkWebResourceRequest request,
             XWalkWebResourceResponse response) {
         mOnReceivedResponseHeadersHelper.notifyCalled(request, response);
+    }
+
+    public void onReceivedHttpAuthRequest(String host) {
+        mOnReceivedHttpAuthRequestHelper.notifyCalled(host);
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -31,6 +31,7 @@ import org.chromium.ui.gfx.DeviceDisplayInfo;
 
 import org.xwalk.core.ClientCertRequest;
 import org.xwalk.core.XWalkDownloadListener;
+import org.xwalk.core.XWalkHttpAuthHandler;
 import org.xwalk.core.XWalkJavascriptResult;
 import org.xwalk.core.XWalkNavigationHistory;
 import org.xwalk.core.XWalkNavigationItem;
@@ -220,6 +221,12 @@ public class XWalkViewTestBase
                 XWalkWebResourceRequest request,
                 XWalkWebResourceResponse response) {
             mTestHelperBridge.onReceivedResponseHeaders(view, request, response);
+        }
+
+        @Override
+        public void onReceivedHttpAuthRequest(XWalkView view,
+                XWalkHttpAuthHandler handler, String host, String realm) {
+            mInnerContentsClient.onReceivedHttpAuthRequest(host);
         }
     }
 

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/TestHelperBridge.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/TestHelperBridge.java
@@ -127,20 +127,6 @@ class TestHelperBridge {
         }
     }
 
-    public class OnReceivedHttpAuthRequestHelper extends CallbackHelper {
-        private String mHost;
-
-        public String getHost() {
-            assert getCallCount() > 0;
-            return mHost;
-        }
-
-        public void notifyCalled(String host) {
-            mHost = host;
-            notifyCalled();
-        }
-    }
-
     private String mChangedTitle;
     private final OnPageStartedHelper mOnPageStartedHelper;
     private final OnPageFinishedHelper mOnPageFinishedHelper;
@@ -151,7 +137,6 @@ class TestHelperBridge {
     private final OnTitleUpdatedHelper mOnTitleUpdatedHelper;
     private final ShouldInterceptLoadRequestHelper mShouldInterceptLoadRequestHelper;
     private final OnLoadStartedHelper mOnLoadStartedHelper;
-    private final OnReceivedHttpAuthRequestHelper mOnReceivedHttpAuthRequestHelper;
 
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -161,7 +146,6 @@ class TestHelperBridge {
         mOnTitleUpdatedHelper = new OnTitleUpdatedHelper();
         mShouldInterceptLoadRequestHelper = new ShouldInterceptLoadRequestHelper();
         mOnLoadStartedHelper = new OnLoadStartedHelper();
-        mOnReceivedHttpAuthRequestHelper = new OnReceivedHttpAuthRequestHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -190,10 +174,6 @@ class TestHelperBridge {
 
     public OnLoadStartedHelper getOnLoadStartedHelper() {
         return mOnLoadStartedHelper;
-    }
-
-    public OnReceivedHttpAuthRequestHelper getOnReceivedHttpAuthRequestHelper() {
-        return mOnReceivedHttpAuthRequestHelper;
     }
 
     public void onTitleChanged(String title) {
@@ -225,9 +205,5 @@ class TestHelperBridge {
 
     public void onLoadStarted(String url) {
         mOnLoadStartedHelper.notifyCalled(url);
-    }
-
-    public void onReceivedHttpAuthRequest(String host) {
-        mOnReceivedHttpAuthRequestHelper.notifyCalled(host);
     }
 }

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
@@ -106,12 +106,6 @@ public class XWalkViewInternalTestBase
                 XWalkWebResourceRequestInternal request) {
             return mInnerContentsClient.shouldInterceptLoadRequest(request.getUrl().toString());
         }
-
-        @Override
-        public void onReceivedHttpAuthRequest(XWalkViewInternal view,
-                XWalkHttpAuthHandlerInternal handler, String host, String realm) {
-            mInnerContentsClient.onReceivedHttpAuthRequest(host);
-        }
     }
 
     class TestXWalkResourceClient extends TestXWalkResourceClientBase {

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -32,6 +32,7 @@ CLASSES_TO_BE_PROCESS = [
     'XWalkExtensionInternal',
     'XWalkGetBitmapCallbackInternal',
     'XWalkHttpAuthHandlerInternal',
+    'XWalkHttpAuthInternal',
     'XWalkViewInternal',
     'XWalkUIClientInternal',
     'XWalkResourceClientInternal',


### PR DESCRIPTION
This patch is to fix the issue about onReceivedHttpAuthRequest() was not
called when this function was overridden in class of XWalkResourceClient.
Modify the attribute of XWalkHttpAuthHandlerInternal to generate right
parameter for XWalkResourceClientBridge.
Move test case from XWalkViewInternal to XWalkView.

BUG=XWALK-5117