### PR TITLE
[Android] Add build target for XWalkRuntimeLibLzma.apk

### DIFF
--- a/build/android/lzma_compress.py
+++ b/build/android/lzma_compress.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# pylint: disable=F0401
+
+import optparse
+import os
+import shutil
+import sys
+import subprocess
+
+GYP_ANDROID_DIR = os.path.join(os.path.dirname(__file__),
+                               os.pardir, os.pardir, os.pardir,
+                               'build',
+                               'android',
+                               'gyp')
+sys.path.append(GYP_ANDROID_DIR)
+
+from util import build_utils
+
+
+def DoCompress(dest_path, sources):
+  build_utils.DeleteDirectory(dest_path)
+  build_utils.MakeDirectory(dest_path)
+
+  for source in sources:
+    shutil.copy(source, dest_path)
+    file_to_compress = os.path.join(dest_path, os.path.basename(source))
+    subprocess.check_call(['lzma', '-f', file_to_compress])
+
+
+def DoShowOutputNames(dest_path, sources):
+  for source in sources:
+    print('%s.lzma' % os.path.join(dest_path, os.path.basename(source)))
+
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option('--dest-path',
+                    help='Destination directory for compressed files')
+  parser.add_option('--mode', choices=('compress', 'show-output-names'),
+                    help='Whether to compress the files or show their '
+                    'compressed names')
+  parser.add_option('--sources', help='The list of files to be compressed')
+
+  options, _ = parser.parse_args(sys.argv)
+  sources = build_utils.ParseGypList(options.sources)
+
+  if options.mode == 'compress':
+    return DoCompress(options.dest_path, sources)
+  else:
+    return DoShowOutputNames(options.dest_path, sources)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -855,6 +855,7 @@
             'pack_xwalk_shared_library',
             'xwalk_core_library_documentation',
             'xwalk_runtime_lib_apk',
+            'xwalk_runtime_lib_lzma_apk',
             'xwalk_app_hello_world_apk',
             'xwalk_app_template',
             'xwalk_core_sample_apk',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -213,6 +213,23 @@
       'includes': ['../build/jni_generator.gypi'],
     },
     {
+      'target_name': 'xwalk_runtime_lib_lzma_apk',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_runtime_lib_apk'
+      ],
+      'variables': {
+        'apk_name': 'XWalkRuntimeLibLzma',
+        'java_in_dir': 'runtime/android/runtime_lib',
+        'resource_dir': 'runtime/android/runtime_lib/res',
+        'asset_location': '<(PRODUCT_DIR)/xwalk_runtime_lib_lzma/assets',
+        'app_manifest_version_name': '<(xwalk_version)',
+        'app_manifest_version_code': '<(xwalk_version_code)',
+        'is_test_apk': 1,
+      },
+      'includes': ['../build/java_apk.gypi'],
+    },
+    {
       'target_name': 'xwalk_runtime_lib_apk',
       'type': 'none',
       'dependencies': [
@@ -252,6 +269,47 @@
         'app_manifest_version_code': '<(xwalk_version_code)',
       },
       'includes': ['../build/java_apk.gypi'],
+      'actions': [
+        {
+          'action_name': 'runtime_lib_lzma',
+          'message': 'Compressing runtime APK assets with LZMA',
+          'variables': {
+            # We have to use three separate variables because libxwalkcore.so
+            # in the <(stripped_libraries_dir) is not registered as an output
+            # in the build system, so we cannot use it as an input for the
+            # action. Instead, we use the stamp file produced by
+            # strip_native_libraries.gypi and pass the library as an input only
+            # to the lzma_compress.py script.
+            'base_inputs': [
+              '<(dex_path)',
+              '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/xwalk.pak',
+              '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/icudtl.dat',
+            ],
+            'build_system_inputs': [
+              '<@(base_inputs)',
+              '<(strip_stamp)',
+            ],
+            'lzma_compress_inputs': [
+              '<@(base_inputs)',
+              '<(stripped_libraries_dir)/libxwalkcore.so',
+            ],
+            'assets_dir': '<(PRODUCT_DIR)/xwalk_runtime_lib_lzma/assets',
+          },
+          'inputs': [
+            '<@(build_system_inputs)',
+          ],
+          'outputs': [
+            "<!@(['python', 'build/android/lzma_compress.py', '--mode=show-output-names', \
+                  '--sources=<(lzma_compress_inputs)', '--dest-path=<(assets_dir)'])",
+          ],
+          'action': [
+            'python', 'build/android/lzma_compress.py',
+            '--mode=compress',
+            '--dest-path=<(assets_dir)',
+            '--sources=<(lzma_compress_inputs)',
+          ],
+        },
+      ],
     },
     {
       'target_name': 'xwalk_runtime_lib_apk_pak',


### PR DESCRIPTION
This runtime APK is used in silent download mode and the size is
significantly reduced by using LZMA compression to compress the
key components of the runtime APK.

We put the compressed ingredients to assets and then package them as
an APK, this is intented to utilize the APK integrity/signature
check for security concern.

This is a partial implementation for XWALK-5214