### PR TITLE
[Android] Enable scrollTo/By in XWalkView

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -664,6 +664,14 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         mContentView.setOnTouchListener(l);
     }
 
+    public void scrollTo(int x, int y) {
+        mContentView.scrollTo(x, y);
+    }
+
+    public void scrollBy(int x, int y) {
+        mContentView.scrollBy(x, y);
+    }
+
     //--------------------------------------------------------------------------------------------
     private class XWalkIoThreadClientImpl extends XWalkContentsIoThreadClient {
         // All methods are called on the IO thread.

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1335,4 +1335,16 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     public void setOnTouchListener(OnTouchListener l) {
         mContent.setOnTouchListener(l);
     }
+
+    @Override
+    @XWalkAPI
+    public void scrollTo(int x, int y) {
+        mContent.scrollTo(x, y);
+    }
+
+    @Override
+    @XWalkAPI
+    public void scrollBy(int x, int y) {
+        mContent.scrollBy(x, y);
+    }
 }


### PR DESCRIPTION
Delegate scrollTo and scrollBy methods to ContentView as the
actual scroll is done in native

BUG=XWALK-3112