### PR TITLE
[Android] Fix crash.

### DIFF
--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -93,7 +93,9 @@ XWalkBrowserContext::XWalkBrowserContext()
 }
 
 XWalkBrowserContext::~XWalkBrowserContext() {
+#if !defined(OS_ANDROID)
   XWalkContentSettings::GetInstance()->Shutdown();
+#endif
   if (resource_context_.get()) {
     BrowserThread::DeleteSoon(
         BrowserThread::IO, FROM_HERE, resource_context_.release());
@@ -125,7 +127,9 @@ void XWalkBrowserContext::InitWhileIOAllowed() {
     PathService::OverrideAndCreateIfNeeded(
         DIR_DATA_PATH, path, false, true);
   }
+#if !defined(OS_ANDROID)
   XWalkContentSettings::GetInstance()->Init();
+#endif
 }
 
 scoped_ptr<content::ZoomLevelDelegate>


### PR DESCRIPTION
Make sure to use the content settings only for desktop platforms
as Android does not need it.