### PR TITLE
[Lite] Disable Web MIDI API by default

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -27,7 +27,7 @@ ozone_wayland_rev = '1cde4077b26fb5cbb2661b465b496550a587df55'
 # the blink-crosswalk repository, so that the devtools code can use it to fetch
 # assets from Chromium's servers with a revision that exists there. We need an
 # SVN revision while Blink is still in SVN.
-blink_crosswalk_rev = 'eabe0b0fcb41cd8150b6399eccdf0ecdc42fd437'
+blink_crosswalk_rev = '2ab0104d03b22084968f658de34ef133bd3e8afc'
 blink_upstream_rev = '200670'
 
 crosswalk_git = 'https://github.com/crosswalk-project'

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -393,7 +393,7 @@ if __name__ == '__main__':
     # Disable Web Database by default
     args.append('-Ddisable_webdatabase=1')
     # Disable Web MIDI API by default
-    args.append('-Ddisable_webmidi=0')
+    args.append('-Ddisable_webmidi=1')
     # Disable Plugins by default
     args.append('-Denable_plugins=0')
 


### PR DESCRIPTION
Roll DEPS.xwalk
Blink-Crosswalk:
    977d6795ee1c9b208f30ca70f1196005c5e3e381
    To resolve build problem of disabling WebMIDI