### PR TITLE
[Android] Refine the accept language from OS.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -186,7 +186,7 @@ class XWalkContent extends FrameLayout implements XWalkPreferencesInternal.KeyVa
         // loaded by XMLHttpRequest.
         mSettings.setAllowFileAccessFromFileURLs(true);
 
-        String language = Locale.getDefault().toString();
+        String language = Locale.getDefault().toString().replaceAll("_", "-").toLowerCase();
         if (language.isEmpty()) language = "en";
         mSettings.setAcceptLanguages(language);
 


### PR DESCRIPTION
The language's format from OS sometimes is like as "zh_CN", but the
adopted format by HTTP protocol is "zh-cn".
Replace "_" with "-" and change the alphabet to lower case.

BUG=XWALK-5045

(cherry picked from commit 57e4f404868306e2b2987904eed79c0946ed7e47)