### PR TITLE
[Windows] Fix crash/assert with inspector when launching with app:// …

### DIFF
--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -258,7 +258,8 @@ XWalkBrowserContext::GetURLRequestContextGetterById(
 net::URLRequestContextGetter* XWalkBrowserContext::CreateRequestContext(
     content::ProtocolHandlerMap* protocol_handlers,
     content::URLRequestInterceptorScopedVector request_interceptors) {
-  DCHECK(!url_request_getter_.get());
+  if (url_request_getter_)
+    return url_request_getter_.get();
 
   application::ApplicationService* service =
       XWalkRunner::GetInstance()->app_system()->application_service();
@@ -311,7 +312,7 @@ net::URLRequestContextGetter*
   // Make sure that the default url request getter has been initialized,
   // please refer to https://crosswalk-project.org/jira/browse/XWALK-2890
   // for more details.
-  if (!url_request_getter_.get())
+  if (!url_request_getter_)
     CreateRequestContext(protocol_handlers, request_interceptors.Pass());
 
   return context_getter.get();


### PR DESCRIPTION
…protocol.

When opening the inspector (after passing --enable-inspector)
in crosswalk while running an app with app:// protocol (so launched
with the manifest) an assert is triggered
XWalkBrowserContext::CreateRequestContext.

The reason for the ASSERT was perfectly valid before landing the
inspector support. If crosswalk would run anything but app://
an url_context_getter would be created from StoragePartitionImplMap.
If crosswalk would run with the app:// protocol, StoragePartitionImplMap
would call CreateRequestContextForStoragePartition rather than
CreateRequestContext because the partition_domain for app:// protocol
is not empty (see XWalkContentBrowserClient::GetStoragePartitionConfigForSite).

The problem is that
XWalkBrowserContext::CreateRequestContextForStoragePartition calls
CreateRequestContext which then will create the url_context_getter. That
is fine until we show the inspector. When showing it we're creating a
new Runtime() instance (but with the *same* context) and points
to another protocol than app:// therefore StoragePartitionImplMap will try
to create the context for the empty partition_domain but as we've created
already the url_context_getter the first time while creating the main
runtime instance (the one running the app) then it asserts.

In this case the fix is to return the current url_context_getter if there
is one.

BUG=None, I figured out the crash/assert while debbuging something else.