### PR TITLE
Implement .NET external extension system.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -42,6 +42,10 @@ solutions = [
       'src/v8':
         crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
 
+      # Temporary roll GYP forward so we can have support to compile managed code on Windows.
+      'src/tools/gyp':
+        'https://chromium.googlesource.com/external/gyp.git@1f374df95de1c0a125485496e8d23d36303a93fd',
+
       # Include OpenCL header files for WebCL support, target version 1.2.
       'src/third_party/khronos/CL':
         crosswalk_git + '/khronos-cl-api-1.2.git@6f4be98d10f03ce2b12c769cd9835c73a441c00f',

--- a/dotnet/dotnet_bridge.gyp
+++ b/dotnet/dotnet_bridge.gyp
@@ -1,0 +1,43 @@
+{
+    # This is needed so that /RTC1 and /MTx are not added to the
+    # compilation command line (it's not compatible with /clr)
+    'target_defaults': {
+      'variables': {
+        'win_release_RuntimeChecks': '0',
+        'win_debug_RuntimeChecks': '0',
+        'win_release_RuntimeLibrary': '2', # 2 = /MD (nondebug DLL)
+        'win_debug_RuntimeLibrary': '3',   # 3 = /MDd (debug DLL)
+      },
+    },
+    'targets': [
+      {
+          'target_name': 'dotnet_bridge',
+          'type': 'none',
+          'dependencies': [
+            'xwalk_dotnet_bridge'
+          ],
+      },
+      {
+        'target_name': 'xwalk_dotnet_bridge',
+        'type': 'shared_library',
+        'sources': [
+          'xwalk_dotnet_bridge.cc',
+          'xwalk_dotnet_bridge.h',
+          '../extensions/public/XW_Extension.h',
+          '../extensions/public/XW_Extension_EntryPoints.h',
+          '../extensions/public/XW_Extension_Permissions.h',
+          '../extensions/public/XW_Extension_Runtime.h',
+          '../extensions/public/XW_Extension_SyncMessage.h',
+        ],
+        'include_dirs': [
+          '../../',
+        ],
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'RuntimeTypeInfo': 'true',
+            'CompileAsManaged':'true',
+          }
+        },
+     },
+   ],
+}

