### PR TITLE
[Android] Put the call to onPageFinished in message loop

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -66,7 +66,7 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
         @Override
         public void didStopLoading(String url) {
-            onPageFinished(url);
+            mCallbackHelper.postOnPageFinished(url);
         }
 
         @Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientCallbackHelper.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientCallbackHelper.java
@@ -72,6 +72,7 @@ class XWalkContentsClientCallbackHelper {
     private final static int MSG_ON_RECEIVED_LOGIN_REQUEST = 4;
     private final static int MSG_ON_RECEIVED_ERROR = 5;
     private final static int MSG_ON_RESOURCE_LOAD_STARTED = 6;
+    private final static int MSG_ON_PAGE_FINISHED = 7;
 
     private final XWalkContentsClient mContentsClient;
 
@@ -109,6 +110,11 @@ class XWalkContentsClientCallbackHelper {
                 case MSG_ON_RESOURCE_LOAD_STARTED: {
                     final String url = (String) msg.obj;
                     mContentsClient.onResourceLoadStarted(url);
+                    break;
+                }
+                case MSG_ON_PAGE_FINISHED: {
+                    final String url = (String) msg.obj;
+                    mContentsClient.onPageFinished(url);
                     break;
                 }
                 default:
@@ -149,5 +155,9 @@ class XWalkContentsClientCallbackHelper {
 
     public void postOnResourceLoadStarted(String url) {
         mHandler.sendMessage(mHandler.obtainMessage(MSG_ON_RESOURCE_LOAD_STARTED, url));
+    }
+
+    public void postOnPageFinished(String url) {
+        mHandler.sendMessage(mHandler.obtainMessage(MSG_ON_PAGE_FINISHED, url));
     }
 }


### PR DESCRIPTION
Originally, onPageFinished is invoked directly. In contrast,
onPageStarted is invoked through message loop. So the order of these two
methods maybe reversed.

BUG=XWALK-4849