### PR TITLE
[Android] crosswalk-15:Backport patch to obtain image taken from Camera on Android M

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -654,7 +654,9 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
 
             // Check that the response is a good one
             if(Activity.RESULT_OK == resultCode) {
-                if(data == null) {
+                // In Android M, camera results return an empty Intent rather than null.
+                if(data == null ||
+                        (data.getAction() == null && data.getData() == null)) {
                     // If there is not data, then we may have taken a photo
                     if(mCameraPhotoPath != null) {
                         results = Uri.parse(mCameraPhotoPath);


### PR DESCRIPTION
Android M return an empty Intent rather than a null intent to onActivityResult
from camera activity; updated the function to check for an empty Intent
if the intent is not null.

BUG=XWALK-5076

(cherry picked from commit 894f3e5bdca5174af3b078c4da6987b10fdba9f2)