### PR TITLE
gyp: Invoke pkg-config via Chromium's wrapper script.

### DIFF
--- a/build/system.gyp
+++ b/build/system.gyp
@@ -10,15 +10,15 @@
       'direct_dependent_settings': {
         'defines': ['USE_LIBNOTIFY=1'],
         'cflags': [
-          '<!@(pkg-config --cflags libnotify)',
+          '<!@(<(pkg-config) --cflags libnotify)',
         ],
       },
       'link_settings': {
         'ldflags': [
-          '<!@(pkg-config --libs-only-L --libs-only-other libnotify)',
+          '<!@(<(pkg-config) --libs-only-L --libs-only-other libnotify)',
         ],
         'libraries': [
-          '<!@(pkg-config --libs-only-l libnotify)',
+          '<!@(<(pkg-config) --libs-only-l libnotify)',
         ],
       },
     },


### PR DESCRIPTION
Invoking pkg-config via `<(pkg-config)` instead of directly calling it
makes sure the call goes through Chromium's wrapper script that returns
appropriate values for sysroots.

This change has no effect at the moment by default, but helps when using
a sysroot such as the one provided by Chromium.

Related to: XWALK-5977