--- a/dotnet/xwalk_dotnet_bridge.cc
+++ b/dotnet/xwalk_dotnet_bridge.cc
@@ -1,0 +1,423 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/dotnet/xwalk_dotnet_bridge.h"
+
+#include <Objbase.h>
+#include <vcclr.h>
+
+#include <assert.h>
+#include <iostream>
+
+using namespace System; // NOLINT
+using namespace System::IO; // NOLINT
+using namespace System::Reflection; // NOLINT
+using namespace System::Text; // NOLINT
+using namespace Runtime::InteropServices; // NOLINT
+
+namespace {
+
+xwalk::extensions::XWalkDotNetBridge* g_bridge = nullptr;
+XW_Extension g_xw_extension = 0;
+const XW_CoreInterface* g_core = nullptr;
+const XW_MessagingInterface* g_messaging = nullptr;
+const XW_Internal_SyncMessagingInterface* g_sync_messaging = nullptr;
+const XW_Internal_EntryPointsInterface* g_entry_points = nullptr;
+const XW_Internal_RuntimeInterface* g_runtime = nullptr;
+const XW_Internal_PermissionsInterface* g_permission = nullptr;
+
+typedef void* XWalkExtensionDotNet;
+typedef void* XWalkExtensionAssembly;
+
+static void MarshalString(String^ input, std::string* output) {
+  const char* chars = reinterpret_cast<const char*>(
+    Marshal::StringToHGlobalAnsi(input).ToPointer());
+  *output = chars;
+  Marshal::FreeHGlobal(IntPtr((void*)chars)); //NOLINT
+}
+
+bool InitializeInterfaces(XW_GetInterface get_interface) {
+  g_core = reinterpret_cast<const XW_CoreInterface*>(
+    get_interface(XW_CORE_INTERFACE));
+  if (!g_core) {
+    std::cerr << "Can't initialize extension: error getting Core interface.\n";
+    return false;
+  }
+
+  g_messaging = reinterpret_cast<const XW_MessagingInterface*>(
+      get_interface(XW_MESSAGING_INTERFACE));
+  if (!g_messaging) {
+    std::cerr <<
+        "Can't initialize extension: error getting Messaging interface.\n";
+    return false;
+  }
+
+  g_sync_messaging =
+      reinterpret_cast<const XW_Internal_SyncMessagingInterface*>(
+      get_interface(XW_INTERNAL_SYNC_MESSAGING_INTERFACE));
+  if (!g_sync_messaging) {
+    std::cerr <<
+        "Can't initialize extension: error getting SyncMessaging interface.\n";
+    return false;
+  }
+
+  g_entry_points = reinterpret_cast<const XW_Internal_EntryPointsInterface*>(
+      get_interface(XW_INTERNAL_ENTRY_POINTS_INTERFACE));
+  if (!g_entry_points) {
+    std::cerr << "NOTE: Entry points interface not available in this version "
+              << "of Crosswalk, ignoring entry point data for extensions.\n";
+  }
+
+  g_runtime = reinterpret_cast<const XW_Internal_RuntimeInterface*>(
+      get_interface(XW_INTERNAL_RUNTIME_INTERFACE));
+  if (!g_runtime) {
+    std::cerr << "NOTE: runtime interface not available in this version "
+              << "of Crosswalk, ignoring runtime variables for extensions.\n";
+  }
+
+  g_permission = reinterpret_cast<const XW_Internal_PermissionsInterface*>(
+      get_interface(XW_INTERNAL_PERMISSIONS_INTERFACE));
+  if (!g_permission) {
+    std::cerr << "NOTE: permission interface not available in this version "
+              << "of Crosswalk, ignoring permission for extensions.\n";
+  }
+
+  return true;
+}
+}  // anonymous namespace
+
+int32_t XW_Initialize(XW_Extension extension, XW_GetInterface get_interface) {
+  assert(extension);
+  g_xw_extension = extension;
+
+  if (!InitializeInterfaces(get_interface))
+    return XW_ERROR;
+
+  g_bridge = new xwalk::extensions::XWalkDotNetBridge();
+  if (!g_bridge->Initialize()) {
+    std::cerr << "Can't initialize .NET extension bridge \n";
+    return XW_ERROR;
+  }
+  using namespace xwalk::extensions; // NOLINT
+  g_core->RegisterShutdownCallback(
+      g_xw_extension, XWalkDotNetBridge::OnShutdown);
+  g_core->RegisterInstanceCallbacks(
+    g_xw_extension, XWalkDotNetBridge::OnInstanceCreated,
+    XWalkDotNetBridge::OnInstanceDestroyed);
+  g_messaging->Register(
+      g_xw_extension, XWalkDotNetBridge::HandleMessage);
+  g_sync_messaging->Register(
+      g_xw_extension, XWalkDotNetBridge::HandleSyncMessage);
+  return XW_OK;
+}
+
+namespace xwalk {
+namespace extensions {
+
+struct PrivateBridgeData {
+  PrivateBridgeData()
+    : initialized_(false),
+      extension_dotnet_(nullptr),
+      extension_assembly_(nullptr) {
+  }
+  std::string library_path_;
+  bool initialized_;
+  XWalkExtensionDotNet extension_dotnet_;
+  XWalkExtensionAssembly extension_assembly_;
+};
+
+public ref class Bridge : public Object {
+public:
+  explicit Bridge(XWalkDotNetBridge* bridge)
+    : bridge_(bridge),
+    instance_(0) {
+  }
+  void setNativeInstance(XW_Instance instance) {
+    instance_ = instance;
+  }
+  void PostMessageToJS(String^ message) {
+    std::string message_to_js;
+    MarshalString(message, &message_to_js);
+    bridge_->PostMessageToInstance(instance_, message_to_js);
+  }
+  void SendSyncReply(String^ message) {
+    std::string message_to_js;
+    MarshalString(message, &message_to_js);
+    bridge_->SetSyncReply(instance_, message_to_js);
+  }
+private:
+  XWalkDotNetBridge* bridge_;
+  XW_Instance instance_;
+};
+
+XWalkDotNetBridge::XWalkDotNetBridge()
+  : private_data_(new PrivateBridgeData) {
+}
+
+void XWalkDotNetBridge::OnShutdown(XW_Extension) {
+  delete g_bridge;
+  g_bridge = nullptr;
+}
+
+XWalkDotNetBridge::~XWalkDotNetBridge() {
+  if (private_data_->extension_dotnet_) {
+    gcroot<Object^> *extension_object_ptr =
+        static_cast<gcroot<Object^>*>(private_data_->extension_dotnet_);
+    delete extension_object_ptr;
+    private_data_->extension_dotnet_ = nullptr;
+  }
+  if (private_data_->extension_assembly_) {
+    gcroot<Assembly^> *extension_assembly_ptr =
+        static_cast<gcroot<Assembly^>*>(private_data_->extension_assembly_);
+    delete extension_assembly_ptr;
+    private_data_->extension_assembly_ = nullptr;
+  }
+  delete private_data_;
+}
+
+bool XWalkDotNetBridge::Initialize() {
+  if (private_data_->initialized_)
+    return true;
+  try {
+    char extension_path[4096];
+    g_runtime->GetRuntimeVariableString(g_xw_extension,
+        "extension_path",
+        extension_path,
+        sizeof(extension_path));
+    String^ path = gcnew String(extension_path);
+    if (path->Length == 0) {
+      std::cerr << "Error loading extension "
+                << extension_path
+                << " : path to the bridge doesn't exist";
+      return false;
+    }
+
+    // Remove the quotes added by the JSON framework.
+    path = path->Replace("\"", "");
+
+    // We load the .NET extension with the same name but without the _bridge
+    // suffix.
+    path = path->Replace("_bridge", "");
+
+    MarshalString(path, &private_data_->library_path_);
+    Assembly^ extension_assembly = Assembly::LoadFrom(path);
+    gcroot<Assembly^> *extension_assembly_ptr =
+        new gcroot<Assembly^>(extension_assembly);
+    private_data_->extension_assembly_ =
+        static_cast<XWalkExtensionAssembly>(extension_assembly_ptr);
+    // Figure out if the XWalkExtension class is present.
+    Type^ extension_type =
+        extension_assembly->GetType("xwalk.XWalkExtension", true);
+    if (!extension_type) {
+      std::cerr << "Error loading extension " << private_data_->library_path_
+                << "': XWalkExtension class is not defined";
+      return false;
+    }
+    ConstructorInfo^ extension_constructor =
+        extension_type->GetConstructor(Type::EmptyTypes);
+    if (!extension_constructor) {
+      std::cerr << "Error loading extension " << private_data_->library_path_
+                << "': XWalkExtension constructor is not defined";
+      return false;
+    }
+
+    MethodInfo^ extension_name_method =
+        extension_type->GetMethod("ExtensionName");
+    if (!extension_name_method) {
+      std::cerr << "Error loading extension " << private_data_->library_path_
+                << "': ExtensionName method is not defined";
+      return false;
+    }
+
+    MethodInfo^ extension_api_method =
+        extension_type->GetMethod("ExtensionAPI");
+    if (!extension_api_method) {
+      std::cerr << "Error loading extension " << private_data_->library_path_
+                << "': ExtensionAPI method is not defined";
+      return false;
+    }
+
+    Object^ extension_object =
+        extension_constructor->Invoke(gcnew array<Object^>(0){});
+    gcroot<Object^> *extension_object_ptr =
+        new gcroot<Object^>(extension_object);
+    private_data_->extension_dotnet_ =
+        static_cast<XWalkExtensionDotNet>(extension_object_ptr);
+
+    Object^ extension_name_clr =
+        extension_name_method->Invoke(extension_object,
+        gcnew array<Object^>(0){});
+    if (extension_name_clr->GetType() != String::typeid) {
+      std::cerr << "Error loading extension " << private_data_->library_path_
+                << "': ExtensionName return type is not valid";
+      return false;
+    }
+    std::string extension_name;
+    MarshalString(extension_name_clr->ToString(), &extension_name);
+    g_core->SetExtensionName(g_xw_extension, extension_name.c_str());
+
+    Object^ api_clr = extension_api_method->Invoke(extension_object,
+        gcnew array<Object^>(0){});
+    if (api_clr->GetType() != String::typeid) {
+      std::cerr << "Error loading extension " << private_data_->library_path_
+                << "': ExtensionAPI return type is not valid";
+      return false;
+    }
+    std::string api;
+    MarshalString(api_clr->ToString(), &api);
+    g_core->SetJavaScriptAPI(g_xw_extension, api.c_str());
+
+    private_data_->initialized_ = true;
+    return true;
+  }
+  catch (Exception^ e) {
+    std::string message;
+    MarshalString(e->ToString(), &message);
+    std::cerr << "Error loading extension " << private_data_->library_path_
+              << "': " << message;
+    return false;
+  }
+}
+
+XWalkExtensionDotNetInstance XWalkDotNetBridge::CreateInstance(
+    XW_Instance native_instance) {
+  if (!private_data_->initialized_)
+    return nullptr;
+  try {
+    gcroot<Assembly^> *extension_assembly_ptr =
+        static_cast<gcroot<Assembly^>*>(private_data_->extension_assembly_);
+    Type^ extension_instance_type =
+        ((Assembly^)*extension_assembly_ptr)->GetType(
+        "xwalk.XWalkExtensionInstance", true);
+    if (!extension_instance_type) {
+      std::cerr << "Error creating .NET extension instance "
+                << private_data_->library_path_
+                << "': XWalkExtensionInstance class is not defined";
+      return nullptr;
+    }
+
+    array<Type^>^types = gcnew array<Type^>(1);
+    types[0] = Object::typeid;
+    ConstructorInfo^ extension_instance_constructor =
+        extension_instance_type->GetConstructor(types);
+    if (!extension_instance_constructor) {
+      std::cerr << "Error loading extension instance "
+                << private_data_->library_path_
+                << "': XWalkExtensionInstance constructor is not defined";
+      return nullptr;
+    }
+
+    array<Type^>^types_string = gcnew array<Type^>(1);
+    types_string[0] = String::typeid;
+    MethodInfo^ handle_sync_message_method =
+        extension_instance_type->GetMethod("HandleSyncMessage", types_string);
+    if (!handle_sync_message_method) {
+      std::cerr << "Error loading extension instance "
+                << private_data_->library_path_
+                << "': HandleSyncMessage is not defined or has"
+                << " an incorrect prototype";
+      return nullptr;
+    }
+
+    MethodInfo^ handle_message_method =
+        extension_instance_type->GetMethod("HandleMessage", types_string);
+    if (!handle_message_method) {
+      std::cerr << "Error loading extension instance "
+                << private_data_->library_path_
+                << "': HandleMessage is not defined or has"
+                << " an incorrect prototype";
+      return nullptr;
+    }
+
+    Bridge^ callback = gcnew Bridge(this);
+    Object^ extension_instance_object =
+        extension_instance_constructor->Invoke(
+        gcnew array<Object^>(1){ callback });
+    gcroot<Object^> *extension_instance_object_ptr =
+        new gcroot<Object^>(extension_instance_object);
+    XWalkExtensionDotNetInstance extension_instance_dotnet =
+        static_cast<XWalkExtensionDotNet>(extension_instance_object_ptr);
+    callback->setNativeInstance(native_instance);
+    return extension_instance_dotnet;
+  }
+  catch (Exception^ e) {
+    std::string message;
+    MarshalString(e->ToString(), &message);
+    std::cerr << "Error creating extension instance"
+              << private_data_->library_path_ << "': " << message;
+    return nullptr;
+  }
+}
+
+void XWalkDotNetBridge::OnInstanceCreated(XW_Instance xw_instance) {
+  assert(!g_core->GetInstanceData(xw_instance));
+  XWalkExtensionDotNetInstance instance =
+      g_bridge->CreateInstance(xw_instance);
+  if (!instance)
+    return;
+  g_core->SetInstanceData(xw_instance, instance);
+}
+
+// static
+void XWalkDotNetBridge::OnInstanceDestroyed(XW_Instance xw_instance) {
+  XWalkExtensionDotNetInstance instance =
+      g_core->GetInstanceData(xw_instance);
+  if (!instance)
+    return;
+  gcroot<Object^> *instance_object_ptr =
+      static_cast<gcroot<Object^>*>(instance);
+  delete instance_object_ptr;
+}
+
+void XWalkDotNetBridge::HandleMessage(XW_Instance instance,
+  const char* message) {
+  XWalkExtensionDotNetInstance instance_dot_net =
+      g_core->GetInstanceData(instance);
+  String^ message_str = gcnew String(message);
+  gcroot<Object^> *instance_object_ptr =
+      static_cast<gcroot<Object^>*>(instance_dot_net);
+  Type^ extension_instance_type = ((Object^)*instance_object_ptr)->GetType();
+  MethodInfo^ handle_message_method =
+      extension_instance_type->GetMethod("HandleMessage");
+  if (!handle_message_method) {
+    std::cerr << "Error invoking HandleMessage on extension instance "
+              << "': HandleMessage method is not defined";
+    return;
+  }
+  Object^ returnValue = handle_message_method->Invoke(
+      ((Object^)*instance_object_ptr), gcnew array<Object^>(1){ message_str });
+}
+
+void XWalkDotNetBridge::HandleSyncMessage(XW_Instance instance,
+  const char* message) {
+  XWalkExtensionDotNetInstance instance_dot_net =
+      g_core->GetInstanceData(instance);
+  String^ message_str = gcnew String(message);
+  gcroot<Object^> *instance_object_ptr =
+      static_cast<gcroot<Object^>*>(instance_dot_net);
+  Type^ extension_instance_type = ((Object^)*instance_object_ptr)->GetType();
+  MethodInfo^ handle_sync_message_method =
+      extension_instance_type->GetMethod("HandleSyncMessage");
+  if (!handle_sync_message_method) {
+    std::cerr << "Error invoking HandleSyncMessage on extension instance "
+              << "': HandleMessage method is not defined";
+    return;
+  }
+  Object^ returnValue = handle_sync_message_method->Invoke(
+      ((Object^)*instance_object_ptr), gcnew array<Object^>(1){ message_str });
+}
+
+#undef PostMessage
+void XWalkDotNetBridge::PostMessageToInstance(XW_Instance instance,
+  const std::string& message) {
+  g_messaging->PostMessage(instance, message.c_str());
+}
+
+void XWalkDotNetBridge::SetSyncReply(XW_Instance instance,
+  const std::string& reply) {
+  g_sync_messaging->SetSyncReply(instance, reply.c_str());
+}
+
+}  // namespace extensions
+}  // namespace xwalk

