### PR TITLE
[Android] Ignore the second loading when library was loaded by houdini.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -40,6 +40,7 @@ class XWalkViewDelegate {
     private static boolean sInitialized = false;
     private static boolean sLibraryLoaded = false;
     private static boolean sRunningOnIA = true;
+    private static boolean sLoadedByHoudini = false;
     private static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
 
     // TODO(rakuco,lincsoon): This list is also in generate_xwalk_core_library.py.
@@ -115,7 +116,7 @@ class XWalkViewDelegate {
             throws UnsatisfiedLinkError {
         if (sLibraryLoaded) return true;
 
-        if (libDir != null) {
+        if (libDir != null && sLoadedByHoudini == false) {
             for (String library : MANDATORY_LIBRARIES) {
                 System.load(libDir + File.separator + "lib" + library + ".so");
             }
@@ -132,8 +133,12 @@ class XWalkViewDelegate {
             libraryLoader.loadNow(context);
         } catch (ProcessInitException e) {
         }
-
-        if (sRunningOnIA != nativeIsLibraryBuiltForIA()) return false;
+        // If sRunningOnIA is true and nativeIsLibraryBuiltForIA() is false,
+        // it means that library was loaded successfully by houdini.
+        if (sRunningOnIA != nativeIsLibraryBuiltForIA()) {
+            sLoadedByHoudini = true;
+            return false;
+        }
 
         sLibraryLoaded = true;
         return true;


### PR DESCRIPTION
For embedded arm application was installed on x86 device, the library
under folder "/data/app-lib" will be loaded successfully by houdini, for
stability reason, we don't use houdini now, so the variable
"sLibraryLoaded" was not set to "true", then try to load library from
specified url by System.load(). Load library twice will lead to crash
in houdini.
If library was loaded successfully by houdini then ignore the second
loading.

BUG=XWALK-5804

(cherry picked from commit f366b1a9ebddcc6716b03cebbd4edfdd4b8cd97f)