### PR TITLE
[Android] Fix error of missing class in the app package

### DIFF
--- a/tools/reflection_generator/bridge_generator.py
+++ b/tools/reflection_generator/bridge_generator.py
@@ -114,6 +114,7 @@ ${REFLECTION_INIT_SECTION}}
       ref_init_templete = Template("""
         ReflectConstructor constructor = new ReflectConstructor(
                 coreBridge.getWrapperClass("${WRAPPER_NAME}"), Object.class);
+        if (constructor.isNull()) return;
         this.wrapper = constructor.newInstance(this);
 """)
       value = {'WRAPPER_NAME': self._java_data.GetWrapperName()}

--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -537,8 +537,12 @@ class Method(object):
     if return_is_internal:
       template = Template("""\
     public ${RETURN_TYPE} ${NAME}(${PARAMS}) {
-        ${GENERIC_TYPE_DECLARE}${RETURN}coreBridge.getBridgeObject(\
+        if (${METHOD_DECLARE_NAME}.isNull()) {
+            ${RETURN_SUPER}${NAME}Super(${PARAMS_PASSING_SUPER});
+        } else {
+            ${GENERIC_TYPE_DECLARE}${RETURN}coreBridge.getBridgeObject(\
 ${METHOD_DECLARE_NAME}.invoke(${PARAMS_PASSING}));
+        }
     }
 """)
     elif self._is_abstract:


### PR DESCRIPTION
Don't throw an exception when the object of new added class is created
in the library package but the app package lacks corresponding class
because of old version.

Relate to XWALK-5796
(cherry picked from commit 1a90ce31e27823bfba542204b3835b5653e5d28f)