### PR TITLE
[Android] Add test APKs for shared mode

### DIFF
--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/test/XWalkViewTestRunnerActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/test/XWalkViewTestRunnerActivity.java
@@ -12,16 +12,32 @@ import android.view.ViewGroup.LayoutParams;
 import android.view.WindowManager;
 import android.widget.LinearLayout;
 
+import org.xwalk.core.XWalkActivityDelegate;
+
 /*
  * This is a lightweight activity for tests that only require XWalk functionality.
  */
 public class XWalkViewTestRunnerActivity extends Activity {
 
     private LinearLayout mLinearLayout;
+    private XWalkActivityDelegate mActivityDelegate;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        Runnable cancelCommand = new Runnable() {
+            @Override
+            public void run() {
+                finish();
+            }
+        };
+        Runnable completeCommand = new Runnable() {
+            @Override
+            public void run() {
+            }
+        };
+        mActivityDelegate = new XWalkActivityDelegate(this, cancelCommand, completeCommand);
 
         getWindow().setFlags(
                 WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
@@ -34,6 +50,10 @@ public class XWalkViewTestRunnerActivity extends Activity {
                 LayoutParams.WRAP_CONTENT));
 
         setContentView(mLinearLayout);
+    }
+
+    public boolean isXWalkReady() {
+        return mActivityDelegate.isXWalkReady();
     }
 
     /**

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearHistoryTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearHistoryTest.java
@@ -11,7 +11,6 @@ import android.test.suitebuilder.annotation.SmallTest;
 import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkClient;
 
 /**
  * Test suite for clearHistory().

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
@@ -13,7 +13,6 @@ import org.chromium.content.browser.test.util.TestCallbackHelperContainer;
 import org.chromium.net.test.util.TestWebServer;
 
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkClient;
 
 import java.util.concurrent.TimeUnit;
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnUpdateTitleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnUpdateTitleTest.java
@@ -10,8 +10,6 @@ import android.test.suitebuilder.annotation.SmallTest;
 import android.util.Log;
 import org.chromium.base.test.util.Feature;
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkClient;
-import org.xwalk.core.internal.XWalkWebChromeClient;
 
 /**
  * Test suite for onUpdateTitle().

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ReloadTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ReloadTest.java
@@ -12,7 +12,6 @@ import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.chromium.net.test.util.TestWebServer;
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkClient;
 
 /**
  * Test suite for reload().

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SaveRestoreStateTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SaveRestoreStateTest.java
@@ -19,7 +19,6 @@ import org.chromium.net.test.util.TestWebServer;
 
 import org.xwalk.core.XWalkNavigationHistory;
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkClient;
 import org.xwalk.core.xwview.test.util.CommonResources;
 
 import java.util.concurrent.Callable;

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -92,7 +92,7 @@ public class XWalkViewTestBase
                 XWalkUIClient.JavascriptMessageType type, String url, String message,
                         String defaultValue, XWalkJavascriptResult result) {
             /**
-             * NOTE: Since onJavascriptModalDialog, onJsAlert, onJsConfirm, 
+             * NOTE: Since onJavascriptModalDialog, onJsAlert, onJsConfirm,
              *       and onJsPrompt API are overriden in the same subclass,
              *       call onJsAlert, onJsConfirm and onJsPrompt here to invoke
              *       overriden implementation.
@@ -279,8 +279,12 @@ public class XWalkViewTestBase
     protected void setUp() throws Exception {
         super.setUp();
 
+        final XWalkViewTestRunnerActivity activity = getActivity();
+        while(!activity.isXWalkReady()) {
+            Thread.sleep(100);
+        }
+
         // Must call getActivity() here but not in main thread.
-        final Activity activity = getActivity();
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -809,6 +809,8 @@
             'xwalk_core_internal_test_apk',
             'xwalk_core_shell_apk',
             'xwalk_core_test_apk',
+            'xwalk_shared_shell_apk',
+            'xwalk_shared_test_apk',
             'xwalk_runtime_client_embedded_shell_apk',
             'xwalk_runtime_client_embedded_test_apk',
             'xwalk_runtime_client_shell_apk',

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -35,6 +35,7 @@
         'xwalk_core_java',
         'xwalk_core_shell_apk_pak',
         'libxwalkdummy',
+        'xwalk_xwview_assets',
       ],
       'variables': {
         'apk_name': 'XWalkCoreShell',
@@ -67,6 +68,42 @@
         ],
         'asset_location': '<(PRODUCT_DIR)/xwalk_xwview/assets',
       },
+      'includes': [ '../build/java_apk.gypi' ],
+    },
+    {
+      'target_name': 'xwalk_shared_shell_apk',
+      'type': 'none',
+      'dependencies': [
+        '../third_party/android_tools/android_tools.gyp:android_support_v13_javalib',
+        '../content/content.gyp:content_java',
+        'xwalk_core_java',
+        'xwalk_xwview_assets',
+      ],
+      'variables': {
+        'apk_name': 'XWalkSharedShell',
+        'java_in_dir': 'runtime/android/core_shell',
+        'resource_dir': 'runtime/android/core_shell/res',
+        'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/www/index.html',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/www/request_focus_left_frame.html',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/www/request_focus_main.html',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/www/request_focus_right_frame.html',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/www/request_focus_right_frame1.html',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/xwalk.pak',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/jsapi/contacts_api.js',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/jsapi/device_capabilities_api.js',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/jsapi/launch_screen_api.js',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/jsapi/messaging_api.js',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/jsapi/presentation_api.js',
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/jsapi/wifidirect_api.js',
+        ],
+        'asset_location': '<(PRODUCT_DIR)/xwalk_xwview/assets',
+      },
+      'includes': [ '../build/java_apk.gypi' ],
+    },
+    {
+      'target_name': 'xwalk_xwview_assets',
+      'type': 'none',
       'copies': [
         {
           'destination': '<(PRODUCT_DIR)/xwalk_xwview/assets/www',
@@ -90,7 +127,6 @@
           ],
         },
       ],
-      'includes': [ '../build/java_apk.gypi' ],
     },
     {
       'target_name': 'xwalk_core_shell_apk_pak',
@@ -129,6 +165,14 @@
       'includes': [ '../build/apk_fake_jar.gypi' ],
     },
     {
+      'target_name': 'xwalk_shared_shell_apk_java',
+      'type': 'none',
+      'dependencies': [
+        'xwalk_shared_shell_apk',
+      ],
+      'includes': [ '../build/apk_fake_jar.gypi' ],
+    },
+    {
       'target_name': 'xwalk_core_test_apk',
       'type': 'none',
       'dependencies': [
@@ -138,6 +182,7 @@
         'xwalk_core_shell_apk_java',
         '../tools/android/md5sum/md5sum.gyp:md5sum',
         '../tools/android/forwarder2/forwarder.gyp:forwarder2',
+        'xwalk_xwview_test_assets',
       ],
       'variables': {
         'apk_name': 'XWalkCoreTest',
@@ -166,6 +211,52 @@
         ],
         'asset_location': '<(PRODUCT_DIR)/xwalk_xwview_test/assets',
       },
+      'includes': [ '../build/java_apk.gypi' ],
+    },
+    {
+      'target_name': 'xwalk_shared_test_apk',
+      'type': 'none',
+      'dependencies': [
+        '../base/base.gyp:base_java_test_support',
+        '../content/content_shell_and_tests.gyp:content_java_test_support',
+        '../net/net.gyp:net_java_test_support',
+        'xwalk_shared_shell_apk_java',
+        '../tools/android/md5sum/md5sum.gyp:md5sum',
+        '../tools/android/forwarder2/forwarder.gyp:forwarder2',
+        'xwalk_xwview_test_assets',
+      ],
+      'variables': {
+        'apk_name': 'XWalkSharedTest',
+        'java_in_dir': 'test/android/core/javatests',
+        'is_test_apk': 1,
+        'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/add_js_interface.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/create_window_1.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/create_window_2.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/console_message.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/echo_binary_java.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/echo_java.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/echo_sync_java.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/favicon.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/file_chooser.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/framesEcho.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/fullscreen_enter_exit.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/fullscreen_togged.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/icon.png',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/index.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/js_modal_dialog.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/new_window.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/profile.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/scale_changed.html',
+          '<(PRODUCT_DIR)/xwalk_xwview_test/assets/window.close.html',
+        ],
+        'asset_location': '<(PRODUCT_DIR)/xwalk_xwview_test/assets',
+      },
+      'includes': [ '../build/java_apk.gypi' ],
+    },
+    {
+      'target_name': 'xwalk_xwview_test_assets',
+      'type': 'none',
       'copies': [
         {
           'destination': '<(PRODUCT_DIR)/xwalk_xwview_test/assets',
@@ -192,7 +283,6 @@
           ],
         },
       ],
-      'includes': [ '../build/java_apk.gypi' ],
     },
     {
       'target_name': 'xwalk_core_unittests',


### PR DESCRIPTION
Add XWalkSharedShell and XWalkSharedTest for shared mode test, the
package name, test cases, assets of these APKs are just like
XWalkCoreShell and XWalkCoreTest except that they must work with
XWalkRuntimeLib.