### PR TITLE
[Android] Fix the mismatch issue.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -105,6 +105,11 @@ class XWalkViewDelegate {
         }
     }
 
+    // Keep this function to preserve backward compatibility.
+    public static boolean loadXWalkLibrary(Context context) {
+        return loadXWalkLibrary(context, null);
+    }
+
     // If context is null, it's running in embedded mode, otherwise in shared mode.
     public static boolean loadXWalkLibrary(Context context, String libDir)
             throws UnsatisfiedLinkError {


### PR DESCRIPTION
In newer crosswalk, the parameter nums for loadXWalkLibrary() is
increased, this leads to older crosswalk can not invoke the right
function to load library in shared mode.
Keep the single parameter function to preserve backward compatibility.

Related to XWALK-5796

(cherry picked from commit 3bbe2951c1e36df079d749a2569fbc25bd042a3f)