### PR TITLE
Fixed the fail to build issue on Android.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -322,6 +322,8 @@
             'experimental/native_file_system/virtual_root_provider_android.cc',
           ],
           'sources!':[
+            'runtime/browser/devtools/xwalk_devtools_frontend.cc',
+            'runtime/browser/devtools/xwalk_devtools_frontend.h',
             'runtime/browser/runtime_ui_delegate_desktop.cc',
             'runtime/browser/runtime_ui_delegate_desktop.h',
             'runtime/browser/ui/desktop/download_views.cc',


### PR DESCRIPTION
In runtime/browser/devtools/xwalk_devtools_frontend.h/.cc, the class
xwalk::NativeAppWindowDesktop is needed, but the source files of this
class's implementation at:
runtime/browser/ui/native_app_window_desktop.h/.cc are excluded within
Android build. As XWalkDevToolsFrontend is not needed for Android
platform for now, we'd better exclude its source files for Android
build as well.