### PR TITLE
crosswalk-17: Fix some memory leaks in the widget handling code.

### DIFF
--- a/application/common/manifest_handlers/widget_handler.h
+++ b/application/common/manifest_handlers/widget_handler.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/scoped_ptr.h"
 #include "base/values.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/manifest_handler.h"
@@ -20,7 +21,7 @@ class WidgetInfo : public ApplicationData::ManifestData {
   WidgetInfo();
   ~WidgetInfo() override;
   void SetString(const std::string& key, const std::string& value);
-  void Set(const std::string& key, base::Value* value);
+  void Set(const std::string& key, scoped_ptr<base::Value> value);
 
   // Name, shrot name and description are i18n items, they will be set
   // if their value were changed after loacle was changed.


### PR DESCRIPTION
They only manifest themselves in case ParsePreferenceItem() fails: in
this case, DictionaryValue::Set() is not called and |preference| leaks.

Fix it by turning most raw pointers in WidgetHandler::Parse() into
scoped_ptr's, even where it is not strictly necessary.

WidgetInfo::Set()'s prototype had to be adjusted a little to accept and
forward scoped_ptr's instead of base::Value*'s, but it is a change for
the good that prevents similar mistakes in the future.

CID=323513
CID=323514

(cherry picked from commit 56450318523a98f63e9c0aeccce5110443c9b73d)