### PR TITLE
[Android] Switch to the non-deprecated version of JSONReader::Read().

### DIFF
--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -281,18 +281,13 @@ jboolean XWalkContent::SetManifest(JNIEnv* env,
   std::string json_input =
       base::android::ConvertJavaStringToUTF8(env, manifest_string);
 
-  base::Value* manifest_value = base::JSONReader::DeprecatedRead(json_input);
-  if (!manifest_value) return false;
-
-  base::DictionaryValue* manifest_dictionary;
-  manifest_value->GetAsDictionary(&manifest_dictionary);
-  if (!manifest_dictionary) return false;
-
-  scoped_ptr<base::DictionaryValue>
-      manifest_dictionary_ptr(manifest_dictionary);
+  scoped_ptr<base::Value> manifest_value = base::JSONReader::Read(json_input);
+  if (!manifest_value || !manifest_value->IsType(base::Value::TYPE_DICTIONARY))
+      return false;
 
   xwalk::application::Manifest manifest(
-      manifest_dictionary_ptr.Pass());
+      make_scoped_ptr(
+          static_cast<base::DictionaryValue*>(manifest_value.release())));
 
   std::string url;
   if (manifest.GetString(keys::kStartURLKey, &url)) {

--- a/runtime/renderer/android/xwalk_render_process_observer.cc
+++ b/runtime/renderer/android/xwalk_render_process_observer.cc
@@ -60,7 +60,7 @@ void XWalkRenderProcessObserver::OnSetOriginAccessWhitelist(
   if (base_url.empty() || match_patterns.empty())
     return;
 
-  base::Value* patterns = base::JSONReader::DeprecatedRead(match_patterns);
+  scoped_ptr<base::Value> patterns = base::JSONReader::Read(match_patterns);
   if (!patterns)
     return;
 


### PR DESCRIPTION
Prepare for the M48 update by switching away from
`JSONREader::DeprecatedRead()`, which is gone in that milestone.

In `XWalkContent::SetManifest()`, we just need to receive a `scoped_ptr`
instead, and it is also possible to simplify the code:
`manifest_dictionary` and `manifest_dictionary_ptr` are unnecessary and
only clutter the code.