### PR TITLE
[Android] Fix parameter name in captureBitmapAsync()'s documentation.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -852,7 +852,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
 
     /**
      * Capture a bitmap of visible content.
-     * @param XWalkGetBitmapCallbackInternal callback when bitmap capture is done.
+     * @param callback callback to call when the bitmap capture is done.
      * @since 6.0
      */
     @XWalkAPI


### PR DESCRIPTION
This only produces a javadoc warning with OpenJDK6 that our bots use,
but is a fatal error at least with Fedora's OpenJDK8:

```
../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkView.java:671: error: @param name not found
     * @param XWalkGetBitmapCallback callback when bitmap capture is done.
                   ^
```