### PR TITLE
M48 gardening: Fix XWalk core shell crashed with proxy service.

### DIFF
--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -103,7 +103,6 @@ RuntimeURLRequestContextGetter::RuntimeURLRequestContextGetter(
   net::ProxyConfigServiceAndroid* android_config_service =
       static_cast<net::ProxyConfigServiceAndroid*>(proxy_config_service_.get());
   android_config_service->set_exclude_pac_url(true);
-  proxy_config_service_.reset(android_config_service);
 #else
   proxy_config_service_ = net::ProxyService::CreateSystemProxyConfigService(
       io_loop_->task_runner(), file_loop_->task_runner());


### PR DESCRIPTION
From https://codereview.chromium.org/1356933002, in
aw_browser_context.cc, we can see the proxy config service was not reset
to the casted service.
This is the part 1 to fix the core shell crashed.

BUG=XWALK-6046