### PR TITLE
[Windows] Fix build after the move to Chromium M46.

### DIFF
--- a/runtime/browser/runtime_javascript_dialog_manager.cc
+++ b/runtime/browser/runtime_javascript_dialog_manager.cc
@@ -7,9 +7,9 @@
 #include <string>
 
 #include "base/strings/utf_string_conversions.h"
+#include "components/url_formatter/url_formatter.h"
 #include "content/public/browser/javascript_dialog_manager.h"
 #include "content/public/browser/web_contents.h"
-#include "net/base/net_util.h"
 
 #if defined(OS_ANDROID)
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
@@ -53,7 +53,8 @@ void RuntimeJavaScriptDialogManager::RunJavaScriptDialog(
     return;
   }
 
-  base::string16 new_message_text = net::FormatUrl(origin_url, accept_lang) +
+  base::string16 new_message_text =
+      url_formatter::FormatUrl(origin_url, accept_lang) +
       base::ASCIIToUTF16("\n\n") +
       message_text;
   gfx::NativeWindow parent_window = web_contents->GetTopLevelNativeWindow();

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -41,6 +41,7 @@
         '../components/components.gyp:user_prefs',
         '../components/components.gyp:visitedlink_browser',
         '../components/components.gyp:visitedlink_renderer',
+        '../components/url_formatter/url_formatter.gyp:url_formatter',
         '../content/content.gyp:content',
         '../content/content.gyp:content_app_both',
         '../content/content.gyp:content_browser',


### PR DESCRIPTION
Basically adapt to https://codereview.chromium.org/1171333003, which
turned net::FormatUrl() into url_formatter:FormatUrl(). Fixes this build
error at least on Windows:

```
c:\b\b\slave\crosswalk_windows\build\src\xwalk\runtime\browser\runtime_javascript_dialog_manager.cc(56)
: error C2039: 'FormatUrl' : is not a member of 'net'
c:\b\b\slave\crosswalk_windows\build\src\xwalk\runtime\browser\runtime_javascript_dialog_manager.cc(56)
: error C3861: 'FormatUrl': identifier not found
```