### PR TITLE
[Android] Add LZMA compressed runtime support in download mode

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryDecompressor.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryDecompressor.java
@@ -106,7 +106,7 @@ class XWalkLibraryDecompressor {
         return true;
     }
 
-    private static void decodeWithLzma(InputStream input, OutputStream output) throws IOException {
+    static void decodeWithLzma(InputStream input, OutputStream output) throws IOException {
         final int propSize = 5;
         final int outSizeLength = 8;
 


### PR DESCRIPTION
We support both the original XWalkRuntimeLib.apk and the LZMA compressed XWalkRuntimeLibLzma.apk in download mode.

BUG=XWALK-5214