### PR TITLE
[Android] Fix the issue about manifest.json was always used.

### DIFF
--- a/app/tools/android/customize.py
+++ b/app/tools/android/customize.py
@@ -323,7 +323,7 @@ def SetVariable(file_path, string_line, variable, value):
   shutil.move(temp_file_path, file_path)
 
 
-def CustomizeJava(app_info, app_url, app_local_path, keep_screen_on):
+def CustomizeJava(app_info, app_url, app_local_path, keep_screen_on, manifest):
   name = app_info.android_name
   package = app_info.package
   app_dir = GetBuildDir(name)
@@ -331,12 +331,14 @@ def CustomizeJava(app_info, app_url, app_local_path, keep_screen_on):
   dest_activity = os.path.join(app_pkg_dir, name + 'Activity.java')
   ReplaceString(dest_activity, 'org.xwalk.app.template', package)
   ReplaceString(dest_activity, 'AppTemplate', name)
-  manifest_file = os.path.join(app_dir, 'assets', 'www', 'manifest.json')
-  if os.path.isfile(manifest_file):
+  if manifest:
+    manifest_name = os.path.basename(manifest.input_path)
+    manifest_in_asset = 'file:///android_asset/www/' + manifest_name
+    load_from_manifest = 'loadAppFromManifest("' + manifest_in_asset + '")'
     ReplaceString(
         dest_activity,
         'loadAppFromUrl("file:///android_asset/www/index.html")',
-        'loadAppFromManifest("file:///android_asset/www/manifest.json")')
+        load_from_manifest)
   else:
     if app_url:
       if re.search(r'^http(|s)', app_url):
@@ -589,7 +591,7 @@ def CustomizeAll(app_info, description, icon_dict, permissions, app_url,
   try:
     Prepare(app_info, compressor)
     CustomizeXML(app_info, description, icon_dict, manifest, permissions)
-    CustomizeJava(app_info, app_url, app_local_path, keep_screen_on)
+    CustomizeJava(app_info, app_url, app_local_path, keep_screen_on, manifest)
     CustomizeExtensions(app_info, extensions)
     GenerateCommandLineFile(app_info, xwalk_command_line)
   except SystemExit as ec:

--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -908,16 +908,12 @@ def main(argv):
     if not os.path.isfile(options.manifest):
       print('Error: The manifest file does not exist.')
       sys.exit(8)
-
-  if options.app_root and not options.manifest:
-    manifest_path = os.path.join(options.app_root, 'manifest.json')
-    if os.path.exists(manifest_path):
-      print('Using manifest.json distributed with the application.')
-      options.manifest = manifest_path
-
-  app_info = AppInfo()
-  manifest = None
-  if not options.manifest:
+    try:
+      manifest = ParseManifest(options)
+    except SystemExit as ec:
+      return ec.code
+  else:
+    manifest = None
     # The checks here are really convoluted, but at the moment make_apk
     # misbehaves any of the following conditions is true.
     if options.app_url:
@@ -946,11 +942,6 @@ def main(argv):
       permission_list = permission_mapping_table.keys()
     options.permissions = HandlePermissionList(permission_list)
     options.icon_dict = {}
-  else:
-    try:
-      manifest = ParseManifest(options)
-    except SystemExit as ec:
-      return ec.code
 
   if not options.name:
     parser.error('An APK name is required. Please use the "--name" option.')
@@ -988,6 +979,7 @@ def main(argv):
     sys.exit(14)
 
   try:
+    app_info = AppInfo()
     MakeApk(options, app_info, manifest)
   except SystemExit as ec:
     return ec.code

--- a/app/tools/android/make_apk_test.py
+++ b/app/tools/android/make_apk_test.py
@@ -781,6 +781,50 @@ class TestMakeApk(unittest.TestCase):
     self.assertTrue(
         out.find('\'Telephony\' related API is not supported') != -1)
 
+  def testManifestWithAppRoot(self):
+    manifest_path = os.path.join('test_data', 'manifest',
+                                 'manifest_and_app_root', 'manifest.json')
+    cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
+           '--manifest=%s' % manifest_path, '--project-dir=.', self._mode]
+    RunCommand(cmd)
+    self.addCleanup(Clean, 'Example', '1.0.1')
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('landscape') != -1)
+    theme = 'Example/res/values-v14/theme.xml'
+    with open(theme, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(theme))
+    self.assertTrue(
+        content.find(
+            '<item name="android:windowFullscreen">true</item>') != -1)
+    self.assertTrue(os.path.exists('Example'))
+    self.checkApks('Example', '1.0.1')
+
+  def testAppRootWithManifest(self):
+    html_path = os.path.join('test_data', 'manifest', 'manifest_and_app_root')
+    cmd = ['python', 'make_apk.py', '--package=org.xwalk.example',
+           '--name=example', '--app-version=1.0.0', '--app-root=%s' % html_path,
+           '--app-local-path=%s' % 'index.html', '--project-dir=.', self._mode]
+    RunCommand(cmd)
+    self.addCleanup(Clean, 'Example', '1.0.0')
+    manifest = 'Example/AndroidManifest.xml'
+    with open(manifest, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(manifest))
+    self.assertTrue(content.find('landscape') == -1)
+    theme = 'Example/res/values-v14/theme.xml'
+    with open(theme, 'r') as content_file:
+      content = content_file.read()
+    self.assertTrue(os.path.exists(theme))
+    self.assertTrue(
+        content.find(
+            '<item name="android:windowFullscreen">true</item>') == -1)
+    self.assertTrue(os.path.exists('Example'))
+    self.checkApks('Example', '1.0.0')
+
   def testExtensionsWithOneExtension(self):
     # Test with an existed extension.
     extension_path = 'test_data/extensions/myextension'
