### PR TITLE
[Android] Use a better action output definition for the javadoc target.

### DIFF
--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -49,7 +49,7 @@
             '>(xwalk_core_jar)',
           ],
           'outputs': [
-            '<(docs)/index.html',
+            '<(docs)',
           ],
           'action': [
             'javadoc',


### PR DESCRIPTION
index.html ends up being generated even if javadoc has failed with
errors. Consequently, even if javadoc fails it will not be run again
because index.html will have been generated and have an up-to-date
mtime.

Instead, indicate that the entire documentation directory is the
action's output to force javadoc to run again until it exits
successfully.