### PR TITLE
[Android] Update XWalkContentView to track ContentView

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'f6dc12323e2705833c7b9b3cc25f264efd4714b4'
+chromium_crosswalk_rev = '6576bdb08fdecc552328fd856f5c818279be279d'
 v8_crosswalk_rev = '8e0f20386c9d322eb9fb5738d0dd9e63a3a0b7b2'
 
 crosswalk_git = 'https://github.com/crosswalk-project'

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -68,7 +68,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
 
     private ContentViewCore mContentViewCore;
     private Context mViewContext;
-    private ContentView mContentView;
+    private XWalkContentView mContentView;
     private ContentViewRenderView mContentViewRenderView;
     private ActivityWindowAndroid mWindow;
     private XWalkDevToolsServer mDevToolsServer;
@@ -192,7 +192,8 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
 
         // Initialize ContentView.
         mContentViewCore = new ContentViewCore(mViewContext);
-        mContentView = ContentView.createContentView(mViewContext, mContentViewCore);
+        mContentView = XWalkContentView.createContentView(
+                mViewContext, mContentViewCore, mXWalkView);
         mContentViewCore.initialize(mContentView, mContentView, webContents, mWindow);
         mWebContents = mContentViewCore.getWebContents();
         mNavigationController = mWebContents.getNavigationController();

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
@@ -1,108 +1,116 @@
-// TODO(lincsoon) Adapt or probably remove XWalkContentView as per
-// https://codereview.chromium.org/1347103003
-//
-//// Copyright 2012 The Chromium Authors. All rights reserved.
-//// Copyright (c) 2015 Intel Corporation. All rights reserved.
-//// Use of this source code is governed by a BSD-style license that can be
-//// found in the LICENSE file.
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-//package org.xwalk.core.internal;
+package org.xwalk.core.internal;
 
-//import android.content.Context;
-//import android.graphics.Rect;
-//import android.os.Build;
-//import android.os.Bundle;
-//import android.util.Log;
-//import android.view.accessibility.AccessibilityNodeProvider;
-//import android.view.inputmethod.EditorInfo;
-//import android.view.inputmethod.InputConnection;
-//import android.view.MotionEvent;
-//import android.view.View;
+import android.content.Context;
+import android.graphics.Rect;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.accessibility.AccessibilityNodeProvider;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewStructure;
 
-//import org.chromium.content.browser.ContentView;
-//import org.chromium.content.browser.ContentViewCore;
+import org.chromium.content.browser.ContentView;
+import org.chromium.content.browser.ContentViewCore;
 
-//public class XWalkContentView extends ContentView {
-//    private static final String TAG = "XWalkContentView";
-//    private XWalkViewInternal mXWalkView;
+public class XWalkContentView extends ContentView {
+    private static final String TAG = "XWalkContentView";
+    private XWalkViewInternal mXWalkView;
 
-//    XWalkContentView(Context context, ContentViewCore cvc, XWalkViewInternal xwView) {
-//        super(context, cvc);
-//        mXWalkView = xwView;
-//    }
+    public static XWalkContentView createContentView(Context context, ContentViewCore cvc,
+            XWalkViewInternal xwView) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return new XWalkContentViewApi23(context, cvc, xwView);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            return new XWalkContentViewApi16(context, cvc, xwView);
+        }
+        return new XWalkContentView(context, cvc, xwView);
+    }
 
-//    @Override
-//    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-//        return mXWalkView.onCreateInputConnection(outAttrs);
-//    }
+    private XWalkContentView(Context context, ContentViewCore cvc, XWalkViewInternal xwView) {
+        super(context, cvc);
+        mXWalkView = xwView;
+    }
 
-//    public InputConnection onCreateInputConnectionSuper(EditorInfo outAttrs) {
-//        return super.onCreateInputConnection(outAttrs);
-//    }
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        return mXWalkView.onCreateInputConnection(outAttrs);
+    }
 
-//    @Override
-//    public boolean performAccessibilityAction(int action, Bundle arguments) {
-//        // Originally, we obtain a ContentView instance through ContentView.newInstance().
-//        // The method newInstance will return ContentView or JellyBeanContentView
-//        // respectively according to the sdk version like below:
-//        // public static ContentView newInstance(Context context, ContentViewCore cvc) {
-//        //     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-//        //         return new ContentView(context, cvc);
-//        //     } else {
-//        //         return new JellyBeanContentView(context, cvc);
-//        //     }
-//        // }
-//        // Now we use XWalkContentView uniformly, so this is a substitute for it.
-//        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-//            return super.performAccessibilityAction(action, arguments);
-//        }
+    public InputConnection onCreateInputConnectionSuper(EditorInfo outAttrs) {
+        return super.onCreateInputConnection(outAttrs);
+    }
 
