### PR TITLE
Disable webcl

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -27,7 +27,7 @@ ozone_wayland_rev = '1cde4077b26fb5cbb2661b465b496550a587df55'
 # the blink-crosswalk repository, so that the devtools code can use it to fetch
 # assets from Chromium's servers with a revision that exists there. We need an
 # SVN revision while Blink is still in SVN.
-blink_crosswalk_rev = '0b35e0428e424d451a8c02e8910aca574c692998'
+blink_crosswalk_rev = '05218bd38fe66989b8e39856ce0c223e098143ea'
 blink_upstream_rev = '200670'
 
 crosswalk_git = 'https://github.com/crosswalk-project'

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -380,6 +380,8 @@ if __name__ == '__main__':
     args.append('-Duse_optimize_for_size_compile_option=1')
     # Disable notifications by default
     args.append('-Ddisable_notifications=1')
+    # Disable WebCL by default
+    args.append('-Denable_webcl=1')
 
   if not use_analyzer:
     print 'Updating projects from gyp files...'
@@ -387,15 +389,19 @@ if __name__ == '__main__':
 
   disable_speech = 0
   disable_notifications = 0
+  disable_webcl = 0
   for arg in args:
     if arg == '-Ddisable_speech=1':
       disable_speech = 1
     elif arg == '-Ddisable_notifications=1':
       disable_notifications = 1
+    elif arg == '-Denable_webcl=0':
+      disable_webcl = 1
 
   # Synthesize modules.gypi in WebKit to exclude disabled idl files
   from modules_gypi_generator import  generate_modules_gypi
-  generate_modules_gypi(disable_speech, disable_notifications)
+  modules_flags = (disable_speech, disable_notifications, disable_webcl)
+  generate_modules_gypi(*modules_flags)
 
   # Off we go...
   gyp_rc = gyp.main(args)


### PR DESCRIPTION
    To disable WebCL    
    Leverage existing flag "enable_webcl" to disable functions and exclude
    related code in Blink.    
    Reduced size = 44K