### PR TITLE
Implement --enable-inspector command line.

### DIFF
--- a/runtime/browser/ui/native_app_window_desktop.cc
+++ b/runtime/browser/ui/native_app_window_desktop.cc
@@ -5,6 +5,7 @@
 
 #include "xwalk/runtime/browser/ui/native_app_window_desktop.h"
 
+#include "base/command_line.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_contents.h"
@@ -25,6 +26,7 @@
 #include "xwalk/runtime/browser/ui/top_view_layout_views.h"
 #include "xwalk/runtime/browser/ui/desktop/download_views.h"
 #include "xwalk/runtime/browser/runtime_select_file_policy.h"
+#include "xwalk/runtime/common/xwalk_switches.h"
 
 namespace xwalk {
 
@@ -104,7 +106,10 @@ class NativeAppWindowDesktop::ContextMenuModel : public ui::SimpleMenuModel,
     : ui::SimpleMenuModel(this),
     shell_(shell),
     params_(params) {
-    AddItem(COMMAND_OPEN_DEVTOOLS, base::ASCIIToUTF16("Inspect Element"));
+    const base::CommandLine& command_line =
+      *base::CommandLine::ForCurrentProcess();
+    if (command_line.HasSwitch(switches::kXWalkEnableInspector))
+      AddItem(COMMAND_OPEN_DEVTOOLS, base::ASCIIToUTF16("Inspect Element"));
   }
 
   // ui::SimpleMenuModel::Delegate:

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -29,6 +29,12 @@ const char kXWalkAllowExternalExtensionsForRemoteSources[] =
 // state, e.g. cache, localStorage etc.
 const char kXWalkDataPath[] = "data-path";
 
+#if !defined(OS_ANDROID)
+// Specifies if remote inspector can be opened when right clicking on the
+// application.
+const char kXWalkEnableInspector[] = "enable-inspector";
+#endif
+
 #if defined(OS_ANDROID)
 // Specifies the separated folder to save user data on Android.
 const char kXWalkProfileName[] = "profile-name";

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -17,6 +17,9 @@ extern const char kExperimentalFeatures[];
 extern const char kListFeaturesFlags[];
 extern const char kXWalkAllowExternalExtensionsForRemoteSources[];
 extern const char kXWalkDataPath[];
+#if !defined(OS_ANDROID)
+extern const char kXWalkEnableInspector[];
+#endif
 extern const char kAllowRunningInsecureContent[];
 extern const char kNoDisplayingInsecureContent[];
 


### PR DESCRIPTION
By default there is no inspector support (right click) but
when passing --enable-inspector it is possible to launch the
inspector.

We need that flag so that crosswalk-app-tools can use it to
enable/disable inspector (especially when you actually make
a release of your .msi or application, you don't want the
inspector to be enabled).

BUG=XWALK-4858