### PR TITLE
crosswalk-16: Backport commits creating POM files in Crosswalk.

### DIFF
--- a/build/android/maven_pom.gypi
+++ b/build/android/maven_pom.gypi
@@ -1,0 +1,52 @@
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file is meant to be included into a target to provide a rule to generate
+# a Maven POM XML file that can later be used in Maven repositories.
+# It takes a template POM and substitutes the values @ARTIFACT_ID@ and
+# @ARTIFACT_VERSION@ with the variables provided to this file.
+#
+# Usage:
+# {
+#   'target_name': 'my_artifact_pom_gen',
+#   'type': 'none',
+#   'variables': {
+#     'pom_input': 'path/to/my_artifact.pom.xml.in',
+#     'pom_output': '<(PRODUCT_DIR)/my_artifact.pom.xml',
+#     'artifact_id': 'foo_bar_canary',
+#     'artifact_version': '1.2.3.4',
+#   }
+#   'includes': ['path/to/this/gypi/file'],
+# }
+#
+# Required variables:
+#  pom_input - Path to the POM file that will be processed.
+#  pom_output - Path to the generated POM file.
+#  artifact_id - Value for the <artifactId> field in the POM file.
+#  artifact_version - Value for the <version> field in the POM file.
+
+{
+  'actions': [
+    {
+      'action_name': 'generate_pom_file',
+      'message': 'Generating <(pom_output)',
+      'variables': {
+        'version_py': '<(DEPTH)/build/util/version.py',
+      },
+      'inputs': [
+        '<(version_py)',
+        '<(pom_input)',
+      ],
+      'outputs': [
+        '<(pom_output)',
+      ],
+      'action': [
+        'python', '<(version_py)', '-i', '<(pom_input)',
+                  '-o', '<(pom_output)',
+                  '-e', 'ARTIFACT_ID="<(artifact_id)"',
+                  '-e', 'ARTIFACT_VERSION="<(artifact_version)"',
+      ]
+    },
+  ],
+}

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -6,6 +6,11 @@
     'use_webui_file_picker%': 0,
     'disable_bundled_extensions%': 0,
 
+    # Name of Crosswalk Maven artifacts used to generate their
+    # respective POM files.
+    'xwalk_core_library_artifact_id%': 'xwalk_core_library_canary',
+    'xwalk_shared_library_artifact_id%': 'xwalk_shared_library_canary',
+
     'conditions': [
       ['OS=="android"', {
         # Enable WebCL by default on android.

--- a/runtime/android/maven/xwalk_core_library.pom.xml.in
+++ b/runtime/android/maven/xwalk_core_library.pom.xml.in
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is generated automatically.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.xwalk</groupId>
+  <artifactId>@ARTIFACT_ID@</artifactId>
+  <version>@ARTIFACT_VERSION@</version>
+  <packaging>aar</packaging>
+</project>

--- a/runtime/android/maven/xwalk_core_library.pom.xml.in
+++ b/runtime/android/maven/xwalk_core_library.pom.xml.in
@@ -9,4 +9,15 @@ This file is generated automatically.
   <artifactId>@ARTIFACT_ID@</artifactId>
   <version>@ARTIFACT_VERSION@</version>
   <packaging>aar</packaging>
+
+  <!-- Crosswalk itself does not depend on external libraries, but it inherits
+       some dependencies from Chromium itself. -->
+  <dependencies>
+    <dependency>
+      <groupId>com.android.support</groupId>
+      <artifactId>support-v4</artifactId>
+      <version>[13.0.0,)</version> <!-- >= 13.0.0 -->
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/runtime/android/maven/xwalk_shared_library.pom.xml.in
+++ b/runtime/android/maven/xwalk_shared_library.pom.xml.in
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is generated automatically.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.xwalk</groupId>
+  <artifactId>@ARTIFACT_ID@</artifactId>
+  <version>@ARTIFACT_VERSION@</version>
+  <packaging>aar</packaging>
+</project>

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -408,10 +408,33 @@
       ],
     },
     {
+      'target_name': 'xwalk_core_library_pom_gen',
+      'type': 'none',
+      'variables': {
+        'pom_input': '<(DEPTH)/xwalk/runtime/android/maven/xwalk_core_library.pom.xml.in',
+        'pom_output': '<(PRODUCT_DIR)/xwalk_core_library.pom.xml',
+        'artifact_id': '<(xwalk_core_library_artifact_id)',
+        'artifact_version': '<(xwalk_version)',
+      },
+      'includes': ['build/android/maven_pom.gypi'],
+    },
+    {
+      'target_name': 'xwalk_shared_library_pom_gen',
+      'type': 'none',
+      'variables': {
+        'pom_input': '<(DEPTH)/xwalk/runtime/android/maven/xwalk_shared_library.pom.xml.in',
+        'pom_output': '<(PRODUCT_DIR)/xwalk_shared_library.pom.xml',
+        'artifact_id': '<(xwalk_shared_library_artifact_id)',
+        'artifact_version': '<(xwalk_version)',
+      },
+      'includes': ['build/android/maven_pom.gypi'],
+    },
+    {
       'target_name': 'xwalk_core_library_aar',
       'type': 'none',
       'dependencies': [
         'xwalk_core_empty_embedder_apk',
+        'xwalk_core_library_pom_gen',
       ],
       'actions': [
         {
@@ -436,6 +459,7 @@
       'type': 'none',
       'dependencies': [
         'xwalk_core_empty_embedder_apk',
+        'xwalk_shared_library_pom_gen',
       ],
       'actions': [
         {


### PR DESCRIPTION
Like #3397, this patch set contains two commits. The first one adds all
the required plumbing for generating the Maven POM files we have for
`xwalk_core_library` and `xwalk_shared_library` as part of our build.
The second commit leverages this infrastructure to add a dependency on
the support-v4 Android support library to the xwalk_core_library
artifact, as we have stopped bundling external JARs since #3350.

Related to: XWALK-5092