### PR TITLE
[Android] Move extension registration to file system thread

### DIFF
--- a/extensions/browser/xwalk_extension_service.cc
+++ b/extensions/browser/xwalk_extension_service.cc
@@ -233,9 +233,10 @@ void XWalkExtensionService::OnRenderProcessHostCreatedInternal(
   if (!cmd_line->HasSwitch(switches::kXWalkDisableExtensionProcess)) {
     CreateExtensionProcessHost(host, data, runtime_variables.Pass());
   } else if (!external_extensions_path_.empty()) {
-    RegisterExternalExtensionsInDirectory(
+    BrowserThread::PostTask(BrowserThread::FILE, FROM_HERE, base::Bind(
+        base::IgnoreResult(&RegisterExternalExtensionsInDirectory),
         data->in_process_ui_thread_server(),
-        external_extensions_path_, runtime_variables.Pass());
+        external_extensions_path_, base::Passed(runtime_variables.Pass())));
   }
 
   extension_data_map_[host->GetID()] = data;


### PR DESCRIPTION
The registration of xwalk extension includes file system operations,
while being executed during loading URL which is under UI thread.
In debug mode, this will violate the thread retriction and cause the
app crash. So move this procedure to the thread that dedicates to
file system operation.

BUG=XWALK-5754