### PR TITLE
Roll Chromium to 45.0.2454.101, the last M45 stable release.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,9 +17,8 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'a49762acd2ab1f2803c7bb8898f50d9109f3cb12'
-blink_crosswalk_rev = '16d1b69626699e9ca703e0c24c829e96d07fcd3e'
-v8_crosswalk_rev = 'ae54f41f099123b7315a4772334fcfc7bc9692a2'
+chromium_crosswalk_rev = '5ad5a1890643a7347e9bba34926e588b403b6fcf'
+v8_crosswalk_rev = '8621731320e822b50022a8de5edf4738a731bcf6'
 ozone_wayland_rev = 'd6ad1b8bb4e2c71427283ffc21ac8d66cb576730'
 
 crosswalk_git = 'https://github.com/crosswalk-project'
@@ -37,8 +36,6 @@ solutions = [
     'custom_deps': {
       'src':
         crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
-      'src/third_party/WebKit':
-        crosswalk_git + '/blink-crosswalk.git@' + blink_crosswalk_rev,
       'src/v8':
         crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
 
@@ -96,7 +93,7 @@ hooks = [
     'action': [
       'python',
       'src/build/util/lastchange.py',
-      '--git-svn-go-deeper',
+      '--git-hash-only',
       '--source-dir',
       'src/third_party/WebKit',
       '--output',

--- a/runtime/browser/blink_upstream_version.h.in
+++ b/runtime/browser/blink_upstream_version.h.in
@@ -2,8 +2,8 @@
 // Use of this source is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// upstream_blink_version.h is generated from upstream_blink_version.h.in.
-// It contains the latest upstream SVN revision present in the blink-crosswalk
+// upstream_blink_version.h is generated from upstream_blink_version.h.in. It
+// contains the latest upstream git revision present in the chromium-crosswalk
 // branch we are tracking. The information is obtained via DEPS.xwalk and the
 // lastchange.py script.
 

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -491,8 +491,8 @@
     },
     {
       # While we could just call lastchange.py here and generate the header
-      # directly, it would only work if there is a blink-crosswalk git checkout
-      # (ie. it does not work with a tarball, for example).
+      # directly, it would only work if there is a git checkout (ie. it does
+      # not work with a tarball, for example).
       'target_name': 'generate_upstream_blink_version',
       'type': 'none',
       'actions': [


### PR DESCRIPTION
The most notable change in this roll is that this upstream release was
made after Blink was merged into the Chromium git repository. It also
contains some security fixes, as described in the [release announcement](http://googlechromereleases.blogspot.com/2015/09/stable-channel-update_24.html).

We have inherited this change, and the blink-crosswalk repository is now
deprecated. People `gclient sync`'ing to this commit must pay attention to
gclient's output: the existing blink-crosswalk checkout in
`src/third_party/WebKit` will be moved automatically to a separate
location, and needs to be manually removed.

It is also likely that the `UPSTREAM.blink` file will contain the wrong
value the first time gclient sync is called, so people relying on it
should call gclient sync twice. Release builds are not affected because
they are made from scratch.

Related to: XWALK-5139
BUG=XWALK-5762