### PR TITLE
Fix occasional crash.

### DIFF
--- a/runtime/app/android/xwalk_jni_registrar.cc
+++ b/runtime/app/android/xwalk_jni_registrar.cc
@@ -18,9 +18,7 @@
 #include "xwalk/runtime/browser/android/xwalk_content.h"
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
 #include "xwalk/runtime/browser/android/xwalk_contents_io_thread_client_impl.h"
-#ifndef DISABLE_DEVTOOLS
 #include "xwalk/runtime/browser/android/xwalk_dev_tools_server.h"
-#endif
 #include "xwalk/runtime/browser/android/xwalk_http_auth_handler.h"
 #include "xwalk/runtime/browser/android/xwalk_path_helper.h"
 #include "xwalk/runtime/browser/android/xwalk_settings.h"
@@ -45,9 +43,7 @@ static base::android::RegistrationMethod kXWalkRegisteredMethods[] = {
   { "XWalkContentsIoThreadClientImpl",
       RegisterXWalkContentsIoThreadClientImpl },
   { "XWalkContent", RegisterXWalkContent },
-#ifndef DISABLE_DEVTOOLS
   { "XWalkDevToolsServer", RegisterXWalkDevToolsServer },
-#endif
   { "XWalkExtensionAndroid", extensions::RegisterXWalkExtensionAndroid },
   { "XWalkHttpAuthHandler", RegisterXWalkHttpAuthHandler },
   { "XWalkPathHelper", RegisterXWalkPathHelper },

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -331,8 +331,6 @@
       'conditions': [
         ['disable_devtools==1', {
           'sources!': [
-            'runtime/browser/android/xwalk_dev_tools_server.cc',
-            'runtime/browser/android/xwalk_dev_tools_server.h',
             'runtime/browser/devtools/remote_debugging_server.cc',
             'runtime/browser/devtools/remote_debugging_server.h',
             'runtime/browser/devtools/xwalk_devtools_delegate.cc',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -220,13 +220,6 @@
       ],
 
       'includes': ['../build/jni_generator.gypi'],
-      'conditions': [
-        ['disable_devtools==1', {
-          'sources!': [
-            'runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDevToolsServer.java',
-          ],
-        }],
-      ],
     },
     {
       'target_name': 'xwalk_core_extensions_java',


### PR DESCRIPTION
Empty the Java-bounding functions of C++, once devtools is disabled to
avoid incident invoke from Java.

BUG=XWALK-5051