### PR TITLE
[Android] Fix javadoc build after 8705e628.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -50,7 +50,7 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  * &lt;/application&gt;
  * </pre>
  *
- * <p>To download the Crosswalk runtime APK for the specified CPU architecture, <code>xwalk_apk_url<code>
+ * <p>To download the Crosswalk runtime APK for the specified CPU architecture, <code>xwalk_apk_url</code>
  * will be appended with a query string named "?arch=CPU_ABI" when the download request is sent to server,
  * then server can send back the APK which is exactly built for the specified CPU architecture. The CPU_ABI
  * here is exactly same as the value returned from "getprop ro.product.cpu.abi".</p>


### PR DESCRIPTION
Commit 8705e6288cbdf8a93da42a181749e6c5859b8064 ("[Android] Support
XWalkRuntimeLib.apk download for multiple architectures") broke the
build:

```
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java:53: error: end tag missing: </code>
 * <p>To download the Crosswalk runtime APK for the specified CPU architecture, <code>xwalk_apk_url<code>
                                                                                                   ^
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java:53: error: end tag missing: </code>
 * <p>To download the Crosswalk runtime APK for the specified CPU architecture, <code>xwalk_apk_url<code>
                                                                                ^
```