### PR TITLE
[Android] Only merge JARs which we have built ourselves.

### DIFF
--- a/build/android/merge_jars.py
+++ b/build/android/merge_jars.py
@@ -5,6 +5,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+"""
+Given a list of JAR files passed via --jars, produced one single JAR file with
+all their contents merged. JAR files outside --build-dir are ignored.
+"""
+
 import optparse
 import os
 import sys
@@ -22,15 +27,21 @@ from util import build_utils
 
 def main():
   parser = optparse.OptionParser()
+  parser.add_option('--build-dir',
+                    help='Base build directory, such as out/Release. JARs '
+                    'outside this directory will be skipped.')
   parser.add_option('--jars', help='The jars to merge.')
-  parser.add_option('--jar-path', help='The output merged jar file.')
+  parser.add_option('--output-jar', help='Name of the merged JAR file.')
 
   options, _ = parser.parse_args()
+  build_dir = os.path.abspath(options.build_dir)
 
   with build_utils.TempDir() as temp_dir:
     for jar_file in build_utils.ParseGypList(options.jars):
+      if not os.path.abspath(jar_file).startswith(build_dir):
+        continue
       build_utils.ExtractAll(jar_file, path=temp_dir, pattern='*.class')
-    jar.JarDirectory(temp_dir, [], options.jar_path)
+    jar.JarDirectory(temp_dir, [], options.output_jar)
 
 
 if __name__ == '__main__':

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -219,8 +219,9 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
+            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
-            '--jar-path=<(jar_final_path)',
+            '--output-jar=<(jar_final_path)',
           ],
         },
       ],
@@ -248,8 +249,9 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
+            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
-            '--jar-path=<(jar_final_path)',
+            '--output-jar=<(jar_final_path)',
           ],
         },
       ],
@@ -278,8 +280,9 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
+            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
-            '--jar-path=<(jar_final_path)',
+            '--output-jar=<(jar_final_path)',
           ],
         },
       ],


### PR DESCRIPTION
Add a new parameter to merge_jars.py, --build-dir, and exclude JAR files
which lie outside this directory from merging.

The immediate effect is that android-support-v13.jar will not be part of
xwalk_core_library.jar anymore. The dependency on
org.apache.http.legacy.jar was already dropped with chromium-crosswalk
commit 5909ede ("[Android] Stop using org.apache.http classes in
AccessibilityInjector").

We should not bundle android-support-v13.jar in xwalk_core_library.jar,
as it can cause build problems for users of the embedding API that also
pull the same package themselves or via another dependency. Gradle, for
example, produces the following error message:

```
UNEXPECTED TOP-LEVEL EXCEPTION:
com.android.dex.DexException: Multiple dex files define Landroid/support/annotation/AnimRes;
	at com.android.dx.merge.DexMerger.readSortableTypes(DexMerger.java:596)
	at com.android.dx.merge.DexMerger.getSortedTypes(DexMerger.java:554)
	at com.android.dx.merge.DexMerger.mergeClassDefs(DexMerger.java:535)
	at com.android.dx.merge.DexMerger.mergeDexes(DexMerger.java:171)
	at com.android.dx.merge.DexMerger.merge(DexMerger.java:189)
	at com.android.dx.command.dexer.Main.mergeLibraryDexBuffers(Main.java:454)
	at com.android.dx.command.dexer.Main.runMonoDex(Main.java:303)
	at com.android.dx.command.dexer.Main.run(Main.java:246)
	at com.android.dx.command.dexer.Main.main(Main.java:215)
	at com.android.dx.command.Main.main(Main.java:106)
```

BackgroundSyncLauncherService in content/ is currently the only class
part of Crosswalk's build that depends on android-support-v13.jar
because it uses android.support.v4 API (which is bundled in the
support-v13 JAR).

Users of the embedding API must now depend on at least
android-support-v4.jar themselves. It appears to be done by default for
new applications in both Eclipse and Android Studio. We may need to
update our documentation and make the dependency explicit in Maven as
well as cordova-plugin-crosswalk-webview.

Related to: XWALK-5092