### PR TITLE
[Android] Add Cookie header to download requests.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDownloadListenerImpl.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDownloadListenerImpl.java
@@ -24,14 +24,17 @@ import java.io.OutputStream;
 
 import org.xwalk.core.internal.AndroidProtocolHandler;
 import org.xwalk.core.internal.R;
+import org.xwalk.core.internal.XWalkCookieManagerInternal;
 import org.xwalk.core.internal.XWalkDownloadListenerInternal;
 
 class XWalkDownloadListenerImpl extends XWalkDownloadListenerInternal {
     private Context mContext;
+    private XWalkCookieManagerInternal mCookieManager;
 
     public XWalkDownloadListenerImpl(Context context) {
         super(context);
         mContext = context;
+        mCookieManager = new XWalkCookieManagerInternal();
     }
 
     @Override
@@ -46,6 +49,7 @@ class XWalkDownloadListenerImpl extends XWalkDownloadListenerInternal {
         Uri src = Uri.parse(url);
         if (src.getScheme().equals("http") || src.getScheme().equals("https")) {
             Request request = new Request(Uri.parse(url));
+            request.addRequestHeader("Cookie", mCookieManager.getCookie(url));
             request.addRequestHeader("User-Agent", userAgent);
             request.setDestinationInExternalPublicDir(
                     Environment.DIRECTORY_DOWNLOADS, fileName);


### PR DESCRIPTION
Use any cookies for the URL that is being downloaded from with the default
XWalkDownloadListenerImpl handler. This allows files that require Cookie-based
authentication to be downloaded.

BUG=XWALK-5981