### PR TITLE
M46 Gardening : Fix failing tests where gc() in JavaScript was undefined

### DIFF
--- a/test/base/xwalk_test_launcher.cc
+++ b/test/base/xwalk_test_launcher.cc
@@ -16,12 +16,18 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/content_switches.h"
 #include "content/public/test/test_launcher.h"
+#include "v8/include/v8.h"
 #include "xwalk/runtime/app/xwalk_main_delegate.h"
 #include "xwalk/test/base/xwalk_test_suite.h"
 
 class XWalkTestLauncherDelegate : public content::TestLauncherDelegate {
  public:
-  XWalkTestLauncherDelegate() {}
+  XWalkTestLauncherDelegate() {
+    // Expose the garbage collector interface, so we can test the object
+    // lifecycle tracker interface.
+    std::string flags("--expose-gc");
+    v8::V8::SetFlagsFromString(flags.c_str(), static_cast<int>(flags.size()));
+  }
   ~XWalkTestLauncherDelegate() override {}
 
   int RunTestSuite(int argc, char** argv) override {
@@ -38,11 +44,6 @@ class XWalkTestLauncherDelegate : public content::TestLauncherDelegate {
          iter != switches.end(); ++iter) {
       new_command_line.AppendSwitchNative((*iter).first, (*iter).second);
     }
-
-    // Expose the garbage collector interface, so we can test the object
-    // lifecycle tracker interface.
-    new_command_line.AppendSwitchASCII(
-        switches::kJavaScriptFlags, "--expose-gc");
 
     *command_line = new_command_line;
     return true;


### PR DESCRIPTION
It turns out that the flags were not set in V8 so gc() was not exposed.
The reason why the flag was not set is because V8 initialization happens
before AdjustChildProcessCommandLine() in TestLauncherDelegate is called.
This behavior has slighty changed in M46. It turns out that we need to
set the flags in V8 before the Content delegate is created. In a normal
xwalk run this happens automatically for us : content will pull the command
line flags and pass them to V8. But in the tests the construction is more
convulated and the content delegate is created before
AdjustChildProcessCommandLine() is called and thus V8 is already set up.

As a verification the two other tests using gc() (and thus passing
--expose-gc to the JavaScript flags) are setting the flags before
ContentDelegate is created.

BUG=XWALK-5650