### PR TITLE
[Android] Fix the issue of cordova 4.x app launch crash.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkAPI.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkAPI.java
@@ -9,7 +9,7 @@ public @interface XWalkAPI {
     boolean noInstance() default false;
     boolean isConst() default false;
     boolean delegate() default false;
-    boolean callSuper() default false;
+    boolean disableReflectMethod() default false;
     Class<?> extendClass() default Object.class;
     String[] preWrapperLines() default {};
     String[] postWrapperLines() default {};

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -878,6 +878,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         }
     }
 
+    // It is only used for SurfaceView.
     public void setVisibility(int visibility) {
         SurfaceView surfaceView = mContentViewRenderView.getSurfaceView();
         if (surfaceView == null) return;

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -25,6 +25,7 @@ import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.MotionEvent;
+import android.view.View;
 import android.webkit.ValueCallback;
 import android.widget.FrameLayout;
 
@@ -1088,10 +1089,21 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * @param visibility One of VISIBLE, INVISIBLE, or GONE.
      * @since 6.0
      */
-    @XWalkAPI(callSuper = true,
-              preWrapperLines = {"super.setVisibility(visibility);"})
+    @XWalkAPI(disableReflectMethod = true,
+              preWrapperLines = {
+                  "        if (visibility == View.INVISIBLE) visibility = View.GONE;",
+                  "        super.setVisibility(visibility);",
+                  "        setSurfaceViewVisibility(visibility);"})
     public void setVisibility(int visibility) {
-        super.setVisibility(visibility);
+    }
+
+    /**
+     * Set the enabled state of SurfaceView.
+     * @param visibility One of VISIBLE, INVISIBLE, or GONE.
+     * @since 6.0
+     */
+    @XWalkAPI(reservable = true)
+    public void setSurfaceViewVisibility(int visibility) {
         if (mContent == null) return;
         checkThreadSafety();
         mContent.setVisibility(visibility);

--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -118,7 +118,7 @@ class Method(object):
     self._is_static = is_static
     self._is_abstract = is_abstract
     self._is_delegate = False
-    self._call_super = False
+    self._disable_reflect_method = False
     self._method_name = method_name
     self._method_return = method_return
     self._params = OrderedDict() # Use OrderedDict to avoid parameter misorder.
@@ -173,8 +173,8 @@ class Method(object):
     return self._is_delegate
 
   @property
-  def call_super(self):
-    return self._call_super
+  def disable_reflect_method(self):
+    return self._disable_reflect_method
 
   @property
   def method_name(self):
@@ -226,14 +226,14 @@ class Method(object):
       elif delegate == 'false':
         self._is_delegate = False
 
-    call_super_re = re.compile('callSuper\s*=\s*'
-        '(?P<callSuper>(true|false))')
-    for match in re.finditer(call_super_re, annotation):
-      callsuper = match.group('callSuper')
-      if callsuper == 'true':
-        self._call_super = True
+    disable_reflect_method_re = re.compile('disableReflectMethod\s*=\s*'
+        '(?P<disableReflectMethod>(true|false))')
+    for match in re.finditer(disable_reflect_method_re, annotation):
+      disable_reflect_method = match.group('disableReflectMethod')
+      if disable_reflect_method == 'true':
+        self._disable_reflect_method = True
       else:
-        self._call_super = False
+        self._disable_reflect_method = False
 
     pre_wrapline_re = re.compile('preWrapperLines\s*=\s*\{\s*('
         '?P<pre_wrapline>(".*")(,\s*".*")*)\s*\}')
@@ -757,12 +757,11 @@ ${DOC}
         ${PRE_WRAP_LINES}
     }
 """)
-    elif self._call_super:
+    elif self._disable_reflect_method:
       template = Template("""\
 ${DOC}
     public ${RETURN_TYPE} ${NAME}(${PARAMS}) {
-        ${PRE_WRAP_LINES}
-        ${RETURN}${METHOD_DECLARE_NAME}.invoke(${PARAMS_PASSING});
+${PRE_WRAP_LINES}
     }
 """)
     else:


### PR DESCRIPTION
Provide a separate function for SurfaceView to set visibility.
Keep XWalkView.setVisibility() as an embedding API, the base class's
setVisibility will be called even if xwalk is not ready.
Mark "setSurfaceViewVisibility()" as reserved function to initial later.
In XWalkViewInternal.java, "setVisibility" is just an auxiliary function
to generate XWalkView.setVisibility().

BUG=XWALK-5700