### PR TITLE
[Android]Fix the issue that 'File chooser' does not assume device lan…

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1165,7 +1165,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
 
         Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
         chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
-        chooserIntent.putExtra(Intent.EXTRA_TITLE, "Choose an action");
         chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS,
                 extraIntents.toArray(new Intent[] { }));
         getActivity().startActivityForResult(chooserIntent, INPUT_FILE_REQUEST_CODE);


### PR DESCRIPTION
…guage settings

As the default ChooserActivity will get default title from
internal resource, which includes all languages' string, there
is no need to set the chooser intent title.

BUG=XWALK-5178

(cherry picked from commit 8d00de878ebe25c868f7afb28d8d7526c56f5be6)