### PR TITLE
[Windows] Enable widevine support

### DIFF
--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -351,6 +351,9 @@ if __name__ == '__main__':
     args.append('-Dnotifications=1')
     args.append('-Drelease_unwind_tables=0')
 
+  if sys.platform == 'win32':
+    args.append('-Denable_widevine=1')
+
   if not use_analyzer:
     print 'Updating projects from gyp files...'
     sys.stdout.flush()

--- a/runtime/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/runtime/browser/component_updater/widevine_cdm_component_installer.cc
@@ -1,0 +1,383 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/component_updater/widevine_cdm_component_installer.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <string>
+#include <vector>
+
+#include "base/base_paths.h"
+#include "base/bind.h"
+#include "base/compiler_specific.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/logging.h"
+#include "base/macros.h"
+#include "base/path_service.h"
+#include "base/strings/string16.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/string_split.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/values.h"
+#include "build/build_config.h"
+#include "components/component_updater/component_updater_service.h"
+#include "components/component_updater/default_component_installer.h"
+#include "components/version_info/version_info.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/plugin_service.h"
+#include "content/public/common/pepper_plugin_info.h"
+#include "media/cdm/supported_cdm_versions.h"
+#include "third_party/widevine/cdm/widevine_cdm_common.h"
+#include "xwalk/runtime/common/xwalk_paths.h"
+#include "xwalk/runtime/common/widevine_cdm_constants.h"
+
+#include "widevine_cdm_version.h"  // In SHARED_INTERMEDIATE_DIR. NOLINT
+
+using content::BrowserThread;
+using content::PluginService;
+
+namespace component_updater {
+
+#if defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_IS_COMPONENT)
+
+namespace {
+
+// CRX hash. The extension id is: oimompecagnajdejgnnjijobebaeigek.
+const uint8_t kSha2Hash[] = {0xe8, 0xce, 0xcf, 0x42, 0x06, 0xd0, 0x93, 0x49,
+                             0x6d, 0xd9, 0x89, 0xe1, 0x41, 0x04, 0x86, 0x4a,
+                             0x8f, 0xbd, 0x86, 0x12, 0xb9, 0x58, 0x9b, 0xfb,
+                             0x4f, 0xbb, 0x1b, 0xa9, 0xd3, 0x85, 0x37, 0xef};
+
+// File name of the Widevine CDM component manifest on different platforms.
+const char kWidevineCdmManifestName[] = "WidevineCdm";
+
+// File name of the Widevine CDM adapter version file. The CDM adapter shares
+// the same version number with Chromium version.
+const char kCdmAdapterVersionName[] = "CdmAdapterVersion";
+
+// Name of the Widevine CDM OS in the component manifest.
+const char kWidevineCdmPlatform[] =
+#if defined(OS_MACOSX)
+    "mac";
+#elif defined(OS_WIN)
+    "win";
+#else  // OS_LINUX, etc. TODO(viettrungluu): Separate out Chrome OS and Android?
+    "linux";
+#endif
+
+// Name of the Widevine CDM architecture in the component manifest.
+const char kWidevineCdmArch[] =
+#if defined(ARCH_CPU_X86)
+    "x86";
+#elif defined(ARCH_CPU_X86_64)
+    "x64";
+#else  // TODO(viettrungluu): Support an ARM check?
+    "???";
+#endif
+
+// The CDM manifest includes several custom values, all beginning with "x-cdm-".
+// All values are strings.
+// All values that are lists are delimited by commas. No trailing commas.
+// For example, "1,2,4".
+const char kCdmValueDelimiter = ',';
+static_assert(kCdmValueDelimiter == kCdmSupportedCodecsValueDelimiter,
+              "cdm delimiters must match");
+// The following entries are required.
+//  Interface versions are lists of integers (e.g. "1" or "1,2,4").
+//  These are checked in this file before registering the CDM.
+//  All match the interface versions from content_decryption_module.h that the
+//  CDM supports.
+//    Matches CDM_MODULE_VERSION.
+const char kCdmModuleVersionsName[] = "x-cdm-module-versions";
+//    Matches supported ContentDecryptionModule_* version(s).
+const char kCdmInterfaceVersionsName[] = "x-cdm-interface-versions";
+//    Matches supported Host_* version(s).
+const char kCdmHostVersionsName[] = "x-cdm-host-versions";
+//  The codecs list is a list of simple codec names (e.g. "vp8,vorbis").
+//  The list is passed to other parts of Chrome.
+const char kCdmCodecsListName[] = "x-cdm-codecs";
+
+// Widevine CDM is packaged as a multi-CRX. Widevine CDM binaries are located in
+// _platform_specific/<platform_arch> folder in the package. This function
+// returns the platform-specific subdirectory that is part of that multi-CRX.
+base::FilePath GetPlatformDirectory(const base::FilePath& base_path) {
+  std::string platform_arch = kWidevineCdmPlatform;
+  platform_arch += '_';
+  platform_arch += kWidevineCdmArch;
+  return base_path.AppendASCII("_platform_specific").AppendASCII(platform_arch);
+}
+
+bool MakeWidevineCdmPluginInfo(
+    const base::Version& version,
+    const base::FilePath& path,
+    const std::vector<base::string16>& additional_param_names,
+    const std::vector<base::string16>& additional_param_values,
+    content::PepperPluginInfo* plugin_info) {
+  if (!version.IsValid() ||
+      version.components().size() !=
+          static_cast<size_t>(kWidevineCdmVersionNumComponents)) {
+    return false;
+  }
+
+  plugin_info->is_internal = false;
+  // Widevine CDM must run out of process.
+  plugin_info->is_out_of_process = true;
+  plugin_info->path = path;
+  plugin_info->name = kWidevineCdmDisplayName;
+  plugin_info->description = kWidevineCdmDescription +
+                             std::string(" (version: ") + version.GetString() +
+                             ")";
+  plugin_info->version = version.GetString();
+  content::WebPluginMimeType widevine_cdm_mime_type(
+      kWidevineCdmPluginMimeType,
+      kWidevineCdmPluginExtension,
+      kWidevineCdmPluginMimeTypeDescription);
+  widevine_cdm_mime_type.additional_param_names = additional_param_names;
+  widevine_cdm_mime_type.additional_param_values = additional_param_values;
+  plugin_info->mime_types.push_back(widevine_cdm_mime_type);
+  plugin_info->permissions = kWidevineCdmPluginPermissions;
+
+  return true;
+}
+
+typedef bool (*VersionCheckFunc)(int version);
+
+bool CheckForCompatibleVersion(const base::DictionaryValue& manifest,
+                               const std::string version_name,
+                               VersionCheckFunc version_check_func) {
+  std::string versions_string;
+  if (!manifest.GetString(version_name, &versions_string)) {
+    DLOG(WARNING) << "Widevine CDM component manifest missing " << version_name;
+    return false;
+  }
+  DLOG_IF(WARNING, versions_string.empty())
+      << "Widevine CDM component manifest has empty " << version_name;
+
+  for (const base::StringPiece& ver_str : base::SplitStringPiece(
+           versions_string, std::string(1, kCdmValueDelimiter),
+           base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL)) {
+    int version = 0;
+    if (base::StringToInt(ver_str, &version) && version_check_func(version))
+        return true;
+  }
+
+  DLOG(WARNING) << "Widevine CDM component manifest has no supported "
+                << version_name << " in '" << versions_string << "'";
+  return false;
+}
+
+// Returns whether the CDM's API versions, as specified in the manifest, are
+// compatible with this Chrome binary.
+// Checks the module API, CDM interface API, and Host API.
+// This should never fail except in rare cases where the component has not been
+// updated recently or the user downgrades Chrome.
+bool IsCompatibleWithChrome(const base::DictionaryValue& manifest) {
+  return CheckForCompatibleVersion(manifest,
+                                   kCdmModuleVersionsName,
+                                   media::IsSupportedCdmModuleVersion) &&
+         CheckForCompatibleVersion(manifest,
+                                   kCdmInterfaceVersionsName,
+                                   media::IsSupportedCdmInterfaceVersion) &&
+         CheckForCompatibleVersion(manifest,
+                                   kCdmHostVersionsName,
+                                   media::IsSupportedCdmHostVersion);
+}
+
+void GetAdditionalParams(const base::DictionaryValue& manifest,
+                         std::vector<base::string16>* additional_param_names,
+                         std::vector<base::string16>* additional_param_values) {
+  base::string16 codecs;
+  if (manifest.GetString(kCdmCodecsListName, &codecs)) {
+    DLOG_IF(WARNING, codecs.empty())
+        << "Widevine CDM component manifest has empty codecs list";
+    additional_param_names->push_back(
+        base::ASCIIToUTF16(kCdmSupportedCodecsParamName));
+    additional_param_values->push_back(codecs);
+  } else {
+    DLOG(WARNING) << "Widevine CDM component manifest is missing codecs";
+  }
+}
+
+void RegisterWidevineCdmWithChrome(const base::Version& cdm_version,
+                                   const base::FilePath& adapter_install_path,
+                                   scoped_ptr<base::DictionaryValue> manifest) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  std::vector<base::string16> additional_param_names;
+  std::vector<base::string16> additional_param_values;
+  GetAdditionalParams(
+      *manifest, &additional_param_names, &additional_param_values);
+  content::PepperPluginInfo plugin_info;
+  if (!MakeWidevineCdmPluginInfo(cdm_version,
+                                 adapter_install_path,
+                                 additional_param_names,
+                                 additional_param_values,
+                                 &plugin_info)) {
+    return;
+  }
+
+  // true = Add to beginning of list to override any existing registrations.
+  PluginService::GetInstance()->RegisterInternalPlugin(
+      plugin_info.ToWebPluginInfo(), true);
+  // Tell the browser to refresh the plugin list. Then tell all renderers to
+  // update their plugin list caches.
+  PluginService::GetInstance()->RefreshPlugins();
+  PluginService::GetInstance()->PurgePluginListCache(NULL, false);
+}
+
+}  // namespace
+
+class WidevineCdmComponentInstallerTraits : public ComponentInstallerTraits {
+ public:
+  WidevineCdmComponentInstallerTraits();
+  ~WidevineCdmComponentInstallerTraits() override {}
+
+ private:
+  // The following methods override ComponentInstallerTraits.
+  bool CanAutoUpdate() const override;
+  bool OnCustomInstall(const base::DictionaryValue& manifest,
+                               const base::FilePath& install_dir) override;
+  bool VerifyInstallation(
+      const base::DictionaryValue& manifest,
+      const base::FilePath& install_dir) const override;
+  void ComponentReady(
+      const base::Version& version,
+      const base::FilePath& path,
+      scoped_ptr<base::DictionaryValue> manifest) override;
+  base::FilePath GetBaseDirectory() const override;
+  void GetHash(std::vector<uint8_t>* hash) const override;
+  std::string GetName() const override;
+
+  // Checks and updates CDM adapter if necessary to make sure the latest CDM
+  // adapter is always used.
+  // Note: The component is ready when CDM is present, but the CDM won't be
+  // registered until the adapter is copied by this function (see
+  // VerifyInstallation).
+  void UpdateCdmAdapter(const base::Version& cdm_version,
+                        const base::FilePath& cdm_install_dir,
+                        scoped_ptr<base::DictionaryValue> manifest);
+
+  DISALLOW_COPY_AND_ASSIGN(WidevineCdmComponentInstallerTraits);
+};
+
+WidevineCdmComponentInstallerTraits::WidevineCdmComponentInstallerTraits() {
+}
+
+bool WidevineCdmComponentInstallerTraits::CanAutoUpdate() const {
+  return true;
+}
+
+bool WidevineCdmComponentInstallerTraits::OnCustomInstall(
+    const base::DictionaryValue& manifest,
+    const base::FilePath& install_dir) {
+  return true;
+}
+
+// Once the CDM is ready, check the CDM adapter.
+void WidevineCdmComponentInstallerTraits::ComponentReady(
+    const base::Version& version,
+    const base::FilePath& path,
+    scoped_ptr<base::DictionaryValue> manifest) {
+  if (!IsCompatibleWithChrome(*manifest)) {
+    DLOG(WARNING) << "Installed Widevine CDM component is incompatible.";
+    return;
+  }
+
+  BrowserThread::PostBlockingPoolTask(
+      FROM_HERE,
+      base::Bind(&WidevineCdmComponentInstallerTraits::UpdateCdmAdapter,
+                 base::Unretained(this),
+                 version,
+                 path,
+                 base::Passed(&manifest)));
+}
+
+bool WidevineCdmComponentInstallerTraits::VerifyInstallation(
+    const base::DictionaryValue& manifest,
+    const base::FilePath& install_dir) const {
+  return IsCompatibleWithChrome(manifest) &&
+         base::PathExists(GetPlatformDirectory(install_dir)
+                              .AppendASCII(kWidevineCdmFileName));
+}
+
+// The base directory on Windows looks like:
+// <profile>\AppData\Local\Google\Chrome\User Data\WidevineCdm\.
+base::FilePath WidevineCdmComponentInstallerTraits::GetBaseDirectory() const {
+  base::FilePath result;
+  PathService::Get(xwalk::DIR_COMPONENT_WIDEVINE_CDM, &result);
+  return result;
+}
+
+void WidevineCdmComponentInstallerTraits::GetHash(
+    std::vector<uint8_t>* hash) const {
+  hash->assign(kSha2Hash, kSha2Hash + arraysize(kSha2Hash));
+}
+
+std::string WidevineCdmComponentInstallerTraits::GetName() const {
+  return kWidevineCdmManifestName;
+}
+
+void WidevineCdmComponentInstallerTraits::UpdateCdmAdapter(
+    const base::Version& cdm_version,
+    const base::FilePath& cdm_install_dir,
+    scoped_ptr<base::DictionaryValue> manifest) {
+  const base::FilePath adapter_version_path =
+      GetPlatformDirectory(cdm_install_dir).AppendASCII(kCdmAdapterVersionName);
+  const base::FilePath adapter_install_path =
+      GetPlatformDirectory(cdm_install_dir)
+          .AppendASCII(kWidevineCdmAdapterFileName);
+
+  const std::string chrome_version = version_info::GetVersionNumber();
+  DCHECK(!chrome_version.empty());
+  std::string adapter_version;
+  if (!base::ReadFileToString(adapter_version_path, &adapter_version) ||
+      adapter_version != chrome_version ||
+      !base::PathExists(adapter_install_path)) {
+    int bytes_written = base::WriteFile(
+        adapter_version_path, chrome_version.data(), chrome_version.size());
+    if (bytes_written < 0 ||
+        static_cast<size_t>(bytes_written) != chrome_version.size()) {
+      DLOG(WARNING) << "Failed to write Widevine CDM adapter version file.";
+      // Ignore version file writing failure and try to copy the CDM adapter.
+    }
+
+    base::FilePath adapter_source_path;
+    PathService::Get(xwalk::FILE_WIDEVINE_CDM_ADAPTER, &adapter_source_path);
+    if (!base::CopyFile(adapter_source_path, adapter_install_path)) {
+      DLOG(WARNING) << "Failed to copy Widevine CDM adapter.";
+      return;
+    }
+  }
+
+  BrowserThread::PostTask(content::BrowserThread::UI,
+                          FROM_HERE,
+                          base::Bind(&RegisterWidevineCdmWithChrome,
+                                     cdm_version,
+                                     adapter_install_path,
+                                     base::Passed(&manifest)));
+}
+
+#endif  // defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_IS_COMPONENT)
+
+void RegisterWidevineCdmComponent(ComponentUpdateService* cus) {
+#if defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_IS_COMPONENT)
+  base::FilePath adapter_source_path;
+  PathService::Get(xwalk::FILE_WIDEVINE_CDM_ADAPTER, &adapter_source_path);
+  if (!base::PathExists(adapter_source_path)) {
+    VLOG(1) << "File path " << adapter_source_path.value()
+        << " doesn't exist";
+    return;
+  }
+  scoped_ptr<ComponentInstallerTraits> traits(
+      new WidevineCdmComponentInstallerTraits);
+  // |cus| will take ownership of |installer| during installer->Register(cus).
+  DefaultComponentInstaller* installer =
+      new DefaultComponentInstaller(traits.Pass());
+  installer->Register(cus, base::Closure());
+#endif  // defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_IS_COMPONENT)
+}
+
+}  // namespace component_updater

