### PR TITLE
[Android] Support theme color at task switcher on Lollipop+(5.0+)

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -86,6 +86,7 @@ public class XWalkUIClientInternal {
     public void onDidChangeThemeColor(XWalkViewInternal view, int color) {
         if (view == null || view.getActivity() == null) return;
         ApiCompatibilityUtils.setStatusBarColor(view.getActivity().getWindow(),color);
+        ApiCompatibilityUtils.setTaskDescription(view.getActivity(), null, null, color);
     }
 
     /**


### PR DESCRIPTION
For Android version older than 5.0, this doesn't work.

BUG=XWALK-4305

(cherry picked from commit c6a8be02852b53b67538316ed2ef0c90890e749f)