### PR TITLE
DEPS.xwalk: Re-roll v8-crosswalk.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -18,7 +18,7 @@
 # -----------------------------------
 
 chromium_crosswalk_rev = '5ad5a1890643a7347e9bba34926e588b403b6fcf'
-v8_crosswalk_rev = '8621731320e822b50022a8de5edf4738a731bcf6'
+v8_crosswalk_rev = '63a42b267e66f3b1e8ddceb23c906e62459f3460'
 ozone_wayland_rev = 'd6ad1b8bb4e2c71427283ffc21ac8d66cb576730'
 
 crosswalk_git = 'https://github.com/crosswalk-project'


### PR DESCRIPTION
Follow-up to 9d93b7d ("Roll Chromium to 45.0.2454.101, the last M45
stable release").

The original v8-crosswalk pushed with 45.0.2454.101 was faulty and
missing several commits (of our own, not upstream ones )which were
present when we were in .93.

v8-crosswalk's master branch has been re-pushed, and we need to use the
new hash.

Related to: XWALK-5762