### PR TITLE
[Android] Implement captureBitmapAsync to capture visible content

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkGetBitmapCallbackInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkGetBitmapCallbackInternal.java
@@ -1,0 +1,30 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+import android.graphics.Bitmap;
+
+/**
+ * A callback for content readback into a bitmap.
+ */
+@XWalkAPI(createExternally = true)
+public abstract class XWalkGetBitmapCallbackInternal {
+    /**
+     * Constructor for capture bitmap callback.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public XWalkGetBitmapCallbackInternal() {}
+
+    /**
+     * Called when the content readback finishes.
+     * @param bitmap The bitmap of the content. Null will be passed for
+     * readback failure.
+     * @param response 0 for success, others failure.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public abstract void onFinishGetBitmap(Bitmap bitmap, int response);
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -848,6 +848,18 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     }
 
     /**
+     * Capture a bitmap of visible content.
+     * @param XWalkGetBitmapCallbackInternal callback when bitmap capture is done.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void captureBitmapAsync(XWalkGetBitmapCallbackInternal callback) {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.captureBitmapAsync(callback);
+    }
+
+    /**
      * Get XWalkSettings
      * @return the XWalkSettings object.
      * @since 6.0

--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -462,7 +462,8 @@ class Method(object):
       return '%sMethod' % name
 
   def GenerateBridgeConstructor(self):
-    template = Template("""\
+    if (self._bridge_params_declare != ''):
+      template = Template("""\
     public ${NAME}(${PARAMS}, Object wrapper) {
         super(${PARAMS_PASSING});
 
@@ -470,11 +471,25 @@ class Method(object):
         reflectionInit();
     }
 
-""")
-    value = {'NAME': self._class_java_data.bridge_name,
-             'PARAMS': self._bridge_params_declare,
-             'PARAMS_PASSING': self._bridge_params_pass_to_super}
-    return template.substitute(value)
+    """)
+      value = {'NAME': self._class_java_data.bridge_name,
+               'PARAMS': self._bridge_params_declare,
+               'PARAMS_PASSING': self._bridge_params_pass_to_super}
+      return template.substitute(value)
+    else:
+      template = Template("""\
+    public ${NAME}(Object wrapper) {
+        super();
+
+        this.wrapper = wrapper;
+        reflectionInit();
+    }
+
+    """)
+      value = {'NAME': self._class_java_data.bridge_name,
+               'PARAMS': self._bridge_params_declare,
+               'PARAMS_PASSING': self._bridge_params_pass_to_super}
+      return template.substitute(value)
 
   def GenerateBridgeStaticMethod(self):
     template = Template("""\
@@ -665,8 +680,9 @@ ${PRE_WRAP_LINES}
     pre_wrap_string += "\n"
     pre_wrap_string += "        constructorParams = new ArrayList<Object>();\n"
     for param_name in self._wrapper_params_pass_to_bridge.split(', '):
-      param_name = param_name.replace('.getBridge()', '')
-      pre_wrap_string += "        constructorParams.add(%s);\n" % param_name
+      if (param_name != ''):
+        param_name = param_name.replace('.getBridge()', '')
+        pre_wrap_string += "        constructorParams.add(%s);\n" % param_name
 
     if (post_wrap_string != ''):
       pre_wrap_string += ("""

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -30,6 +30,7 @@ CLASSES_TO_BE_PROCESS = [
     'XWalkCookieManagerInternal',
     'XWalkDownloadListenerInternal',
     'XWalkExtensionInternal',
+    'XWalkGetBitmapCallbackInternal',
     'XWalkHttpAuthHandlerInternal',
     'XWalkViewInternal',
     'XWalkUIClientInternal',

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -24,6 +24,7 @@
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkCookieManager.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkDownloadListener.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkExtension.java',
+          '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkGetBitmapCallback.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkHttpAuthHandler.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkJavascriptResult.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkNativeExtensionLoader.java',


### PR DESCRIPTION
Use this to capture the visible content of web page. Note: XWalkGetBitmapCallback
happens at the same thread as captureBitmapAsync, usually the UI thread.
Also enable the zero parameter constructor support in reflection layer.

BUG=XWALK-5110,XWALK-2233

(cherry picked from commit 55eceb4d089e516ea2b754a61c942cf393841374)