### PR TITLE
[Android] Expose onScrollChanged/onFocusChanged to XWalkView

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
@@ -6,6 +6,7 @@
 package org.xwalk.core.internal;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -91,4 +92,14 @@ public class XWalkContentView extends ContentView {
         return mContentViewCore.onTouchEvent(event);
     }
 
+    @Override
+    public void onScrollChanged(int l, int t, int oldl, int oldt) {
+        mXWalkView.onScrollChangedDelegate(l, t, oldl, oldt);
+    }
+
+    @Override
+    protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
+        mXWalkView.onFocusChangedDelegate(gainFocus, direction, previouslyFocusedRect);
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+    }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1287,4 +1287,14 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         return mContent.onTouchEvent(event);
     }
 
+    // Use delegate to access XWalkView's protected method
+    @XWalkAPI(delegate = true,
+              preWrapperLines = {"onScrollChanged(l, t, oldl, oldt);"})
+    public void onScrollChangedDelegate(int l, int t, int oldl, int oldt) {
+    }
+
+    @XWalkAPI(delegate = true,
+              preWrapperLines = {"onFocusChanged(gainFocus, direction, previouslyFocusedRect);"})
+    public void onFocusChangedDelegate(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
+    }
 }


### PR DESCRIPTION
Use XWalkAPI.delegate annotation for reflection generation script
to generate delegate methods in XWalkView within which View's protected
methods is invoked.

BUG=XWALK-4899, XWALK-4895