### PR TITLE
[Android] Fix the failed test case for database and domstorage.

### DIFF
--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/SetDatabaseEnabledTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/SetDatabaseEnabledTest.java
@@ -117,7 +117,9 @@ public class SetDatabaseEnabledTest extends XWalkViewInternalTestBase {
             // It seems accessing the database through a data scheme is not
             // supported, and fails with a DOM exception (likely a cross-domain
             // violation).
-            loadUrlSync(UrlUtils.getTestFileUrl("xwalkview/database_access.html"));
+            String path = "xwalk/test/android/data/device_files/database_access.html";
+            String url = UrlUtils.getIsolatedTestFileUrl(path);
+            loadUrlSync(url);
             assertEquals(
                 value == ENABLED ? HAS_DATABASE : NO_DATABASE,
                 getTitleOnUiThread());

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/SetDomStorageEnabledTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/SetDomStorageEnabledTest.java
@@ -107,8 +107,9 @@ public class SetDomStorageEnabledTest extends XWalkViewInternalTestBase {
         protected void doEnsureSettingHasValue(Boolean value) throws Throwable {
             // It is not permitted to access localStorage from data URLs in WebKit,
             // that is why a standalone page must be used.
-            loadUrlSyncByContent(mXWalkViewInternal, mHelperBridge,
-                    UrlUtils.getTestFileUrl("xwalkview/localStorage.html"));
+            String path = "xwalk/test/android/data/device_files/localStorage.html";
+            String url = UrlUtils.getIsolatedTestFileUrl(path);
+            loadUrlSyncByContent(mXWalkViewInternal, mHelperBridge, url);
             assertEquals(
                 value == ENABLED ? HAS_LOCAL_STORAGE : NO_LOCAL_STORAGE,
                         mHelperBridge.getChangedTitle());

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -709,6 +709,7 @@
         'apk_name': 'XWalkCoreInternalTest',
         'java_in_dir': 'test/android/core_internal/javatests',
         'is_test_apk': 1,
+        'isolate_file': 'xwalk_view_internal_test_apk.isolate',
         'additional_input_paths': [
           '<(PRODUCT_DIR)/xwalk_internal_xwview_test/assets/broadcast.html',
           '<(PRODUCT_DIR)/xwalk_internal_xwview_test/assets/echo_binary_java.html',

--- a/xwalk_view_internal_test_apk.isolate
+++ b/xwalk_view_internal_test_apk.isolate
@@ -1,0 +1,14 @@
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+{
+  'conditions': [
+    ['OS=="android"', {
+      'variables': {
+        'files': [
+          'test/android/data/device_files/',
+        ],
+      },
+    }],
+  ],
+}


### PR DESCRIPTION
Follow the upstream's change, convert the test to isolate. Please
refer to https://codereview.chromium.org/933593003.
Test case usage:
  ./build/android/test_runner.py instrumentation --release \
  --test-apk=XWalkCoreInternalTest --isolate-file-path \
  xwalk/xwalk_view_internal_test_apk.isolate

BUG=XWALK-5241