--- a/runtime/browser/component_updater/widevine_cdm_component_installer.h
+++ b/runtime/browser/component_updater/widevine_cdm_component_installer.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_COMPONENT_UPDATER_WIDEVINE_CDM_COMPONENT_INSTALLER_H_
+#define XWALK_RUNTIME_BROWSER_COMPONENT_UPDATER_WIDEVINE_CDM_COMPONENT_INSTALLER_H_
+
+#include "components/component_updater/component_updater_service.h"
+
+namespace component_updater {
+
+class ComponentUpdateService;
+
+// Our job is to:
+// 1) Find what Widevine CDM is installed (if any).
+// 2) Register with the component updater to download the latest version when
+//    available.
+// 3) Copy the Widevine CDM adapter bundled with chrome to the install path.
+// 4) Register the Widevine CDM (via the adapter) with Chrome.
+// The first part is IO intensive so we do it asynchronously in the file thread.
+void RegisterWidevineCdmComponent(ComponentUpdateService* cus);
+
+}  // namespace component_updater
+
+#endif  // XWALK_RUNTIME_BROWSER_COMPONENT_UPDATER_WIDEVINE_CDM_COMPONENT_INSTALLER_H_

--- a/runtime/browser/component_updater/xwalk_component_updater_configurator.cc
+++ b/runtime/browser/component_updater/xwalk_component_updater_configurator.cc
@@ -1,0 +1,145 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Copyright 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/component_updater/xwalk_component_updater_configurator.h"
+
+#include <string>
+#include <vector>
+
+#include "base/threading/sequenced_worker_pool.h"
+#include "base/version.h"
+#include "components/component_updater/configurator_impl.h"
+#include "components/update_client/component_patcher_operation.h"
+#include "content/public/browser/browser_thread.h"
+
+namespace component_updater {
+
+namespace {
+
+class XwalkConfigurator : public update_client::Configurator {
+ public:
+  XwalkConfigurator(const base::CommandLine* cmdline,
+                    net::URLRequestContextGetter* url_request_getter);
+
+  // update_client::Configurator overrides.
+  int InitialDelay() const override;
+  int NextCheckDelay() const override;
+  int StepDelay() const override;
+  int OnDemandDelay() const override;
+  int UpdateDelay() const override;
+  std::vector<GURL> UpdateUrl() const override;
+  std::vector<GURL> PingUrl() const override;
+  base::Version GetBrowserVersion() const override;
+  std::string GetChannel() const override;
+  std::string GetLang() const override;
+  std::string GetOSLongName() const override;
+  std::string ExtraRequestParams() const override;
+  net::URLRequestContextGetter* RequestContext() const override;
+  scoped_refptr<update_client::OutOfProcessPatcher> CreateOutOfProcessPatcher()
+      const override;
+  bool DeltasEnabled() const override;
+  bool UseBackgroundDownloader() const override;
+  scoped_refptr<base::SequencedTaskRunner> GetSequencedTaskRunner()
+      const override;
+
+ private:
+  friend class base::RefCountedThreadSafe<XwalkConfigurator>;
+
+  ConfiguratorImpl configurator_impl_;
+
+  ~XwalkConfigurator() override {}
+};
+
+XwalkConfigurator::XwalkConfigurator(
+    const base::CommandLine* cmdline,
+    net::URLRequestContextGetter* url_request_getter)
+    : configurator_impl_(cmdline, url_request_getter) {}
+
+int XwalkConfigurator::InitialDelay() const {
+  return configurator_impl_.InitialDelay();
+}
+
+int XwalkConfigurator::NextCheckDelay() const {
+  return configurator_impl_.NextCheckDelay();
+}
+
+int XwalkConfigurator::StepDelay() const {
+  return configurator_impl_.StepDelay();
+}
+
+int XwalkConfigurator::OnDemandDelay() const {
+  return configurator_impl_.OnDemandDelay();
+}
+
+int XwalkConfigurator::UpdateDelay() const {
+  return configurator_impl_.UpdateDelay();
+}
+
+std::vector<GURL> XwalkConfigurator::UpdateUrl() const {
+  return configurator_impl_.UpdateUrl();
+}
+
+std::vector<GURL> XwalkConfigurator::PingUrl() const {
+  return configurator_impl_.PingUrl();
+}
+
+base::Version XwalkConfigurator::GetBrowserVersion() const {
+  return configurator_impl_.GetBrowserVersion();
+}
+
+std::string XwalkConfigurator::GetChannel() const {
+  NOTIMPLEMENTED();
+  return "";
+}
+
+std::string XwalkConfigurator::GetLang() const {
+  NOTIMPLEMENTED();
+  return "";
+}
+
+std::string XwalkConfigurator::GetOSLongName() const {
+  return configurator_impl_.GetOSLongName();
+}
+
+std::string XwalkConfigurator::ExtraRequestParams() const {
+  return configurator_impl_.ExtraRequestParams();
+}
+
+net::URLRequestContextGetter* XwalkConfigurator::RequestContext() const {
+  return configurator_impl_.RequestContext();
+}
+
+scoped_refptr<update_client::OutOfProcessPatcher>
+XwalkConfigurator::CreateOutOfProcessPatcher() const {
+  NOTIMPLEMENTED();
+  return nullptr;
+}
+
+bool XwalkConfigurator::DeltasEnabled() const {
+  return configurator_impl_.DeltasEnabled();
+}
+
+bool XwalkConfigurator::UseBackgroundDownloader() const {
+  return configurator_impl_.UseBackgroundDownloader();
+}
+
+scoped_refptr<base::SequencedTaskRunner>
+XwalkConfigurator::GetSequencedTaskRunner() const {
+  return content::BrowserThread::GetBlockingPool()
+      ->GetSequencedTaskRunnerWithShutdownBehavior(
+          content::BrowserThread::GetBlockingPool()->GetSequenceToken(),
+          base::SequencedWorkerPool::SKIP_ON_SHUTDOWN);
+}
+
+}  // namespace
+
+scoped_refptr<update_client::Configurator>
+MakeXwalkComponentUpdaterConfigurator(
+    const base::CommandLine* cmdline,
+    net::URLRequestContextGetter* context_getter) {
+  return new XwalkConfigurator(cmdline, context_getter);
+}
+
+}  // namespace component_updater