@@ -1300,6 +1344,7 @@ def SuiteWithModeOption():
   test_suite.addTest(TestMakeApk('testAppVersionCodeBase'))
   test_suite.addTest(TestMakeApk('testAppVersionCodeFromVersionName'))
   test_suite.addTest(TestMakeApk('testAppDescriptionAndVersion'))
+  test_suite.addTest(TestMakeApk('testAppRootWithManifest'))
   test_suite.addTest(TestMakeApk('testArch'))
   test_suite.addTest(TestMakeApk('testEnableRemoteDebugging'))
   test_suite.addTest(TestMakeApk('testEntry'))
@@ -1315,6 +1360,7 @@ def SuiteWithModeOption():
   test_suite.addTest(TestMakeApk('testManifest'))
   test_suite.addTest(TestMakeApk('testManifestWithDeprecatedField'))
   test_suite.addTest(TestMakeApk('testManifestWithError'))
+  test_suite.addTest(TestMakeApk('testManifestWithAppRoot'))
   test_suite.addTest(TestMakeApk('testName'))
   test_suite.addTest(TestMakeApk('testOrientation'))
   test_suite.addTest(TestMakeApk('testPackage'))

--- a/app/tools/android/test_data/manifest/manifest_and_app_root/index.html
+++ b/app/tools/android/test_data/manifest/manifest_and_app_root/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+hello, world!
+</body>
+</html>

--- a/app/tools/android/test_data/manifest/manifest_and_app_root/manifest.json
+++ b/app/tools/android/test_data/manifest/manifest_and_app_root/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Example",
+  "xwalk_version": "1.0.1",
+  "start_url": "http://www.intel.com",
+  "xwalk_description": "a sample description",
+  "icons": [],
+  "orientation": "landscape",
+  "display": ["fullscreen"]
+}


### PR DESCRIPTION
This patch is to fix manifest.json was always used issue.
In application's folder, if manifest.json was existed, it will be
always used even if it was not specified in command line.
e.g. if manifest.json was existed and app was packaged by "make_apk.py
--package=org.xwalk.test --name=test --app-root=path-to-app
--app-local-path=index.html", this way won't work, manifest.json will be
used.

BUG=XWALK-5131