### PR TITLE
[Android] Fix buildbot failure of external extension tests

### DIFF
--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/BindingObjectAutoJS.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/BindingObjectAutoJS.java
@@ -19,7 +19,7 @@ public class BindingObjectAutoJS extends BindingObject {
                 extReflect.getReflectionByBindingClass(this.getClass().getName());
         try {
             result = mReflection.handleMessage(info, this);
-        } catch (ReflectiveOperationException e) {
+        } catch (Exception e) {
             Log.e("BindingObjectAutoJs", e.toString());
         }
         return result;

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/BindingObjectStore.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/BindingObjectStore.java
@@ -78,7 +78,7 @@ public class BindingObjectStore {
             result = reflection.handleMessage(newInfo, null);
         } catch (JSONException e) {
             Log.e(TAG, e.toString());
-        } catch (ReflectiveOperationException e) {
+        } catch (Exception e) {
             Log.e(TAG, e.toString());
         }
         return result;

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/MessageHandler.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/MessageHandler.java
@@ -4,7 +4,6 @@
 
 package org.xwalk.app.runtime.extension;
 
-import android.content.Intent;
 import android.util.Log;
 
 import java.lang.reflect.InvocationTargetException;
@@ -96,7 +95,7 @@ public class MessageHandler {
         if (info.getExtension().isAutoJS() && handler.reflection != null) {
             try {
                 result = handler.reflection.handleMessage(info, obj);
-            } catch (ReflectiveOperationException e) {
+            } catch (Exception e) {
                 Log.e(TAG, e.toString());
             }
         } else {

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/extension/ReflectionHelper.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/extension/ReflectionHelper.java
@@ -306,8 +306,8 @@ class ReflectionHelper {
                 JSONObject.quote(sObj.toString()) : sObj.toString();
     }
 
-    Object invokeMethod(XWalkExtensionClient ext, int instanceID, Object obj, String mName, JSONArray args)
-            throws ReflectiveOperationException {
+    Object invokeMethod(XWalkExtensionClient ext, int instanceID, Object obj,
+                        String mName, JSONArray args) throws Exception {
         if (!hasMethod(mName)) {
             throw new NoSuchMethodException("No such method:" + mName);
         }
@@ -322,8 +322,7 @@ class ReflectionHelper {
         return m.invoke(obj, oArgs);
     }
 
-    Object getProperty(Object obj, String pName)
-            throws ReflectiveOperationException {
+    Object getProperty(Object obj, String pName) throws Exception {
         if (!hasProperty(pName)) {
             throw new NoSuchFieldException("No such property:" + pName);
         }
@@ -338,8 +337,7 @@ class ReflectionHelper {
         return f.get(obj);
     }
 
-    void setProperty(Object obj, String pName, Object value)
-            throws ReflectiveOperationException {
+    void setProperty(Object obj, String pName, Object value) throws Exception {
         if (!hasProperty(pName)) {
             throw new NoSuchFieldException("No such property:" + pName);
         }
@@ -373,8 +371,7 @@ class ReflectionHelper {
         return myClass.isInstance(obj);
     }
 
-    public Object handleMessage(MessageInfo info, Object targetObj)
-            throws ReflectiveOperationException {
+    public Object handleMessage(MessageInfo info, Object targetObj) throws Exception {
         Object result = null;
         try {
             String cmd = info.getCmd();


### PR DESCRIPTION
Some files in extension module used ReflectiveOperationException
which was added in Android API Level 19. So it will tigger verify
error on device with Android version below 4.4.