--- a/runtime/browser/component_updater/xwalk_component_updater_configurator.h
+++ b/runtime/browser/component_updater/xwalk_component_updater_configurator.h
@@ -1,0 +1,29 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Copyright 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_COMPONENT_UPDATER_XWALK_COMPONENT_UPDATER_CONFIGURATOR_H_
+#define XWALK_RUNTIME_BROWSER_COMPONENT_UPDATER_XWALK_COMPONENT_UPDATER_CONFIGURATOR_H_
+
+#include "base/memory/ref_counted.h"
+#include "components/update_client/configurator.h"
+
+namespace base {
+class CommandLine;
+}
+
+namespace net {
+class URLRequestContextGetter;
+}
+
+namespace component_updater {
+
+scoped_refptr<update_client::Configurator>
+MakeXwalkComponentUpdaterConfigurator(
+    const base::CommandLine* cmdline,
+    net::URLRequestContextGetter* context_getter);
+
+}  // namespace component_updater
+
+#endif  // XWALK_RUNTIME_BROWSER_COMPONENT_UPDATER_XWALK_COMPONENT_UPDATER_CONFIGURATOR_H_

--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -15,6 +15,7 @@
 #include "base/message_loop/message_loop.h"
 #include "base/strings/string_number_conversions.h"
 #include "cc/base/switches.h"
