### PR TITLE
[Linux][Windows] Fix crash when triggering the inspector.

### DIFF
--- a/runtime/browser/devtools/xwalk_devtools_frontend.cc
+++ b/runtime/browser/devtools/xwalk_devtools_frontend.cc
@@ -202,7 +202,7 @@ void XWalkDevToolsFrontend::HandleMessageFromDevToolsFrontend(
       params->GetSize() == 1 && params->GetString(0, &browser_message)) {
     agent_host_->DispatchProtocolMessage(browser_message);
   } else if (method == "loadCompleted") {
-    web_contents()->GetMainFrame()->ExecuteJavaScript(
+    web_contents()->GetMainFrame()->ExecuteJavaScriptForTests(
         base::ASCIIToUTF16("DevToolsAPI.setUseSoftMenu(true);"));
   } else if (method == "loadNetworkResource" && params->GetSize() == 3) {
     // TODO(pfeldman): handle some of the embedder messages in content.
@@ -269,7 +269,7 @@ void XWalkDevToolsFrontend::DispatchProtocolMessage(
   if (message.length() < kMaxMessageChunkSize) {
     base::string16 javascript = base::UTF8ToUTF16(
         "DevToolsAPI.dispatchMessage(" + message + ");");
-    web_contents()->GetMainFrame()->ExecuteJavaScript(javascript);
+    web_contents()->GetMainFrame()->ExecuteJavaScriptForTests(javascript);
     return;
   }
 
@@ -280,7 +280,7 @@ void XWalkDevToolsFrontend::DispatchProtocolMessage(
         base::StringValue(message.substr(pos, kMaxMessageChunkSize)), &param);
     std::string code = "DevToolsAPI.dispatchMessageChunk(" + param + ");";
     base::string16 javascript = base::UTF8ToUTF16(code);
-    web_contents()->GetMainFrame()->ExecuteJavaScript(javascript);
+    web_contents()->GetMainFrame()->ExecuteJavaScriptForTests(javascript);
   }
 }
 
@@ -328,7 +328,7 @@ void XWalkDevToolsFrontend::CallClientFunction(
     }
   }
   javascript.append(");");
-  web_contents()->GetMainFrame()->ExecuteJavaScript(
+  web_contents()->GetMainFrame()->ExecuteJavaScriptForTests(
       base::UTF8ToUTF16(javascript));
 }
 


### PR DESCRIPTION
This is due to https://codereview.chromium.org/1123783002 which
make javascript execution more strict and add various runtime checks.
There is a dedicated method that we should use for URLs such as the one
used by the inspector.

BUG=XWALK-5953