--- a/dotnet/xwalk_dotnet_bridge.h
+++ b/dotnet/xwalk_dotnet_bridge.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef XWALK_DOTNET_XWALK_DOTNET_BRIDGE_H_
+#define XWALK_DOTNET_XWALK_DOTNET_BRIDGE_H_
+
+#include <string>
+
+#include "xwalk/extensions/public/XW_Extension.h"
+#include "xwalk/extensions/public/XW_Extension_EntryPoints.h"
+#include "xwalk/extensions/public/XW_Extension_Permissions.h"
+#include "xwalk/extensions/public/XW_Extension_Runtime.h"
+#include "xwalk/extensions/public/XW_Extension_SyncMessage.h"
+
+namespace xwalk {
+namespace extensions {
+
+struct PrivateBridgeData;
+typedef void* XWalkExtensionDotNetInstance;
+
+class XWalkDotNetBridge {
+ public:
+  XWalkDotNetBridge();
+  ~XWalkDotNetBridge();
+
+  // XW_Extension callbacks.
+  static void OnShutdown(XW_Extension xw_extension);
+  static void OnInstanceCreated(XW_Instance xw_instance);
+  static void OnInstanceDestroyed(XW_Instance xw_instance);
+  static void HandleMessage(XW_Instance xw_instance, const char* msg);
+  static void HandleSyncMessage(XW_Instance xw_instance, const char* msg);
+
+  bool Initialize();
+  XWalkExtensionDotNetInstance CreateInstance(XW_Instance native_instance);
+  void PostMessageToInstance(XW_Instance instance, const std::string& message);
+  void SetSyncReply(XW_Instance instance, const std::string& message);
+
+ private:
+  PrivateBridgeData* private_data_;
+};
+
+}  // namespace extensions
+}  // namespace xwalk
+
+#endif  // XWALK_DOTNET_XWALK_DOTNET_BRIDGE_H_

--- a/extensions/common/xwalk_external_extension.h
+++ b/extensions/common/xwalk_external_extension.h
@@ -43,6 +43,10 @@ class XWalkExternalExtension : public XWalkExtension {
     runtime_variables_ = runtime_variables;
   }
 
