### PR TITLE
[Windows][Linux] Favor application name when asking permission.

### DIFF
--- a/runtime/browser/runtime_geolocation_permission_context.cc
+++ b/runtime/browser/runtime_geolocation_permission_context.cc
@@ -4,6 +4,8 @@
 
 #include "xwalk/runtime/browser/runtime_geolocation_permission_context.h"
 
+#include <string>
+
 #include "base/bind.h"
 #include "base/callback.h"
 #include "base/prefs/pref_service.h"
@@ -90,6 +92,7 @@ void
 RuntimeGeolocationPermissionContext::RequestGeolocationPermission(
     content::WebContents* web_contents,
     const GURL& requesting_frame,
+    const std::string& application_name,
     base::Callback<void(bool)> result_callback) {
 #if defined(OS_ANDROID)
   content::BrowserThread::PostTask(
@@ -114,13 +117,7 @@ RuntimeGeolocationPermissionContext::RequestGeolocationPermission(
   PrefService* pref_service =
       user_prefs::UserPrefs::Get(XWalkBrowserContext::GetDefault());
   base::string16 text = l10n_util::GetStringFUTF16(
-      IDS_GEOLOCATION_DIALOG_QUESTION,
-      // FIXME : We should get the application name from the manifest.
-      url_formatter::FormatUrl(
-      requesting_frame, pref_service->GetString(kIntlAcceptLanguage),
-      url_formatter::kFormatUrlOmitUsernamePassword |
-      url_formatter::kFormatUrlOmitTrailingSlashOnBareHostname,
-      net::UnescapeRule::SPACES, nullptr, nullptr, nullptr));
+      IDS_GEOLOCATION_DIALOG_QUESTION, base::ASCIIToUTF16(application_name));
 
   permission_dialog_manager->RequestPermission(
       CONTENT_SETTINGS_TYPE_GEOLOCATION,

--- a/runtime/browser/runtime_geolocation_permission_context.h
+++ b/runtime/browser/runtime_geolocation_permission_context.h
@@ -5,6 +5,8 @@
 #ifndef XWALK_RUNTIME_BROWSER_RUNTIME_GEOLOCATION_PERMISSION_CONTEXT_H_
 #define XWALK_RUNTIME_BROWSER_RUNTIME_GEOLOCATION_PERMISSION_CONTEXT_H_
 
+#include <string>
+
 #include "base/callback.h"
 #include "base/memory/ref_counted.h"
 #include "base/strings/string16.h"
@@ -27,6 +29,7 @@ class RuntimeGeolocationPermissionContext
   virtual void RequestGeolocationPermission(
       content::WebContents* web_contents,
       const GURL& requesting_frame,
+      const std::string& application_name,
       base::Callback<void(bool)> result_callback);
   virtual void CancelGeolocationPermissionRequest(
       content::WebContents* web_contents,

--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -81,7 +81,7 @@ void HandleReadError(PersistentPrefStore::PrefReadError error) {
 }
 
 XWalkBrowserContext::XWalkBrowserContext()
-  : resource_context_(new RuntimeResourceContext),
+    : resource_context_(new RuntimeResourceContext),
     save_form_data_(true) {
   InitWhileIOAllowed();
   InitFormDatabaseService();
@@ -244,7 +244,7 @@ content::SSLHostStateDelegate* XWalkBrowserContext::GetSSLHostStateDelegate() {
 
 content::PermissionManager* XWalkBrowserContext::GetPermissionManager() {
   if (!permission_manager_.get())
-    permission_manager_.reset(new XWalkPermissionManager());
+    permission_manager_.reset(new XWalkPermissionManager(application_service_));
   return permission_manager_.get();
 }
 
@@ -269,12 +269,11 @@ net::URLRequestContextGetter* XWalkBrowserContext::CreateRequestContext(
   if (url_request_getter_)
     return url_request_getter_.get();
 
-  application::ApplicationService* service =
-      XWalkRunner::GetInstance()->app_system()->application_service();
   protocol_handlers->insert(std::pair<std::string,
         linked_ptr<net::URLRequestJobFactory::ProtocolHandler> >(
           application::kApplicationScheme,
-          application::CreateApplicationProtocolHandler(service)));
+          application::CreateApplicationProtocolHandler(
+              application_service_)));
 
   url_request_getter_ = new RuntimeURLRequestContextGetter(
       false, /* ignore_certificate_error = false */

--- a/runtime/browser/xwalk_browser_context.h
+++ b/runtime/browser/xwalk_browser_context.h
@@ -47,6 +47,10 @@ namespace xwalk {
 class RuntimeDownloadManagerDelegate;
 class RuntimeURLRequestContextGetter;
 
+namespace application {
+class ApplicationService;
+}
+
 class XWalkBrowserContext
     : public content::BrowserContext
 #if defined(OS_ANDROID)
@@ -103,6 +107,10 @@ class XWalkBrowserContext
   void UpdateAcceptLanguages(const std::string& accept_languages);
   void set_save_form_data(bool enable) { save_form_data_ = enable; }
   bool save_form_data() const { return save_form_data_; }
+  void set_application_service(
+      application::ApplicationService* application_service) {
+    application_service_ = application_service;
+  }
 #if defined(OS_ANDROID)
   void SetCSPString(const std::string& csp);
   std::string GetCSPString() const;
@@ -125,6 +133,7 @@ class XWalkBrowserContext
   void InitVisitedLinkMaster();
 #endif
 
+  application::ApplicationService* application_service_;
   scoped_ptr<RuntimeResourceContext> resource_context_;
   scoped_refptr<RuntimeDownloadManagerDelegate> download_manager_delegate_;
   scoped_refptr<RuntimeURLRequestContextGetter> url_request_getter_;

--- a/runtime/browser/xwalk_permission_manager.h
+++ b/runtime/browser/xwalk_permission_manager.h
@@ -13,9 +13,14 @@
 
 namespace xwalk {
 
+namespace application {
+class ApplicationService;
+}
+
 class XWalkPermissionManager : public content::PermissionManager {
  public:
-  XWalkPermissionManager();
+  XWalkPermissionManager(
+      application::ApplicationService* application_service);
   ~XWalkPermissionManager() override;
 
   // PermissionManager implementation.
@@ -48,8 +53,9 @@ class XWalkPermissionManager : public content::PermissionManager {
   void UnsubscribePermissionStatusChange(int subscription_id) override;
 
  private:
+  application::ApplicationService* application_service_;
   scoped_refptr<RuntimeGeolocationPermissionContext>
-    geolocation_permission_context_;
+      geolocation_permission_context_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkPermissionManager);
 };

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -74,6 +74,8 @@ void XWalkRunner::PreMainMessageLoopRun() {
 
   CreateComponents();
   app_extension_bridge_->SetApplicationSystem(app_component_->app_system());
+  browser_context_->set_application_service(
+      app_system()->application_service());
 }
 
 void XWalkRunner::PostMainMessageLoopRun() {


### PR DESCRIPTION
Instead of originating URL. If an application is launched from the
manifest.json then the URL is something like app:// and it's not
really what we want to show to the user.