### PR TITLE
[Windows] M46 Presentation API build fixes.

### DIFF
--- a/runtime/browser/xwalk_presentation_service_delegate_win.h
+++ b/runtime/browser/xwalk_presentation_service_delegate_win.h
@@ -65,8 +65,7 @@ class XWalkPresentationServiceDelegateWin
   void SetDefaultPresentationUrl(
       int render_process_id,
       int render_frame_id,
-      const std::string& default_presentation_url,
-      const std::string& default_presentation_id) override;
+      const std::string& default_presentation_url) override;
 
   void StartSession(
       int render_process_id,
@@ -91,11 +90,14 @@ class XWalkPresentationServiceDelegateWin
   void ListenForSessionMessages(
       int render_process_id,
       int render_frame_id,
-      const PresentationSessionMessageCallback& message_cb) override {}
+      const content::PresentationSessionInfo& session,
+      const content::PresentationSessionMessageCallback& message_cb)
+      override {}
 
   void SendMessage(
       int render_process_id,
       int render_frame_id,
+      const content::PresentationSessionInfo& session,
       scoped_ptr<content::PresentationSessionMessage> message_request,
       const SendMessageCallback& send_message_cb) override {}
 


### PR DESCRIPTION
Adapt to https://codereview.chromium.org/1245443002 and make the code
more similar to what's in
chrome/browser/media/router/presentation_service_delegate_impl.{cc,h}.

Also adjust some method signatures.

https://codereview.chromium.org/1302973003 still needs to be analyzed.

```
This change gets rid of the following Windows build errors:
c:\b\b\slave\crosswalk_windows\build\src\xwalk\runtime\browser\xwalk_presentation_service_delegate_win.h(94)
: error C4430: missing type specifier - int assumed. Note: C++ does not
support default-int
c:\b\b\slave\crosswalk_windows\build\src\xwalk\runtime\browser\xwalk_presentation_service_delegate_win.h(94)
: error C2143: syntax error : missing ',' before '&'
c:\b\b\slave\crosswalk_windows\build\src\xwalk\runtime\browser\xwalk_presentation_service_delegate_win.h(65)
: error C3668:
'xwalk::XWalkPresentationServiceDelegateWin::SetDefaultPresentationUrl'
: method with override specifier 'override' did not override any base
class methods
c:\b\b\slave\crosswalk_windows\build\src\xwalk\runtime\browser\xwalk_presentation_service_delegate_win.h(91)
: error C3668:
'xwalk::XWalkPresentationServiceDelegateWin::ListenForSessionMessages' :
method with override specifier 'override' did not override any base
class methods
c:\b\b\slave\crosswalk_windows\build\src\xwalk\runtime\browser\xwalk_presentation_service_delegate_win.h(96)
: error C3668:
'xwalk::XWalkPresentationServiceDelegateWin::SendMessageW' : method with
override specifier 'override' did not override any base class methods
```