+#include "components/component_updater/component_updater_service.h"
 #include "components/devtools_http_handler/devtools_http_handler.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/content_switches.h"
@@ -31,6 +32,7 @@
 #if defined(USE_GTK_UI)
 #include "xwalk/runtime/browser/ui/gtk2_ui.h"
 #endif
+#include "xwalk/runtime/browser/component_updater/widevine_cdm_component_installer.h"
 #include "xwalk/runtime/browser/devtools/xwalk_devtools_manager_delegate.h"
 #include "xwalk/runtime/browser/ui/xwalk_javascript_native_dialog_factory.h"
 #include "xwalk/runtime/browser/xwalk_browser_context.h"
@@ -221,6 +223,11 @@ void XWalkBrowserMainParts::PreMainMessageLoopRun() {
 #if !defined(OS_ANDROID)
   if (command_line->HasSwitch(switches::kXWalkDisableSaveFormData))
     xwalk_runner_->browser_context()->set_save_form_data(false);
+  if (!command_line->HasSwitch(switches::kDisableComponentUpdate)) {
+    component_updater::ComponentUpdateService* component_update_service =
+        xwalk_runner_->component_updater();
+    RegisterWidevineCdmComponent(component_update_service);
+  }
 #endif
 
   NativeAppWindow::Initialize();

--- a/runtime/browser/xwalk_render_message_filter.cc
+++ b/runtime/browser/xwalk_render_message_filter.cc
@@ -4,6 +4,12 @@
 
 #include "xwalk/runtime/browser/xwalk_render_message_filter.h"
 
+#include <vector>
+
+#include "base/metrics/histogram_macros.h"
+#include "content/public/browser/plugin_service.h"
+#include "content/public/common/webplugininfo.h"
+
 #if defined(OS_ANDROID)
 #include "xwalk/runtime/browser/android/xwalk_contents_io_thread_client.h"
 #include "xwalk/runtime/common/android/xwalk_render_view_messages.h"
@@ -12,7 +18,39 @@
 #include "xwalk/runtime/common/xwalk_common_messages.h"
 #include "xwalk/runtime/browser/runtime_platform_util.h"
 
+#include "widevine_cdm_version.h"  // NOLINT
+
+namespace {
+
+#if defined(ENABLE_PEPPER_CDMS)
+
+enum PluginAvailabilityStatusForUMA {
+  PLUGIN_NOT_REGISTERED,
+  PLUGIN_AVAILABLE,
+  PLUGIN_DISABLED,
+  PLUGIN_AVAILABILITY_STATUS_MAX
+};
+
+static void SendPluginAvailabilityUMA(const std::string& mime_type,
+                                      PluginAvailabilityStatusForUMA status) {
+#if defined(WIDEVINE_CDM_AVAILABLE)
+  // Only report results for Widevine CDM.
+  if (mime_type != kWidevineCdmPluginMimeType)
+    return;
+
+  UMA_HISTOGRAM_ENUMERATION("Plugin.AvailabilityStatus.WidevineCdm",
+                            status, PLUGIN_AVAILABILITY_STATUS_MAX);
+#endif  // defined(WIDEVINE_CDM_AVAILABLE)
+}
+
+#endif  // defined(ENABLE_PEPPER_CDMS)
+
+}  // namespace
+
 namespace xwalk {
+
+using content::PluginService;
+using content::WebPluginInfo;
 
 XWalkRenderMessageFilter::XWalkRenderMessageFilter()
     : BrowserMessageFilter(ViewMsgStart) {
@@ -33,6 +71,11 @@ bool XWalkRenderMessageFilter::OnMessageReceived(
 #if defined(OS_ANDROID)
     IPC_MESSAGE_HANDLER(XWalkViewHostMsg_SubFrameCreated, OnSubFrameCreated)
 #endif
+#if defined(ENABLE_PEPPER_CDMS)
+    IPC_MESSAGE_HANDLER(
+        XwalkViewHostMsg_IsInternalPluginAvailableForMimeType,
+        OnIsInternalPluginAvailableForMimeType)
+#endif
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
@@ -51,5 +94,35 @@ void XWalkRenderMessageFilter::OnSubFrameCreated(
       process_id_, parent_render_frame_id, child_render_frame_id);
 }
 #endif
+
+#if defined(ENABLE_PEPPER_CDMS)
+void XWalkRenderMessageFilter::OnIsInternalPluginAvailableForMimeType(
+    const std::string& mime_type,
+    bool* is_available,
+    std::vector<base::string16>* additional_param_names,
+    std::vector<base::string16>* additional_param_values) {
+  std::vector<WebPluginInfo> plugins;
+  PluginService::GetInstance()->GetInternalPlugins(&plugins);
+
+  bool is_plugin_disabled = false;
+  for (const WebPluginInfo& plugin : plugins) {
+    const std::vector<content::WebPluginMimeType>& mime_types =
+        plugin.mime_types;
+    for (const content::WebPluginMimeType& mime_type_item : mime_types) {
+      if (mime_type_item.mime_type == mime_type) {
+        *is_available = true;
+        *additional_param_names = mime_type_item.additional_param_names;
+        *additional_param_values = mime_type_item.additional_param_values;
+        SendPluginAvailabilityUMA(mime_type, PLUGIN_AVAILABLE);
+        return;
+      }
+    }
+  }
+
+  *is_available = false;
+  SendPluginAvailabilityUMA(
+      mime_type, is_plugin_disabled ? PLUGIN_DISABLED : PLUGIN_NOT_REGISTERED);
+}
+#endif  // defined(ENABLE_PEPPER_CDMS)
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_render_message_filter.h
+++ b/runtime/browser/xwalk_render_message_filter.h
@@ -4,6 +4,10 @@
 #ifndef XWALK_RUNTIME_BROWSER_XWALK_RENDER_MESSAGE_FILTER_H_
 #define XWALK_RUNTIME_BROWSER_XWALK_RENDER_MESSAGE_FILTER_H_
 
+#include <string>
+#include <vector>
+
+#include "base/strings/string16.h"
 #include "content/public/browser/browser_message_filter.h"
 #include "url/gurl.h"
 
@@ -20,6 +24,21 @@ class XWalkRenderMessageFilter : public content::BrowserMessageFilter {
 
  private:
   void OnOpenLinkExternal(const GURL& url);
+#if defined(ENABLE_PEPPER_CDMS)
+  // Returns whether any internal plugin supporting |mime_type| is registered
+  // and enabled. Does not determine whether the plugin can actually be
+  // instantiated (e.g. whether it has all its dependencies).
+  // When the returned *|is_available| is true, |additional_param_names| and
+  // |additional_param_values| contain the name-value pairs, if any, specified
+  // for the *first* non-disabled plugin found that is registered for
+  // |mime_type|.
+  void OnIsInternalPluginAvailableForMimeType(
+      const std::string& mime_type,
+      bool* is_available,
+      std::vector<base::string16>* additional_param_names,
+      std::vector<base::string16>* additional_param_values);
+#endif
+
 #if defined(OS_ANDROID)
   void OnSubFrameCreated(int parent_render_frame_id, int child_render_frame_id);
 #endif

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -8,6 +8,7 @@
 #include <vector>
 #include "base/command_line.h"
 #include "base/logging.h"
+#include "components/update_client/configurator.h"
 #include "content/public/browser/render_process_host.h"
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_service.h"
@@ -15,6 +16,7 @@
 #include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension_switches.h"
 #include "xwalk/runtime/browser/application_component.h"
+#include "xwalk/runtime/browser/component_updater/xwalk_component_updater_configurator.h"
 #include "xwalk/runtime/browser/devtools/remote_debugging_server.h"
 #include "xwalk/runtime/browser/storage_component.h"
 #include "xwalk/runtime/browser/sysapps_component.h"
@@ -183,6 +185,20 @@ void XWalkRunner::EnableRemoteDebugging(int port) {
 
 void XWalkRunner::DisableRemoteDebugging() {
   remote_debugging_server_.reset();
+}
+
+component_updater::ComponentUpdateService* XWalkRunner::component_updater() {
+  if (!component_updater_) {
+    scoped_refptr<update_client::Configurator> configurator =
+        component_updater::MakeXwalkComponentUpdaterConfigurator(
+            base::CommandLine::ForCurrentProcess(),
+            browser_context_->GetRequestContext());
+    // Creating the component updater does not do anything, components
+    // need to be registered and Start() needs to be called.
+    component_updater_ =
+        component_updater::ComponentUpdateServiceFactory(configurator);
+  }
+  return component_updater_.get();
 }
 
 // static

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -10,6 +10,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/scoped_vector.h"
 #include "base/values.h"
+#include "components/component_updater/component_updater_service.h"
 
 #include "xwalk/runtime/browser/storage_component.h"
 
@@ -81,6 +82,8 @@ class XWalkRunner {
   void EnableRemoteDebugging(int port);
   void DisableRemoteDebugging();
 
+  component_updater::ComponentUpdateService* component_updater();
+
  protected:
   XWalkRunner();
 
@@ -145,6 +148,8 @@ class XWalkRunner {
 
   // Remote debugger server.
   scoped_ptr<RemoteDebuggingServer> remote_debugging_server_;
+
+  scoped_ptr<component_updater::ComponentUpdateService> component_updater_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRunner);
 };

--- a/runtime/common/widevine_cdm_constants.cc
+++ b/runtime/common/widevine_cdm_constants.cc
@@ -1,0 +1,17 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/common/widevine_cdm_constants.h"
+
+#include "build/build_config.h"
+#include "ppapi/shared_impl/ppapi_permissions.h"
+
+const base::FilePath::CharType kWidevineCdmBaseDirectory[] =
+    FILE_PATH_LITERAL("WidevineCDM");
+
+const char kWidevineCdmPluginExtension[] = "";
+
+const int32 kWidevineCdmPluginPermissions = ppapi::PERMISSION_DEV |
+                                            ppapi::PERMISSION_PRIVATE;

--- a/runtime/common/widevine_cdm_constants.h
+++ b/runtime/common/widevine_cdm_constants.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_COMMON_WIDEVINE_CDM_CONSTANTS_H_
+#define XWALK_RUNTIME_COMMON_WIDEVINE_CDM_CONSTANTS_H_
+
+#include "base/basictypes.h"
+#include "base/files/file_path.h"
+
+// The Widevine CDM adapter and Widevine CDM are in this directory.
+extern const base::FilePath::CharType kWidevineCdmBaseDirectory[];
+
+extern const char kWidevineCdmPluginExtension[];
+
+// Permission bits for Widevine CDM plugin.
+extern const int32 kWidevineCdmPluginPermissions;
+
+#endif  // XWALK_RUNTIME_COMMON_WIDEVINE_CDM_CONSTANTS_H_

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -5,6 +5,7 @@
 
 // Multiply-included file, no traditional include guard.
 #include <string>
+#include <vector>
 
 #include "content/public/common/common_param_traits.h"
 #include "ipc/ipc_channel_handle.h"
@@ -47,3 +48,18 @@ IPC_MESSAGE_ROUTED1(ViewMsg_HWKeyPressed, int /*keycode*/)  // NOLINT
 // These are messages sent from the renderer to the browser process.
 IPC_MESSAGE_CONTROL1(ViewMsg_OpenLinkExternal,  // NOLINT
                      GURL /* target link */)
+
+#if defined(ENABLE_PEPPER_CDMS)
+// Returns whether any internal plugin supporting |mime_type| is registered and
+// enabled. Does not determine whether the plugin can actually be instantiated
+// (e.g. whether it has all its dependencies).
+// When the returned *|is_available| is true, |additional_param_names| and
+// |additional_param_values| contain the name-value pairs, if any, specified
+// for the *first* non-disabled plugin found that is registered for |mime_type|.
+IPC_SYNC_MESSAGE_CONTROL1_3(  // NOLINT
+    XwalkViewHostMsg_IsInternalPluginAvailableForMimeType,
+    std::string /* mime_type */,
+    bool /* is_available */,
+    std::vector<base::string16> /* additional_param_names */,
+    std::vector<base::string16> /* additional_param_values */)
+#endif  // XWALK_RUNTIME_COMMON_XWALK_COMMON_MESSAGES_H_

--- a/runtime/common/xwalk_paths.cc
+++ b/runtime/common/xwalk_paths.cc
@@ -20,6 +20,8 @@
 #import "base/mac/mac_util.h"
 #endif
 
+#include "widevine_cdm_version.h"  // NOLINT
+
 namespace xwalk {
 
 namespace {
@@ -179,6 +181,23 @@ bool PathProvider(int key, base::FilePath* path) {
 #endif
       cur = cur.Append(FILE_PATH_LITERAL("pnacl"));
       break;
+#if defined(WIDEVINE_CDM_AVAILABLE) && defined(ENABLE_PEPPER_CDMS)
+#if defined(WIDEVINE_CDM_IS_COMPONENT)
+    case xwalk::DIR_COMPONENT_WIDEVINE_CDM:
+      if (!PathService::Get(xwalk::DIR_DATA_PATH, &cur))
+        return false;
+      cur = cur.Append(FILE_PATH_LITERAL("WidevineCDM"));
+      break;
+#endif  // defined(WIDEVINE_CDM_IS_COMPONENT)
+      // TODO(xhwang): FILE_WIDEVINE_CDM_ADAPTER has different meanings.
+      // In the component case, this is the source adapter. Otherwise, it is the
+      // actual Pepper module that gets loaded.
+    case xwalk::FILE_WIDEVINE_CDM_ADAPTER:
+      if (!GetInternalPluginsDirectory(&cur))
+        return false;
+      cur = cur.AppendASCII(kWidevineCdmAdapterFileName);
+      break;
+#endif  // defined(WIDEVINE_CDM_AVAILABLE) && defined(ENABLE_PEPPER_CDMS)
     case xwalk::DIR_TEST_DATA:
       if (!PathService::Get(base::DIR_SOURCE_ROOT, &cur))
         return false;

--- a/runtime/common/xwalk_paths.h
+++ b/runtime/common/xwalk_paths.h
@@ -19,6 +19,9 @@ enum {
   FILE_NACL_PLUGIN,            // Full path to the internal NaCl plugin file.
   DIR_PNACL_COMPONENT,         // Full path to the latest PNaCl version
                                // (subdir of DIR_PNACL_BASE).
+  DIR_COMPONENT_WIDEVINE_CDM,  // Directory that contains component-updated
+                               // Widevine CDM files.
+  FILE_WIDEVINE_CDM_ADAPTER,   // Full path to the Widevine CDM adapter file.
   DIR_TEST_DATA,               // Directory where unit test data resides.
   DIR_WGT_STORAGE_PATH,        // Directory where widget storage data resides.
   DIR_APPLICATION_PATH,        // Directory where applications data is stored.

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -10,6 +10,8 @@ namespace switches {
 // Specifies the icon file for the app window.
 const char kAppIcon[] = "app-icon";
 
+const char kDisableComponentUpdate[] = "disable-component-update";
+
 // Disables the usage of Portable Native Client.
 const char kDisablePnacl[] = "disable-pnacl";
 

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -11,6 +11,7 @@
 namespace switches {
 
 extern const char kAppIcon[];
+extern const char kDisableComponentUpdate[];
 extern const char kDisablePnacl[];
 extern const char kDiskCacheSize[];
 extern const char kExperimentalFeatures[];

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -29,6 +29,7 @@
 #include "xwalk/runtime/common/xwalk_localized_error.h"
 #include "xwalk/runtime/renderer/isolated_file_system.h"
 #include "xwalk/runtime/renderer/pepper/pepper_helper.h"
+#include "xwalk/runtime/renderer/xwalk_key_systems.h"
 
 #if defined(OS_ANDROID)
 #include "components/cdm/renderer/android_key_systems.h"
@@ -275,9 +276,7 @@ void XWalkContentRendererClient::GetNavigationErrorStrings(
 
 void XWalkContentRendererClient::AddKeySystems(
     std::vector<media::KeySystemInfo>* key_systems) {
-#if defined(OS_ANDROID)
-  cdm::AddAndroidWidevine(key_systems);
-#endif  // defined(OS_ANDROID)
+  AddXwalkKeySystems(key_systems);
 }
 
 }  // namespace xwalk

--- a/runtime/renderer/xwalk_key_systems.cc
+++ b/runtime/renderer/xwalk_key_systems.cc
@@ -1,0 +1,235 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/renderer/xwalk_key_systems.h"
+
+#include <string>
+#include <vector>
+
+#include "base/logging.h"
+#include "base/strings/string16.h"
+#include "base/strings/string_split.h"
+#include "base/strings/utf_string_conversions.h"
+#include "components/cdm/renderer/widevine_key_systems.h"
+#include "content/public/renderer/render_thread.h"
+#include "media/base/eme_constants.h"
+#include "xwalk/runtime/common/xwalk_common_messages.h"
+
+#if defined(OS_ANDROID)
+#include "components/cdm/renderer/android_key_systems.h"
+#endif
+
+#include "widevine_cdm_version.h"  // NOLINT
+
+// The following must be after widevine_cdm_version.h.
+
+#if defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_MIN_GLIBC_VERSION)
+#include <gnu/libc-version.h>
+#include "base/version.h"
+#endif
+
+using media::KeySystemInfo;
+using media::SupportedCodecs;
+
+#if defined(ENABLE_PEPPER_CDMS)
+static bool IsPepperCdmAvailable(
+    const std::string& pepper_type,
+    std::vector<base::string16>* additional_param_names,
+    std::vector<base::string16>* additional_param_values) {
+  bool is_available = false;
+  content::RenderThread::Get()->Send(
+      new XwalkViewHostMsg_IsInternalPluginAvailableForMimeType(
+          pepper_type,
+          &is_available,
+          additional_param_names,
+          additional_param_values));
+
+  return is_available;
+}
+
+// External Clear Key (used for testing).
+static void AddExternalClearKey(
+    std::vector<KeySystemInfo>* concrete_key_systems) {
+  static const char kExternalClearKeyKeySystem[] =
+      "org.chromium.externalclearkey";
+  static const char kExternalClearKeyDecryptOnlyKeySystem[] =
+      "org.chromium.externalclearkey.decryptonly";
+  static const char kExternalClearKeyFileIOTestKeySystem[] =
+      "org.chromium.externalclearkey.fileiotest";
+  static const char kExternalClearKeyInitializeFailKeySystem[] =
+      "org.chromium.externalclearkey.initializefail";
+  static const char kExternalClearKeyCrashKeySystem[] =
+      "org.chromium.externalclearkey.crash";
+  static const char kExternalClearKeyPepperType[] =
+      "application/x-ppapi-clearkey-cdm";
+
+  std::vector<base::string16> additional_param_names;
+  std::vector<base::string16> additional_param_values;
+  if (!IsPepperCdmAvailable(kExternalClearKeyPepperType,
+                            &additional_param_names,
+                            &additional_param_values)) {
+    return;
+  }
+
+  KeySystemInfo info;
+  info.key_system = kExternalClearKeyKeySystem;
+
+  info.supported_init_data_types =
+    media::kInitDataTypeMaskWebM | media::kInitDataTypeMaskKeyIds;
+  info.supported_codecs = media::EME_CODEC_WEBM_ALL;
+#if defined(USE_PROPRIETARY_CODECS)
+  info.supported_init_data_types |= media::kInitDataTypeMaskCenc;
+  info.supported_codecs |= media::EME_CODEC_MP4_ALL;
+#endif  // defined(USE_PROPRIETARY_CODECS)
+
+  info.max_audio_robustness = media::EmeRobustness::EMPTY;
+  info.max_video_robustness = media::EmeRobustness::EMPTY;
+
+  // Persistent sessions are faked.
+  info.persistent_license_support = media::EmeSessionTypeSupport::SUPPORTED;
+  info.persistent_release_message_support =
+      media::EmeSessionTypeSupport::NOT_SUPPORTED;
+  info.persistent_state_support = media::EmeFeatureSupport::REQUESTABLE;
+  info.distinctive_identifier_support = media::EmeFeatureSupport::NOT_SUPPORTED;
+
+  info.pepper_type = kExternalClearKeyPepperType;
+
+  concrete_key_systems->push_back(info);
+
+  // Add support of decrypt-only mode in ClearKeyCdm.
+  info.key_system = kExternalClearKeyDecryptOnlyKeySystem;
+  concrete_key_systems->push_back(info);
+
+  // A key system that triggers FileIO test in ClearKeyCdm.
+  info.key_system = kExternalClearKeyFileIOTestKeySystem;
+  concrete_key_systems->push_back(info);
+
+  // A key system that Chrome thinks is supported by ClearKeyCdm, but actually
+  // will be refused by ClearKeyCdm. This is to test the CDM initialization
+  // failure case.
+  info.key_system = kExternalClearKeyInitializeFailKeySystem;
+  concrete_key_systems->push_back(info);
+
+  // A key system that triggers a crash in ClearKeyCdm.
+  info.key_system = kExternalClearKeyCrashKeySystem;
+  concrete_key_systems->push_back(info);
+}
+
+#if defined(WIDEVINE_CDM_AVAILABLE)
+// This function finds "codecs" and parses the value into the vector |codecs|.
+// Converts the codec strings to UTF-8 since we only expect ASCII strings and
+// this simplifies the rest of the code in this file.
+void GetSupportedCodecsForPepperCdm(
+    const std::vector<base::string16>& additional_param_names,
+    const std::vector<base::string16>& additional_param_values,
+    std::vector<std::string>* codecs) {
+  DCHECK(codecs->empty());
+  DCHECK_EQ(additional_param_names.size(), additional_param_values.size());
+  for (size_t i = 0; i < additional_param_names.size(); ++i) {
+    if (additional_param_names[i] ==
+        base::ASCIIToUTF16(kCdmSupportedCodecsParamName)) {
+      const base::string16& codecs_string16 = additional_param_values[i];
+      std::string codecs_string;
+      if (!base::UTF16ToUTF8(codecs_string16.c_str(),
+                             codecs_string16.length(),
+                             &codecs_string)) {
+        DLOG(WARNING) << "Non-UTF-8 codecs string.";
+        // Continue using the best effort conversion.
+      }
+      *codecs = base::SplitString(
+          codecs_string, std::string(1, kCdmSupportedCodecsValueDelimiter),
+          base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
+      break;
+    }
+  }
+}
+
+static void AddPepperBasedWidevine(
+    std::vector<KeySystemInfo>* concrete_key_systems) {
+#if defined(WIDEVINE_CDM_MIN_GLIBC_VERSION)
+  Version glibc_version(gnu_get_libc_version());
+  DCHECK(glibc_version.IsValid());
+  if (glibc_version.IsOlderThan(WIDEVINE_CDM_MIN_GLIBC_VERSION))
+    return;
+#endif  // defined(WIDEVINE_CDM_MIN_GLIBC_VERSION)
+
+  std::vector<base::string16> additional_param_names;
+  std::vector<base::string16> additional_param_values;
+  if (!IsPepperCdmAvailable(kWidevineCdmPluginMimeType,
+                            &additional_param_names,
+                            &additional_param_values)) {
+    DVLOG(1) << "Widevine CDM is not currently available.";
+    return;
+  }
+
+  std::vector<std::string> codecs;
+  GetSupportedCodecsForPepperCdm(additional_param_names,
+                                 additional_param_values,
+                                 &codecs);
+
+  SupportedCodecs supported_codecs = media::EME_CODEC_NONE;
+
+  // Audio codecs are always supported.
+  // TODO(sandersd): Distinguish these from those that are directly supported,
+  // as those may offer a higher level of protection.
+  supported_codecs |= media::EME_CODEC_WEBM_OPUS;
+  supported_codecs |= media::EME_CODEC_WEBM_VORBIS;
+#if defined(USE_PROPRIETARY_CODECS)
+  supported_codecs |= media::EME_CODEC_MP4_AAC;
+#endif  // defined(USE_PROPRIETARY_CODECS)
+
+  for (size_t i = 0; i < codecs.size(); ++i) {
+    if (codecs[i] == kCdmSupportedCodecVp8)
+      supported_codecs |= media::EME_CODEC_WEBM_VP8;
+    if (codecs[i] == kCdmSupportedCodecVp9)
+      supported_codecs |= media::EME_CODEC_WEBM_VP9;
+#if defined(USE_PROPRIETARY_CODECS)
+    if (codecs[i] == kCdmSupportedCodecAvc1)
+      supported_codecs |= media::EME_CODEC_MP4_AVC1;
+#endif  // defined(USE_PROPRIETARY_CODECS)
+  }
+
+  cdm::AddWidevineWithCodecs(
+      cdm::WIDEVINE, supported_codecs,
+#if defined(OS_CHROMEOS)
+      media::EmeRobustness::HW_SECURE_ALL,  // Maximum audio robustness.
+      media::EmeRobustness::HW_SECURE_ALL,  // Maximim video robustness.
+      media::EmeSessionTypeSupport::
+          SUPPORTED_WITH_IDENTIFIER,  // Persistent-license.
+      media::EmeSessionTypeSupport::
+          NOT_SUPPORTED,                      // Persistent-release-message.
+      media::EmeFeatureSupport::REQUESTABLE,  // Persistent state.
+      media::EmeFeatureSupport::REQUESTABLE,  // Distinctive identifier.
+#else   // (Desktop)
+      media::EmeRobustness::SW_SECURE_CRYPTO,       // Maximum audio robustness.
+      media::EmeRobustness::SW_SECURE_DECODE,       // Maximum video robustness.
+      media::EmeSessionTypeSupport::NOT_SUPPORTED,  // persistent-license.
+      media::EmeSessionTypeSupport::
+          NOT_SUPPORTED,                        // persistent-release-message.
+      media::EmeFeatureSupport::REQUESTABLE,    // Persistent state.
+      media::EmeFeatureSupport::NOT_SUPPORTED,  // Distinctive identifier.
+#endif  // defined(OS_CHROMEOS)
+      concrete_key_systems);
+}
+#endif  // defined(WIDEVINE_CDM_AVAILABLE)
+#endif  // defined(ENABLE_PEPPER_CDMS)
+
+namespace xwalk {
+
+void AddXwalkKeySystems(std::vector<media::KeySystemInfo>* key_systems_info) {
+#if defined(ENABLE_PEPPER_CDMS)
+  AddExternalClearKey(key_systems_info);
+
+#if defined(WIDEVINE_CDM_AVAILABLE)
+  AddPepperBasedWidevine(key_systems_info);
+#endif  // defined(WIDEVINE_CDM_AVAILABLE)
+#endif  // defined(ENABLE_PEPPER_CDMS)
+
+#if defined(OS_ANDROID)
+  cdm::AddAndroidWidevine(key_systems_info);
+#endif  // defined(OS_ANDROID)
+}
+
+}  // namespace xwalk

--- a/runtime/renderer/xwalk_key_systems.h
+++ b/runtime/renderer/xwalk_key_systems.h
@@ -1,0 +1,19 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_RENDERER_XWALK_KEY_SYSTEMS_H_
+#define XWALK_RUNTIME_RENDERER_XWALK_KEY_SYSTEMS_H_
+
+#include <vector>
+
+#include "media/base/key_system_info.h"
+
+namespace xwalk {
+
+void AddXwalkKeySystems(std::vector<media::KeySystemInfo>* key_systems_info);
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_RENDERER_XWALK_KEY_SYSTEMS_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -38,9 +38,11 @@
         '../components/components.gyp:autofill_content_renderer',
         '../components/components.gyp:autofill_core_browser',
         '../components/components.gyp:cdm_renderer',
+        '../components/components.gyp:component_updater',
         '../components/components_resources.gyp:components_resources',
         '../components/components_strings.gyp:components_strings',
         '../components/components.gyp:devtools_http_handler',
+        '../components/components.gyp:update_client',
         '../components/components.gyp:user_prefs',
         '../components/components.gyp:visitedlink_browser',
         '../components/components.gyp:visitedlink_renderer',
@@ -76,6 +78,7 @@
         'extensions/extensions.gyp:xwalk_extensions',
         'sysapps/sysapps.gyp:sysapps',
         '../third_party/boringssl/boringssl.gyp:boringssl',
+        '../third_party/widevine/cdm/widevine_cdm.gyp:widevine_cdm_version_h',
       ],
       'include_dirs': [
         '..',
@@ -297,6 +300,8 @@
         'runtime/common/logging_xwalk.h',
         'runtime/common/paths_mac.h',
         'runtime/common/paths_mac.mm',
+        'runtime/common/widevine_cdm_constants.cc',
+        'runtime/common/widevine_cdm_constants.h',
         'runtime/common/xwalk_common_messages.cc',
         'runtime/common/xwalk_common_messages.h',
         'runtime/common/xwalk_common_message_generator.cc',
@@ -329,6 +334,8 @@
         'runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.h',
         'runtime/renderer/xwalk_content_renderer_client.cc',
         'runtime/renderer/xwalk_content_renderer_client.h',
+        'runtime/renderer/xwalk_key_systems.cc',
+        'runtime/renderer/xwalk_key_systems.h',
         'runtime/renderer/xwalk_render_process_observer_generic.cc',
         'runtime/renderer/xwalk_render_process_observer_generic.h',
       ],
@@ -527,6 +534,18 @@
         ['OS!="android"', {
           'dependencies': [
             'xwalk_strings',
+          ],
+        }],
+        ['OS!="android" and OS!="ios"', {
+          'sources': [
+            'runtime/browser/component_updater/widevine_cdm_component_installer.cc',
+            'runtime/browser/component_updater/widevine_cdm_component_installer.h',
+          ],
+        }],
+        ['OS!="ios"', {
+          'sources': [
+            'runtime/browser/component_updater/xwalk_component_updater_configurator.cc',
+            'runtime/browser/component_updater/xwalk_component_updater_configurator.h',
           ],
         }],
         ['disable_bundled_extensions==1', {
@@ -731,6 +750,11 @@
         ['OS=="win" and win_use_allocator_shim==1', {
           'dependencies': [
             '../base/allocator/allocator.gyp:allocator',
+          ],
+        }],
+        ['OS=="win" and enable_widevine==1', {
+          'dependencies': [
+            '../third_party/widevine/cdm/widevine_cdm.gyp:widevinecdmadapter',
           ],
         }],
         ['OS=="win"', {


### PR DESCRIPTION
This PR will let xwalk register widevine CDM component and add
corresponding key system. Based on this, Xwalk will have the ability
to play content protected media with widevine CDM.

The steps to verify this feature:
1. python gyp_xwalk.py -Dmediacodecs_EULA=1
2. ninja -C ../out/Debug xwalk.exe
3. Run '../out/Debug/xwalk
http://shaka-player-demo.appspot.com/?dash;asset=assets/car_segmenttemplate.mpd'

After above three steps, you will see the video can be played well.
Notice that adding mediacodecs_EULA=1 flag is because the test video is mp4
format. If your test video is webm, this flag is not needed.(We have opened -Denable_widevine=1 in gyp_xwalk )

BUG=XWALK-6102