### PR TITLE
ROLL DEPS.xwalk

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,8 +17,8 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '326f968871eda512be55176963b4aa6bf21ec2d8'
-v8_crosswalk_rev = '7a41457bad727a2ebac2942a8bdcc78ad2516006'
+chromium_crosswalk_rev = '247f5e0165e2b957beb38bcc2d2fc62a36bb2a47'
+v8_crosswalk_rev = 'c9b68fc3ddd4494faf9970f3fabf09b1bff8294f'
 ozone_wayland_rev = 'd6ad1b8bb4e2c71427283ffc21ac8d66cb576730'
 
 crosswalk_git = 'https://github.com/crosswalk-project'


### PR DESCRIPTION
This is the first Roll DEPS after lite-17 rebasing finished.

Including crosswalk-chromium repo and crosswalk-v8 repo.