### PR TITLE
crosswalk-16: Backport fixes for XWALK-5092.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'e23bfe20113b2ddeeb06ca75bfca263ab4336131'
+chromium_crosswalk_rev = '39190af3f7fab51baceaeb77365e3f3a2757661b'
 blink_crosswalk_rev = '16d1b69626699e9ca703e0c24c829e96d07fcd3e'
 v8_crosswalk_rev = '335bf02c0a6b9b0a2bd506d877e346e5c32e40cb'
 ozone_wayland_rev = 'd6ad1b8bb4e2c71427283ffc21ac8d66cb576730'

--- a/build/android/merge_jars.py
+++ b/build/android/merge_jars.py
@@ -5,6 +5,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+"""
+Given a list of JAR files passed via --jars, produced one single JAR file with
+all their contents merged. JAR files outside --build-dir are ignored.
+"""
+
 import optparse
 import os
 import sys
@@ -22,15 +27,21 @@ from util import build_utils
 
 def main():
   parser = optparse.OptionParser()
+  parser.add_option('--build-dir',
+                    help='Base build directory, such as out/Release. JARs '
+                    'outside this directory will be skipped.')
   parser.add_option('--jars', help='The jars to merge.')
-  parser.add_option('--jar-path', help='The output merged jar file.')
+  parser.add_option('--output-jar', help='Name of the merged JAR file.')
 
   options, _ = parser.parse_args()
+  build_dir = os.path.abspath(options.build_dir)
 
   with build_utils.TempDir() as temp_dir:
     for jar_file in build_utils.ParseGypList(options.jars):
+      if not os.path.abspath(jar_file).startswith(build_dir):
+        continue
       build_utils.ExtractAll(jar_file, path=temp_dir, pattern='*.class')
-    jar.JarDirectory(temp_dir, [], options.jar_path)
+    jar.JarDirectory(temp_dir, [], options.output_jar)
 
 
 if __name__ == '__main__':

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -219,8 +219,9 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
+            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
-            '--jar-path=<(jar_final_path)',
+            '--output-jar=<(jar_final_path)',
           ],
         },
       ],
@@ -248,8 +249,9 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
+            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
-            '--jar-path=<(jar_final_path)',
+            '--output-jar=<(jar_final_path)',
           ],
         },
       ],
@@ -278,8 +280,9 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
+            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
-            '--jar-path=<(jar_final_path)',
+            '--output-jar=<(jar_final_path)',
           ],
         },
       ],


### PR DESCRIPTION
The first commit rolls `DEPS.xwalk` after crosswalk-project/chromium-crosswalk#299. The second one backports #3350.

Related to: XWALK-5092