### PR TITLE
[Android] IPC message should be setup when subframe is created

### DIFF
--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -201,6 +201,7 @@ void XWalkContentBrowserClient::RenderProcessWillLaunch(
   host->AddFilter(new XWalkRenderMessageFilter);
 #if defined(OS_ANDROID)
   host->AddFilter(new cdm::CdmMessageFilterAndroid());
+  host->AddFilter(new XWalkRenderMessageFilter(host->GetID()));
 #endif
 }
 

--- a/runtime/browser/xwalk_render_message_filter.cc
+++ b/runtime/browser/xwalk_render_message_filter.cc
@@ -4,6 +4,11 @@
 
 #include "xwalk/runtime/browser/xwalk_render_message_filter.h"
 
+#if defined(OS_ANDROID)
+#include "xwalk/runtime/browser/android/xwalk_contents_io_thread_client.h"
+#include "xwalk/runtime/common/android/xwalk_render_view_messages.h"
+#endif
+
 #include "xwalk/runtime/common/xwalk_common_messages.h"
 #include "xwalk/runtime/browser/runtime_platform_util.h"
 
@@ -13,11 +18,21 @@ XWalkRenderMessageFilter::XWalkRenderMessageFilter()
     : BrowserMessageFilter(ViewMsgStart) {
 }
 
+#if defined(OS_ANDROID)
+XWalkRenderMessageFilter::XWalkRenderMessageFilter(int process_id)
+    : BrowserMessageFilter(AndroidWebViewMsgStart),
+      process_id_(process_id) {
+}
+#endif
+
 bool XWalkRenderMessageFilter::OnMessageReceived(
     const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(XWalkRenderMessageFilter, message)
     IPC_MESSAGE_HANDLER(ViewMsg_OpenLinkExternal, OnOpenLinkExternal)
+#if defined(OS_ANDROID)
+    IPC_MESSAGE_HANDLER(XWalkViewHostMsg_SubFrameCreated, OnSubFrameCreated)
+#endif
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
@@ -28,5 +43,13 @@ void XWalkRenderMessageFilter::OnOpenLinkExternal(const GURL& url) {
   LOG(INFO) << "OpenLinkExternal: " << url.spec();
   platform_util::OpenExternal(url);
 }
+
+#if defined(OS_ANDROID)
+void XWalkRenderMessageFilter::OnSubFrameCreated(
+    int parent_render_frame_id, int child_render_frame_id) {
+  XWalkContentsIoThreadClient::SubFrameCreated(
+      process_id_, parent_render_frame_id, child_render_frame_id);
+}
+#endif
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_render_message_filter.h
+++ b/runtime/browser/xwalk_render_message_filter.h
@@ -13,11 +13,21 @@ namespace xwalk {
 class XWalkRenderMessageFilter : public content::BrowserMessageFilter {
  public:
   XWalkRenderMessageFilter();
+#if defined(OS_ANDROID)
+  explicit XWalkRenderMessageFilter(int process_id);
+#endif
   bool OnMessageReceived(const IPC::Message& message) override;
 
  private:
   void OnOpenLinkExternal(const GURL& url);
+#if defined(OS_ANDROID)
+  void OnSubFrameCreated(int parent_render_frame_id, int child_render_frame_id);
+#endif
   ~XWalkRenderMessageFilter() override {}
+
+#if defined(OS_ANDROID)
+  int process_id_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRenderMessageFilter);
 };

--- a/runtime/common/android/xwalk_render_view_messages.h
+++ b/runtime/common/android/xwalk_render_view_messages.h
@@ -119,4 +119,8 @@ IPC_MESSAGE_ROUTED0(XWalkViewHostMsg_PictureUpdated) // NOLINT(*)
 IPC_MESSAGE_ROUTED1(XWalkViewHostMsg_DidActivateAcceleratedCompositing, // NOLINT(*)
                     int /* input_handler_id */)
 
+// Sent when a subframe is created.
+IPC_MESSAGE_CONTROL2(XWalkViewHostMsg_SubFrameCreated, // NOLINT(*)
+                     int, /* parent_render_frame_id */
+                     int /* child_render_frame_id */)
 


### PR DESCRIPTION
Currently, intercepting http requests with shouldInterceptLoadRequest
is unreliable in combination with iframes, the root cause is that no
ipc message sent from renderer to browser process when subframe is
created, then the XWalkContentsIoThreadClient will not be created.

BUG=XWALK-5621