### PR TITLE
[Lite] App crush when use --disable-lzma flag.

### DIFF
--- a/app/tools/android/make_apk.py
+++ b/app/tools/android/make_apk.py
@@ -320,10 +320,6 @@ def CopyCompressedLibrary(native_path, library_path, raw_path, arch):
 
 
 def CopyNativeLibrary(native_path, library_path, raw_path, arch):
-  dummy_library = os.path.join(native_path, DUMMY_LIBRARY);
-  if os.path.isfile(dummy_library):
-    os.remove(dummy_library)
-
   shutil.copytree(native_path, os.path.join(library_path, arch))
 
 


### PR DESCRIPTION
Flag "--disable-lzma" in make_apk.py cause crush.