-//        // Copy code from JellyBeanContentView because the class is not public
-//        if (mContentViewCore.supportsAccessibilityAction(action)) {
-//            return mContentViewCore.performAccessibilityAction(action, arguments);
-//        }
+    @Override
+    public boolean performLongClick(){
+        return mXWalkView.performLongClickDelegate();
+    }
 
-//        return super.performAccessibilityAction(action, arguments);
-//    }
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        // Give XWalkView a chance to handle touch event
+        if(mXWalkView.onTouchEventDelegate(event)) {
+            return true;
+        }
+        return mContentViewCore.onTouchEvent(event);
+    }
 
-//    @Override
-//    public AccessibilityNodeProvider getAccessibilityNodeProvider() {
-//        // Ditto
-//        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-//            return super.getAccessibilityNodeProvider();
-//        }
+    @Override
+    public void onScrollChanged(int l, int t, int oldl, int oldt) {
+        mXWalkView.onScrollChangedDelegate(l, t, oldl, oldt);
+    }
 
-//        // Copy code from JellyBeanContentView because the class is not public
-//        AccessibilityNodeProvider provider = mContentViewCore.getAccessibilityNodeProvider();
-//        if (provider != null) {
-//            return provider;
-//        } else {
-//            return super.getAccessibilityNodeProvider();
-//        }
-//    }
+    @Override
+    protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
+        mXWalkView.onFocusChangedDelegate(gainFocus, direction, previouslyFocusedRect);
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+    }
 
-//    @Override
-//    public boolean performLongClick(){
-//        return mXWalkView.performLongClickDelegate();
-//    }
+    // Imitate JellyBeanContentView
+    private static class XWalkContentViewApi16 extends XWalkContentView {
+        public XWalkContentViewApi16(Context context, ContentViewCore cvc,
+                XWalkViewInternal xwView) {
+            super(context, cvc, xwView);
+        }
 
-//    @Override
-//    public boolean onTouchEvent(MotionEvent event) {
-//        // Give XWalkView a chance to handle touch event
-//        if(mXWalkView.onTouchEventDelegate(event)) {
-//            return true;
-//        }
-//        return mContentViewCore.onTouchEvent(event);
-//    }
+        @Override
+        public boolean performAccessibilityAction(int action, Bundle arguments) {
+            if (mContentViewCore.supportsAccessibilityAction(action)) {
+                return mContentViewCore.performAccessibilityAction(action, arguments);
+            }
 
-//    @Override
-//    public void onScrollChanged(int l, int t, int oldl, int oldt) {
-//        mXWalkView.onScrollChangedDelegate(l, t, oldl, oldt);
-//    }
+            return super.performAccessibilityAction(action, arguments);
+        }
 
-//    @Override
-//    protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
-//        mXWalkView.onFocusChangedDelegate(gainFocus, direction, previouslyFocusedRect);
-//        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
-//    }
-//}
+        // Copy the implementation of JellyBeanContentView
+        @Override
+        public AccessibilityNodeProvider getAccessibilityNodeProvider() {
+            AccessibilityNodeProvider provider = mContentViewCore.getAccessibilityNodeProvider();
+            if (provider != null) {
+                return provider;
+            } else {
+                return super.getAccessibilityNodeProvider();
+            }
+        }
+    }
+
+    // Imitate ContentView.ContentViewApi23
+    private static class XWalkContentViewApi23 extends XWalkContentViewApi16 {
+        public XWalkContentViewApi23(Context context, ContentViewCore cvc,
+                XWalkViewInternal xwView) {
+            super(context, cvc, xwView);
+        }
+
+        @Override
+        public void onProvideVirtualStructure(final ViewStructure structure) {
+            mContentViewCore.onProvideVirtualStructure(structure);
+        }
+    }
+}


### PR DESCRIPTION
Move the methods for JellyBean to XWalkContentViewApi16 to imitate
JellyBeanContentView.
Move the mothods for AndroidM to XWalkContentViewApi23 to imitate
ContentView.ContentViewApi23.
All methods remaining in XWalkContentView is for XWalkView's usage.

XWalkContentView is a temporary solution. We are targeting to optimize
the hierarchy of XWalkView to make it more like WebView. This task can
be tracked via XWALK-6118.

BUG=XWALK-6014