+ protected:
+  // XWalkExtension implementation.
+  XWalkExtensionInstance* CreateInstance() override;
+
  private:
   friend class XWalkExternalAdapter;
   friend class XWalkExternalInstance;
@@ -50,9 +54,6 @@ class XWalkExternalExtension : public XWalkExtension {
   // Variables from the browser process. Usually things like currently-running
   // application ID.
   base::ValueMap runtime_variables_;
-
-  // XWalkExtension implementation.
-  XWalkExtensionInstance* CreateInstance() override;
 
   // XW_CoreInterface_1 (from XW_Extension.h) implementation.
   void CoreSetExtensionName(const char* name);

--- a/extensions/common/xwalk_external_instance.h
+++ b/extensions/common/xwalk_external_instance.h
@@ -17,6 +17,8 @@ namespace extensions {
 class XWalkExternalAdapter;
 class XWalkExternalExtension;
 
+typedef void* InstanceData;
+
 // XWalkExternalInstance implements the concrete context of execution of an
 // external extension.
 //
@@ -29,6 +31,8 @@ class XWalkExternalInstance : public XWalkExtensionInstance {
   XWalkExternalInstance(XWalkExternalExtension* extension,
                         XW_Instance xw_instance);
   ~XWalkExternalInstance() override;
+
+  InstanceData GetInstanceData() const { return instance_data_; }
 
  private:
   friend class XWalkExternalAdapter;
@@ -54,7 +58,7 @@ class XWalkExternalInstance : public XWalkExtensionInstance {
   XW_Instance xw_instance_;
   std::string sync_reply_;
   XWalkExternalExtension* extension_;
-  void* instance_data_;
+  InstanceData instance_data_;
   bool is_handling_sync_msg_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkExternalInstance);

--- a/extensions/dotnet_extension_sample.gyp
+++ b/extensions/dotnet_extension_sample.gyp
@@ -1,0 +1,689 @@
+{
+  'targets': [
+    {
+      'target_name': 'dotnet_echo_extension',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_echo_extension',
+          'inputs': [
+            'test/win/echo_extension/XWalkExtension.cs',
+            'test/win/echo_extension/XWalkExtensionInstance.cs',
+          ],
+          'outputs': [
+            'echo_extension.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/echo_extension',
+                     '--project', 'echo_extension/echo_extension.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_echo_extension_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_echo_extension',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_echo_extension',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'echo_extension_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/echo_extension',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'echo_extension_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_1',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_1',
+          'inputs': [
+            'test/win/invalid_extension_1/Bla.cs'
+          ],
+          'outputs': [
+            'invalid_extension_1.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_1',
+                     '--project', 'invalid_extension_1/invalid_extension_1.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_1_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_1',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_1',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_1_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_1',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_1_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_2',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_2',
+          'inputs': [
+            'test/win/invalid_extension_2/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_2.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_2',
+                     '--project', 'invalid_extension_2/invalid_extension_2.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_2_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_2',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_2',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_2_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_2',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_2_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_3',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_3',
+          'inputs': [
+            'test/win/invalid_extension_3/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_3.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_3',
+                     '--project', 'invalid_extension_3/invalid_extension_3.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_3_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_3',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_3',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_3_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_3',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_3_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_4',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_4',
+          'inputs': [
+            'test/win/invalid_extension_4/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_4.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_4',
+                     '--project', 'invalid_extension_4/invalid_extension_4.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_4_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_4',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_4',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_4_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_4',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_4_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_5',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_5',
+          'inputs': [
+            'test/win/invalid_extension_5/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_5.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_5',
+                     '--project', 'invalid_extension_5/invalid_extension_5.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_5_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_5',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_5',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_5_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_5',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_5_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_6',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_6',
+          'inputs': [
+            'test/win/invalid_extension_6/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_6.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_6',
+                     '--project', 'invalid_extension_6/invalid_extension_6.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_6_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_6',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_6',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_6_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_6',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_6_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_7',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_7',
+          'inputs': [
+            'test/win/invalid_extension_7/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_7.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_7',
+                     '--project', 'invalid_extension_7/invalid_extension_7.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_7_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_7',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_7',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_7_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_7',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_7_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_8',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_8',
+          'inputs': [
+            'test/win/invalid_extension_8/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_8.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_8',
+                     '--project', 'invalid_extension_8/invalid_extension_8.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_8_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_8',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_8',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_8_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_8',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_8_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_9',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_9',
+          'inputs': [
+            'test/win/invalid_extension_9/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_9.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_9',
+                     '--project', 'invalid_extension_9/invalid_extension_9.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_9_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_9',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_9',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_9_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_9',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_9_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_10',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_10',
+          'inputs': [
+            'test/win/invalid_extension_10/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_10.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_10',
+                     '--project', 'invalid_extension_10/invalid_extension_10.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_10_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_10',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_10',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_10_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_10',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_10_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_11',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_11',
+          'inputs': [
+            'test/win/invalid_extension_11/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_11.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_11',
+                     '--project', 'invalid_extension_11/invalid_extension_11.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_11_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_11',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_11',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_11_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_11',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_11_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_invalid_extension_12',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_invalid_extension_12',
+          'inputs': [
+            'test/win/invalid_extension_12/XWalkExtension.cs'
+          ],
+          'outputs': [
+            'invalid_extension_12.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_12',
+                     '--project', 'invalid_extension_12/invalid_extension_12.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'copy_invalid_extension_12_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_invalid_extension_12',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_and_rename_bridge_invalid_extension_12',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'invalid_extension_12_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_12',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'invalid_extension_12_bridge.dll',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_echo_extension2',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_echo_extension2',
+          'inputs': [
+            'test/win/echo_extension2/XWalkExtension.cs',
+            'test/win/echo_extension2/XWalkExtensionInstance.cs',
+          ],
+          'outputs': [
+            'echo_extension2.dll',
+          ],
+          'action': ['python',
+                     '../tools/msbuild_dotnet.py',
+                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
+                     '--project', 'echo_extension2/echo_extension2.csproj',
+                     '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'dotnet_echo_extension1',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'build_dotnet_test_echo_extension1',
+          'inputs': [
+            'test/win/echo_extension1/XWalkExtension.cs',
+            'test/win/echo_extension1/XWalkExtensionInstance.cs',
+          ],
+          'outputs': [
+            'echo_extension1.dll',
+          ],
+          'action': ['python',
+                      '../tools/msbuild_dotnet.py',
+                      '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
+                      '--project', 'echo_extension1/echo_extension1.csproj',
+                      '--build-type', 'Debug',
+          ],
+        },
+      ],
+    },
+    {
+      'target_name': 'create_dir_with_multiple_extensions',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_echo_extension1',
+        'dotnet_echo_extension2',
+      ],
+      'actions': [
+        {
+          'action_name': 'copy_echo_extension2_bridge',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'echo_extension2_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'echo_extension2_bridge.dll',
+          ],
+        },
+        {
+          'action_name': 'copy_echo_extension1_bridge',
+          'inputs': [
+            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'outputs': [
+            'echo_extension1_bridge.dll',
+          ],
+          'action': ['python',
+                      '../tools/copy_rename.py',
+                      '--source-dir', '<(PRODUCT_DIR)',
+                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
+                      '--input-file', 'xwalk_dotnet_bridge.dll',
+                      '--output-file', 'echo_extension1_bridge.dll',
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/extensions/extensions_tests.gyp
+++ b/extensions/extensions_tests.gyp
@@ -61,4 +61,55 @@
       ],
     },
   ],
+  'conditions': [
+    ['OS=="win"', {
+      'targets': [
+        {
+          'target_name': 'xwalk_dotnet_extensions_browsertest',
+          'type': 'executable',
+          'dependencies': [
+            '../../base/base.gyp:base',
+            '../../content/content.gyp:content_browser',
+            '../../content/content_shell_and_tests.gyp:test_support_content',
+            '../../net/net.gyp:net',
+            '../../skia/skia.gyp:skia',
+            '../../testing/gtest.gyp:gtest',
+            '../test/base/base.gyp:xwalk_test_base',
+            '../xwalk.gyp:xwalk_runtime',
+            'dotnet_extension_sample.gyp:*',
+            'extensions.gyp:xwalk_extensions',
+          ],
+          'defines': [
+            'HAS_OUT_OF_PROC_TEST_RUNNER',
+          ],
+          'sources': [
+            'test/win/xwalk_dotnet_extensions_browsertest.cc',
+            'test/xwalk_extensions_test_base.cc',
+            'test/xwalk_extensions_test_base.h',
+          ],
+        },
+        {
+          'target_name': 'xwalk_dotnet_extensions_unittest',
+          'type': 'executable',
+          'dependencies': [
+           '../../base/base.gyp:base',
+            '../../content/content.gyp:content_browser',
+            '../../content/content_shell_and_tests.gyp:test_support_content',
+            '../../net/net.gyp:net',
+            '../../skia/skia.gyp:skia',
+            '../../testing/gtest.gyp:gtest',
+            '../test/base/base.gyp:xwalk_test_base',
+            '../xwalk.gyp:xwalk_runtime',
+            'dotnet_extension_sample.gyp:*',
+            'extensions.gyp:xwalk_extensions',
+          ],
+          'sources': [
+            'test/win/xwalk_dotnet_extension_unittest.cc',
+            'test/xwalk_extensions_test_base.cc',
+            'test/xwalk_extensions_test_base.h',
+          ],
+        },
+      ],
+    }],
+  ],
 }

--- a/extensions/test/data/echo_multiple.html
+++ b/extensions/test/data/echo_multiple.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+<script>
+try {
+    var echoAnswer = echo.syncEcho("Pass");
+    var echo2Answer = echo2.syncEcho2("Pass");
+    if (echoAnswer == "Pass" && echo2Answer == "Pass")
+        document.title = "Pass";
+     else
+        document.title = "Fail";
+} catch(e) {
+    console.log(e);
+    document.title = "Fail";
+}
+</script>
+</body>
+</html>

--- a/extensions/test/win/echo_extension/XWalkExtension.cs
+++ b/extensions/test/win/echo_extension/XWalkExtension.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+    return "echo";
+  }
+
+  public String ExtensionAPI() {
+    return
+      @"var echoListener = null;
+        extension.setMessageListener(function(msg) {
+          if (echoListener instanceof Function) {
+            echoListener(msg);
+          };
+        });
+        exports.echo = function(msg, callback) {
+          echoListener = callback;
+          extension.postMessage(msg);
+        };
+        exports.syncEcho = function(msg) {
+          return extension.internal.sendSyncMessage(msg);
+        };";
+  }
+}
+}

--- a/extensions/test/win/echo_extension/XWalkExtensionInstance.cs
+++ b/extensions/test/win/echo_extension/XWalkExtensionInstance.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(dynamic native) {
+    native_ = native;
+  }
+
+  public void HandleMessage(String message) {
+    native_.PostMessageToJS(message);
+  }
+  public void HandleSyncMessage(String message) {
+    native_.SendSyncReply(message);
+  }
+  private dynamic native_;
+}
+}

--- a/extensions/test/win/echo_extension/echo_extension.csproj
+++ b/extensions/test/win/echo_extension/echo_extension.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>echo_extension</RootNamespace>
+    <AssemblyName>echo_extension</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/echo_extension1/XWalkExtension.cs
+++ b/extensions/test/win/echo_extension1/XWalkExtension.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+    return "echo";
+  }
+
+  public String ExtensionAPI() {
+    return
+      @"var echoListener = null;
+        extension.setMessageListener(function(msg) {
+          if (echoListener instanceof Function) {
+            echoListener(msg);
+          };
+        });
+        exports.echo = function(msg, callback) {
+          echoListener = callback;
+          extension.postMessage(msg);
+        };
+        exports.syncEcho = function(msg) {
+          return extension.internal.sendSyncMessage(msg);
+        };";
+  }
+}
+}

--- a/extensions/test/win/echo_extension1/XWalkExtensionInstance.cs
+++ b/extensions/test/win/echo_extension1/XWalkExtensionInstance.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(dynamic native) {
+    native_ = native;
+  }
+
+  public void HandleMessage(String message) {
+    native_.PostMessageToJS(message);
+  }
+  public void HandleSyncMessage(String message) {
+    native_.SendSyncReply(message);
+  }
+  private dynamic native_;
+}
+}

--- a/extensions/test/win/echo_extension1/echo_extension1.csproj
+++ b/extensions/test/win/echo_extension1/echo_extension1.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>echo_extension1</RootNamespace>
+    <AssemblyName>echo_extension1</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/echo_extension2/XWalkExtension.cs
+++ b/extensions/test/win/echo_extension2/XWalkExtension.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+    return "echo2";
+  }
+
+  public String ExtensionAPI() {
+    return
+      @"var echoListener = null;
+        extension.setMessageListener(function(msg) {
+          if (echoListener instanceof Function) {
+            echoListener(msg);
+          };
+        });
+        exports.echo2 = function(msg, callback) {
+          echoListener = callback;
+          extension.postMessage(msg);
+        };
+        exports.syncEcho2 = function(msg) {
+          return extension.internal.sendSyncMessage(msg);
+        };";
+  }
+}
+}

--- a/extensions/test/win/echo_extension2/XWalkExtensionInstance.cs
+++ b/extensions/test/win/echo_extension2/XWalkExtensionInstance.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(dynamic native) {
+    native_ = native;
+  }
+
+  public void HandleMessage(String message) {
+    native_.PostMessageToJS(message);
+  }
+  public void HandleSyncMessage(String message) {
+    native_.SendSyncReply(message);
+  }
+  private dynamic native_;
+}
+}

--- a/extensions/test/win/echo_extension2/echo_extension2.csproj
+++ b/extensions/test/win/echo_extension2/echo_extension2.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>echo_extension2</RootNamespace>
+    <AssemblyName>echo_extension2</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_1/Bla.cs
+++ b/extensions/test/win/invalid_extension_1/Bla.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace invalid
+{
+public class Foo
+{
+  public Foo() {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_1/invalid_extension_1.csproj
+++ b/extensions/test/win/invalid_extension_1/invalid_extension_1.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_1</RootNamespace>
+    <AssemblyName>invalid_extension_1</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Bla.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_10/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_10/XWalkExtension.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+  public String ExtensionName() {
+      return "foo";
+  }
+  public String ExtensionAPI() {
+      return "foo";
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_10/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_10/XWalkExtensionInstance.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(dynamic native) {
+  }
+
+  public void HandleSyncMessage(String message) {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_10/invalid_extension_10.csproj
+++ b/extensions/test/win/invalid_extension_10/invalid_extension_10.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_10</RootNamespace>
+    <AssemblyName>invalid_extension_10</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_11/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_11/XWalkExtension.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+    return "echo";
+  }
+
+  public String ExtensionAPI() {
+    return
+      @"var echoListener = null;
+      extension.setMessageListener(function(msg) {
+        if (echoListener instanceof Function) {
+          echoListener(msg);
+        };
+      });
+      exports.echo = function(msg, callback) {
+        echoListener = callback;
+        extension.postMessage(msg);
+      };
+      exports.syncEcho = function(msg) {
+        return extension.internal.sendSyncMessage(msg);
+      };";
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_11/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_11/XWalkExtensionInstance.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(dynamic native) {
+  }
+
+  public void HandleMessage(int message) {
+  }
+
+  public void HandleSyncMessage(int message) {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_11/invalid_extension_11.csproj
+++ b/extensions/test/win/invalid_extension_11/invalid_extension_11.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_11</RootNamespace>
+    <AssemblyName>invalid_extension_11</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_12/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_12/XWalkExtension.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension {
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+    return "echo";
+  }
+
+  public String ExtensionAPI() {
+    return
+      @"var echoListener = null;
+      extension.setMessageListener(function(msg) {
+        if (echoListener instanceof Function) {
+          echoListener(msg);
+        };
+      });
+      exports.echo = function(msg, callback) {
+        echoListener = callback;
+        extension.postMessage(msg);
+      };
+      exports.syncEcho = function(msg) {
+        return extension.internal.sendSyncMessage(msg);
+      };";
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_12/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_12/XWalkExtensionInstance.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(dynamic native) {
+  }
+
+  public void HandleMessage(int message) {
+  }
+
+  public void HandleSyncMessage(String message) {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_12/invalid_extension_12.csproj
+++ b/extensions/test/win/invalid_extension_12/invalid_extension_12.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_12</RootNamespace>
+    <AssemblyName>invalid_extension_12</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_2/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_2/XWalkExtension.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension(String invalidConstructor) {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_2/invalid_extension_2.csproj
+++ b/extensions/test/win/invalid_extension_2/invalid_extension_2.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_2</RootNamespace>
+    <AssemblyName>invalid_extension_2</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_3/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_3/XWalkExtension.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_3/invalid_extension_3.csproj
+++ b/extensions/test/win/invalid_extension_3/invalid_extension_3.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_3</RootNamespace>
+    <AssemblyName>invalid_extension_3</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_4/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_4/XWalkExtension.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+    public String ExtensionName() {
+        return "test";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_4/invalid_extension_4.csproj
+++ b/extensions/test/win/invalid_extension_4/invalid_extension_4.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_4</RootNamespace>
+    <AssemblyName>invalid_extension_4</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_5/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_5/XWalkExtension.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+
+    public int ExtensionName() {
+        return 3;
+    }
+    public String ExtensionAPI() {
+        return "foo";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_5/invalid_extension_5.csproj
+++ b/extensions/test/win/invalid_extension_5/invalid_extension_5.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_5</RootNamespace>
+    <AssemblyName>invalid_extension_5</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_6/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_6/XWalkExtension.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+    public String ExtensionName() {
+        return "foo";
+    }
+    public int ExtensionAPI() {
+        return 3;
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_6/invalid_extension_6.csproj
+++ b/extensions/test/win/invalid_extension_6/invalid_extension_6.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_6</RootNamespace>
+    <AssemblyName>invalid_extension_6</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_7/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_7/XWalkExtension.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension(){
+    }
+
+    public String ExtensionName() {
+        return "foo";
+    }
+    public String ExtensionAPI() {
+        return "foo";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_7/invalid_extension_7.csproj
+++ b/extensions/test/win/invalid_extension_7/invalid_extension_7.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_7</RootNamespace>
+    <AssemblyName>invalid_extension_7</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_8/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_8/XWalkExtension.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+  public XWalkExtension() {
+  }
+
+  public String ExtensionName() {
+      return "foo";
+  }
+  public String ExtensionAPI() {
+      return "foo";
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_8/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_8/XWalkExtensionInstance.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(int native) {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_8/invalid_extension_8.csproj
+++ b/extensions/test/win/invalid_extension_8/invalid_extension_8.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_8</RootNamespace>
+    <AssemblyName>invalid_extension_8</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/invalid_extension_9/XWalkExtension.cs
+++ b/extensions/test/win/invalid_extension_9/XWalkExtension.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtension
+{
+    public XWalkExtension() {
+    }
+    public String ExtensionName() {
+        return "foo";
+    }
+    public String ExtensionAPI() {
+        return "foo";
+    }
+}
+}

--- a/extensions/test/win/invalid_extension_9/XWalkExtensionInstance.cs
+++ b/extensions/test/win/invalid_extension_9/XWalkExtensionInstance.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace xwalk
+{
+public class XWalkExtensionInstance
+{
+  public XWalkExtensionInstance(dynamic native) {
+  }
+}
+}

--- a/extensions/test/win/invalid_extension_9/invalid_extension_9.csproj
+++ b/extensions/test/win/invalid_extension_9/invalid_extension_9.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CFBA884E-5C3C-4E36-B4C7-5EE7A435B12F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>invalid_extension_9</RootNamespace>
+    <AssemblyName>invalid_extension_9</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XWalkExtension.cs" />
+    <Compile Include="XWalkExtensionInstance.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/extensions/test/win/xwalk_dotnet_extension_unittest.cc
+++ b/extensions/test/win/xwalk_dotnet_extension_unittest.cc
@@ -1,0 +1,136 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/extensions/test/xwalk_extensions_test_base.h"
+
+#include "base/basictypes.h"
+#include "base/files/file_path.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "xwalk/extensions/common/xwalk_external_extension.h"
+#include "xwalk/extensions/common/xwalk_external_instance.h"
+
+using namespace xwalk::extensions;  // NOLINT
+
+class TestExtension : public XWalkExternalExtension {
+ public:
+  explicit TestExtension(const base::FilePath& path)
+    : XWalkExternalExtension(path),
+    runtime_variables_(new base::ValueMap) {
+    (*runtime_variables_)["extension_path"] =
+      new base::StringValue(path.AsUTF8Unsafe());
+    set_runtime_variables(*runtime_variables_);
+  }
+  XWalkExternalInstance* CreateExternalInstance() {
+    return static_cast<XWalkExternalInstance*>(
+        XWalkExternalExtension::CreateInstance());
+  }
+ private:
+  scoped_ptr<base::ValueMap> runtime_variables_;
+};
+
+TEST(XWalkDotNetExtensionTest, InvalidExtensions) {
+  base::FilePath test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("echo_extension/echo_extension_bridge.dll"));
+  TestExtension* valid_extension = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(valid_extension->Initialize());
+  XWalkExternalInstance* instance = valid_extension->CreateExternalInstance();
+  EXPECT_TRUE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_1/invalid_extension_1_bridge.dll"));
+  TestExtension* invalid_extension_1 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_1->Initialize());
+  instance = invalid_extension_1->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_2/invalid_extension_2_bridge.dll"));
+  TestExtension* invalid_extension_2 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_2->Initialize());
+  instance = invalid_extension_2->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_3/invalid_extension_3_bridge.dll"));
+  TestExtension* invalid_extension_3 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_3->Initialize());
+  instance = invalid_extension_3->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_4/invalid_extension_4_bridge.dll"));
+  TestExtension* invalid_extension_4 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_4->Initialize());
+  instance = invalid_extension_4->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_5/invalid_extension_5_bridge.dll"));
+  TestExtension* invalid_extension_5 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_5->Initialize());
+  instance = invalid_extension_5->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_6/invalid_extension_6_bridge.dll"));
+  TestExtension* invalid_extension_6 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_FALSE(invalid_extension_6->Initialize());
+  instance = invalid_extension_6->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_7/invalid_extension_7_bridge.dll"));
+  TestExtension* invalid_extension_7 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_7->Initialize());
+  instance = invalid_extension_7->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_8/invalid_extension_8_bridge.dll"));
+  TestExtension* invalid_extension_8 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_8->Initialize());
+  instance = invalid_extension_8->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_9/invalid_extension_9_bridge.dll"));
+  TestExtension* invalid_extension_9 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_9->Initialize());
+  instance = invalid_extension_9->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_10/invalid_extension_10_bridge.dll"));
+  TestExtension* invalid_extension_10 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_10->Initialize());
+  instance = invalid_extension_10->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_11/invalid_extension_11_bridge.dll"));
+  TestExtension* invalid_extension_11 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_11->Initialize());
+  instance = invalid_extension_11->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+
+  test_path = GetDotNetExtensionTestPath(
+    FILE_PATH_LITERAL("invalid_extension_12/invalid_extension_12_bridge.dll"));
+  TestExtension* invalid_extension_12 = new TestExtension(test_path);
+  EXPECT_TRUE(base::PathExists(test_path));
+  EXPECT_TRUE(invalid_extension_12->Initialize());
+  instance = invalid_extension_12->CreateExternalInstance();
+  EXPECT_FALSE(instance->GetInstanceData());
+}

--- a/extensions/test/win/xwalk_dotnet_extensions_browsertest.cc
+++ b/extensions/test/win/xwalk_dotnet_extensions_browsertest.cc
@@ -1,0 +1,67 @@
+// Copyright (c) 2015  Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/native_library.h"
+#include "base/path_service.h"
+#include "base/strings/utf_string_conversions.h"
+#include "xwalk/extensions/browser/xwalk_extension_service.h"
+#include "xwalk/extensions/test/xwalk_extensions_test_base.h"
+#include "xwalk/runtime/browser/runtime.h"
+#include "xwalk/test/base/xwalk_test_utils.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
+
+using namespace xwalk::extensions;  // NOLINT
+using xwalk::extensions::XWalkExtensionService;
+using xwalk::Runtime;
+
+class DotNetEchoTest : public XWalkExtensionsTestBase {
+ public:
+  void SetUp() override {
+    XWalkExtensionService::SetExternalExtensionsPathForTesting(
+      GetDotNetExtensionTestPath(FILE_PATH_LITERAL("echo_extension")));
+    XWalkExtensionsTestBase::SetUp();
+  }
+};
+
+class DotNetMultipleExtensionTest : public XWalkExtensionsTestBase {
+ public:
+  void SetUp() override {
+    XWalkExtensionService::SetExternalExtensionsPathForTesting(
+      GetDotNetExtensionTestPath(FILE_PATH_LITERAL("multiple_extension")));
+    XWalkExtensionsTestBase::SetUp();
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(DotNetEchoTest, DotNetExtension) {
+  Runtime* runtime = CreateRuntime();
+  GURL url = GetExtensionsTestURL(base::FilePath(),
+    base::FilePath().AppendASCII("echo.html"));
+  content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+  xwalk_test_utils::NavigateToURL(runtime, url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}
+
+IN_PROC_BROWSER_TEST_F(DotNetEchoTest, DotNetExtensionSync) {
+  Runtime* runtime = CreateRuntime();
+  GURL url = GetExtensionsTestURL(
+    base::FilePath(),
+    base::FilePath().AppendASCII("sync_echo.html"));
+  content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+  xwalk_test_utils::NavigateToURL(runtime, url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}
+
+IN_PROC_BROWSER_TEST_F(DotNetMultipleExtensionTest, DotnetExtensionMultiple) {
+  Runtime* runtime = CreateRuntime();
+  GURL url = GetExtensionsTestURL(
+    base::FilePath(),
+    base::FilePath().AppendASCII("echo_multiple.html"));
+  content::TitleWatcher title_watcher(runtime->web_contents(), kPassString);
+  title_watcher.AlsoWaitForTitle(kFailString);
+  xwalk_test_utils::NavigateToURL(runtime, url);
+  EXPECT_EQ(kPassString, title_watcher.WaitAndGetTitle());
+}

--- a/extensions/test/xwalk_extensions_test_base.cc
+++ b/extensions/test/xwalk_extensions_test_base.cc
@@ -58,3 +58,16 @@ base::FilePath GetExternalExtensionTestPath(
                   .Append(test);
   return extension_dir;
 }
+
+#if defined(OS_WIN)
+base::FilePath GetDotNetExtensionTestPath(
+  const base::FilePath::CharType test[]) {
+  base::FilePath extension_dir;
+  PathService::Get(base::DIR_EXE, &extension_dir);
+  extension_dir = extension_dir
+    .Append(FILE_PATH_LITERAL("tests"))
+    .Append(FILE_PATH_LITERAL("dotnet_extension"))
+    .Append(test);
+  return extension_dir;
+}
+#endif

--- a/extensions/test/xwalk_extensions_test_base.h
+++ b/extensions/test/xwalk_extensions_test_base.h
@@ -25,6 +25,10 @@ GURL GetExtensionsTestURL(const base::FilePath& dir,
 
 base::FilePath GetExternalExtensionTestPath(
     const base::FilePath::CharType test[]);
+#if defined(OS_WIN)
+base::FilePath GetDotNetExtensionTestPath(
+    const base::FilePath::CharType test[]);
+#endif
 
 const base::string16 kPassString = base::ASCIIToUTF16("Pass");
 const base::string16 kFailString = base::ASCIIToUTF16("Fail");

--- a/tools/copy_rename.py
+++ b/tools/copy_rename.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 Intel Corp. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+copy_rename.py -- Copy and rename a file to a given destination
+"""
+
+import logging
+import optparse
+import os
+import shutil
+import sys
+
+
+def CopyAndRename(options):
+  if not options.source_dir:
+    print('You must specify the source directory')
+    return 1
+  if not options.destination_dir:
+    print('You must specify the destination directory')
+    return 1
+  if not options.input_file:
+    print('You must specify the file to copy')
+    return 1
+  if not options.output_file:
+    print('You must specify the destination file name')
+    return 1
+
+  dest_dir = os.path.abspath(options.destination_dir)
+  src_dir = os.path.abspath(options.source_dir)
+  source_file = os.path.join(src_dir, options.input_file)
+  shutil.copy(source_file, dest_dir)
+  
+  dest_file = os.path.join(dest_dir, options.input_file)
+  new_dest_file_name = os.path.join(dest_dir, options.output_file)
+  if os.path.isfile(new_dest_file_name):
+    os.remove(new_dest_file_name)
+  os.rename(dest_file, new_dest_file_name)
+
+def main():
+  option_parser = optparse.OptionParser()
+  option_parser.add_option('--source-dir',
+                           help='Source path')
+  option_parser.add_option('--destination-dir',
+                           help='Path to copy into')
+  option_parser.add_option('--input-file',
+                           help='Source file to copy')
+  option_parser.add_option('--output-file',
+                           help='Destination file name')
+  options, _ = option_parser.parse_args()
+  CopyAndRename(options)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/msbuild_dotnet.py
+++ b/tools/msbuild_dotnet.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 Intel Corp. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+msbuild_dotnet.py -- Invoke MSBuild for .NET project.
+"""
+
+import logging
+import optparse
+import os
+import subprocess
+import sys
+
+
+def LaunchMSBuild(options):
+  if not options.output_dir:
+    print('You must specify the output-dir')
+    return 1
+  if not options.project:
+    print('You have not specified the project you want to build')
+    return 1
+  if not options.build_type:
+    print('You have not specified the build-type')
+    return 1
+
+  output_dir = os.path.abspath(options.output_dir)
+  tools_dir = os.path.dirname(os.path.abspath(__file__))
+  xwalk_dir = os.path.dirname(tools_dir)
+  extensions_dir = os.path.join(xwalk_dir, 'extensions')
+  extensions_test_dir = os.path.join(extensions_dir, 'test')
+  extensions_win_test_dir = os.path.join(extensions_test_dir,
+                                         'win' + os.path.sep)
+
+  output = subprocess.call(['msbuild', extensions_win_test_dir
+      + options.project, '/p:Platform=AnyCPU,Configuration='
+      + options.build_type + ',OutDir=' + output_dir
+      + ',BaseIntermediateOutputPath=' + output_dir + os.path.sep],
+      cwd=extensions_win_test_dir)
+  if output != 0:
+    return output
+
+def main():
+  option_parser = optparse.OptionParser()
+  option_parser.add_option('--output-dir',
+                           help='Set the output dir for MSBuild.')
+  option_parser.add_option('--project',
+                           help='The project to build with MSBuild.')
+  option_parser.add_option('--build-type',
+                           help='The type of build : Release/Debug.')
+  options, _ = option_parser.parse_args()
+  LaunchMSBuild(options)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -759,6 +759,7 @@
         ['OS == "win"', {
           'dependencies': [
             '../sandbox/sandbox.gyp:sandbox',
+            'dotnet/dotnet_bridge.gyp:dotnet_bridge'
           ],
         }],  # OS=="win"
         ['OS=="mac"', {

--- a/xwalk_tests.gypi
+++ b/xwalk_tests.gypi
@@ -11,6 +11,14 @@
         'sysapps/sysapps_tests.gyp:xwalk_sysapps_browsertest',
         'sysapps/sysapps_tests.gyp:xwalk_sysapps_unittest',
       ],
+      'conditions': [
+        ['OS=="win"', {
+          'dependencies': [
+            'extensions/extensions_tests.gyp:xwalk_dotnet_extensions_browsertest',
+            'extensions/extensions_tests.gyp:xwalk_dotnet_extensions_unittest',
+          ],
+        }],
+      ],
     },
     {
       'target_name': 'xwalk_unittest',


### PR DESCRIPTION
This commit adds support to load external .NET extensions
for 3rd party developers.

You can specify the path of the extensions to load using
--external-extension-path=/path/to/extension

The extensions are expected to be a .DLL constructed with
Visual Studio as a C# Library (and thus multiarch). Alongside
with that library the 3rd party developer needs to include a .NET bridge
named myextension_bridge.dll given the .NET extension is called
myextension.dll. The dotnet bridge is shipped part of Crosswalk
and is called xwalk_dotnet_bridge and it's a simple copy/rename
for the developer.

This .NET library needs to contains two classes XWalkExtension and
XWalkExtensionInstance which are going to be invoked by Crosswalk
to load the extensions and call the various methods on each instances
to make communication between .NET and JS. .NET extensions are a bit
higher level than our C or C++ extensions because the .NET extension
system will automatically call the constructors in .NET when needed :
e.g. creating the XWalkExtension instance and then create the various
XWalkExtensionInstance instances. This is following inspiration of
what's inside tizen-extension-crosswalk common/ directory which is used
to abstract the low levelness to who write t-e-c extensions.

```
 _______       _______       ______________
| xwalk | <-> | bridge| <-> |.NET extension|
|_______|     |_______|     |______________|
```
The bridge is loaded dynamically like an external extension would
be loaded : it's a DLL and it contains a single exported symbol : XW_Initialize.

One bridge instance is used by each extension and it is responsible to load
the .NET extension, verify using .NET reflection that the entry points
(e.g. XWalkExtension constructor, XWalkInstance handleMessage method...)
are present and that the .NET extension can be used. It then handles the
communication back and forth with Crosswalk and the extension.

One implementation detail worth to note is the usage of the dynamic parameter
in XWalkExtensionInstance, this pointer is used to communicate back from
.NET to C++/XWalk and the fact is dynamic is to hide implementation
details to the 3rd party developer which should only care about calling
the right functions on it. If they don't exists, there will be a runtime
error showing up. It makes using the system very simple (nothing to
include, nothing to import).

Please note that we don't support all the features of the extension
system at the moment, for example you can't add multiple entry points
in JS, and you can't have access to the runtime variables inside the
extension. These features can be added in a following patch.

This commit also roll GYP forward so we can compile passing /clr as
a compiler paramenter. It will probably be not needed by the next
rebase.

Part of the feature work I've added a bunch of tests which
actually build .NET extensions and test the overall system (thus
the .csproj files checked in). There is a little script to invoke
msbuild so it builds the DLL in .NET (GYP doesn't know about that).