### PR TITLE
crosswalk-16: DEPS.xwalk: Roll chromium-crosswalk (6cba28a -> 45111a7)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '6cba28a2d157bdff10777d991ef796480219f5e1'
+chromium_crosswalk_rev = '45111a77fed0c90c45a1dcc23fdaa0a1c7def478'
 v8_crosswalk_rev = 'f9c7034dff7139f09c7fa5a663dd7052d09b2301'
 ozone_wayland_rev = 'd6ad1b8bb4e2c71427283ffc21ac8d66cb576730'
 


### PR DESCRIPTION
* 45111a7 [Backport] Use the latest hash with a commit position as webkit version

This backport ended up being left out of 27f3d70 ("Roll Chromium to
45.0.2454.101, the last M45 stable release"), and is required for
`UPSTREAM.blink` to have a correct value in a build (the version of
lastchange.py in M45 would just choose the tip of the tree of
chromium-crosswalk, which is usually a commit of our own).

BUG=XWALK-5762