### PR TITLE
[Android] Fix javadoc build after 5942d33.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -324,8 +324,8 @@ public class XWalkResourceClientInternal {
      * Notify the host application that an HTTP response has been received from the server while loading a resource.
      * This callback will be called for any resource (iframe, image, etc), not just for the main page.
      * Thus, it is recommended to perform minimum required work in this callback.
-     * The feature the same as Android WebView's onReceivedHttpError when HTTP errors have status codes >= 400
-     * Customer also can get response cookies from headers when there are no errors.
+     * This method behaves similarly to the Android WebView's onReceivedHttpError if the HTTP response has a status code &gt;= 400.
+     * If there are no errors, {@code response} contains the cookies set by the HTTP response.
      *
      * @param view The XWalkView that is initiating the callback
      * @param request The originating request


### PR DESCRIPTION
Commit 5942d33 ("[Android] Notify the host application that an HTTP
response has been received from the server") introduced invalid javadoc
markup. Build output with OpenJDK8:

```
../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkResourceClient.java:331: error: bad use of '>'
     * The feature the same as Android WebView's onReceivedHttpError when HTTP errors have status codes >= 400
```

While here, improve the wording in the comments and, in particular, stop
saying "customers" when we just mean users. Not all users are customers.