### PR TITLE
[Android] Notify the host application that an HTTP response has been …

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -732,6 +732,12 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         public void newLoginRequest(String realm, String account, String args) {
             mContentsClientBridge.getCallbackHelper().postOnReceivedLoginRequest(realm, account, args);
         }
+
+        @Override
+        public void onReceivedResponseHeaders(XWalkContentsClient.WebResourceRequestInner request,
+                XWalkWebResourceResponseInternal response) {
+            mContentsClientBridge.getCallbackHelper().postOnReceivedResponseHeaders(request, response);
+        }
     }
 
     private class XWalkGeolocationCallback implements XWalkGeolocationPermissions.Callback {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -179,6 +179,9 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
     public abstract void onReceivedClientCertRequest(ClientCertRequestInternal handler);    
 
+    public abstract void onReceivedResponseHeaders(WebResourceRequestInner request,
+            XWalkWebResourceResponseInternal response);
+
     public abstract void onReceivedLoginRequest(String realm, String account, String args);
 
     public abstract void onFormResubmission(Message dontResend, Message resend);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -371,6 +371,15 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
+    public void onReceivedResponseHeaders(WebResourceRequestInner request,
+            XWalkWebResourceResponseInternal response) {
+        if (mXWalkResourceClient != null && isOwnerActivityRunning()) {
+            mXWalkResourceClient.onReceivedResponseHeaders(mXWalkView,
+                    new XWalkWebResourceRequestHandlerInternal(request), response);
+        }
+    }
+
+    @Override
     public void onGeolocationPermissionsShowPrompt(String origin,
             XWalkGeolocationPermissions.Callback callback) {
         if (mXWalkWebChromeClient != null && isOwnerActivityRunning()) {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientCallbackHelper.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientCallbackHelper.java
@@ -66,6 +66,18 @@ class XWalkContentsClientCallbackHelper {
         }
     }
 
+    private static class OnReceivedResponseHeadersInfo {
+        final XWalkContentsClient.WebResourceRequestInner mRequest;
+        final XWalkWebResourceResponseInternal mResponse;
+
+        OnReceivedResponseHeadersInfo(
+                XWalkContentsClient.WebResourceRequestInner request,
+                XWalkWebResourceResponseInternal response) {
+            mRequest = request;
+            mResponse = response;
+        }
+    }
+
     private final static int MSG_ON_LOAD_RESOURCE = 1;
     private final static int MSG_ON_PAGE_STARTED = 2;
     private final static int MSG_ON_DOWNLOAD_START = 3;
@@ -73,6 +85,7 @@ class XWalkContentsClientCallbackHelper {
     private final static int MSG_ON_RECEIVED_ERROR = 5;
     private final static int MSG_ON_RESOURCE_LOAD_STARTED = 6;
     private final static int MSG_ON_PAGE_FINISHED = 7;
+    private final static int MSG_ON_RECEIVED_RESPONSE_HEADERS = 8;
 
     private final XWalkContentsClient mContentsClient;
 
@@ -117,6 +130,11 @@ class XWalkContentsClientCallbackHelper {
                     mContentsClient.onPageFinished(url);
                     break;
                 }
+                case MSG_ON_RECEIVED_RESPONSE_HEADERS: {
+                    OnReceivedResponseHeadersInfo info = (OnReceivedResponseHeadersInfo) msg.obj;
+                    mContentsClient.onReceivedResponseHeaders(info.mRequest, info.mResponse);
+                    break;
+                }
                 default:
                     throw new IllegalStateException(
                             "XWalkContentsClientCallbackHelper: unhandled message " + msg.what);
@@ -159,5 +177,12 @@ class XWalkContentsClientCallbackHelper {
 
     public void postOnPageFinished(String url) {
         mHandler.sendMessage(mHandler.obtainMessage(MSG_ON_PAGE_FINISHED, url));
+    }
+
+    public void postOnReceivedResponseHeaders(XWalkContentsClient.WebResourceRequestInner request,
+            XWalkWebResourceResponseInternal response) {
+        OnReceivedResponseHeadersInfo info =
+                new OnReceivedResponseHeadersInfo(request, response);
+        mHandler.sendMessage(mHandler.obtainMessage(MSG_ON_RECEIVED_RESPONSE_HEADERS, info));
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsIoThreadClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsIoThreadClient.java
@@ -9,6 +9,9 @@ import java.util.HashMap;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Delegate for handling callbacks. All methods are called on the IO thread.
  */
@@ -39,6 +42,10 @@ public abstract class XWalkContentsIoThreadClient {
     public abstract XWalkWebResourceResponseInternal shouldInterceptRequest(
         XWalkContentsClient.WebResourceRequestInner request);
 
+    public abstract void onReceivedResponseHeaders(
+            XWalkContentsClient.WebResourceRequestInner request,
+            XWalkWebResourceResponseInternal response);
+
     // Protected methods ---------------------------------------------------------------------------
     @CalledByNative
     protected XWalkWebResourceResponseInternal shouldInterceptRequest(String url, boolean isMainFrame,
@@ -55,5 +62,43 @@ public abstract class XWalkContentsIoThreadClient {
             request.requestHeaders.put(requestHeaderNames[i], requestHeaderValues[i]);
         }
         return shouldInterceptRequest(request);
+    }
+
+    @CalledByNative
+    protected void onReceivedResponseHeaders(
+            // WebResourceRequest
+            String url, boolean isMainFrame, boolean hasUserGesture, String method,
+            String[] requestHeaderNames, String[] requestHeaderValues,
+            // WebResourceResponse
+            String mimeType, String encoding, int statusCode, String reasonPhrase,
+            String[] responseHeaderNames, String[] responseHeaderValues) {
+        XWalkContentsClient.WebResourceRequestInner request =
+                new XWalkContentsClient.WebResourceRequestInner();
+        request.url = url;
+        request.isMainFrame = isMainFrame;
+        request.hasUserGesture = hasUserGesture;
+        request.method = method;
+        request.requestHeaders = new HashMap<String, String>(requestHeaderNames.length);
+        for (int i = 0; i < requestHeaderNames.length; ++i) {
+            request.requestHeaders.put(requestHeaderNames[i], requestHeaderValues[i]);
+        }
+        Map<String, String> responseHeaders =
+                new HashMap<String, String>(responseHeaderNames.length);
+        // Note that we receive un-coalesced response header lines, thus we need to combine
+        // values for the same header.
+        for (int i = 0; i < responseHeaderNames.length; ++i) {
+            if (!responseHeaders.containsKey(responseHeaderNames[i])) {
+                responseHeaders.put(responseHeaderNames[i], responseHeaderValues[i]);
+            } else if (!responseHeaderValues[i].isEmpty()) {
+                String currentValue = responseHeaders.get(responseHeaderNames[i]);
+                if (!currentValue.isEmpty()) {
+                    currentValue += ", ";
+                }
+                responseHeaders.put(responseHeaderNames[i], currentValue + responseHeaderValues[i]);
+            }
+        }
+        XWalkWebResourceResponseInternal response = new XWalkWebResourceResponseInternal(
+                mimeType, encoding, null, statusCode, reasonPhrase, responseHeaders);
+        onReceivedResponseHeaders(request, response);
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -321,6 +321,25 @@ public class XWalkResourceClientInternal {
     }
 
     /**
+     * Notify the host application that an HTTP response has been received from the server while loading a resource.
+     * This callback will be called for any resource (iframe, image, etc), not just for the main page.
+     * Thus, it is recommended to perform minimum required work in this callback.
+     * The feature the same as Android WebView's onReceivedHttpError when HTTP errors have status codes >= 400
+     * Customer also can get response cookies from headers when there are no errors.
+     *
+     * @param view The XWalkView that is initiating the callback
+     * @param request The originating request
+     * @param response The response information
+     *
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void onReceivedResponseHeaders(XWalkViewInternal view,
+            XWalkWebResourceRequestInternal request,
+            XWalkWebResourceResponseInternal response) {
+    }
+
+    /**
      * Notify the host application to update its visited links database.
      *
      * @param view The XWalkView that is initiating the callback.

--- a/runtime/browser/android/xwalk_contents_io_thread_client.h
+++ b/runtime/browser/android/xwalk_contents_io_thread_client.h
@@ -12,6 +12,7 @@
 class GURL;
 
 namespace net {
+class HttpResponseHeaders;
 class URLRequest;
 }
 
@@ -99,6 +100,10 @@ class XWalkContentsIoThreadClient {
   virtual void NewLoginRequest(const std::string& realm,
                                const std::string& account,
                                const std::string& args) = 0;
+
+  virtual void OnReceivedResponseHeaders(
+    const net::URLRequest* request,
+    const net::HttpResponseHeaders* response_headers) = 0;
 };
 
 }  // namespace xwalk

--- a/runtime/browser/android/xwalk_contents_io_thread_client_impl.cc
+++ b/runtime/browser/android/xwalk_contents_io_thread_client_impl.cc
@@ -25,6 +25,7 @@
 #include "content/public/browser/web_contents_observer.h"
 #include "jni/XWalkContentsIoThreadClient_jni.h"
 #include "net/http/http_request_headers.h"
+#include "net/http/http_response_headers.h"
 #include "net/url_request/url_request.h"
 #include "url/gurl.h"
 #include "xwalk/runtime/browser/android/xwalk_web_resource_response_impl.h"
@@ -152,6 +153,38 @@ void ClientMapEntryUpdater::RenderFrameDeleted(RenderFrameHost* rfh) {
 void ClientMapEntryUpdater::WebContentsDestroyed() {
   delete this;
 }
+
+struct WebResourceRequest {
+  ScopedJavaLocalRef<jstring> jstring_url;
+  bool is_main_frame;
+  bool has_user_gesture;
+  ScopedJavaLocalRef<jstring> jstring_method;
+  ScopedJavaLocalRef<jobjectArray> jstringArray_header_names;
+  ScopedJavaLocalRef<jobjectArray> jstringArray_header_values;
+
+  WebResourceRequest(JNIEnv* env, const net::URLRequest* request)
+      : jstring_url(ConvertUTF8ToJavaString(env, request->url().spec())),
+        jstring_method(ConvertUTF8ToJavaString(env, request->method())) {
+    const content::ResourceRequestInfo* info =
+        content::ResourceRequestInfo::ForRequest(request);
+    is_main_frame =
+        info && info->GetResourceType() == content::RESOURCE_TYPE_MAIN_FRAME;
+    has_user_gesture = info && info->HasUserGesture();
+
+    vector<string> header_names;
+    vector<string> header_values;
+    net::HttpRequestHeaders headers;
+    if (!request->GetFullRequestHeaders(&headers))
+      headers = request->extra_request_headers();
+    net::HttpRequestHeaders::Iterator headers_iterator(headers);
+    while (headers_iterator.GetNext()) {
+      header_names.push_back(headers_iterator.name());
+      header_values.push_back(headers_iterator.value());
+    }
+    jstringArray_header_names = ToJavaArrayOfStrings(env, header_names);
+    jstringArray_header_values = ToJavaArrayOfStrings(env, header_values);
+  }
+};
 
 }  // namespace
 
@@ -367,6 +400,59 @@ void XWalkContentsIoThreadClientImpl::NewLoginRequest(
 
   Java_XWalkContentsIoThreadClient_newLoginRequest(
       env, java_object_.obj(), jrealm.obj(), jaccount.obj(), jargs.obj());
+}
+
+void XWalkContentsIoThreadClientImpl::OnReceivedResponseHeaders(
+    const net::URLRequest* request,
+    const net::HttpResponseHeaders* response_headers) {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+  if (java_object_.is_null())
+    return;
+
+  JNIEnv* env = AttachCurrentThread();
+  WebResourceRequest web_request(env, request);
+
+  vector<string> response_header_names;
+  vector<string> response_header_values;
+  {
+    void* headers_iterator = NULL;
+    string header_name, header_value;
+    while (response_headers->EnumerateHeaderLines(
+        &headers_iterator, &header_name, &header_value)) {
+      response_header_names.push_back(header_name);
+      response_header_values.push_back(header_value);
+    }
+  }
+
+  string mime_type, encoding;
+  response_headers->GetMimeTypeAndCharset(&mime_type, &encoding);
+  ScopedJavaLocalRef<jstring> jstring_mime_type =
+      ConvertUTF8ToJavaString(env, mime_type);
+  ScopedJavaLocalRef<jstring> jstring_encoding =
+      ConvertUTF8ToJavaString(env, encoding);
+  int status_code = response_headers->response_code();
+  ScopedJavaLocalRef<jstring> jstring_reason =
+      ConvertUTF8ToJavaString(env, response_headers->GetStatusText());
+  ScopedJavaLocalRef<jobjectArray> jstringArray_response_header_names =
+      ToJavaArrayOfStrings(env, response_header_names);
+  ScopedJavaLocalRef<jobjectArray> jstringArray_response_header_values =
+      ToJavaArrayOfStrings(env, response_header_values);
+
+  Java_XWalkContentsIoThreadClient_onReceivedResponseHeaders(
+      env,
+      java_object_.obj(),
+      web_request.jstring_url.obj(),
+      web_request.is_main_frame,
+      web_request.has_user_gesture,
+      web_request.jstring_method.obj(),
+      web_request.jstringArray_header_names.obj(),
+      web_request.jstringArray_header_values.obj(),
+      jstring_mime_type.obj(),
+      jstring_encoding.obj(),
+      status_code,
+      jstring_reason.obj(),
+      jstringArray_response_header_names.obj(),
+      jstringArray_response_header_values.obj());
 }
 
 bool RegisterXWalkContentsIoThreadClientImpl(JNIEnv* env) {

--- a/runtime/browser/android/xwalk_contents_io_thread_client_impl.h
+++ b/runtime/browser/android/xwalk_contents_io_thread_client_impl.h
@@ -64,6 +64,10 @@ class XWalkContentsIoThreadClientImpl : public XWalkContentsIoThreadClient {
                        const std::string& account,
                        const std::string& args) override;
 
+  void OnReceivedResponseHeaders(
+    const net::URLRequest* request,
+    const net::HttpResponseHeaders* response_headers) override;
+
  private:
   bool pending_association_;
   base::android::ScopedJavaGlobalRef<jobject> java_object_;

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedResponseHeadersTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedResponseHeadersTest.java
@@ -1,0 +1,124 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Pair;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.base.test.util.MinAndroidSdkLevel;
+import org.chromium.net.test.util.TestWebServer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.xwalk.core.XWalkWebResourceRequest;
+import org.xwalk.core.XWalkWebResourceResponse;
+import org.xwalk.core.xwview.test.util.CommonResources;
+
+/**
+ * Tests for the XWalkResourceClient.onReceivedResponseHeaders() method.
+ */
+public class OnReceivedResponseHeadersTest extends XWalkViewTestBase {
+
+    private TestHelperBridge.OnReceivedResponseHeadersHelper mOnReceivedResponseHeadersHelper;
+    private TestWebServer mWebServer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mOnReceivedResponseHeadersHelper = mTestHelperBridge.getOnReceivedResponseHeadersHelper();
+        mWebServer = TestWebServer.start();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        if (mWebServer != null) mWebServer.shutdown();
+        super.tearDown();
+    }
+
+    @SmallTest
+    @Feature({"OnReceivedResponseHeaders"})
+    public void testForMainResource() throws Throwable {
+        List<Pair<String, String>> headers = new ArrayList<Pair<String, String>>();
+        headers.add(Pair.create("Content-Type", "text/html; charset=utf-8"));
+        headers.add(Pair.create("Coalesce", ""));
+        headers.add(Pair.create("Coalesce", "a"));
+        headers.add(Pair.create("Coalesce", ""));
+        headers.add(Pair.create("Coalesce", "a"));
+        final String url = mWebServer.setResponseWithNotFoundStatus("/404.html", headers);
+        loadUrlSync(url);
+
+        XWalkWebResourceRequest request = mOnReceivedResponseHeadersHelper.getRequest();
+        assertNotNull(request);
+        assertEquals("GET", request.getMethod());
+        assertNotNull(request.getRequestHeaders());
+        assertFalse(request.getRequestHeaders().isEmpty());
+        assertTrue(request.isForMainFrame());
+        assertFalse(request.hasGesture());
+        XWalkWebResourceResponse response = mOnReceivedResponseHeadersHelper.getResponse();
+        assertEquals(404, response.getStatusCode());
+        assertEquals("Not Found", response.getReasonPhrase());
+        assertEquals("text/html", response.getMimeType());
+        assertNotNull(response.getResponseHeaders());
+        assertTrue(response.getResponseHeaders().containsKey("Content-Type"));
+        assertEquals("text/html; charset=utf-8", response.getResponseHeaders().get("Content-Type"));
+        assertTrue(response.getResponseHeaders().containsKey("Coalesce"));
+        assertEquals("a, a", response.getResponseHeaders().get("Coalesce"));
+    }
+
+    @SmallTest
+    @Feature({"OnReceivedResponseHeaders"})
+    public void testForSubresource() throws Throwable {
+        List<Pair<String, String>> headers = new ArrayList<Pair<String, String>>();
+        headers.add(Pair.create("Content-Type", "text/html; charset=utf-8"));
+        final String imageUrl = mWebServer.setResponseWithNotFoundStatus("/404.png", headers);
+        final String pageHtml = CommonResources.makeHtmlPageFrom(
+                "", "<img src='" + imageUrl + "' class='img.big' />");
+        final String pageUrl = mWebServer.setResponse("/page.html", pageHtml, null);
+        loadUrlSync(pageUrl);
+
+        XWalkWebResourceRequest request = mOnReceivedResponseHeadersHelper.getRequest();
+        assertNotNull(request);
+        assertEquals("GET", request.getMethod());
+        assertNotNull(request.getRequestHeaders());
+        assertFalse(request.getRequestHeaders().isEmpty());
+        assertFalse(request.isForMainFrame());
+        assertFalse(request.hasGesture());
+        XWalkWebResourceResponse response = mOnReceivedResponseHeadersHelper.getResponse();
+        assertEquals(404, response.getStatusCode());
+        assertEquals("Not Found", response.getReasonPhrase());
+        assertEquals("text/html", response.getMimeType());
+        assertNotNull(response.getResponseHeaders());
+        assertTrue(response.getResponseHeaders().containsKey("Content-Type"));
+        assertEquals("text/html; charset=utf-8", response.getResponseHeaders().get("Content-Type"));
+    }
+
+    @SmallTest
+    @Feature({"OnReceivedResponseHeaders"})
+    public void testAfterRedirect() throws Throwable {
+        List<Pair<String, String>> headers = new ArrayList<Pair<String, String>>();
+        headers.add(Pair.create("Content-Type", "text/html; charset=utf-8"));
+        final String secondUrl = mWebServer.setResponseWithNotFoundStatus("/404.html", headers);
+        final String firstUrl = mWebServer.setRedirect("/302.html", secondUrl);
+        loadUrlSync(firstUrl);
+
+        XWalkWebResourceRequest request = mOnReceivedResponseHeadersHelper.getRequest();
+        assertNotNull(request);
+        assertEquals("GET", request.getMethod());
+        assertNotNull(request.getRequestHeaders());
+        assertFalse(request.getRequestHeaders().isEmpty());
+        assertTrue(request.isForMainFrame());
+        assertFalse(request.hasGesture());
+        XWalkWebResourceResponse response = mOnReceivedResponseHeadersHelper.getResponse();
+        assertEquals(404, response.getStatusCode());
+        assertEquals("Not Found", response.getReasonPhrase());
+        assertEquals("text/html", response.getMimeType());
+        assertNotNull(response.getResponseHeaders());
+        assertTrue(response.getResponseHeaders().containsKey("Content-Type"));
+        assertEquals("text/html; charset=utf-8", response.getResponseHeaders().get("Content-Type"));
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
@@ -29,6 +29,7 @@ import org.xwalk.core.ClientCertRequest;
 import org.xwalk.core.XWalkUIClient.ConsoleMessageType;
 import org.xwalk.core.XWalkUIClient.LoadStatus;
 import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkWebResourceRequest;
 import org.xwalk.core.XWalkWebResourceResponse;
 
 class TestHelperBridge {
@@ -474,6 +475,28 @@ class TestHelperBridge {
         }
     }
 
+    /**
+     * CallbackHelper for OnReceivedResponseHeaders.
+     */
+    public static class OnReceivedResponseHeadersHelper extends CallbackHelper {
+        private XWalkWebResourceRequest mRequest;
+        private XWalkWebResourceResponse mResponse;
+
+        public void notifyCalled(XWalkWebResourceRequest request, XWalkWebResourceResponse response) {
+            mRequest = request;
+            mResponse = response;
+            notifyCalled();
+        }
+        public XWalkWebResourceRequest getRequest() {
+            assert getCallCount() > 0;
+            return mRequest;
+        }
+        public XWalkWebResourceResponse getResponse() {
+            assert getCallCount() > 0;
+            return mResponse;
+        }
+    }
+
     private String mChangedTitle;
     private LoadStatus mLoadStatus;
     private final OnPageStartedHelper mOnPageStartedHelper;
@@ -504,6 +527,7 @@ class TestHelperBridge {
     private final OnLoadFinishedHelper mOnLoadFinishedHelper;
     private final OnDownloadStartHelper mOnDownloadStartHelper;
     private final OnReceivedClientCertRequestHelper mOnReceivedClientCertRequestHelper;
+    private final OnReceivedResponseHeadersHelper mOnReceivedResponseHeadersHelper;
 
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -532,6 +556,7 @@ class TestHelperBridge {
         mOnLoadFinishedHelper = new OnLoadFinishedHelper();
         mOnDownloadStartHelper = new OnDownloadStartHelper();
         mOnReceivedClientCertRequestHelper = new OnReceivedClientCertRequestHelper();
+        mOnReceivedResponseHeadersHelper = new OnReceivedResponseHeadersHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -636,6 +661,10 @@ class TestHelperBridge {
 
     public OnReceivedClientCertRequestHelper getOnReceivedClientCertRequestHelper() {
         return mOnReceivedClientCertRequestHelper;
+    }
+
+    public OnReceivedResponseHeadersHelper getOnReceivedResponseHeadersHelper() {
+        return mOnReceivedResponseHeadersHelper;
     }
 
     public void onTitleChanged(String title) {
@@ -752,5 +781,11 @@ class TestHelperBridge {
 
     public void onReceivedClientCertRequest(XWalkView view, ClientCertRequest handler) {
         mOnReceivedClientCertRequestHelper.notifyCalled(handler);
+    }
+
+    public void onReceivedResponseHeaders(XWalkView view,
+            XWalkWebResourceRequest request,
+            XWalkWebResourceResponse response) {
+        mOnReceivedResponseHeadersHelper.notifyCalled(request, response);
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -214,6 +214,13 @@ public class XWalkViewTestBase
         public void onReceivedClientCertRequest(XWalkView view, ClientCertRequest handler)  {
             mTestHelperBridge.onReceivedClientCertRequest(view, handler);
         }
+
+        @Override
+        public void onReceivedResponseHeaders(XWalkView view,
+                XWalkWebResourceRequest request,
+                XWalkWebResourceResponse response) {
+            mTestHelperBridge.onReceivedResponseHeaders(view, request, response);
+        }
     }
 
     class TestXWalkResourceClient extends TestXWalkResourceClientBase {


### PR DESCRIPTION
…received from the server

Notify the host application that an HTTP response has been received from the server
while loading a resource.
This callback will be called for any resource (iframe, image, etc), not just for the main page.
Thus, it is recommended to perform minimum required work in this callback.
The feature the same as Android WebView's onReceivedHttpError when HTTP errors have status codes >= 400.
Customer also can get response cookies from headers when there are no errors.

BUG=XWALK-4260, XWALK-4643