### PR TITLE
gyp: Remove "gio" target.

### DIFF
--- a/build/system.gyp
+++ b/build/system.gyp
@@ -5,26 +5,6 @@
 {
   'targets' : [
     {
-      'target_name': 'gio',
-      'type': 'none',
-      'variables': {
-        'glib_packages': 'glib-2.0 gio-unix-2.0',
-      },
-      'direct_dependent_settings': {
-        'cflags': [
-          '<!@(pkg-config --cflags <(glib_packages))',
-        ],
-      },
-      'link_settings': {
-        'ldflags': [
-          '<!@(pkg-config --libs-only-L --libs-only-other <(glib_packages))',
-        ],
-        'libraries': [
-          '<!@(pkg-config --libs-only-l <(glib_packages))',
-        ],
-      },
-    },
-    {
       'target_name': 'libnotify',
       'type': 'none',
       'direct_dependent_settings': {


### PR DESCRIPTION
It duplicates what is already present in src/build/linux/system.gyp, and
was only used by Tizen code.