### PR TITLE
[Android] Fixed the fail to link issue when building Debug build.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -371,6 +371,8 @@
             'experimental/native_file_system/virtual_root_provider_android.cc',
           ],
           'sources!':[
+            'runtime/browser/devtools/xwalk_devtools_frontend.cc',
+            'runtime/browser/devtools/xwalk_devtools_frontend.h',
             'runtime/browser/runtime_ui_delegate_desktop.cc',
             'runtime/browser/runtime_ui_delegate_desktop.h',
             'runtime/browser/ui/desktop/download_views.cc',


### PR DESCRIPTION
In runtime/browser/devtools/xwalk_devtools_frontend.h/.cc, the class
xwalk::NativeAppWindowDesktop is needed, but the source files of this
class's implementation at:
runtime/browser/ui/native_app_window_desktop.h/.cc are excluded within
Android build. As XWalkDevToolsFrontend is not needed for Android
platform for now, this fix exclude its source files for Android
build as well to make the linking pass.

This issue is brought by patch 1d1067e1 which hasn't excluded all of the
unnecessary source files for Debug build.

Error log is posted below:

[307/436] SOLINK lib/libxwalkcore.so
FAILED: if [ ! -e lib/libxwalkcore.so -o ! -e lib/libxwalkcore.so.TOC ]; then /home/jonathan/projects/crosswalk/crosswalk-android/src/third_party/android_tools/ndk//toolchains/x86-4.9/prebuilt/linux-x86_64/bin/i686-linux-android-g++ -shared -Wl,-z,now -Wl,-z,relro -Wl,--fatal-warnings -Wl,-z,defs -Wl,-z,noexecstack -fPIC -Wl,--no-fatal-warnings -m32 -fuse-ld=gold -Wl,--build-id=sha1 -Wl,--no-undefined --sysroot=../../third_party/android_tools/ndk//platforms/android-16/arch-x86 -nostdlib -L../../third_party/android_tools/ndk//sources/cxx-stl/llvm-libc++/libs/x86 -Wl,--exclude-libs=libgcc.a -Wl,--exclude-libs=libc++_static.a -Wl,--exclude-libs=libcommon_audio.a -Wl,--exclude-libs=libcommon_audio_neon.a -Wl,--exclude-libs=libcommon_audio_sse2.a -Wl,--exclude-libs=libiSACFix.a -Wl,--exclude-libs=libisac_neon.a -Wl,--exclude-libs=libopus.a -Wl,--exclude-libs=libvpx.a -Wl,-shared,-Bsymbolic ../../third_party/android_tools/ndk//platforms/android-16/arch-x86/usr/lib/crtbegin_so.o -Wl,--version-script=/home/jonathan/projects/crosswalk/crosswalk-android/src/build/android/android_no_jni_exports.lst -Wl,--warn-shared-textrel -Wl,-O1 -Wl,--as-needed -o lib/libxwalkcore.so -Wl,-soname=libxwalkcore.so @lib/libxwalkcore.so.rsp && { readelf -d lib/libxwalkcore.so | grep SONAME ; nm -gD -f p lib/libxwalkcore.so | cut -f1-2 -d' '; } > lib/libxwalkcore.so.TOC; else /home/jonathan/projects/crosswalk/crosswalk-android/src/third_party/android_tools/ndk//toolchains/x86-4.9/prebuilt/linux-x86_64/bin/i686-linux-android-g++ -shared -Wl,-z,now -Wl,-z,relro -Wl,--fatal-warnings -Wl,-z,defs -Wl,-z,noexecstack -fPIC -Wl,--no-fatal-warnings -m32 -fuse-ld=gold -Wl,--build-id=sha1 -Wl,--no-undefined --sysroot=../../third_party/android_tools/ndk//platforms/android-16/arch-x86 -nostdlib -L../../third_party/android_tools/ndk//sources/cxx-stl/llvm-libc++/libs/x86 -Wl,--exclude-libs=libgcc.a -Wl,--exclude-libs=libc++_static.a -Wl,--exclude-libs=libcommon_audio.a -Wl,--exclude-libs=libcommon_audio_neon.a -Wl,--exclude-libs=libcommon_audio_sse2.a -Wl,--exclude-libs=libiSACFix.a -Wl,--exclude-libs=libisac_neon.a -Wl,--exclude-libs=libopus.a -Wl,--exclude-libs=libvpx.a -Wl,-shared,-Bsymbolic ../../third_party/android_tools/ndk//platforms/android-16/arch-x86/usr/lib/crtbegin_so.o -Wl,--version-script=/home/jonathan/projects/crosswalk/crosswalk-android/src/build/android/android_no_jni_exports.lst -Wl,--warn-shared-textrel -Wl,-O1 -Wl,--as-needed -o lib/libxwalkcore.so -Wl,-soname=libxwalkcore.so @lib/libxwalkcore.so.rsp && { readelf -d lib/libxwalkcore.so | grep SONAME ; nm -gD -f p lib/libxwalkcore.so | cut -f1-2 -d' '; } > lib/libxwalkcore.so.tmp && if ! cmp -s lib/libxwalkcore.so.tmp lib/libxwalkcore.so.TOC; then mv lib/libxwalkcore.so.tmp lib/libxwalkcore.so.TOC ; fi; fi
../../xwalk/runtime/browser/devtools/xwalk_devtools_frontend.cc:122: error: undefined reference to 'xwalk::NativeAppWindowDesktop::FocusContent()'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.

(cherry picked from commit 4023935f099327bb0b3eba3550d86e01e6ca87ad)