### PR TITLE
Keep single instance of ApplicationDataCache

### DIFF
--- a/application/browser/application_protocols.h
+++ b/application/browser/application_protocols.h
@@ -5,18 +5,36 @@
 #ifndef XWALK_APPLICATION_BROWSER_APPLICATION_PROTOCOLS_H_
 #define XWALK_APPLICATION_BROWSER_APPLICATION_PROTOCOLS_H_
 
+#include <string>
+
 #include "base/memory/linked_ptr.h"
 #include "net/url_request/url_request_job_factory.h"
-#include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/browser/application_service.h"
 
 namespace xwalk {
 namespace application {
 
-class ApplicationService;
+// This class is a thread-safe cache of active application's data.
+// This class is used by ApplicationProtocolHandler as it lives on IO thread
+// and hence cannot access ApplicationService directly.
+class ApplicationDataCache : public ApplicationService::Observer {
+ public:
+  scoped_refptr<ApplicationData> GetApplicationData(
+      const std::string& application_id) const;
+  ApplicationDataCache();
+  ~ApplicationDataCache() override;
+
+ private:
+  void DidLaunchApplication(Application* app) override;
+  void WillDestroyApplication(Application* app) override;
+
+  ApplicationData::ApplicationDataMap cache_;
+  mutable base::Lock lock_;
+};
 
 // Creates the handlers for the app:// scheme.
 linked_ptr<net::URLRequestJobFactory::ProtocolHandler>
-CreateApplicationProtocolHandler(ApplicationService* service);
+CreateApplicationProtocolHandler(ApplicationDataCache* cache);
 
 }  // namespace application
 }  // namespace xwalk

--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -25,10 +25,6 @@
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/content_switches.h"
-#include "xwalk/application/browser/application.h"
-#include "xwalk/application/browser/application_protocols.h"
-#include "xwalk/application/browser/application_service.h"
-#include "xwalk/application/browser/application_system.h"
 #include "xwalk/application/common/constants.h"
 #include "xwalk/runtime/browser/runtime_download_manager_delegate.h"
 #include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
@@ -259,14 +255,6 @@ net::URLRequestContextGetter* XWalkBrowserContext::CreateRequestContext(
     content::ProtocolHandlerMap* protocol_handlers,
     content::URLRequestInterceptorScopedVector request_interceptors) {
   DCHECK(!url_request_getter_.get());
-
-  application::ApplicationService* service =
-      XWalkRunner::GetInstance()->app_system()->application_service();
-  protocol_handlers->insert(std::pair<std::string,
-        linked_ptr<net::URLRequestJobFactory::ProtocolHandler> >(
-          application::kApplicationScheme,
-          application::CreateApplicationProtocolHandler(service)));
-
   url_request_getter_ = new RuntimeURLRequestContextGetter(
       false, /* ignore_certificate_error = false */
       GetPath(),
@@ -290,13 +278,6 @@ net::URLRequestContextGetter*
     context_getters_.find(partition_path.value());
   if (iter != context_getters_.end())
     return iter->second.get();
-
-  application::ApplicationService* service =
-      XWalkRunner::GetInstance()->app_system()->application_service();
-  protocol_handlers->insert(std::pair<std::string,
-        linked_ptr<net::URLRequestJobFactory::ProtocolHandler> >(
-          application::kApplicationScheme,
-          application::CreateApplicationProtocolHandler(service)));
 
   scoped_refptr<RuntimeURLRequestContextGetter>
   context_getter = new RuntimeURLRequestContextGetter(

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -34,6 +34,10 @@ class XWalkBrowserContext;
 class XWalkBrowserMainParts;
 class XWalkRunner;
 
+namespace application {
+class ApplicationDataCache;
+}
+
 class XWalkContentBrowserClient : public content::ContentBrowserClient {
  public:
   static XWalkContentBrowserClient* Get();
@@ -174,7 +178,7 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
 
   XWalkBrowserMainParts* main_parts_;
   XWalkBrowserContext* browser_context_;
-
+  scoped_ptr<application::ApplicationDataCache> app_data_cache_;
   scoped_ptr<RuntimeResourceDispatcherHostDelegate>
       resource_dispatcher_host_delegate_;
 


### PR DESCRIPTION
Rationals:
- The ApplicationDataCache is supposed to be shared.
- This avoids crashes on exit if there are WebConents instances apart from Application (like it happens during presentation sessions)