### PR TITLE
[Android] Add basic silent download mode support

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryLoader.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryLoader.java
@@ -9,13 +9,20 @@ import android.app.DownloadManager;
 import android.app.DownloadManager.Request;
 import android.app.DownloadManager.Query;
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Environment;
 import android.util.Log;
 
+import java.io.File;
 import java.lang.Thread;
+import java.net.URL;
+import java.net.MalformedURLException;
+import java.util.Arrays;
 
 import junit.framework.Assert;
 
@@ -112,7 +119,9 @@ class XWalkLibraryLoader {
         public void onDownloadFailed(int status, int error);
     }
 
-    private static final String XWALK_APK_NAME = "XWalkRuntimeLib.apk";
+    private static final String DEFAULT_DOWNLOAD_FILE_NAME = "xwalk_download.tmp";
+    private static final String DOWNLOAD_WITHOUT_NOTIFICATION =
+            "android.permission.DOWNLOAD_WITHOUT_NOTIFICATION";
     private static final String TAG = "XWalkLib";
 
     private static AsyncTask<Void, Integer, Integer> sActiveTask;
@@ -301,6 +310,7 @@ class XWalkLibraryLoader {
         private static final int MAX_PAUSED_COUNT = 6000; // 10 minutes
 
         private DownloadListener mListener;
+        private Context mContext;
         private String mDownloadUrl;
         private DownloadManager mDownloadManager;
         private long mDownloadId;
@@ -308,6 +318,7 @@ class XWalkLibraryLoader {
         DownloadTask(DownloadListener listener, Context context, String url) {
             super();
             mListener = listener;
+            mContext = context;
             mDownloadUrl = url;
             mDownloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
         }
@@ -317,9 +328,26 @@ class XWalkLibraryLoader {
             Log.d(TAG, "DownloadTask started, " + mDownloadUrl);
             sActiveTask = this;
 
+            String savedFile = DEFAULT_DOWNLOAD_FILE_NAME;
+            try {
+                String name = new File(new URL(mDownloadUrl).getPath()).getName();
+                if (!name.isEmpty()) savedFile = name;
+            } catch (MalformedURLException | NullPointerException e) {
+                Log.e(TAG, "Invalid download URL " + mDownloadUrl);
+                mDownloadUrl = null;
+                return;
+            }
+
+            File downloadDir = mContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS);
+            File downloadFile = new File(downloadDir, savedFile);
+            if (downloadFile.isFile()) downloadFile.delete();
+
             Request request = new Request(Uri.parse(mDownloadUrl));
-            request.setDestinationInExternalPublicDir(
-                    Environment.DIRECTORY_DOWNLOADS, XWALK_APK_NAME);
+            request.setDestinationInExternalFilesDir(
+                    mContext, Environment.DIRECTORY_DOWNLOADS, savedFile);
+            if (isSilentDownload()) {
+                request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_HIDDEN);
+            }
             mDownloadId = mDownloadManager.enqueue(request);
 
             mListener.onDownloadStarted();
@@ -327,6 +355,8 @@ class XWalkLibraryLoader {
 
         @Override
         protected Integer doInBackground(Void... params) {
+            if (mDownloadUrl == null) return DownloadManager.STATUS_FAILED;
+
             Query query = new Query().setFilterById(mDownloadId);
             int pausedCount = 0;
 
@@ -386,7 +416,7 @@ class XWalkLibraryLoader {
                 Uri uri = mDownloadManager.getUriForDownloadedFile(mDownloadId);
                 mListener.onDownloadCompleted(uri);
             } else {
-                int error = -1;
+                int error = DownloadManager.ERROR_UNKNOWN;
                 if (result == DownloadManager.STATUS_FAILED) {
                     Query query = new Query().setFilterById(mDownloadId);
                     Cursor cursor = mDownloadManager.query(query);
@@ -397,6 +427,18 @@ class XWalkLibraryLoader {
                 }
                 mListener.onDownloadFailed(result, error);
             }
+        }
+
+        private boolean isSilentDownload() {
+            try {
+                PackageManager packageManager = mContext.getPackageManager();
+                PackageInfo packageInfo = packageManager.getPackageInfo(
+                        mContext.getPackageName(), PackageManager.GET_PERMISSIONS);
+                return Arrays.asList(packageInfo.requestedPermissions).contains(
+                        DOWNLOAD_WITHOUT_NOTIFICATION);
+            } catch (NameNotFoundException | NullPointerException e) {
+            }
+            return false;
         }
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -6,30 +6,47 @@ package org.xwalk.core;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Environment;
 import android.util.Log;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+import junit.framework.Assert;
 
 import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
 
 /**
  * <p><code>XWalkUpdater</code> is a follow-up solution for {@link XWalkInitializer} in case the
- * initialization has failed. The users of {@link XWalkActivity} don't need to use this class.</p>
+ * initialization failed. The users of {@link XWalkActivity} don't need to use this class.</p>
  *
- * <p><code>XWalkUpdater</code> helps to donwload the Crosswalk runtime and displays dialogs to
+ * <p><code>XWalkUpdater</code> helps to download the Crosswalk runtime and displays dialogs to
  * interact with the user. By default, it will navigate to the Crosswalk runtime's page on the
  * default application store, subsequent process will be up to the user. If the developer specified
  * the download URL of the Crosswalk runtime, it will launch the download manager to fetch the APK.
- * To specify the download URL, insert a meta-data element with the name "xwalk_apk_url" inside the
- * application tag in the Android manifest.
+ * To specify the download URL, insert a meta-data element named "xwalk_apk_url" inside the
+ * application tag in the Android manifest.</p>
  *
  * <pre>
- * &lt;application android:name="org.xwalk.core.XWalkApplication"&gt;
+ * &lt;application&gt;
  *     &lt;meta-data android:name="xwalk_apk_url" android:value="http://host/XWalkRuntimeLib.apk" /&gt;
+ * &lt;/application&gt;
  * </pre>
  *
  * <p>After the proper Crosswalk runtime is downloaded and installed, the user will return to
@@ -50,9 +67,9 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  *     protected void onResume() {
  *         super.onResume();
  *
- *         // Try to initialize again when the user completed updating and returned to current
+ *         // Try to initialize again when the user completed update and returned to current
  *         // activity. The initAsync() will do nothing if the initialization has already been
- *         // completed successfully.
+ *         // completed successfully or previous update dialog is still being displayed.
  *         mXWalkInitializer.initAsync();
  *     }
  *
@@ -66,7 +83,8 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  *
  *     &#64;Override
  *     public void onXWalkUpdateCancelled() {
- *         // Perform error handling here
+ *         // The user clicked the "Cancel" button during download.
+ *         // Perform error handling here.
  *     }
  * }
  * </pre>
@@ -79,6 +97,61 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  * &lt;uses-permission android:name="android.permission.ACCESS_WIFI_STATE" /&gt;
  * &lt;uses-permission android:name="android.permission.INTERNET" /&gt;
  * &lt;uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /&gt;
+ * </pre>
+ *
+ * <p>There is an experimental way to update the Crosswalk runtime. All of the download process are
+ * executed in background silently without interrupting the user.</p>
+ *
+ * <p>For example:</p>
+ *
+ * <pre>
+ * public class MyActivity extends Activity
+ *         implements XWalkInitializer.XWalkInitListener, XWalkUpdater.XWalkSilentUpdateListener {
+ *     XWalkUpdater mXWalkUpdater;
+ *
+ *     ......
+ *
+ *     &#64;Override
+ *     protected void onResume() {
+ *         super.onResume();
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkInitFailed() {
+ *         if (mXWalkUpdater == null) mXWalkUpdater = new mXWalkUpdater(this, this);
+ *         mXWalkUpdater.updateXWalkLibrary();
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkUpdateStarted() {
+ *         // Download started in background
+ *         // Nothing particular to do here.
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkUpdateCancelled() {
+ *         // Background download is cancelled by invoking cancelSilentDownload().
+ *         // Perform error handling here
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkUpdateFailed() {
+ *         // Background download failed.
+ *         // Perform error handling here
+ *     }
+ *
+ *     &#64;Override
+ *     public void onXWalkUpdateCompleted() {
+ *         // Try to initialize again when the Crosswalk libraries are ready.
+ *         mXWalkInitializer.initAsync();
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>If you grant following permission further, the download doesn't show in the notifications.</p>
+ *
+ * <pre>
+ * &lt;uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" /&gt;
  * </pre>
  */
 
@@ -94,15 +167,59 @@ public class XWalkUpdater {
         public void onXWalkUpdateCancelled();
     }
 
+    /**
+     * Interface used to update the Crosswalk runtime silently
+     */
+    public interface XWalkSilentUpdateListener {
+        /**
+         * Run on the UI thread to notify the update is started.
+         */
+        public void onXWalkUpdateStarted();
+
+        /**
+         * Run on the UI thread to notify the update is cancelled.
+         */
+        public void onXWalkUpdateCancelled();
+
+        /**
+         * Run on the UI thread to notify the update failed.
+         */
+        public void onXWalkUpdateFailed();
+
+        /**
+         * Run on the UI thread to notify the update is completed.
+         */
+        public void onXWalkUpdateCompleted();
+    }
+
     private static final String XWALK_APK_MARKET_URL = "market://details?id=org.xwalk.core";
-    private static final String TAG = "XWalkActivity";
+
+    private static final String META_XWALK_LIB_URL = "xwalk_lib_url";
+    private static final String META_XWALK_APK_URL = "xwalk_apk_url";
+
+    private static final String XWALK_LIB_DIR =
+            Environment.getExternalStorageDirectory().getAbsolutePath()
+            + File.separator + "XWalkRuntimeLib";
+
+    private static final String[] XWALK_LIB_RESOURCES = {
+        "libxwalkcore.so",
+        "icudtl.dat",
+        "xwalk.pak",
+    };
+
+    private static final String TAG = "XWalkLib";
+
+    private static final int STREAM_BUFFER_SIZE = 0x1000;
 
     private XWalkUpdateListener mUpdateListener;
+    private XWalkSilentUpdateListener mSilentUpdateListener;
     private Activity mActivity;
     private XWalkDialogManager mDialogManager;
     private Runnable mDownloadCommand;
     private Runnable mCancelCommand;
     private String mXWalkApkUrl;
+    private String mXWalkLibUrl;
+    private boolean mIsDownloading;
 
     /**
      * Create XWalkUpdater for single activity
@@ -111,28 +228,28 @@ public class XWalkUpdater {
      * @param activity The activity which initiate the update
      */
     public XWalkUpdater(XWalkUpdateListener listener, Activity activity) {
-        this(listener, activity, new XWalkDialogManager(activity));
+        mUpdateListener = listener;
+        mActivity = activity;
+        mDialogManager = new XWalkDialogManager(activity);
     }
 
+    // This constructor is for XWalkActivityDelegate
     XWalkUpdater(XWalkUpdateListener listener, Activity activity,
             XWalkDialogManager dialogManager) {
         mUpdateListener = listener;
         mActivity = activity;
         mDialogManager = dialogManager;
+    }
 
-        mDownloadCommand = new Runnable() {
-            @Override
-            public void run() {
-                downloadXWalkApk();
-            }
-        };
-        mCancelCommand = new Runnable() {
-            @Override
-            public void run() {
-                Log.d(TAG, "XWalkUpdater cancelled");
-                mUpdateListener.onXWalkUpdateCancelled();
-            }
-        };
+    /**
+     * Create XWalkUpdater for single activity. This updater will download silently.
+     *
+     * @param listener The {@link XWalkSilentUpdateListener} to use
+     * @param activity The activity which initiate the update
+     */
+    public XWalkUpdater(XWalkSilentUpdateListener listener, Activity activity) {
+        mSilentUpdateListener = listener;
+        mActivity = activity;
     }
 
     /**
@@ -148,14 +265,36 @@ public class XWalkUpdater {
      *         doesn't need to be updated, or the Crosswalk runtime has not been initialized yet.
      */
     public boolean updateXWalkRuntime() {
-        if (mDialogManager.isShowingDialog()) return false;
+        if (mIsDownloading || (mDialogManager != null && mDialogManager.isShowingDialog())) {
+            return false;
+        }
 
         int status = XWalkLibraryLoader.getLibraryStatus();
         if (status == XWalkLibraryInterface.STATUS_PENDING ||
                 status == XWalkLibraryInterface.STATUS_MATCH) return false;
 
-        Log.d(TAG, "Update the Crosswalk runtime with status " + status);
-        mDialogManager.showInitializationError(status, mCancelCommand, mDownloadCommand);
+        if (mUpdateListener != null) {
+            mDownloadCommand = new Runnable() {
+                @Override
+                public void run() {
+                    downloadXWalkApk();
+                }
+            };
+            mCancelCommand = new Runnable() {
+                @Override
+                public void run() {
+                    Log.d(TAG, "XWalkUpdater cancelled");
+                    mUpdateListener.onXWalkUpdateCancelled();
+                }
+            };
+
+            mDialogManager.showInitializationError(status, mCancelCommand, mDownloadCommand);
+        } else if (mSilentUpdateListener != null) {
+            downloadXWalkApkSilently();
+        } else {
+            Assert.fail();
+        }
+
         return true;
     }
 
@@ -165,7 +304,7 @@ public class XWalkUpdater {
      * @return Return false if no dialog is being displayed, true if dismissed the showing dialog.
      */
     public boolean dismissDialog() {
-        if (!mDialogManager.isShowingDialog()) return false;
+        if (mDialogManager == null || !mDialogManager.isShowingDialog()) return false;
         mDialogManager.dismissDialog();
         return true;
     }
@@ -180,10 +319,28 @@ public class XWalkUpdater {
         mXWalkApkUrl = url;
     }
 
+    /**
+     * Cancel the silent download
+     *
+     * @param Return false if it is not a silent updater or is not downloading, true otherwise.
+     */
+    public boolean cancelSilentDownload() {
+        if (mSilentUpdateListener == null || !mIsDownloading) return false;
+        return XWalkLibraryLoader.cancelDownload();
+    }
+
     private void downloadXWalkApk() {
-        String downloadUrl = getXWalkApkUrl();
-        if (!downloadUrl.isEmpty()) {
-            XWalkLibraryLoader.startDownload(new XWalkLibraryListener(), mActivity, downloadUrl);
+        // The download url is defined by the meta-data element with the name "xwalk_apk_url"
+        // inside the application tag in the Android manifest. It can also be specified via
+        // the option --xwalk-apk-url of the script make_apk.
+        if (mXWalkApkUrl == null) {
+            mXWalkApkUrl = getAppMetaData(META_XWALK_APK_URL);
+            if (mXWalkApkUrl == null) mXWalkApkUrl = "";
+            Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
+        }
+
+        if (!mXWalkApkUrl.isEmpty()) {
+            XWalkLibraryLoader.startDownload(new ForegroundListener(), mActivity, mXWalkApkUrl);
             return;
         }
 
@@ -199,26 +356,38 @@ public class XWalkUpdater {
         }
     }
 
-    private String getXWalkApkUrl() {
-        if (mXWalkApkUrl != null) return mXWalkApkUrl;
+    private void downloadXWalkApkSilently() {
+        File dir = new File(XWALK_LIB_DIR);
+        if (dir.isDirectory()) {
+            if (checkLibResources()) {
+                new AsyncTask<Void, Void, Void>() {
+                    @Override
+                    protected Void doInBackground(Void... params) {
+                        if (!copyNativeLibraries()) Assert.fail();
+                        return null;
+                    }
 
-        // The download url is defined by the meta-data element with the name "xwalk_apk_url"
-        // inside the application tag in the Android manifest. It can also be specified via
-        // the option --xwalk-apk-url of the script make_apk.
-        try {
-            PackageManager packageManager = mActivity.getPackageManager();
-            ApplicationInfo appInfo = packageManager.getApplicationInfo(
-                    mActivity.getPackageName(), PackageManager.GET_META_DATA);
-            mXWalkApkUrl = appInfo.metaData.getString("xwalk_apk_url");
-        } catch (NameNotFoundException | NullPointerException e) {
+                    @Override
+                    protected void onPostExecute(Void result) {
+                        mSilentUpdateListener.onXWalkUpdateCompleted();
+                    }
+                }.execute();
+                return;
+            }
+        } else {
+            dir.mkdir();
         }
 
-        if (mXWalkApkUrl == null) mXWalkApkUrl = "";
-        Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
-        return mXWalkApkUrl;
+        if (mXWalkLibUrl == null) {
+            mXWalkLibUrl = getAppMetaData(META_XWALK_LIB_URL);
+            Assert.assertNotNull(mXWalkLibUrl);
+            Log.d(TAG, "Crosswalk lib download URL: " + mXWalkLibUrl);
+        }
+
+        XWalkLibraryLoader.startDownload(new BackgroundListener(), mActivity, mXWalkLibUrl);
     }
 
-    private class XWalkLibraryListener implements DownloadListener {
+    private class ForegroundListener implements DownloadListener {
         @Override
         public void onDownloadStarted() {
             mDialogManager.showDownloadProgress(new Runnable() {
@@ -240,6 +409,12 @@ public class XWalkUpdater {
         }
 
         @Override
+        public void onDownloadFailed(int status, int error) {
+            mDialogManager.dismissDialog();
+            mDialogManager.showDownloadError(status, error, mCancelCommand, mDownloadCommand);
+        }
+
+        @Override
         public void onDownloadCompleted(Uri uri) {
             mDialogManager.dismissDialog();
 
@@ -248,11 +423,174 @@ public class XWalkUpdater {
             install.setDataAndType(uri, "application/vnd.android.package-archive");
             mActivity.startActivity(install);
         }
+    }
+
+    private class BackgroundListener implements DownloadListener {
+        @Override
+        public void onDownloadStarted() {
+            mIsDownloading = true;
+            mSilentUpdateListener.onXWalkUpdateStarted();
+        }
+
+        @Override
+        public void onDownloadUpdated(int percentage) {
+        }
+
+        @Override
+        public void onDownloadCancelled() {
+            mIsDownloading = false;
+            mSilentUpdateListener.onXWalkUpdateCancelled();
+        }
 
         @Override
         public void onDownloadFailed(int status, int error) {
-            mDialogManager.dismissDialog();
-            mDialogManager.showDownloadError(status, error, mCancelCommand, mDownloadCommand);
+            mIsDownloading = false;
+            mSilentUpdateListener.onXWalkUpdateFailed();
+        }
+
+        @Override
+        public void onDownloadCompleted(Uri uri) {
+            mIsDownloading = false;
+
+            final Uri downloadedUri = uri;
+            new AsyncTask<Void, Void, Void>() {
+                @Override
+                protected Void doInBackground(Void... params) {
+                    if (!extractLibResources(downloadedUri.getPath(), XWALK_LIB_DIR)) Assert.fail();
+                    if (!checkLibResources()) Assert.fail();
+                    if (!copyNativeLibraries()) Assert.fail();
+                    return null;
+                }
+
+                @Override
+                protected void onPostExecute(Void result) {
+                    mSilentUpdateListener.onXWalkUpdateCompleted();
+                }
+            }.execute();
+        }
+    }
+
+    private String getAppMetaData(String name) {
+        try {
+            PackageManager packageManager = mActivity.getPackageManager();
+            ApplicationInfo appInfo = packageManager.getApplicationInfo(
+                    mActivity.getPackageName(), PackageManager.GET_META_DATA);
+            return appInfo.metaData.getString(name);
+        } catch (NameNotFoundException | NullPointerException e) {
+        }
+        return null;
+    }
+
+    private boolean extractLibResources(String libFile, String destDir) {
+        Log.d(TAG, "Extract from " + libFile);
+        ZipFile zipFile = null;
+
+        try {
+            zipFile = new ZipFile(libFile);
+            Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+
+            while (zipEntries.hasMoreElements()) {
+                ZipEntry entry = zipEntries.nextElement();
+                Log.d(TAG, "Extract " + entry.getName());
+                saveStreamToFile(zipFile.getInputStream(entry), new File(destDir, entry.getName()));
+            }
+
+        } catch (IOException e) {
+            Log.d(TAG, e.getLocalizedMessage());
+            return false;
+        } finally {
+            try {
+                zipFile.close();
+            } catch (IOException | NullPointerException e) {
+            }
+        }
+
+        return true;
+    }
+
+    private boolean checkLibResources() {
+        for (String resource : XWALK_LIB_RESOURCES) {
+            File file = new File(XWALK_LIB_DIR, resource);
+            if (!file.isFile()) {
+                Log.d(TAG, file.getAbsolutePath() + " doesn't exist");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean copyNativeLibraries() {
+        String libDir = mActivity.getDir(
+                XWalkLibraryInterface.PRIVATE_DATA_DIRECTORY_SUFFIX,
+                Context.MODE_PRIVATE).getAbsolutePath();
+
+        for (String resource : XWALK_LIB_RESOURCES) {
+            if (isNativeLibrary(resource)) {
+                try {
+                    copyFile(new File(XWALK_LIB_DIR, resource), new File(libDir, resource));
+                } catch (IOException e) {
+                    Log.d(TAG, e.getLocalizedMessage());
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isNativeLibrary(String name) {
+        int index = name.lastIndexOf('.');
+        return index > 0 && name.substring(index + 1).equals("so");
+    }
+
+    private void copyFile(File src, File dest) throws IOException {
+        Log.d(TAG, "Copy from " + src.getAbsolutePath());
+        saveStreamToFile(new FileInputStream(src), dest);
+    }
+
+    private void saveStreamToFile(InputStream input, File file) throws IOException {
+        Log.d(TAG, "Save to " + file.getAbsolutePath());
+        IOException outputException = null;
+
+        try {
+            // If the input stream is already closed, this method will throw an IOException so that
+            // we don't create an unused output stream.
+            input.available();
+
+            FileOutputStream output = new FileOutputStream(file);
+
+            try {
+                byte[] buffer = new byte[STREAM_BUFFER_SIZE];
+                for (int len = 0; (len = input.read(buffer)) >= 0;) {
+                    output.write(buffer, 0, len);
+                }
+            } catch (IOException e) {
+                outputException = e;
+            }
+
+            try {
+                output.flush();
+            } catch (IOException e) {
+                if (outputException == null) outputException = e;
+            }
+
+            try {
+                output.close();
+            } catch (IOException e) {
+                if (outputException == null) outputException = e;
+            }
+        } catch (IOException e) {
+            throw e;
+        } finally {
+            try {
+                input.close();
+            } catch (IOException e) {
+            }
+        }
+
+        if (outputException != null) {
+            if (file.isFile()) file.delete();
+            throw outputException;
         }
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -50,6 +50,11 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  * &lt;/application&gt;
  * </pre>
  *
+ * <p>To download the Crosswalk runtime APK for the specified CPU architecture, <code>xwalk_apk_url<code>
+ * will be appended with a query string named "?arch=CPU_ABI" when the download request is sent to server,
+ * then server can send back the APK which is exactly built for the specified CPU architecture. The CPU_ABI
+ * here is exactly same as the value returned from "getprop ro.product.cpu.abi".</p>
+ *
  * <p>After the proper Crosswalk runtime is downloaded and installed, the user will return to
  * current activity from the application store or the installer. The developer should check this
  * point and invoke <code>XWalkInitializer.initAsync()</code> again to repeat the initialization
@@ -197,6 +202,7 @@ public class XWalkUpdater {
 
     private static final String META_XWALK_APK_URL = "xwalk_apk_url";
     private static final String XWALK_CORE_EXTRACTED_DIR = "extracted_xwalkcore";
+    private static final String ARCH_QUERY_STRING = "?arch=";
 
     private static final String[] XWALK_LIB_RESOURCES = {
         "libxwalkcore.so",
@@ -331,8 +337,7 @@ public class XWalkUpdater {
         // inside the application tag in the Android manifest. It can also be specified via
         // the option --xwalk-apk-url of the script make_apk.
         if (mXWalkApkUrl == null) {
-            mXWalkApkUrl = getAppMetaData(META_XWALK_APK_URL);
-            if (mXWalkApkUrl == null) mXWalkApkUrl = "";
+            mXWalkApkUrl = getXWalkApkUrl();
             Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
         }
 
@@ -355,11 +360,15 @@ public class XWalkUpdater {
 
     private void downloadXWalkApkSilently() {
         if (mXWalkApkUrl == null) {
-            mXWalkApkUrl = getAppMetaData(META_XWALK_APK_URL);
-            Assert.assertNotNull(mXWalkApkUrl);
+            mXWalkApkUrl = getXWalkApkUrl();
             Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
         }
         XWalkLibraryLoader.startDownload(new BackgroundListener(), mActivity, mXWalkApkUrl);
+    }
+
+    private String getXWalkApkUrl() {
+        String url = getAppMetaData(META_XWALK_APK_URL);
+        return url == null ? "" : url + ARCH_QUERY_STRING + Build.CPU_ABI;
     }
 
     private class ForegroundListener implements DownloadListener {

--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -14,6 +14,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Environment;
 import android.util.Log;
 
@@ -194,15 +195,12 @@ public class XWalkUpdater {
 
     private static final String XWALK_APK_MARKET_URL = "market://details?id=org.xwalk.core";
 
-    private static final String META_XWALK_LIB_URL = "xwalk_lib_url";
     private static final String META_XWALK_APK_URL = "xwalk_apk_url";
-
-    private static final String XWALK_LIB_DIR =
-            Environment.getExternalStorageDirectory().getAbsolutePath()
-            + File.separator + "XWalkRuntimeLib";
+    private static final String XWALK_CORE_EXTRACTED_DIR = "extracted_xwalkcore";
 
     private static final String[] XWALK_LIB_RESOURCES = {
         "libxwalkcore.so",
+        "classes.dex",
         "icudtl.dat",
         "xwalk.pak",
     };
@@ -218,7 +216,6 @@ public class XWalkUpdater {
     private Runnable mDownloadCommand;
     private Runnable mCancelCommand;
     private String mXWalkApkUrl;
-    private String mXWalkLibUrl;
     private boolean mIsDownloading;
 
     /**
@@ -322,7 +319,7 @@ public class XWalkUpdater {
     /**
      * Cancel the silent download
      *
-     * @param Return false if it is not a silent updater or is not downloading, true otherwise.
+     * @return Return false if it is not a silent updater or is not downloading, true otherwise.
      */
     public boolean cancelSilentDownload() {
         if (mSilentUpdateListener == null || !mIsDownloading) return false;
@@ -357,34 +354,12 @@ public class XWalkUpdater {
     }
 
     private void downloadXWalkApkSilently() {
-        File dir = new File(XWALK_LIB_DIR);
-        if (dir.isDirectory()) {
-            if (checkLibResources()) {
-                new AsyncTask<Void, Void, Void>() {
-                    @Override
-                    protected Void doInBackground(Void... params) {
-                        if (!copyNativeLibraries()) Assert.fail();
-                        return null;
-                    }
-
-                    @Override
-                    protected void onPostExecute(Void result) {
-                        mSilentUpdateListener.onXWalkUpdateCompleted();
-                    }
-                }.execute();
-                return;
-            }
-        } else {
-            dir.mkdir();
+        if (mXWalkApkUrl == null) {
+            mXWalkApkUrl = getAppMetaData(META_XWALK_APK_URL);
+            Assert.assertNotNull(mXWalkApkUrl);
+            Log.d(TAG, "Crosswalk APK download URL: " + mXWalkApkUrl);
         }
-
-        if (mXWalkLibUrl == null) {
-            mXWalkLibUrl = getAppMetaData(META_XWALK_LIB_URL);
-            Assert.assertNotNull(mXWalkLibUrl);
-            Log.d(TAG, "Crosswalk lib download URL: " + mXWalkLibUrl);
-        }
-
-        XWalkLibraryLoader.startDownload(new BackgroundListener(), mActivity, mXWalkLibUrl);
+        XWalkLibraryLoader.startDownload(new BackgroundListener(), mActivity, mXWalkApkUrl);
     }
 
     private class ForegroundListener implements DownloadListener {
@@ -456,9 +431,9 @@ public class XWalkUpdater {
             new AsyncTask<Void, Void, Void>() {
                 @Override
                 protected Void doInBackground(Void... params) {
-                    if (!extractLibResources(downloadedUri.getPath(), XWALK_LIB_DIR)) Assert.fail();
-                    if (!checkLibResources()) Assert.fail();
-                    if (!copyNativeLibraries()) Assert.fail();
+                    final String destDir = mActivity.getDir(XWALK_CORE_EXTRACTED_DIR,
+                            Context.MODE_PRIVATE).getAbsolutePath();
+                    if (!extractLibResources(downloadedUri.getPath(), destDir)) Assert.fail();
                     return null;
                 }
 
@@ -484,18 +459,25 @@ public class XWalkUpdater {
     private boolean extractLibResources(String libFile, String destDir) {
         Log.d(TAG, "Extract from " + libFile);
         ZipFile zipFile = null;
-
         try {
             zipFile = new ZipFile(libFile);
-            Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
-
-            while (zipEntries.hasMoreElements()) {
-                ZipEntry entry = zipEntries.nextElement();
-                Log.d(TAG, "Extract " + entry.getName());
-                saveStreamToFile(zipFile.getInputStream(entry), new File(destDir, entry.getName()));
+            for (String resource : XWALK_LIB_RESOURCES) {
+                String entryDir = "";
+                if (isNativeLibrary(resource)) {
+                    if(Build.CPU_ABI.equalsIgnoreCase("armeabi")) {
+                        // We build armeabi-v7a native lib for both armeabi & armeabi-v7a
+                        entryDir = "lib" + File.separator + "armeabi-v7a" + File.separator;
+                    } else {
+                        entryDir = "lib" + File.separator + Build.CPU_ABI + File.separator;
+                    }
+                } else if (isAsset(resource)) {
+                    entryDir = "assets" + File.separator;
+                }
+                Log.d(TAG, "unzip " + entryDir + resource);
+                ZipEntry entry = zipFile.getEntry(entryDir + resource);
+                saveStreamToFile(zipFile.getInputStream(entry), new File(destDir, resource));
             }
-
-        } catch (IOException e) {
+        } catch (IOException | NullPointerException e) {
             Log.d(TAG, e.getLocalizedMessage());
             return false;
         } finally {
@@ -504,48 +486,15 @@ public class XWalkUpdater {
             } catch (IOException | NullPointerException e) {
             }
         }
-
         return true;
     }
 
-    private boolean checkLibResources() {
-        for (String resource : XWALK_LIB_RESOURCES) {
-            File file = new File(XWALK_LIB_DIR, resource);
-            if (!file.isFile()) {
-                Log.d(TAG, file.getAbsolutePath() + " doesn't exist");
-                return false;
-            }
-        }
-        return true;
+    private boolean isNativeLibrary(String resource) {
+        return resource.endsWith(".so");
     }
 
-    private boolean copyNativeLibraries() {
-        String libDir = mActivity.getDir(
-                XWalkLibraryInterface.PRIVATE_DATA_DIRECTORY_SUFFIX,
-                Context.MODE_PRIVATE).getAbsolutePath();
-
-        for (String resource : XWALK_LIB_RESOURCES) {
-            if (isNativeLibrary(resource)) {
-                try {
-                    copyFile(new File(XWALK_LIB_DIR, resource), new File(libDir, resource));
-                } catch (IOException e) {
-                    Log.d(TAG, e.getLocalizedMessage());
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private boolean isNativeLibrary(String name) {
-        int index = name.lastIndexOf('.');
-        return index > 0 && name.substring(index + 1).equals("so");
-    }
-
-    private void copyFile(File src, File dest) throws IOException {
-        Log.d(TAG, "Copy from " + src.getAbsolutePath());
-        saveStreamToFile(new FileInputStream(src), dest);
+    private boolean isAsset(String resource) {
+        return resource.endsWith(".dat") || resource.endsWith(".pak");
     }
 
     private void saveStreamToFile(InputStream input, File file) throws IOException {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -6,6 +6,8 @@ package org.xwalk.core.internal;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
@@ -18,6 +20,7 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.content.res.Resources.NotFoundException;
 import android.os.Build;
+import android.os.Environment;
 import android.util.Log;
 
 import junit.framework.Assert;
@@ -41,6 +44,9 @@ class XWalkViewDelegate {
     private static boolean sLibraryLoaded = false;
     private static boolean sRunningOnIA = true;
     private static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
+
+    private static final String XWALK_LIB_DIR = Environment.getExternalStorageDirectory().toString()
+            + File.separator + "XWalkRuntimeLib";
 
     // TODO(rakuco,lincsoon): This list is also in generate_xwalk_core_library.py.
     // We should remove it from one of the places to avoid duplication.
@@ -207,19 +213,15 @@ class XWalkViewDelegate {
                 !isSharedMode && Arrays.asList(context.getAssets().list("")).contains(XWALK_PAK_NAME);
 
         HashMap<String, ResourceEntry> resourceList = new HashMap<String, ResourceEntry>();
-        if (isSharedMode || isTestApk) {
-            for (String resource : MANDATORY_PAKS) {
+        try {
+            int resourceListId = getResourceId(context, XWALK_RESOURCES_LIST_RES_NAME, "array");
+            String[] crosswalkResources = context.getResources().getStringArray(resourceListId);
+            for (String resource : crosswalkResources) {
                 resourceList.put(resource, new ResourceEntry(0, "", resource));
             }
-        } else {
-            int resourceListId = getResourceId(context, XWALK_RESOURCES_LIST_RES_NAME, "array");
-            try {
-                final String[] crosswalkResources = context.getResources().getStringArray(resourceListId);
-                for (String resource : crosswalkResources) {
-                    resourceList.put(resource, new ResourceEntry(0, "", resource));
-                }
-            } catch (NotFoundException e) {
-                Assert.fail("R.array." + XWALK_RESOURCES_LIST_RES_NAME + " can't be found.");
+        } catch (NotFoundException e) {
+            for (String resource : MANDATORY_PAKS) {
+                resourceList.put(resource, new ResourceEntry(0, "", resource));
             }
         }
         ResourceExtractor.setResourcesToExtract(
@@ -248,8 +250,12 @@ class XWalkViewDelegate {
                     String resourceName = resource.split("\\.")[0];
                     int resourceId = getResourceId(context, resourceName, "raw");
                     try {
-                        return context.getResources().openRawResource(resourceId);
-                    } catch (NotFoundException e) {
+                        try {
+                            return context.getResources().openRawResource(resourceId);
+                        } catch (NotFoundException e) {
+                            return new FileInputStream(new File(XWALK_LIB_DIR, resource));
+                        }
+                    } catch (FileNotFoundException e) {
                         Assert.fail("R.raw." + resourceName + " can't be found.");
                     }
                 }


### PR DESCRIPTION
Please find intent to implement @ https://lists.crosswalk-project.org/pipermail/crosswalk-dev/2015-October/003133.html

This PR contains the basic silent download mode implementation.

1) The runtime APK will be downloaded in the background silently without any user interaction.
2) The essential ingredients (libxwalkcore.so, classes.dex, icudtl.dat and xwalk.pak) will be extracted from the downloaded APK and saved to application's private storage.
3) Download mode will be working exclusively, that is, at the first launch, even if the runtime APK had been installed on the device, it still requests to download the dedicated runtime APK and only load the core libraries from that APK

BUG=XWALK-5121