### PR TITLE
[Android] Change the library load logic for embedded application.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -117,7 +117,7 @@ class XWalkViewDelegate {
             throws UnsatisfiedLinkError {
         if (sLibraryLoaded) return true;
 
-        if (libDir != null) {
+        if ((libDir != null) && (sRunningOnIA == nativeIsLibraryBuiltForIA())) {
             for (String library : MANDATORY_LIBRARIES) {
                 System.load(libDir + File.separator + "lib" + library + ".so");
             }


### PR DESCRIPTION
For embedded application, it loads the library from "app-lib" at first,
if that failed, then loads library from "/data/data/". This will also be
failed when the architecture is inconsistent and lead to crash.
So architecture should be checked before library loaded from "/data/data/".

BUG=XWALK-5804