### PR TITLE
Fix flakiness when building the .NET extensions tests

### DIFF
--- a/extensions/dotnet_extension_sample.gyp
+++ b/extensions/dotnet_extension_sample.gyp
@@ -644,10 +644,10 @@
       ],
     },
     {
-      'target_name': 'create_dir_with_multiple_extensions',
+      'target_name': 'copy_echo_extension2_bridge',
       'type': 'none',
       'dependencies': [
-        'dotnet_echo_extension1',
+        'copy_echo_extension1_bridge',
         'dotnet_echo_extension2',
       ],
       'actions': [
@@ -655,6 +655,9 @@
           'action_name': 'copy_echo_extension2_bridge',
           'inputs': [
             '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+          ],
+          'dependencies': [
+            'copy_echo_extension1_bridge',
           ],
           'outputs': [
             'echo_extension2_bridge.dll',
@@ -667,6 +670,15 @@
                       '--output-file', 'echo_extension2_bridge.dll',
           ],
         },
+      ],
+     },
+     {
+      'target_name': 'copy_echo_extension1_bridge',
+      'type': 'none',
+      'dependencies': [
+        'dotnet_echo_extension1',
+      ],
+      'actions': [
         {
           'action_name': 'copy_echo_extension1_bridge',
           'inputs': [

--- a/extensions/extensions_tests.gyp
+++ b/extensions/extensions_tests.gyp
@@ -78,6 +78,7 @@
             '../xwalk.gyp:xwalk_runtime',
             'dotnet_extension_sample.gyp:*',
             'extensions.gyp:xwalk_extensions',
+            '../dotnet/dotnet_bridge.gyp:dotnet_bridge',
           ],
           'defines': [
             'HAS_OUT_OF_PROC_TEST_RUNNER',
@@ -102,6 +103,7 @@
             '../xwalk.gyp:xwalk_runtime',
             'dotnet_extension_sample.gyp:*',
             'extensions.gyp:xwalk_extensions',
+            '../dotnet/dotnet_bridge.gyp:dotnet_bridge',
           ],
           'sources': [
             'test/win/xwalk_dotnet_extension_unittest.cc',


### PR DESCRIPTION
On a machine where ninja creates a lot of parrallel tasks we were
running in some build errors :
- The .NET extensions tests depends on the .NET bridge but it was
not listed as an explicit dependency.
- In the multiple extensions tests (where we have several extensions in
the same directory with multiple bridges) we were copying multiple times
the bridge and renaming it according to each extension in the directory.
We can't do these tasks in parallel because we copy then rename the bridge for
extension 1 and then in the same time we copy and rename the bridge
for extension 2. Turns out that the bridge file may be accessed by
both actions running in parrallel. We make it sequential : we copy
the bridge for extension 1, then rename it, then copy the bridge for
extension 2 and then rename it.