### PR TITLE
[Android] Implement embedding API for support zoom and builtin zoom c…

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -199,6 +199,17 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         if (language.isEmpty()) language = "en";
         mSettings.setAcceptLanguages(language);
 
+        XWalkSettingsInternal.ZoomSupportChangeListener zoomListener =
+                new XWalkSettingsInternal.ZoomSupportChangeListener() {
+                    @Override
+                    public void onGestureZoomSupportChanged(
+                            boolean supportsDoubleTapZoom, boolean supportsMultiTouchZoom) {
+                        mContentViewCore.updateDoubleTapSupport(supportsDoubleTapZoom);
+                        mContentViewCore.updateMultiTouchZoomSupport(supportsMultiTouchZoom);
+                    }
+                };
+        mSettings.setZoomListener(zoomListener);
+
         nativeSetJavaPeers(mNativeContent, this, mXWalkContentsDelegateAdapter, mContentsClientBridge,
                 mIoThreadClient, mContentsClientBridge.getInterceptNavigationDelegate());
     }

--- a/runtime/android/sample/AndroidManifest.xml
+++ b/runtime/android/sample/AndroidManifest.xml
@@ -165,6 +165,15 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="org.xwalk.core.sample.SupportZoomActivity"
+            android:label="Zoom"
+            android:parentActivityName="org.xwalk.core.sample.XWalkEmbeddingAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/runtime/android/sample/assets/builtinzoom.html
+++ b/runtime/android/sample/assets/builtinzoom.html
@@ -1,0 +1,8 @@
+<html>
+    <body>
+        Test for built in zoom controls.
+        1. Press enable button, pinch gesture to zoom in/out.
+        2. Press disable button, pinch gesture is disabled.
+        Note: for the built in zoom controls showing, it should be supported by "setDisplayZoomControls()".
+    </body>
+</html>

--- a/runtime/android/sample/assets/doubletapzoom.html
+++ b/runtime/android/sample/assets/doubletapzoom.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        Test for double tap zoom.
+        Double click the current page, it will be scaled.
+    </body>
+</html>

--- a/runtime/android/sample/src/org/xwalk/core/sample/SupportZoomActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/SupportZoomActivity.java
@@ -1,0 +1,89 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.sample;
+
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkSettings;
+
+import android.os.Bundle;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+
+public class SupportZoomActivity extends XWalkBaseActivity {
+    private Button mEnableBuiltInZoomButton;
+    private Button mDisableBuiltInZoomButton;
+    private Button mEnableDoubleTapZoomButton;
+    private Button mDisableDoubleTapZoomButton;
+    private XWalkSettings mXWalkSettings;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.container);
+        LinearLayout parent = (LinearLayout) findViewById(R.id.container);
+
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.FILL_PARENT,
+                FrameLayout.LayoutParams.FILL_PARENT);
+        FrameLayout.LayoutParams buttonParams = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.FILL_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT);
+
+        mEnableBuiltInZoomButton = new Button(this);
+        mEnableBuiltInZoomButton.setText("Enable BuiltInZoom");
+        parent.addView(mEnableBuiltInZoomButton, buttonParams);
+        mEnableBuiltInZoomButton.setOnClickListener(new OnClickListener() {
+            public void onClick(View v) {
+                setAndLoadForBuiltInZoom(true);
+            }
+        });
+
+        mEnableDoubleTapZoomButton = new Button(this);
+        mEnableDoubleTapZoomButton.setText("Disable BuiltInZoom");
+        parent.addView(mEnableDoubleTapZoomButton, buttonParams);
+        mEnableDoubleTapZoomButton.setOnClickListener(new OnClickListener() {
+            public void onClick(View v) {
+                setAndLoadForBuiltInZoom(false);
+            }
+        });
+
+        mEnableDoubleTapZoomButton = new Button(this);
+        mEnableDoubleTapZoomButton.setText("Enable DoubleTapZoom");
+        parent.addView(mEnableDoubleTapZoomButton, buttonParams);
+        mEnableDoubleTapZoomButton.setOnClickListener(new OnClickListener() {
+            public void onClick(View v) {
+                setAndLoadForDoubleTapZoom(true);
+            }
+        });
+
+        mDisableDoubleTapZoomButton = new Button(this);
+        mDisableDoubleTapZoomButton.setText("Disable DoubleTapZoom");
+        parent.addView(mDisableDoubleTapZoomButton, buttonParams);
+        mDisableDoubleTapZoomButton.setOnClickListener(new OnClickListener() {
+            public void onClick(View v) {
+                setAndLoadForDoubleTapZoom(false);;
+            }
+        });
+        mXWalkView = new XWalkView(this, this);
+        parent.addView(mXWalkView, params);
+        mXWalkSettings = mXWalkView.getSettings();
+    }
+
+    void setAndLoadForBuiltInZoom(boolean flag) {
+        mXWalkSettings.setBuiltInZoomControls(flag);
+        mXWalkView.load("file:///android_asset/builtinzoom.html", null);
+    }
+
+    void setAndLoadForDoubleTapZoom(boolean flag) {
+        // setUseWideViewPort() should be called at first.
+        mXWalkSettings.setUseWideViewPort(flag);
+        mXWalkSettings.setBuiltInZoomControls(flag);
+        mXWalkView.load("file:///android_asset/doubletapzoom.html", null);
+    }
+}

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -216,6 +216,9 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
   prefs.password_echo_enabled =
       Java_XWalkSettingsInternal_getPasswordEchoEnabledLocked(env, obj);
 
