### PR TITLE
[Lite] Maintain gyp_xwalk

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -27,7 +27,7 @@ ozone_wayland_rev = '1cde4077b26fb5cbb2661b465b496550a587df55'
 # the blink-crosswalk repository, so that the devtools code can use it to fetch
 # assets from Chromium's servers with a revision that exists there. We need an
 # SVN revision while Blink is still in SVN.
-blink_crosswalk_rev = 'e11b129bc16580455ad298d20552b46c0599db28'
+blink_crosswalk_rev = 'ff0bfa42ad6c86bddbc7cad13c5aebe557a7f095'
 blink_upstream_rev = '200670'
 
 crosswalk_git = 'https://github.com/crosswalk-project'

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -46,7 +46,7 @@
         'defines': ['DISABLE_ACCESSIBILITY=1'],
       }],
 
-      ['disable_web_audio==1', {
+      ['disable_webaudio==1', {
         'defines': ['DISABLE_WEB_AUDIO=1'],
       }],
 

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -363,7 +363,7 @@ if __name__ == '__main__':
     # Disable Sync compositor by default
     args.append('-Ddisable_sync_compositor=1')
     # Disable webaudio by default
-    args.append('-Ddisable_web_audio=0')
+    args.append('-Ddisable_webaudio=0')
     args.append('-Ddisable_webaudio_hrtf=0')
     args.append('-Duse_openmax_dl_fft=1')
     # Enable use_minimum_resources by default
@@ -393,7 +393,7 @@ if __name__ == '__main__':
     # Disable webdatabase by default
     args.append('-Ddisable_webdatabase=1')
     # Disable webmidi by default
-    args.append('-Ddisable_webmidi=1')
+    args.append('-Ddisable_webmidi=0')
 
   if not use_analyzer:
     print 'Updating projects from gyp files...'
@@ -405,6 +405,7 @@ if __name__ == '__main__':
   disable_indexeddb = 0
   disable_notifications = 0
   disable_speech = 0
+  disable_webaudio = 0
   disable_webcl = 0
   disable_webdatabase = 0
   disable_webmidi = 0
@@ -425,6 +426,8 @@ if __name__ == '__main__':
       disable_webcl = 1
     elif arg == '-Ddisable_webdatabase=1':
       disable_webdatabase = 1
+    elif arg == '-Ddisable_webaudio=1':
+      disable_webaudio = 1
     elif arg == '-Ddisable_webmidi=1':
       disable_webmidi = 1
 
@@ -433,7 +436,8 @@ if __name__ == '__main__':
 
   modules_flags = (disable_accessibility, disable_bluetooth, disable_geo_features,\
                    disable_indexeddb, disable_notifications, disable_speech,\
-                   disable_webcl, disable_webdatabase, disable_webmidi)
+                   disable_webaudio, disable_webcl, disable_webdatabase,\
+                   disable_webmidi)
 
   generate_modules_gypi(modules_flags)
 


### PR DESCRIPTION
(1) to support to exclude WebAudio related code in Blink.
(2) Enable 'WebMIDI' by default due to the bug in disabling patch.

Roll DEPS.xwalk
Blink-Crosswalk:
742cd913572586a2ecb3f142f41931692c8e233e
    To exclude code of WebAudio in Blink