### PR TITLE
[Tools] Stop reimplementing Touch() in different scripts.

### DIFF
--- a/build/android/generate_resource_map.py
+++ b/build/android/generate_resource_map.py
@@ -10,6 +10,15 @@ import re
 import shutil
 import sys
 
+GYP_ANDROID_DIR = os.path.join(os.path.dirname(__file__),
+                               os.pardir, os.pardir, os.pardir,
+                               'build',
+                               'android',
+                               'gyp')
+sys.path.append(GYP_ANDROID_DIR)
+
+from util import build_utils
+
 
 def CreateResourceMap(r_java, res_map):
   package_regex = re.compile('^package ([a-zA-Z0-9_\.]*);$')
@@ -26,15 +35,6 @@ def CreateResourceMap(r_java, res_map):
     os.makedirs(output_path)
   with open(os.path.join(output_path, 'R.java'), 'w') as output:
     output.write(''.join(output_content))
-
-
-def Touch(stamp):
-  if not stamp:
-    return
-  if not os.path.isdir(os.path.dirname(stamp)):
-    os.makedirs(os.path.dirname(stamp))
-  with open(stamp, 'a'):
-    os.utime(stamp, None)
 
 
 def main():
@@ -62,7 +62,7 @@ def main():
       r_java = os.path.join(root, 'R.java')
       CreateResourceMap(r_java, options.resource_map_dir)
 
-  Touch(options.stamp)
+  build_utils.Touch(options.stamp)
 
 
 if __name__ == '__main__':

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -15,6 +15,16 @@ from java_class import JavaClassLoader
 from string import Template
 from wrapper_generator import WrapperGenerator
 
+GYP_ANDROID_DIR = os.path.join(os.path.dirname(__file__),
+                               os.pardir, os.pardir, os.pardir,
+                               'build',
+                               'android',
+                               'gyp')
+sys.path.append(GYP_ANDROID_DIR)
+
+from util import build_utils
+
+
 # Classes list that have to generate bridge and wrap code.
 CLASSES_TO_BE_PROCESS = [
     'XWalkCookieManagerInternal',
@@ -45,6 +55,7 @@ BRIDGE_PACKAGE = 'org.xwalk.core.internal'
 
 bridge_path = ''
 wrapper_path = ''
+
 
 def PerformSerialize(output_path, generator):
   file_name = generator.GetGeneratedClassFileName()
@@ -103,13 +114,6 @@ def GenerateJavaTemplateClass(template_dir,
     f.write(template.substitute(value))
 
 
-def Touch(path):
-  if not os.path.isdir(os.path.dirname(path)):
-    os.makedirs(os.path.dirname(path))
-  with open(path, 'a'):
-    os.utime(path, None)
-
-
 def main(argv):
   usage = """Usage: %prog [OPTIONS]
 This script can generate bridge and wrap source files for given directory.
@@ -165,7 +169,7 @@ This script can generate bridge and wrap source files for given directory.
         options.api_version, options.min_api_version, options.verify_xwalk_apk)
 
   if options.stamp:
-    Touch(options.stamp)
+    build_utils.Touch(options.stamp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Remove the implementations of `Touch()` that we have in our scripts and
use the one from the `build_utils` module instead.