### PR TITLE
crosswalk-16: Fix issue in coverity : Uninitialized pointer field in XWalkExternalExtension.

### DIFF
--- a/extensions/common/xwalk_external_extension.cc
+++ b/extensions/common/xwalk_external_extension.cc
@@ -23,6 +23,7 @@ XWalkExternalExtension::XWalkExternalExtension(const base::FilePath& path)
       shutdown_callback_(NULL),
       handle_msg_callback_(NULL),
       handle_sync_msg_callback_(NULL),
+      handle_binary_msg_callback_(NULL),
       initialized_(false),
       library_path_(path) {
 }


### PR DESCRIPTION
Make sure the constructor gives a NULL value.

(cherry picked from commit 84cf207b398be9bb5ff8044b465fda7746fef85a)