### PR TITLE
[Android] Fix javadoc build after cc194840.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -117,7 +117,7 @@ import org.xwalk.core.internal.extension.BuiltinXWalkExtensions;
  *               // Similar with before, there are two function to use:
  *               // 1) createXWalkWebResourceResponse(String mimeType, String encoding, InputStream data)
  *               // 2) createXWalkWebResourceResponse(String mimeType, String encoding, InputStream data,
- *               //             int statusCode, String reasonPhrase, Map<String, String> responseHeaders)
+ *               //             int statusCode, String reasonPhrase, Map&lt;String, String&gt; responseHeaders)
  *               ...
  *           }
  *       }


### PR DESCRIPTION
OpenJDK8 is stricter and produces an error instead of a warning (the
documentation would have looked wrong anyway):

```
../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkView.java:111:
error: malformed HTML
 *               //             int statusCode, String reasonPhrase, Map<String, String> responseHeaders)
                                                                        ^
../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkView.java:111:
error: bad use of '>'
 *               //             int statusCode, String reasonPhrase, Map<String, String> responseHeaders)
                                                                                       ^
```