### PR TITLE
[Android] Remove unused code generated by disableReflectMethod

### DIFF
--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -853,7 +853,7 @@ ${DOC}
           self.GenerateWrapperStaticMethod(), """\
     private static ReflectMethod %s = new ReflectMethod(null, "%s");\n""" %
               (self._method_declare_name, self._method_name))
-    elif self._is_abstract or self._is_delegate:
+    elif self._is_abstract or self._is_delegate or self._disable_reflect_method:
       return self.GenerateWrapperBridgeMethod()
     else:
       return '%s\n%s\n' % (

--- a/tools/reflection_generator/wrapper_generator.py
+++ b/tools/reflection_generator/wrapper_generator.py
@@ -279,7 +279,8 @@ coreWrapper.getBridgeObject(constructorParams.get(i)));
     if (ref_methods_string != ''):
       ref_methods_string += "\n"
     for method in self._java_data.methods:
-      if method.is_constructor or method.is_static or method.is_abstract or method.is_delegate:
+      if method.is_constructor or method.is_static or method.is_abstract \
+        or method.is_delegate or method.disable_reflect_method:
         continue
       value = { 'METHOD_DECLARE_NAME': method._method_declare_name,
                 'METHOD': method.method_name,


### PR DESCRIPTION
The annotation field is used to generate methods without calling back to internal via reflection, so code like below is unused.

private ReflectMethod setUserXXX = new ReflectMethod(null, "setUserXXX");

BUG=XWALK-5792