### PR TITLE
[Windows] Build fix

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -256,6 +256,8 @@
         'runtime/browser/xwalk_platform_notification_service.h',
         'runtime/browser/xwalk_pref_store.cc',
         'runtime/browser/xwalk_pref_store.h',
+        'runtime/browser/xwalk_presentation_service_delegate_win.cc',
+        'runtime/browser/xwalk_presentation_service_delegate_win.h',
         'runtime/browser/xwalk_render_message_filter.cc',
         'runtime/browser/xwalk_render_message_filter.h',
         'runtime/browser/xwalk_runner.cc',
@@ -682,8 +684,6 @@
         ['OS=="win"', {
           'sources': [
             '../content/app/startup_helper_win.cc', # Needed by InitializedSandbox
-            'runtime/browser/xwalk_presentation_service_delegate_win.cc',
-            'runtime/browser/xwalk_presentation_service_delegate_win.h',
             'runtime/resources/xwalk.rc'
           ],
           'configurations': {


### PR DESCRIPTION
Fix Crosswalk on Windows build after e8ca4dfd65147a2474341426d448473696381b4c