+  prefs.double_tap_to_zoom_enabled =
+      Java_XWalkSettingsInternal_supportsDoubleTapZoomLocked(env, obj);
+
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   prefs.allow_running_insecure_content =
       command_line->HasSwitch(switches::kAllowRunningInsecureContent);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ZoomTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ZoomTest.java
@@ -1,0 +1,52 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+
+import java.util.Locale;
+
+import org.chromium.base.test.util.Feature;
+import org.xwalk.core.XWalkSettings;
+
+/**
+ * Test suite for zoom related functions.
+ */
+public class ZoomTest extends XWalkViewTestBase {
+    private static final float MAXIMUM_SCALE = 2.0f;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    private String getZoomableHtml(float scale) {
+        final int divWidthPercent = (int) (100.0f / scale);
+        return String.format(Locale.US, "<html><head><meta name=\"viewport\" content=\""
+                + "width=device-width, minimum-scale=%f, maximum-scale=%f, initial-scale=%f"
+                + "\"/></head><body style='margin:0'>"
+                + "<div style='width:%d%%;height:100px;border:1px solid black'>Zoomable</div>"
+                + "</body></html>",
+                scale, MAXIMUM_SCALE, scale, divWidthPercent);
+    }
+
+    @SmallTest
+    @Feature({"Zoom test"})
+    public void testZoomUsingMultiTouch() throws Throwable {
+        XWalkSettings settings = getXWalkSettingsOnUiThreadByXWalkView(getXWalkView());
+        loadDataSync(null, getZoomableHtml(0.5f), "text/html", false);
+
+        assertTrue(settings.supportZoom());
+        assertFalse(settings.getBuiltInZoomControls());
+        assertFalse(settings.supportsMultiTouchZoomForTest());
+
+        settings.setBuiltInZoomControls(true);
+        assertTrue(settings.supportsMultiTouchZoomForTest());
+
+        settings.setSupportZoom(false);
+        assertFalse(settings.supportsMultiTouchZoomForTest());
+    }
+}

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -560,8 +560,10 @@
         'resource_dir': 'runtime/android/sample/res',
         'native_lib_target': 'libxwalkcore',
         'additional_input_paths': [
+          '<(PRODUCT_DIR)/sample/assets/builtinzoom.html',
           '<(PRODUCT_DIR)/sample/assets/create_window_1.html',
           '<(PRODUCT_DIR)/sample/assets/create_window_2.html',
+          '<(PRODUCT_DIR)/sample/assets/doubletapzoom.html',
           '<(PRODUCT_DIR)/sample/assets/echo_java.html',
           '<(PRODUCT_DIR)/sample/assets/favicon.html',
           '<(PRODUCT_DIR)/sample/assets/icon.png',
@@ -590,8 +592,10 @@
         {
           'destination': '<(PRODUCT_DIR)/sample/assets',
           'files': [
+            'runtime/android/sample/assets/builtinzoom.html',
             'runtime/android/sample/assets/create_window_1.html',
             'runtime/android/sample/assets/create_window_2.html',
+            'runtime/android/sample/assets/doubletapzoom.html',
             'runtime/android/sample/assets/favicon.html',
             'runtime/android/sample/assets/icon.png',
             'runtime/android/sample/assets/index.html',


### PR DESCRIPTION
…ontrol.

Implement embedding API for setSupportZoom()/supportZoom() and
setBuiltInZoomControls()/getBuiltInZoomControls().
Expose setUseWideViewPort()/getUseWideViewPort() to support zoom.
For the usage of double tap zoom and pinch gesture to zoom, please refer
to SupportZoomActivity.java.

BUG=XWALK-4912