### PR TITLE
Roll DEPS.xwalk

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'e8ee4cc888e75a82171f06152447e86a30ca8e15'
+chromium_crosswalk_rev = '221ebde80fdd20eed9dda38f84b1dc80c1d9ddcd'
 v8_crosswalk_rev = '255b844a25c36e84145bab3751adde7c0e8f5dd6'
 ozone_wayland_rev = '1cde4077b26fb5cbb2661b465b496550a587df55'
 
@@ -27,7 +27,7 @@ ozone_wayland_rev = '1cde4077b26fb5cbb2661b465b496550a587df55'
 # the blink-crosswalk repository, so that the devtools code can use it to fetch
 # assets from Chromium's servers with a revision that exists there. We need an
 # SVN revision while Blink is still in SVN.
-blink_crosswalk_rev = '98eb9d837b4d70ba9e808e8d98f2f57ea92dc1c7'
+blink_crosswalk_rev = '0b35e0428e424d451a8c02e8910aca574c692998'
 blink_upstream_rev = '200670'
 
 crosswalk_git = 'https://github.com/crosswalk-project'


### PR DESCRIPTION
Chromium-Crosswalk:
d6f877df60d414a2f0683e1442456ba320bd10cb
    Web-Video-related resources should be controled by 'disable_web_video'

Blink-Crosswalk:
be510f5b0037cd52a4a0c58d2ec734aa46f5df6c
    Remove the message output of "modules_gypi_generator.py"

e98990e4130b1f902d259026d3b31df059c7ee6d
    Web-Video-related resources should be controled by 'disable_web_viedeo'