### PR TITLE
M48 gardening: adapt to https://codereview.chromium.org/1408393003

### DIFF
--- a/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc
+++ b/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc
@@ -115,6 +115,13 @@ void XWalkRenderViewHostExt::DidNavigateAnyFrame(
       ->AddVisitedURLs(params.redirects);
 }
 
+void XWalkRenderViewHostExt::OnPageScaleFactorChanged(float page_scale_factor) {
+  XWalkContentsClientBridgeBase* client_bridge =
+      XWalkContentsClientBridgeBase::FromWebContents(web_contents());
+  if (client_bridge != NULL)
+    client_bridge->OnWebLayoutPageScaleFactorChanged(page_scale_factor);
+}
+
 bool XWalkRenderViewHostExt::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(XWalkRenderViewHostExt, message)
@@ -122,8 +129,6 @@ bool XWalkRenderViewHostExt::OnMessageReceived(const IPC::Message& message) {
                         OnDocumentHasImagesResponse)
     IPC_MESSAGE_HANDLER(XWalkViewHostMsg_UpdateHitTestData,
                         OnUpdateHitTestData)
-    IPC_MESSAGE_HANDLER(XWalkViewHostMsg_PageScaleFactorChanged,
-                        OnPageScaleFactorChanged)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
@@ -161,13 +166,6 @@ void XWalkRenderViewHostExt::SetOriginAccessWhitelist(
     Send(new XWalkViewMsg_SetOriginAccessWhitelist(
         pending_base_url_, pending_match_patterns_));
   }
-}
-
-void XWalkRenderViewHostExt::OnPageScaleFactorChanged(float page_scale_factor) {
-  XWalkContentsClientBridgeBase* client_bridge =
-      XWalkContentsClientBridgeBase::FromWebContents(web_contents());
-  if (client_bridge != NULL)
-    client_bridge->OnWebLayoutPageScaleFactorChanged(page_scale_factor);
 }
 
 void XWalkRenderViewHostExt::SetBackgroundColor(SkColor c) {

--- a/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h
+++ b/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h
@@ -79,12 +79,12 @@ class XWalkRenderViewHostExt : public content::WebContentsObserver,
       content::RenderFrameHost* render_frame_host,
       const content::LoadCommittedDetails& details,
       const content::FrameNavigateParams& params) override;
+  void OnPageScaleFactorChanged(float page_scale_factor) override;
   bool OnMessageReceived(const IPC::Message& message) override;
 
   void OnDocumentHasImagesResponse(int msg_id, bool has_images);
   void OnUpdateHitTestData(const XWalkHitTestData& hit_test_data);
   void OnPictureUpdated();
-  void OnPageScaleFactorChanged(float page_scale_factor);
 
   bool IsRenderViewReady() const;
 

--- a/runtime/common/android/xwalk_render_view_messages.h
+++ b/runtime/common/android/xwalk_render_view_messages.h
@@ -106,10 +106,6 @@ IPC_MESSAGE_ROUTED2(XWalkViewHostMsg_DocumentHasImagesResponse, // NOLINT(*)
 IPC_MESSAGE_ROUTED1(XWalkViewHostMsg_UpdateHitTestData, // NOLINT(*)
                     xwalk::XWalkHitTestData)
 
-// Sent whenever the page scale factor (as seen by RenderView) is changed.
-IPC_MESSAGE_ROUTED1(XWalkViewHostMsg_PageScaleFactorChanged, // NOLINT(*)
-                    float /* page_scale_factor */)
-
 // Notification that a new picture becomes available. It is only sent if
 // XWalkViewMsg_EnableCapturePictureCallback was previously enabled.
 IPC_MESSAGE_ROUTED0(XWalkViewHostMsg_PictureUpdated) // NOLINT(*)

--- a/runtime/renderer/android/xwalk_render_view_ext.cc
+++ b/runtime/renderer/android/xwalk_render_view_ext.cc
@@ -126,7 +126,7 @@ void PopulateHitTestData(const GURL& absolute_link_url,
 }  // namespace
 
 XWalkRenderViewExt::XWalkRenderViewExt(content::RenderView* render_view)
-    : content::RenderViewObserver(render_view), page_scale_factor_(0.0f) {
+    : content::RenderViewObserver(render_view) {
 }
 
 XWalkRenderViewExt::~XWalkRenderViewExt() {
@@ -175,18 +175,6 @@ void XWalkRenderViewExt::DidCommitProvisionalLoad(blink::WebLocalFrame* frame,
   if (document_state->can_load_local_resources()) {
     blink::WebSecurityOrigin origin = frame->document().securityOrigin();
     origin.grantLoadLocalResources();
-  }
-}
-
-void XWalkRenderViewExt::DidCommitCompositorFrame() {
-  UpdatePageScaleFactor();
-}
-
-void XWalkRenderViewExt::UpdatePageScaleFactor() {
-  if (page_scale_factor_ != render_view()->GetWebView()->pageScaleFactor()) {
-    page_scale_factor_ = render_view()->GetWebView()->pageScaleFactor();
-    Send(new XWalkViewHostMsg_PageScaleFactorChanged(routing_id(),
-                                                  page_scale_factor_));
   }
 }
 

--- a/runtime/renderer/android/xwalk_render_view_ext.h
+++ b/runtime/renderer/android/xwalk_render_view_ext.h
@@ -35,7 +35,6 @@ class XWalkRenderViewExt : public content::RenderViewObserver {
   void DidCommitProvisionalLoad(blink::WebLocalFrame* frame,
                                 bool is_new_navigation) override;
   void FocusedNodeChanged(const blink::WebNode& node) override;
-  void DidCommitCompositorFrame() override;
 
   void OnDocumentHasImagesRequest(int id);
 
@@ -47,13 +46,9 @@ class XWalkRenderViewExt : public content::RenderViewObserver {
 
   void OnSetInitialPageScale(double page_scale_factor);
 
-  void UpdatePageScaleFactor();
-
   void OnSetBackgroundColor(SkColor c);
 
   void OnSetTextZoomFactor(float zoom_factor);
-
-  float page_scale_factor_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRenderViewExt);
 };

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
@@ -76,16 +76,17 @@ public class SetInitialScaleTest extends XWalkViewTestBase {
                 + "testSetInitialScale</p></body></html>";
         final float defaultScaleFactor = 0;
         final float defaultScale = 0.5f;
+        final float scaleFactor = 0.25f;
 
         assertEquals(defaultScaleFactor, getScaleFactor(), .01f);
         loadDataSync(null, page, "text/html", false);
-        assertEquals(defaultScaleFactor, getScaleFactor(), .01f);
+        assertEquals(scaleFactor, getScaleFactor(), .01f);
 
         int onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
-        setInitialScale(50);
+        setInitialScale(60);
         loadDataSync(null, page, "text/html", false);
         mOnScaleChangedHelper.waitForCallback(onScaleChangedCallCount);
-        assertEquals(0.5f, getPixelScale(), .01f);
+        assertEquals(0.6f, getPixelScale(), .01f);
 
         onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
         setInitialScale(500);


### PR DESCRIPTION
Upstream has made all of the pageScaleFactor changes to browser process,
WebContentsObserver can observe the changed page scale factors.
XWalkRenderViewHostExt was inherited from WebContentsObserver, so the
changed factors were propagated to it.
The previous notification has side effects that the scale factor's changed
messages were delayed.
Modify the test case to adapt to this change.

BUG=XWALK-6046