### PR TITLE
Roll Chromium 48.0.2564.79.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -38,6 +38,25 @@ hooks = [
     "action": ["python", "src/xwalk/tools/fetch_deps.py", "-v"],
   },
   {
+    # From src/DEPS: fetch the Google Play services library and, if
+    # necessary, prompt the user to accept its EULA.
+    # Run here because fetch_deps.py (itself a hook) runs another gclient
+    # instance and it all causes buffering problems that do not show the EULA
+    # prompt when necessary.
+    # Note that this hook is run after all Chromium hooks. This is not a
+    # problem as of M48, but this needs to be kept in mind in case things start
+    # to break.
+    'action': [
+      'python',
+      'src/build/android/play_services/update.py',
+      'download'
+    ],
+    'pattern':
+      '.',
+    'name':
+      'sdkextras'
+  },
+  {
     # A change to a .gyp, .gypi, or to GYP itself should run the generator.
     "name": "gyp-xwalk",
     "pattern": ".",

--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,12 +17,10 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '57bf41c15767f514360acf32f81888028aba5b58'
-v8_crosswalk_rev = '7a41457bad727a2ebac2942a8bdcc78ad2516006'
-ozone_wayland_rev = 'd6ad1b8bb4e2c71427283ffc21ac8d66cb576730'
+chromium_crosswalk_rev = '107253704f19075f6765f3a53ed0534f90338ae0'
+v8_crosswalk_rev = '8b62e725138c72ef06491a2c85006eb16117a24c'
 
 crosswalk_git = 'https://github.com/crosswalk-project'
-ozone_wayland_git = 'https://github.com/01org'
 
 # ------------------------------------------------------
 # gclient solutions.
@@ -38,10 +36,6 @@ solutions = [
         crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
       'src/v8':
         crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
-
-      # Temporary roll GYP forward so we can have support to compile managed code on Windows.
-      'src/tools/gyp':
-        'https://chromium.googlesource.com/external/gyp.git@1f374df95de1c0a125485496e8d23d36303a93fd',
 
       # Include OpenCL header files for WebCL support, target version 1.2.
       'src/third_party/khronos/CL':
@@ -74,6 +68,12 @@ solutions = [
     },
 
     'custom_hooks': [
+      # Disable the hook that downloads the Google Play services library and
+      # asks the user to accept its EULA if necessary. The prompt is not show
+      # correctly, and we call it ourselves in DEPS.xwalk.
+      {
+        'name': 'sdkextras',
+      },
       # Disable Chromium's "gyp" hooks, which runs the gyp_chromium script. We
       # are not interested in running it as we use gyp_xwalk instead (and it is
       # run at a later stage as a hook in Crosswalk's own DEPS).
@@ -83,14 +83,6 @@ solutions = [
     ],
   },
 
-  # ozone-wayland is set as a separate solution because we gclient _not_ to read
-  # its .DEPS.git: it changes the recursion limit and tries to check Chromium
-  # upstream out itself, leading to URL conflicts and errors about duplicate
-  # entries.
-  { 'name': 'src/ozone',
-    'url': ozone_wayland_git + '/ozone-wayland.git@' + ozone_wayland_rev,
-    'deps_file': '',
-  }
 ]
 
 hooks = [

--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -234,7 +234,7 @@ void ApplicationService::OnApplicationTerminated(
 
   if (applications_.empty()) {
     base::MessageLoop::current()->PostTask(
-          FROM_HERE, base::MessageLoop::QuitClosure());
+          FROM_HERE, base::MessageLoop::QuitWhenIdleClosure());
   }
 }
 

--- a/build/android/merge_jars.py
+++ b/build/android/merge_jars.py
@@ -41,7 +41,7 @@ def main():
       if not os.path.abspath(jar_file).startswith(build_dir):
         continue
       build_utils.ExtractAll(jar_file, path=temp_dir, pattern='*.class')
-    jar.JarDirectory(temp_dir, [], options.output_jar)
+    jar.JarDirectory(temp_dir, options.output_jar)
 
 
 if __name__ == '__main__':

--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -234,8 +234,12 @@ void XWalkExtensionAndroidInstance::HandleSyncMessage(
   SendSyncReplyToJS(ret_val.Pass());
 }
 
-static jlong GetOrCreateExtension(JNIEnv* env, jobject obj, jstring name,
-                                 jstring js_api, jobjectArray js_entry_points) {
+static jlong GetOrCreateExtension(
+    JNIEnv* env,
+    const JavaParamRef<jobject>& obj,
+    const JavaParamRef<jstring>& name,
+    const JavaParamRef<jstring>& js_api,
+    const JavaParamRef<jobjectArray>& js_entry_points) {
   xwalk::XWalkBrowserMainPartsAndroid* main_parts =
       ToAndroidMainParts(XWalkContentBrowserClient::Get()->main_parts());
 

--- a/extensions/common/android/xwalk_native_extension_loader_android.cc
+++ b/extensions/common/android/xwalk_native_extension_loader_android.cc
@@ -13,7 +13,9 @@
 namespace xwalk {
 namespace extensions {
 
-void RegisterExtensionInPath(JNIEnv* env, jclass jcaller, jstring path) {
+void RegisterExtensionInPath(JNIEnv* env,
+                             const JavaParamRef<jclass>& jcaller,
+                             const JavaParamRef<jstring>& path) {
   const char *str = env->GetStringUTFChars(path, 0);
   xwalk::XWalkBrowserMainPartsAndroid* main_parts =
       ToAndroidMainParts(XWalkContentBrowserClient::Get()->main_parts());

--- a/extensions/common/xwalk_external_adapter.cc
+++ b/extensions/common/xwalk_external_adapter.cc
@@ -17,7 +17,7 @@ XWalkExternalAdapter::XWalkExternalAdapter()
 XWalkExternalAdapter::~XWalkExternalAdapter() {}
 
 XWalkExternalAdapter* XWalkExternalAdapter::GetInstance() {
-  return Singleton<XWalkExternalAdapter>::get();
+  return base::Singleton<XWalkExternalAdapter>::get();
 }
 
 XW_Extension XWalkExternalAdapter::GetNextXWExtension() {

--- a/extensions/common/xwalk_external_adapter.h
+++ b/extensions/common/xwalk_external_adapter.h
@@ -56,8 +56,6 @@
     return NULL;                                                \
   }
 
-template <typename T> struct DefaultSingletonTraits;
-
 namespace xwalk {
 namespace extensions {
 
@@ -90,7 +88,7 @@ class XWalkExternalAdapter {
   static const void* GetInterface(const char* name);
 
  private:
-  friend struct DefaultSingletonTraits<XWalkExternalAdapter>;
+  friend struct base::DefaultSingletonTraits<XWalkExternalAdapter>;
 
   XWalkExternalAdapter();
   ~XWalkExternalAdapter();

--- a/extensions/test/internal_extension_browsertest.h
+++ b/extensions/test/internal_extension_browsertest.h
@@ -49,7 +49,7 @@ class TestExtensionInstance
 
   int counter_;
   scoped_ptr<XWalkExtensionFunctionInfo> heartbeat_info_;
-  base::RepeatingTimer<TestExtensionInstance> timer_;
+  base::RepeatingTimer timer_;
 
   XWalkExtensionFunctionHandler handler_;
 };

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -192,7 +192,8 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
 
         // Initialize ContentView.
         mContentViewCore = new ContentViewCore(mViewContext);
-        mContentView = new XWalkContentView(mViewContext, mContentViewCore, mXWalkView);
+        mContentView = XWalkContentView.createContentView(
+                mViewContext, mContentViewCore, mXWalkView);
         mContentViewCore.initialize(mContentView, mContentView, webContents, mWindow);
         mWebContents = mContentViewCore.getWebContents();
         mNavigationController = mWebContents.getNavigationController();

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -846,6 +846,9 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     public void onDangerousDownload(String filename, int downloadId) {
     }
 
+    public void requestFileAccess(final long callbackId) {
+    }
+
     @CalledByNative
     public void onWebLayoutPageScaleFactorChanged(float pageScaleFactor) {
         if (mPageScaleFactor == pageScaleFactor) return;

--- a/runtime/app/xwalk_main.cc
+++ b/runtime/app/xwalk_main.cc
@@ -14,7 +14,7 @@
 #include <shellscalingapi.h>
 #include "base/win/win_util.h"
 #include "base/win/windows_version.h"
-#include "content/public/app/startup_helper_win.h"
+#include "content/public/app/sandbox_helper_win.h"
 #include "sandbox/win/src/sandbox_types.h"
 #endif
 

--- a/runtime/browser/android/cookie_manager.cc
+++ b/runtime/browser/android/cookie_manager.cc
@@ -301,54 +301,63 @@ void CookieManager::SetAcceptFileSchemeCookies(bool accept) {
 
 }  // namespace
 
-static void SetAcceptCookie(JNIEnv* env, jobject obj, jboolean accept) {
+static void SetAcceptCookie(JNIEnv* env,
+                            const JavaParamRef<jobject>& obj,
+                            jboolean accept) {
   CookieManager::GetInstance()->SetAcceptCookie(accept);
 }
 
-static jboolean AcceptCookie(JNIEnv* env, jobject obj) {
+static jboolean AcceptCookie(JNIEnv* env, const JavaParamRef<jobject>& obj) {
   return CookieManager::GetInstance()->AcceptCookie();
 }
 
-static void SetCookie(JNIEnv* env, jobject obj, jstring url, jstring value) {
+static void SetCookie(JNIEnv* env,
+                      const JavaParamRef<jobject>& obj,
+                      const JavaParamRef<jstring>& url,
+                      const JavaParamRef<jstring>& value) {
   GURL host(ConvertJavaStringToUTF16(env, url));
   std::string cookie_value(ConvertJavaStringToUTF8(env, value));
 
   CookieManager::GetInstance()->SetCookie(host, cookie_value);
 }
 
-static jstring GetCookie(JNIEnv* env, jobject obj, jstring url) {
+static ScopedJavaLocalRef<jstring>
+GetCookie(JNIEnv* env,
+          const JavaParamRef<jobject>& obj,
+          const JavaParamRef<jstring>& url) {
   GURL host(ConvertJavaStringToUTF16(env, url));
 
   return base::android::ConvertUTF8ToJavaString(
-      env,
-      CookieManager::GetInstance()->GetCookie(host)).Release();
+      env, CookieManager::GetInstance()->GetCookie(host));
 }
 
-static void RemoveSessionCookie(JNIEnv* env, jobject obj) {
+static void RemoveSessionCookie(JNIEnv* env, const JavaParamRef<jobject>& obj) {
   CookieManager::GetInstance()->RemoveSessionCookie();
 }
 
-static void RemoveAllCookie(JNIEnv* env, jobject obj) {
+static void RemoveAllCookie(JNIEnv* env, const JavaParamRef<jobject>& obj) {
   CookieManager::GetInstance()->RemoveAllCookie();
 }
 
-static void RemoveExpiredCookie(JNIEnv* env, jobject obj) {
+static void RemoveExpiredCookie(JNIEnv* env, const JavaParamRef<jobject>& obj) {
   CookieManager::GetInstance()->RemoveExpiredCookie();
 }
 
-static void FlushCookieStore(JNIEnv* env, jobject obj) {
+static void FlushCookieStore(JNIEnv* env, const JavaParamRef<jobject>& obj) {
   CookieManager::GetInstance()->FlushCookieStore();
 }
 
-static jboolean HasCookies(JNIEnv* env, jobject obj) {
+static jboolean HasCookies(JNIEnv* env, const JavaParamRef<jobject>& obj) {
   return CookieManager::GetInstance()->HasCookies();
 }
 
-static jboolean AllowFileSchemeCookies(JNIEnv* env, jobject obj) {
+static jboolean AllowFileSchemeCookies(JNIEnv* env,
+                                       const JavaParamRef<jobject>& obj) {
   return CookieManager::GetInstance()->AllowFileSchemeCookies();
 }
 
-static void SetAcceptFileSchemeCookies(JNIEnv* env, jobject obj,
+static void SetAcceptFileSchemeCookies(JNIEnv* env,
+                                       const JavaParamRef<jobject>& obj,
                                        jboolean accept) {
   return CookieManager::GetInstance()->SetAcceptFileSchemeCookies(accept);
 }

--- a/runtime/browser/android/net/android_protocol_handler.cc
+++ b/runtime/browser/android/net/android_protocol_handler.cc
@@ -354,8 +354,9 @@ scoped_ptr<net::URLRequestInterceptor> CreateAppSchemeRequestInterceptor() {
 //
 // |context| should be a android.content.Context instance or NULL to enable
 // the use of the standard application context.
-static void SetResourceContextForTesting(JNIEnv* env, jclass /*clazz*/,
-                                         jobject context) {
+static void SetResourceContextForTesting(JNIEnv* env,
+                                         const JavaParamRef<jclass>& /*clazz*/,
+                                         const JavaParamRef<jobject>& context) {
   if (context) {
     ResetResourceContext(new JavaObjectWeakGlobalRef(env, context));
   } else {
@@ -363,16 +364,16 @@ static void SetResourceContextForTesting(JNIEnv* env, jclass /*clazz*/,
   }
 }
 
-static jstring GetAndroidAssetPath(JNIEnv* env, jclass /*clazz*/) {
+static ScopedJavaLocalRef<jstring> GetAndroidAssetPath(JNIEnv* env,
+                                   const JavaParamRef<jclass>& /*clazz*/) {
   // OK to release, JNI binding.
-  return ConvertUTF8ToJavaString(
-      env, xwalk::kAndroidAssetPath).Release();
+  return ConvertUTF8ToJavaString(env, xwalk::kAndroidAssetPath);
 }
 
-static jstring GetAndroidResourcePath(JNIEnv* env, jclass /*clazz*/) {
+static ScopedJavaLocalRef<jstring> GetAndroidResourcePath(
+    JNIEnv* env, const JavaParamRef<jclass>& /*clazz*/) {
   // OK to release, JNI binding.
-  return ConvertUTF8ToJavaString(
-      env, xwalk::kAndroidResourcePath).Release();
+  return ConvertUTF8ToJavaString(env, xwalk::kAndroidResourcePath);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/android/net/xwalk_url_request_job_factory.cc
+++ b/runtime/browser/android/net/xwalk_url_request_job_factory.cc
@@ -73,8 +73,8 @@ net::URLRequestJob* XWalkURLRequestJobFactory::MaybeInterceptResponse(
 
 bool XWalkURLRequestJobFactory::SetProtocolHandler(
     const std::string& scheme,
-    ProtocolHandler* protocol_handler) {
-  return next_factory_->SetProtocolHandler(scheme, protocol_handler);
+    scoped_ptr<ProtocolHandler> protocol_handler) {
+  return next_factory_->SetProtocolHandler(scheme, protocol_handler.Pass());
 }
 
 bool XWalkURLRequestJobFactory::IsSafeRedirectTarget(

--- a/runtime/browser/android/net/xwalk_url_request_job_factory.h
+++ b/runtime/browser/android/net/xwalk_url_request_job_factory.h
@@ -29,7 +29,7 @@ class XWalkURLRequestJobFactory : public net::URLRequestJobFactory {
   ~XWalkURLRequestJobFactory() override;
 
   bool SetProtocolHandler(const std::string& scheme,
-                          ProtocolHandler* protocol_handler);
+                          scoped_ptr<ProtocolHandler> protocol_handler);
 
   // net::URLRequestJobFactory implementation.
   virtual net::URLRequestJob* MaybeCreateJobWithProtocolHandler(

--- a/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc
+++ b/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc
@@ -115,6 +115,13 @@ void XWalkRenderViewHostExt::DidNavigateAnyFrame(
       ->AddVisitedURLs(params.redirects);
 }
 
+void XWalkRenderViewHostExt::OnPageScaleFactorChanged(float page_scale_factor) {
+  XWalkContentsClientBridgeBase* client_bridge =
+      XWalkContentsClientBridgeBase::FromWebContents(web_contents());
+  if (client_bridge != NULL)
+    client_bridge->OnWebLayoutPageScaleFactorChanged(page_scale_factor);
+}
+
 bool XWalkRenderViewHostExt::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(XWalkRenderViewHostExt, message)
@@ -122,8 +129,6 @@ bool XWalkRenderViewHostExt::OnMessageReceived(const IPC::Message& message) {
                         OnDocumentHasImagesResponse)
     IPC_MESSAGE_HANDLER(XWalkViewHostMsg_UpdateHitTestData,
                         OnUpdateHitTestData)
-    IPC_MESSAGE_HANDLER(XWalkViewHostMsg_PageScaleFactorChanged,
-                        OnPageScaleFactorChanged)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
@@ -161,13 +166,6 @@ void XWalkRenderViewHostExt::SetOriginAccessWhitelist(
     Send(new XWalkViewMsg_SetOriginAccessWhitelist(
         pending_base_url_, pending_match_patterns_));
   }
-}
-
-void XWalkRenderViewHostExt::OnPageScaleFactorChanged(float page_scale_factor) {
-  XWalkContentsClientBridgeBase* client_bridge =
-      XWalkContentsClientBridgeBase::FromWebContents(web_contents());
-  if (client_bridge != NULL)
-    client_bridge->OnWebLayoutPageScaleFactorChanged(page_scale_factor);
 }
 
 void XWalkRenderViewHostExt::SetBackgroundColor(SkColor c) {

--- a/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h
+++ b/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h
@@ -79,12 +79,12 @@ class XWalkRenderViewHostExt : public content::WebContentsObserver,
       content::RenderFrameHost* render_frame_host,
       const content::LoadCommittedDetails& details,
       const content::FrameNavigateParams& params) override;
+  void OnPageScaleFactorChanged(float page_scale_factor) override;
   bool OnMessageReceived(const IPC::Message& message) override;
 
   void OnDocumentHasImagesResponse(int msg_id, bool has_images);
   void OnUpdateHitTestData(const XWalkHitTestData& hit_test_data);
   void OnPictureUpdated();
-  void OnPageScaleFactorChanged(float page_scale_factor);
 
   bool IsRenderViewReady() const;
 

--- a/runtime/browser/android/xwalk_autofill_client_android.cc
+++ b/runtime/browser/android/xwalk_autofill_client_android.cc
@@ -10,6 +10,7 @@
 #include "base/android/scoped_java_ref.h"
 #include "components/autofill/core/browser/autofill_manager.h"
 #include "jni/XWalkAutofillClientAndroid_jni.h"
+#include "ui/gfx/geometry/rect_f.h"
 #include "xwalk/runtime/browser/android/xwalk_content.h"
 
 using base::android::AttachCurrentThread;

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -113,7 +113,7 @@ bool ManifestGetString(const xwalk::application::Manifest& manifest,
 XWalkContent* XWalkContent::FromID(int render_process_id,
                                    int render_view_id) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
-  const content::RenderViewHost* rvh =
+  content::RenderViewHost* rvh =
       content::RenderViewHost::FromID(render_process_id, render_view_id);
   if (!rvh) return NULL;
   content::WebContents* web_contents =
@@ -457,7 +457,7 @@ jboolean XWalkContent::SetState(JNIEnv* env, jobject obj, jbyteArray state) {
   return RestoreFromPickle(&iterator, web_contents_.get());
 }
 
-static jlong Init(JNIEnv* env, jobject obj) {
+static jlong Init(JNIEnv* env, const JavaParamRef<jobject>& obj) {
   scoped_ptr<WebContents> web_contents(content::WebContents::Create(
       content::WebContents::CreateParams(
           XWalkRunner::GetInstance()->browser_context())));

--- a/runtime/browser/android/xwalk_contents_client_bridge_base.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge_base.cc
@@ -60,7 +60,7 @@ XWalkContentsClientBridgeBase* XWalkContentsClientBridgeBase::FromRenderViewID(
     int render_process_id,
     int render_view_id) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
-  const content::RenderViewHost* rvh =
+  content::RenderViewHost* rvh =
       content::RenderViewHost::FromID(render_process_id, render_view_id);
   if (!rvh) return NULL;
   content::WebContents* web_contents =

--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -76,6 +76,10 @@ class XWalkAndroidDevToolsHttpHandlerDelegate
   std::string GetPageThumbnailData(const GURL& url) override {
     return std::string();
   }
+  content::DevToolsExternalAgentProxyDelegate*
+      HandleWebSocketConnection(const std::string& path) override {
+    return nullptr;
+  }
 
  private:
   DISALLOW_COPY_AND_ASSIGN(XWalkAndroidDevToolsHttpHandlerDelegate);
@@ -173,25 +177,27 @@ bool RegisterXWalkDevToolsServer(JNIEnv* env) {
 }
 
 static jlong InitRemoteDebugging(JNIEnv* env,
-                                jobject obj,
-                                jstring socketName) {
+                                const JavaParamRef<jobject>& obj,
+                                const JavaParamRef<jstring>& socketName) {
   XWalkDevToolsServer* server = new XWalkDevToolsServer(
       base::android::ConvertJavaStringToUTF8(env, socketName));
   return reinterpret_cast<intptr_t>(server);
 }
 
-static void DestroyRemoteDebugging(JNIEnv* env, jobject obj, jlong server) {
+static void DestroyRemoteDebugging(JNIEnv* env,
+                                   const JavaParamRef<jobject>& obj,
+                                   jlong server) {
   delete reinterpret_cast<XWalkDevToolsServer*>(server);
 }
 
 static jboolean IsRemoteDebuggingEnabled(JNIEnv* env,
-                                         jobject obj,
+                                         const JavaParamRef<jobject>& obj,
                                          jlong server) {
   return reinterpret_cast<XWalkDevToolsServer*>(server)->IsStarted();
 }
 
 static void SetRemoteDebuggingEnabled(JNIEnv* env,
-                                      jobject obj,
+                                      const JavaParamRef<jobject>& obj,
                                       jlong server,
                                       jboolean enabled,
                                       jboolean allow_debug_permission,

--- a/runtime/browser/android/xwalk_path_helper.cc
+++ b/runtime/browser/android/xwalk_path_helper.cc
@@ -27,8 +27,10 @@ void XWalkPathHelper::SetDirectory(const std::string& virtualRoot,
       base::FilePath::FromUTF8Unsafe(path);
 }
 
-static void SetDirectory(JNIEnv* env, jclass clazz,
-    jstring virtualRoot, jstring path) {
+static void SetDirectory(JNIEnv* env,
+                         const JavaParamRef<jclass>& clazz,
+                         const JavaParamRef<jstring>& virtualRoot,
+                         const JavaParamRef<jstring>& path) {
   const char* strVirtualRoot = env->GetStringUTFChars(virtualRoot, NULL);
   const char* strPath = env->GetStringUTFChars(path, NULL);
   XWalkPathHelper::SetDirectory(

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -291,17 +291,17 @@ PrefService* XWalkSettings::GetPrefs() {
 }
 
 static jlong Init(JNIEnv* env,
-                 jobject obj,
-                 jobject web_contents) {
+                 const JavaParamRef<jobject>& obj,
+                 const JavaParamRef<jobject>& web_contents) {
   content::WebContents* contents = content::WebContents::FromJavaWebContents(
       web_contents);
   XWalkSettings* settings = new XWalkSettings(env, obj, contents);
   return reinterpret_cast<intptr_t>(settings);
 }
 
-static jstring GetDefaultUserAgent(JNIEnv* env, jclass clazz) {
-  return base::android::ConvertUTF8ToJavaString(
-      env, GetUserAgent()).Release();
+static ScopedJavaLocalRef<jstring>
+GetDefaultUserAgent(JNIEnv* env, const JavaParamRef<jclass>& clazz) {
+  return base::android::ConvertUTF8ToJavaString(env, GetUserAgent());
 }
 
 void XWalkSettings::UpdateInitialPageScale(JNIEnv* env, jobject obj) {

--- a/runtime/browser/android/xwalk_view_delegate.cc
+++ b/runtime/browser/android/xwalk_view_delegate.cc
@@ -10,7 +10,7 @@
 
 namespace xwalk {
 
-jboolean IsLibraryBuiltForIA(JNIEnv* env, jclass jcaller) {
+jboolean IsLibraryBuiltForIA(JNIEnv* env, const JavaParamRef<jclass>& jcaller) {
 #if defined(ARCH_CPU_X86) || defined(ARCH_CPU_X86_64)
   return JNI_TRUE;
 #else

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -13,9 +13,10 @@
 #include "base/lazy_instance.h"
 #include "base/message_loop/message_loop.h"
 #include "base/strings/utf_string_conversions.h"
-#include "content/public/browser/web_contents.h"
+#include "content/public/browser/native_web_keyboard_event.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/common/file_chooser_file_info.h"
 #include "content/public/common/file_chooser_params.h"
 #include "jni/XWalkWebContentsDelegate_jni.h"
@@ -254,8 +255,9 @@ bool XWalkWebContentsDelegate::IsFullscreenForTabOrPending(
 
 bool XWalkWebContentsDelegate::ShouldCreateWebContents(
     content::WebContents* web_contents,
-    int route_id,
-    int main_frame_route_id,
+    int32_t route_id,
+    int32_t main_frame_route_id,
+    int32_t main_frame_widget_route_id,
     WindowContainerType window_container_type,
     const std::string& frame_name,
     const GURL& target_url,

--- a/runtime/browser/android/xwalk_web_contents_delegate.h
+++ b/runtime/browser/android/xwalk_web_contents_delegate.h
@@ -61,8 +61,9 @@ class XWalkWebContentsDelegate
 
   bool ShouldCreateWebContents(
       content::WebContents* web_contents,
-      int route_id,
-      int main_frame_route_id,
+      int32_t route_id,
+      int32_t main_frame_route_id,
+      int32_t main_frame_widget_route_id,
       WindowContainerType window_container_type,
       const std::string& frame_name,
       const GURL& target_url,

--- a/runtime/browser/devtools/remote_debugging_server.cc
+++ b/runtime/browser/devtools/remote_debugging_server.cc
@@ -64,6 +64,8 @@ class XWalkDevToolsHttpHandlerDelegate :
   std::string GetDiscoveryPageHTML() override;
   std::string GetFrontendResource(const std::string& path) override;
   std::string GetPageThumbnailData(const GURL& url) override;
+  content::DevToolsExternalAgentProxyDelegate*
+      HandleWebSocketConnection(const std::string& path) override;
   void ProcessAndSaveThumbnail(const GURL& url,
                                scoped_refptr<base::RefCountedBytes> png);
 
@@ -119,6 +121,12 @@ std::string XWalkDevToolsHttpHandlerDelegate::GetPageThumbnailData(
     }
   }
   return std::string();
+}
+
+content::DevToolsExternalAgentProxyDelegate*
+XWalkDevToolsHttpHandlerDelegate::HandleWebSocketConnection(
+    const std::string& path) {
+  return nullptr;
 }
 
 void XWalkDevToolsHttpHandlerDelegate::ProcessAndSaveThumbnail(

--- a/runtime/browser/devtools/xwalk_devtools_frontend.h
+++ b/runtime/browser/devtools/xwalk_devtools_frontend.h
@@ -35,7 +35,6 @@ namespace xwalk {
 class NativeAppWindowDesktop;
 
 class XWalkDevToolsFrontend : public content::WebContentsObserver,
-                              public content::DevToolsFrontendHost::Delegate,
                               public content::DevToolsAgentHostClient,
                               public net::URLFetcherDelegate,
                               public Runtime::Observer {
@@ -78,9 +77,7 @@ class XWalkDevToolsFrontend : public content::WebContentsObserver,
   void WebContentsDestroyed() override;
 
   // content::DevToolsFrontendHost::Delegate implementation.
-  void HandleMessageFromDevToolsFrontend(const std::string& message) override;
-  void HandleMessageFromDevToolsFrontendToBackend(
-      const std::string& message) override;
+  void HandleMessageFromDevToolsFrontend(const std::string& message);
 
   // net::URLFetcherDelegate overrides.
   void OnURLFetchComplete(const net::URLFetcher* source) override;

--- a/runtime/browser/devtools/xwalk_devtools_manager_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_manager_delegate.cc
@@ -111,6 +111,8 @@ class XWalkDevToolsDelegate :
   std::string GetDiscoveryPageHTML() override;
   std::string GetFrontendResource(const std::string& path) override;
   std::string GetPageThumbnailData(const GURL& url) override;
+  content::DevToolsExternalAgentProxyDelegate*
+      HandleWebSocketConnection(const std::string& path) override;
 
  private:
   XWalkBrowserContext* browser_context_;
@@ -144,6 +146,11 @@ std::string XWalkDevToolsDelegate::GetFrontendResource(
 
 std::string XWalkDevToolsDelegate::GetPageThumbnailData(const GURL& url) {
   return std::string();
+}
+
+content::DevToolsExternalAgentProxyDelegate*
+XWalkDevToolsDelegate::HandleWebSocketConnection(const std::string& path) {
+  return nullptr;
 }
 
 }  // namespace

--- a/runtime/browser/media/media_capture_devices_dispatcher.cc
+++ b/runtime/browser/media/media_capture_devices_dispatcher.cc
@@ -36,7 +36,7 @@ const content::MediaStreamDevice* FindDefaultDeviceWithId(
 
 XWalkMediaCaptureDevicesDispatcher*
     XWalkMediaCaptureDevicesDispatcher::GetInstance() {
-  return Singleton<XWalkMediaCaptureDevicesDispatcher>::get();
+  return base::Singleton<XWalkMediaCaptureDevicesDispatcher>::get();
 }
 
 void XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission(
@@ -51,7 +51,7 @@ void XWalkMediaCaptureDevicesDispatcher::RunRequestMediaAccessPermission(
       (request.video_type == content::MEDIA_DEVICE_VIDEO_CAPTURE);
   if (microphone_requested || webcam_requested) {
     switch (request.request_type) {
-      case content::MEDIA_OPEN_DEVICE:
+      case content::MEDIA_OPEN_DEVICE_PEPPER_ONLY:
       case content::MEDIA_DEVICE_ACCESS:
       case content::MEDIA_GENERATE_STREAM:
       case content::MEDIA_ENUMERATE_DEVICES:

--- a/runtime/browser/media/media_capture_devices_dispatcher.h
+++ b/runtime/browser/media/media_capture_devices_dispatcher.h
@@ -85,7 +85,8 @@ class XWalkMediaCaptureDevicesDispatcher : public content::MediaObserver {
   void SetTestVideoCaptureDevices(const content::MediaStreamDevices& devices);
 
  private:
-  friend struct DefaultSingletonTraits<XWalkMediaCaptureDevicesDispatcher>;
+  friend struct
+      base::DefaultSingletonTraits<XWalkMediaCaptureDevicesDispatcher>;
 
   XWalkMediaCaptureDevicesDispatcher();
   ~XWalkMediaCaptureDevicesDispatcher() override;

--- a/runtime/browser/runtime.cc
+++ b/runtime/browser/runtime.cc
@@ -17,6 +17,7 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
+#include "content/public/browser/render_widget_host.h"
 #include "content/public/browser/web_contents.h"
 #include "grit/xwalk_resources.h"
 #include "ui/base/resource/resource_bundle.h"
@@ -237,11 +238,7 @@ content::JavaScriptDialogManager* Runtime::GetJavaScriptDialogManager(
 }
 
 void Runtime::ActivateContents(content::WebContents* contents) {
-  contents->GetRenderViewHost()->Focus();
-}
-
-void Runtime::DeactivateContents(content::WebContents* contents) {
-  contents->GetRenderViewHost()->Blur();
+  contents->GetRenderViewHost()->GetWidget()->Focus();
 }
 
 content::ColorChooser* Runtime::OpenColorChooser(

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -129,7 +129,6 @@ class Runtime : public content::WebContentsDelegate,
   content::JavaScriptDialogManager* GetJavaScriptDialogManager(
       content::WebContents* contents) override;
   void ActivateContents(content::WebContents* contents) override;
-  void DeactivateContents(content::WebContents* contents) override;
   bool CanOverscrollContent() const override;
   bool PreHandleKeyboardEvent(
       content::WebContents* source,

--- a/runtime/browser/runtime_file_select_helper.cc
+++ b/runtime/browser/runtime_file_select_helper.cc
@@ -20,6 +20,7 @@
 #include "content/public/browser/notification_source.h"
 #include "content/public/browser/notification_types.h"
 #include "content/public/browser/render_view_host.h"
+#include "content/public/browser/render_widget_host.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/file_chooser_file_info.h"
@@ -338,7 +339,7 @@ void RuntimeFileSelectHelper::RunFileChooser(RenderViewHost* render_view_host,
   notification_registrar_.RemoveAll();
   notification_registrar_.Add(
       this, content::NOTIFICATION_RENDER_WIDGET_HOST_DESTROYED,
-      content::Source<RenderWidgetHost>(render_view_host_));
+      content::Source<RenderWidgetHost>(render_view_host_->GetWidget()));
   notification_registrar_.Add(
       this, content::NOTIFICATION_WEB_CONTENTS_DESTROYED,
       content::Source<WebContents>(web_contents_));
@@ -405,8 +406,8 @@ void RuntimeFileSelectHelper::RunFileChooserOnUIThread(
       // TODO(wang16): Load last select directory here
       base::FilePath();
 
-  gfx::NativeWindow owning_window =
-      platform_util::GetTopLevel(render_view_host_->GetView()->GetNativeView());
+  gfx::NativeWindow owning_window = platform_util::GetTopLevel(
+      render_view_host_->GetWidget()->GetView()->GetNativeView());
 
 #if defined(OS_ANDROID)
   // Android needs the original MIME types and an additional capture value.
@@ -470,7 +471,7 @@ void RuntimeFileSelectHelper::Observe(
   switch (type) {
     case content::NOTIFICATION_RENDER_WIDGET_HOST_DESTROYED: {
       DCHECK(content::Source<RenderWidgetHost>(source).ptr() ==
-             render_view_host_);
+             render_view_host_->GetWidget());
       render_view_host_ = NULL;
       break;
     }

--- a/runtime/browser/runtime_network_delegate.cc
+++ b/runtime/browser/runtime_network_delegate.cc
@@ -73,8 +73,8 @@ void RuntimeNetworkDelegate::OnBeforeRedirect(net::URLRequest* request,
 void RuntimeNetworkDelegate::OnResponseStarted(net::URLRequest* request) {
 }
 
-void RuntimeNetworkDelegate::OnRawBytesRead(const net::URLRequest& request,
-                                            int bytes_read) {
+void RuntimeNetworkDelegate::OnNetworkBytesReceived(net::URLRequest* request,
+                                                    int64_t bytes_received) {
 }
 
 void RuntimeNetworkDelegate::OnCompleted(net::URLRequest* request,

--- a/runtime/browser/runtime_network_delegate.h
+++ b/runtime/browser/runtime_network_delegate.h
@@ -37,8 +37,8 @@ class RuntimeNetworkDelegate : public net::NetworkDelegateImpl {
   void OnBeforeRedirect(net::URLRequest* request,
                         const GURL& new_location) override;
   void OnResponseStarted(net::URLRequest* request) override;
-  void OnRawBytesRead(const net::URLRequest& request,
-                      int bytes_read) override;
+  void OnNetworkBytesReceived(net::URLRequest* request,
+                              int64_t bytes_received) override;
   void OnCompleted(net::URLRequest* request, bool started) override;
   void OnURLRequestDestroyed(net::URLRequest* request) override;
   void OnPACScriptError(int line_number,

--- a/runtime/browser/runtime_resource_dispatcher_host_delegate_android.cc
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate_android.cc
@@ -214,14 +214,6 @@ void RuntimeResourceDispatcherHostDelegateAndroid::RequestBeginning(
   const content::ResourceRequestInfo* request_info =
       content::ResourceRequestInfo::ForRequest(request);
 
-  // We allow intercepting only navigations within main frames. This
-  // is used to post onPageStarted. We handle shouldOverrideUrlLoading
-  // via a sync IPC for url loading in iframe.
-  if (resource_type == content::RESOURCE_TYPE_MAIN_FRAME) {
-    throttles->push_back(InterceptNavigationDelegate::CreateThrottleFor(
-        request));
-  }
-
   // If io_client is NULL, then the browser side objects have already been
   // destroyed, so do not do anything to the request. Conversely if the
   // request relates to a not-yet-created popup window, then the client will

--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -11,6 +11,7 @@
 
 #include "base/command_line.h"
 #include "base/logging.h"
+#include "base/memory/scoped_ptr.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
@@ -97,17 +98,14 @@ RuntimeURLRequestContextGetter::RuntimeURLRequestContextGetter(
   // must synchronously run on the glib message loop. This will be passed to
   // the URLRequestContextStorage on the IO thread in GetURLRequestContext().
 #if defined(OS_ANDROID)
-  net::ProxyConfigServiceAndroid* config_service =
-      static_cast<net::ProxyConfigServiceAndroid*>(
-          net::ProxyService::CreateSystemProxyConfigService(
-              io_loop_->task_runner(), file_loop_->task_runner()));
-  config_service->set_exclude_pac_url(true);
-
-  proxy_config_service_.reset(config_service);
+  proxy_config_service_ = net::ProxyService::CreateSystemProxyConfigService(
+      io_loop_->task_runner(), file_loop_->task_runner());
+  net::ProxyConfigServiceAndroid* android_config_service =
+      static_cast<net::ProxyConfigServiceAndroid*>(proxy_config_service_.get());
+  android_config_service->set_exclude_pac_url(true);
 #else
-  proxy_config_service_.reset(
-      net::ProxyService::CreateSystemProxyConfigService(
-          io_loop_->task_runner(), file_loop_->task_runner()));
+  proxy_config_service_ = net::ProxyService::CreateSystemProxyConfigService(
+      io_loop_->task_runner(), file_loop_->task_runner());
 #endif
 }
 
@@ -146,26 +144,28 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
     storage_->set_channel_id_service(make_scoped_ptr(new net::ChannelIDService(
         new net::DefaultChannelIDStore(NULL),
         base::WorkerPool::GetTaskRunner(true))));
-    storage_->set_http_user_agent_settings(new net::StaticHttpUserAgentSettings(
-        "en-us,en", xwalk::GetUserAgent()));
+    storage_->set_http_user_agent_settings(make_scoped_ptr(
+        new net::StaticHttpUserAgentSettings("en-us,en",
+                                             xwalk::GetUserAgent())));
 
     scoped_ptr<net::HostResolver> host_resolver(
         net::HostResolver::CreateDefaultResolver(NULL));
 
     storage_->set_cert_verifier(net::CertVerifier::CreateDefault());
-    storage_->set_transport_security_state(new net::TransportSecurityState);
+    storage_->set_transport_security_state(
+        make_scoped_ptr(new net::TransportSecurityState));
 #if defined(OS_ANDROID)
     // Android provides a local HTTP proxy that handles all the proxying.
     // Create the proxy without a resolver since we rely
     // on this local HTTP proxy.
     storage_->set_proxy_service(
         net::ProxyService::CreateWithoutProxyResolver(
-        proxy_config_service_.release(),
+        proxy_config_service_.Pass(),
         NULL));
 #else
     storage_->set_proxy_service(
         net::ProxyService::CreateUsingSystemProxyResolver(
-        proxy_config_service_.release(),
+        proxy_config_service_.Pass(),
         0,
         NULL));
 #endif
@@ -176,14 +176,14 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
         new net::HttpServerPropertiesImpl));
 
     base::FilePath cache_path = base_path_.Append(FILE_PATH_LITERAL("Cache"));
-    net::HttpCache::DefaultBackend* main_backend =
+    scoped_ptr<net::HttpCache::DefaultBackend> main_backend(
         new net::HttpCache::DefaultBackend(
             net::DISK_CACHE,
             net::CACHE_BACKEND_DEFAULT,
             cache_path,
             GetDiskCacheSize(),
             BrowserThread::GetMessageLoopProxyForThread(
-                BrowserThread::CACHE));
+                BrowserThread::CACHE)));
 
     net::HttpNetworkSession::Params network_session_params;
     network_session_params.cert_verifier =
@@ -210,10 +210,12 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
     network_session_params.host_resolver =
         url_request_context_->host_resolver();
 
-    net::HttpCache* main_cache = new net::HttpCache(
-        network_session_params, main_backend);
-    storage_->set_http_transaction_factory(main_cache);
-
+    storage_->set_http_network_session(
+        make_scoped_ptr(new net::HttpNetworkSession(network_session_params)));
+    storage_->set_http_transaction_factory(
+        make_scoped_ptr(new net::HttpCache(storage_->http_network_session(),
+                        main_backend.Pass(),
+                        false /* set_up_quic_server_info */)));
 #if defined(OS_ANDROID)
     scoped_ptr<XWalkURLRequestJobFactory> job_factory_impl(
         new XWalkURLRequestJobFactory);
@@ -231,7 +233,7 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
          it != protocol_handlers_.end();
          ++it) {
       set_protocol = job_factory_impl->SetProtocolHandler(
-          it->first, it->second.release());
+          it->first, make_scoped_ptr(it->second.release()));
       DCHECK(set_protocol);
     }
     protocol_handlers_.clear();
@@ -240,14 +242,14 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
     // Add new basic schemes.
     set_protocol = job_factory_impl->SetProtocolHandler(
         url::kDataScheme,
-        new net::DataProtocolHandler);
+        make_scoped_ptr(new net::DataProtocolHandler));
     DCHECK(set_protocol);
     set_protocol = job_factory_impl->SetProtocolHandler(
         url::kFileScheme,
-        new net::FileProtocolHandler(
+        make_scoped_ptr(new net::FileProtocolHandler(
             content::BrowserThread::GetBlockingPool()->
             GetTaskRunnerWithShutdownBehavior(
-                base::SequencedWorkerPool::SKIP_ON_SHUTDOWN)));
+                base::SequencedWorkerPool::SKIP_ON_SHUTDOWN))));
     DCHECK(set_protocol);
 
     // Step 3:
@@ -298,7 +300,7 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
     }
     request_interceptors_.weak_clear();
 
-    storage_->set_job_factory(top_job_factory.release());
+    storage_->set_job_factory(top_job_factory.Pass());
   }
 
   return url_request_context_.get();
@@ -317,8 +319,9 @@ void RuntimeURLRequestContextGetter::UpdateAcceptLanguages(
     const std::string& accept_languages) {
   if (!storage_)
     return;
-  storage_->set_http_user_agent_settings(new net::StaticHttpUserAgentSettings(
-      accept_languages, xwalk::GetUserAgent()));
+  storage_->set_http_user_agent_settings(make_scoped_ptr(
+      new net::StaticHttpUserAgentSettings(accept_languages,
+                                           xwalk::GetUserAgent())));
 }
 
 }  // namespace xwalk

--- a/runtime/browser/ui/desktop/xwalk_autofill_popup_controller.cc
+++ b/runtime/browser/ui/desktop/xwalk_autofill_popup_controller.cc
@@ -359,7 +359,6 @@ bool XWalkAutofillPopupController::HasSuggestions() {
       id == autofill::POPUP_ITEM_ID_AUTOCOMPLETE_ENTRY ||
       id == autofill::POPUP_ITEM_ID_PASSWORD_ENTRY ||
       id == autofill::POPUP_ITEM_ID_DATALIST_ENTRY ||
-      id == autofill::POPUP_ITEM_ID_MAC_ACCESS_CONTACTS ||
       id == autofill::POPUP_ITEM_ID_SCAN_CREDIT_CARD;
 }
 

--- a/runtime/browser/ui/desktop/xwalk_popup_controller.cc
+++ b/runtime/browser/ui/desktop/xwalk_popup_controller.cc
@@ -38,7 +38,7 @@ void XWalkPopupController::SetKeyPressCallback(
 void XWalkPopupController::RegisterKeyPressCallback() {
   if (web_contents_ && !key_press_event_target_) {
     key_press_event_target_ = web_contents_->GetRenderViewHost();
-    key_press_event_target_->AddKeyPressEventCallback(
+    key_press_event_target_->GetWidget()->AddKeyPressEventCallback(
         key_press_event_callback_);
   }
 }
@@ -46,8 +46,8 @@ void XWalkPopupController::RegisterKeyPressCallback() {
 void XWalkPopupController::UnregisterKeyPressCallback() {
   if (web_contents_ && (!web_contents_->IsBeingDestroyed()) &&
     key_press_event_target_ == web_contents_->GetRenderViewHost()) {
-    web_contents_->GetRenderViewHost()->RemoveKeyPressEventCallback(
-        key_press_event_callback_);
+    web_contents_->GetRenderViewHost()->GetWidget()
+        ->RemoveKeyPressEventCallback(key_press_event_callback_);
   }
   key_press_event_target_ = nullptr;
 }

--- a/runtime/browser/ui/native_app_window_desktop.cc
+++ b/runtime/browser/ui/native_app_window_desktop.cc
@@ -8,6 +8,7 @@
 #include "base/command_line.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/render_view_host.h"
+#include "content/public/browser/render_widget_host.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "grit/xwalk_strings.h"
@@ -306,7 +307,7 @@ void NativeAppWindowDesktop::ButtonPressed(views::Button* sender,
 }
 
 void NativeAppWindowDesktop::FocusContent() {
-  web_contents_->GetRenderViewHost()->Focus();
+  web_contents_->GetRenderViewHost()->GetWidget()->Focus();
 }
 
 void NativeAppWindowDesktop::ShowWebViewContextMenu(

--- a/runtime/browser/xwalk_autofill_client.cc
+++ b/runtime/browser/xwalk_autofill_client.cc
@@ -5,6 +5,8 @@
 
 #include "xwalk/runtime/browser/xwalk_autofill_client.h"
 
+#include <string>
+
 #include "base/logging.h"
 #include "base/prefs/pref_registry_simple.h"
 #include "base/prefs/pref_service.h"
@@ -17,6 +19,7 @@
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/ssl_status.h"
+#include "ui/gfx/geometry/rect_f.h"
 #include "xwalk/runtime/browser/xwalk_browser_context.h"
 #include "xwalk/runtime/browser/xwalk_content_browser_client.h"
 
@@ -113,11 +116,6 @@ void XWalkAutofillClient::OnFirstUserGestureObserved() {
   NOTIMPLEMENTED();
 }
 
-void XWalkAutofillClient::LinkClicked(const GURL& url,
-                                      WindowOpenDisposition disposition) {
-  NOTIMPLEMENTED();
-}
-
 bool XWalkAutofillClient::IsContextSecure(const GURL& form_origin) {
   content::SSLStatus ssl_status;
   content::NavigationEntry* navigation_entry =
@@ -156,12 +154,23 @@ void XWalkAutofillClient::ShowUnmaskPrompt(
   NOTIMPLEMENTED();
 }
 
-void XWalkAutofillClient::OnUnmaskVerificationResult(GetRealPanResult result) {
+void XWalkAutofillClient::OnUnmaskVerificationResult(PaymentsRpcResult result) {
   NOTIMPLEMENTED();
 }
 
-void XWalkAutofillClient::ConfirmSaveCreditCard(
+void XWalkAutofillClient::ConfirmSaveCreditCardLocally(
     const base::Closure& save_card_callback) {
+  NOTIMPLEMENTED();
+}
+
+void XWalkAutofillClient::ConfirmSaveCreditCardToCloud(
+    const base::Closure& callback,
+    scoped_ptr<base::DictionaryValue> legal_message) {
+  NOTIMPLEMENTED();
+}
+
+void XWalkAutofillClient::LoadRiskData(
+    const base::Callback<void(const std::string&)>& callback) {
   NOTIMPLEMENTED();
 }
 

--- a/runtime/browser/xwalk_autofill_client.h
+++ b/runtime/browser/xwalk_autofill_client.h
@@ -6,6 +6,7 @@
 #ifndef XWALK_RUNTIME_BROWSER_XWALK_AUTOFILL_CLIENT_H_
 #define XWALK_RUNTIME_BROWSER_XWALK_AUTOFILL_CLIENT_H_
 
+#include <string>
 #include <vector>
 
 #include "base/basictypes.h"
@@ -64,9 +65,14 @@ class XWalkAutofillClient : public autofill::AutofillClient {
   void ShowUnmaskPrompt(
       const autofill::CreditCard& card,
       base::WeakPtr<autofill::CardUnmaskDelegate> delegate) override;
-  void OnUnmaskVerificationResult(GetRealPanResult result) override;
-  void ConfirmSaveCreditCard(
-      const base::Closure& save_card_callback) override;
+  void OnUnmaskVerificationResult(PaymentsRpcResult result) override;
+  void ConfirmSaveCreditCardLocally(
+      const base::Closure& callback) override;
+  void ConfirmSaveCreditCardToCloud(
+      const base::Closure& callback,
+      scoped_ptr<base::DictionaryValue> legal_message) override;
+  void LoadRiskData(
+      const base::Callback<void(const std::string&)>& callback) override;
   bool HasCreditCardScanFeature() override;
   void ScanCreditCard(const CreditCardScanCallback& callback) override;
   void ShowRequestAutocompleteDialog(
@@ -90,8 +96,6 @@ class XWalkAutofillClient : public autofill::AutofillClient {
       const base::string16& autofilled_value,
       const base::string16& profile_full_name) override;
   void OnFirstUserGestureObserved() override;
-  void LinkClicked(
-      const GURL& url, WindowOpenDisposition disposition) override;
   bool IsContextSecure(const GURL& form_origin) override;
   void SuggestionSelected(int position);
 

--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -248,6 +248,11 @@ content::PermissionManager* XWalkBrowserContext::GetPermissionManager() {
   return permission_manager_.get();
 }
 
+content::BackgroundSyncController*
+XWalkBrowserContext::GetBackgroundSyncController() {
+  return nullptr;
+}
+
 RuntimeURLRequestContextGetter*
 XWalkBrowserContext::GetURLRequestContextGetterById(
     const std::string& pkg_id) {

--- a/runtime/browser/xwalk_browser_context.h
+++ b/runtime/browser/xwalk_browser_context.h
@@ -90,6 +90,7 @@ class XWalkBrowserContext
   content::PushMessagingService* GetPushMessagingService() override;
   content::SSLHostStateDelegate* GetSSLHostStateDelegate() override;
   content::PermissionManager* GetPermissionManager() override;
+  content::BackgroundSyncController* GetBackgroundSyncController() override;
 
   RuntimeURLRequestContextGetter* GetURLRequestContextGetterById(
       const std::string& pkg_id);

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -161,8 +161,6 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   command_line->AppendSwitch(switches::kDisableWebRtcHWEncoding);
 #endif
 
-  command_line->AppendSwitch(switches::kEnableViewportMeta);
-
   // WebView does not (yet) save Chromium data during shutdown, so add setting
   // for Chrome to aggressively persist DOM Storage to minimize data loss.
   // http://crbug.com/479767

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -166,6 +166,11 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
 
   std::string GetApplicationLocale() override;
 
+#if defined(OS_ANDROID)
+  ScopedVector<content::NavigationThrottle> CreateThrottlesForNavigation(
+      content::NavigationHandle* navigation_handle) override;
+#endif
+
  private:
   XWalkRunner* xwalk_runner_;
   net::URLRequestContextGetter* url_request_context_getter_;

--- a/runtime/browser/xwalk_content_settings.cc
+++ b/runtime/browser/xwalk_content_settings.cc
@@ -20,7 +20,7 @@ namespace xwalk {
 
 // static
 XWalkContentSettings* XWalkContentSettings::GetInstance() {
-  return Singleton<XWalkContentSettings>::get();
+  return base::Singleton<XWalkContentSettings>::get();
 }
 
 base::FilePath XWalkContentSettings::GetPrefFilePathFromPath(

--- a/runtime/browser/xwalk_content_settings.h
+++ b/runtime/browser/xwalk_content_settings.h
@@ -43,7 +43,7 @@ class XWalkContentSettings {
   scoped_refptr<JsonPrefStore> pref_store_;
   scoped_refptr<base::SequencedTaskRunner> sequenced_task_runner_;
   scoped_refptr<HostContentSettingsMap> host_content_settings_map_;
-  friend struct DefaultSingletonTraits<XWalkContentSettings>;
+  friend struct base::DefaultSingletonTraits<XWalkContentSettings>;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkContentSettings);
 };

--- a/runtime/browser/xwalk_form_database_service.cc
+++ b/runtime/browser/xwalk_form_database_service.cc
@@ -94,7 +94,8 @@ void XWalkFormDatabaseService::HasFormDataImpl(
     WaitableEvent* completion,
     bool* result) {
   WebDataServiceBase::Handle pending_query_handle =
-      autofill_data_->HasFormElements(this);
+      autofill_data_->GetCountOfValuesContainedBetween(
+          base::Time(), base::Time::Max(), this);
   PendingQuery query;
   query.result = result;
   query.completion = completion;
@@ -109,9 +110,9 @@ void XWalkFormDatabaseService::OnWebDataServiceRequestDone(
   bool has_form_data = false;
   if (result) {
     DCHECK_EQ(AUTOFILL_VALUE_RESULT, result->GetType());
-    const WDResult<bool>* autofill_result =
-        static_cast<const WDResult<bool>*>(result);
-    has_form_data = autofill_result->GetValue();
+    const WDResult<int>* autofill_result =
+        static_cast<const WDResult<int>*>(result);
+    has_form_data = autofill_result->GetValue() > 0;
   }
   QueryMap::const_iterator it = result_map_.find(h);
   if (it == result_map_.end()) {

--- a/runtime/browser/xwalk_permission_manager.cc
+++ b/runtime/browser/xwalk_permission_manager.cc
@@ -6,6 +6,7 @@
 #include "xwalk/runtime/browser/xwalk_permission_manager.h"
 
 #include <string>
+#include <vector>
 
 #include "base/callback.h"
 #include "content/public/browser/permission_type.h"
@@ -15,52 +16,91 @@
 #include "xwalk/application/browser/application.h"
 #include "xwalk/application/browser/application_service.h"
 
+using content::PermissionStatus;
+using content::PermissionType;
+
 namespace xwalk {
 
-namespace {
+struct XWalkPermissionManager::PendingRequest {
+ public:
+  PendingRequest(PermissionType permission,
+                 GURL requesting_origin,
+                 GURL embedding_origin,
+                 content::RenderFrameHost* render_frame_host,
+                 const base::Callback<void(PermissionStatus)>& callback)
+    : permission(permission),
+      requesting_origin(requesting_origin),
+      embedding_origin(embedding_origin),
+      render_process_id(render_frame_host->GetProcess()->GetID()),
+      render_frame_id(render_frame_host->GetRoutingID()),
+      callback(callback) {
+  }
 
-void CallbackPermisisonStatusWrapper(
-    const base::Callback<void(content::PermissionStatus)>& callback,
-    bool allowed) {
-  callback.Run(allowed ? content::PERMISSION_STATUS_GRANTED
-                       : content::PERMISSION_STATUS_DENIED);
-}
+  ~PendingRequest() = default;
 
-}  // anonymous namespace
+  PermissionType permission;
+  GURL requesting_origin;
+  GURL embedding_origin;
+  int render_process_id;
+  int render_frame_id;
+  base::Callback<void(PermissionStatus)> callback;
+};
 
 XWalkPermissionManager::XWalkPermissionManager(
     application::ApplicationService* application_service)
     : content::PermissionManager(),
-    application_service_(application_service) {
+      application_service_(application_service),
+      weak_ptr_factory_(this) {
 }
 
 XWalkPermissionManager::~XWalkPermissionManager() {
 }
 
-void XWalkPermissionManager::RequestPermission(
-    content::PermissionType permission,
-    content::RenderFrameHost* render_frame_host,
-    int request_id,
-    const GURL& requesting_origin,
-    bool user_gesture,
-    const base::Callback<void(content::PermissionStatus)>& callback) {
+int XWalkPermissionManager::RequestPermission(
+      content::PermissionType permission,
+      content::RenderFrameHost* render_frame_host,
+      const GURL& requesting_origin,
+      bool user_gesture,
+      const base::Callback<void(content::PermissionStatus)>& callback) {
+  bool should_delegate_request = true;
+  for (PendingRequestsMap::Iterator<PendingRequest> it(&pending_requests_);
+      !it.IsAtEnd(); it.Advance()) {
+    if (permission == it.GetCurrentValue()->permission) {
+      should_delegate_request = false;
+      break;
+    }
+  }
+
+  const GURL& embedding_origin =
+      content::WebContents::FromRenderFrameHost(render_frame_host)
+          ->GetLastCommittedURL().GetOrigin();
+  int request_id = kNoPendingOperation;
+
   switch (permission) {
     case content::PermissionType::GEOLOCATION: {
-      if (!geolocation_permission_context_.get()) {
-        geolocation_permission_context_ =
-            new RuntimeGeolocationPermissionContext();
-      }
-      application::Application* app =
-          application_service_->GetApplicationByRenderHostID(
+      request_id = pending_requests_.Add(new PendingRequest(
+          permission, requesting_origin,
+          embedding_origin, render_frame_host,
+          callback));
+
+      if (should_delegate_request) {
+        if (!geolocation_permission_context_.get()) {
+          geolocation_permission_context_ =
+              new RuntimeGeolocationPermissionContext();
+        }
+        application::Application* app =
+            application_service_->GetApplicationByRenderHostID(
             render_frame_host->GetProcess()->GetID());
-      std::string app_name;
-      if (app)
-        app_name = app->data()->Name();
-      geolocation_permission_context_->RequestGeolocationPermission(
-          content::WebContents::FromRenderFrameHost(render_frame_host),
-          requesting_origin,
-          app_name,
-          base::Bind(&CallbackPermisisonStatusWrapper, callback));
+        std::string app_name;
+        if (app)
+          app_name = app->data()->Name();
+        geolocation_permission_context_->RequestGeolocationPermission(
+            content::WebContents::FromRenderFrameHost(render_frame_host),
+            requesting_origin,
+            app_name,
+            base::Bind(&OnRequestResponse, weak_ptr_factory_.GetWeakPtr(),
+                       request_id, callback));
+      }
       break;
     }
     case content::PermissionType::PROTECTED_MEDIA_IDENTIFIER:
@@ -71,6 +111,8 @@ void XWalkPermissionManager::RequestPermission(
     case content::PermissionType::PUSH_MESSAGING:
     case content::PermissionType::MIDI:
     case content::PermissionType::DURABLE_STORAGE:
+    case content::PermissionType::AUDIO_CAPTURE:
+    case content::PermissionType::VIDEO_CAPTURE:
       NOTIMPLEMENTED() << "RequestPermission is not implemented for "
                        << static_cast<int>(permission);
       callback.Run(content::PERMISSION_STATUS_DENIED);
@@ -80,18 +122,35 @@ void XWalkPermissionManager::RequestPermission(
       callback.Run(content::PERMISSION_STATUS_DENIED);
       break;
   }
+  return request_id;
 }
 
-void XWalkPermissionManager::CancelPermissionRequest(
-    content::PermissionType permission,
+int XWalkPermissionManager::RequestPermissions(
+    const std::vector<content::PermissionType>& permissions,
     content::RenderFrameHost* render_frame_host,
-    int request_id,
-    const GURL& requesting_origin) {
-  switch (permission) {
+    const GURL& requesting_origin,
+    bool user_gesture,
+    const base::Callback<void(
+        const std::vector<content::PermissionStatus>&)>& callback) {
+  // TODO(mrunalk): Rework this as per,
+  // https://codereview.chromium.org/1419083002
+  NOTIMPLEMENTED() << "RequestPermissions not implemented in Crosswalk";
+  return kNoPendingOperation;
+}
+
+void XWalkPermissionManager::CancelPermissionRequest(int request_id) {
+  PendingRequest* pending_request = pending_requests_.Lookup(request_id);
+  if (!pending_request)
+    return;
+  content::RenderFrameHost* render_frame_host =
+      content::RenderFrameHost::FromID(pending_request->render_process_id,
+          pending_request->render_frame_id);
+
+  switch (pending_request->permission) {
     case content::PermissionType::GEOLOCATION:
       geolocation_permission_context_->CancelGeolocationPermissionRequest(
           content::WebContents::FromRenderFrameHost(render_frame_host),
-          requesting_origin);
+          pending_request->requesting_origin);
       break;
     case content::PermissionType::PROTECTED_MEDIA_IDENTIFIER:
       break;
@@ -100,13 +159,43 @@ void XWalkPermissionManager::CancelPermissionRequest(
     case content::PermissionType::PUSH_MESSAGING:
     case content::PermissionType::MIDI:
     case content::PermissionType::DURABLE_STORAGE:
+    case content::PermissionType::AUDIO_CAPTURE:
+    case content::PermissionType::VIDEO_CAPTURE:
       NOTIMPLEMENTED() << "CancelPermission not implemented for "
-                       << static_cast<int>(permission);
+                       << static_cast<int>(pending_request->permission);
       break;
     case content::PermissionType::NUM:
       NOTREACHED() << "PermissionType::NUM was not expected here.";
       break;
   }
+  pending_requests_.Remove(request_id);
+}
+
+// static
+void XWalkPermissionManager::OnRequestResponse(
+    const base::WeakPtr<XWalkPermissionManager>& manager,
+    int request_id,
+    const base::Callback<void(PermissionStatus)>& callback,
+    bool allowed) {
+  PermissionStatus status = allowed ? content::PERMISSION_STATUS_GRANTED
+                                    : content::PERMISSION_STATUS_DENIED;
+  if (manager.get()) {
+    PendingRequest* pending_request =
+    manager->pending_requests_.Lookup(request_id);
+
+    for (PendingRequestsMap::Iterator<PendingRequest> it(
+            &manager->pending_requests_);
+         !it.IsAtEnd(); it.Advance()) {
+      if (pending_request->permission == it.GetCurrentValue()->permission &&
+          it.GetCurrentKey() != request_id) {
+        it.GetCurrentValue()->callback.Run(status);
+        manager->pending_requests_.Remove(it.GetCurrentKey());
+      }
+    }
+
+    manager->pending_requests_.Remove(request_id);
+  }
+  callback.Run(status);
 }
 
 void XWalkPermissionManager::ResetPermission(
@@ -136,7 +225,7 @@ int XWalkPermissionManager::SubscribePermissionStatusChange(
     const GURL& requesting_origin,
     const GURL& embedding_origin,
     const base::Callback<void(content::PermissionStatus)>& callback) {
-  return -1;
+  return kNoPendingOperation;
 }
 
 void XWalkPermissionManager::UnsubscribePermissionStatusChange(

--- a/runtime/browser/xwalk_platform_notification_service.cc
+++ b/runtime/browser/xwalk_platform_notification_service.cc
@@ -24,7 +24,7 @@ namespace xwalk {
 // static
 XWalkPlatformNotificationService*
 XWalkPlatformNotificationService::GetInstance() {
-  return Singleton<XWalkPlatformNotificationService>::get();
+  return base::Singleton<XWalkPlatformNotificationService>::get();
 }
 
 XWalkPlatformNotificationService::XWalkPlatformNotificationService() {}

--- a/runtime/browser/xwalk_platform_notification_service.h
+++ b/runtime/browser/xwalk_platform_notification_service.h
@@ -58,7 +58,7 @@ class XWalkPlatformNotificationService
       std::set<std::string>* displayed_notifications) override;
 
  private:
-  friend struct DefaultSingletonTraits<XWalkPlatformNotificationService>;
+  friend struct base::DefaultSingletonTraits<XWalkPlatformNotificationService>;
 
   XWalkPlatformNotificationService();
   ~XWalkPlatformNotificationService() override;

--- a/runtime/browser/xwalk_presentation_service_delegate_win.h
+++ b/runtime/browser/xwalk_presentation_service_delegate_win.h
@@ -65,22 +65,23 @@ class XWalkPresentationServiceDelegateWin
   void SetDefaultPresentationUrl(
       int render_process_id,
       int render_frame_id,
-      const std::string& default_presentation_url) override;
+      const std::string& default_presentation_url,
+      const content::PresentationSessionStartedCallback& callback) override;
 
   void StartSession(
       int render_process_id,
       int render_frame_id,
       const std::string& presentation_url,
-      const PresentationSessionSuccessCallback& success_cb,
-      const PresentationSessionErrorCallback& error_cb) override;
+      const content::PresentationSessionStartedCallback& success_cb,
+      const content::PresentationSessionErrorCallback& error_cb) override;
 
   void JoinSession(
       int render_process_id,
       int render_frame_id,
       const std::string& presentation_url,
       const std::string& presentation_id,
-      const PresentationSessionSuccessCallback& success_cb,
-      const PresentationSessionErrorCallback& error_cb) override;
+      const content::PresentationSessionStartedCallback& success_cb,
+      const content::PresentationSessionErrorCallback& error_cb) override;
 
   void CloseSession(
       int render_process_id,
@@ -111,8 +112,8 @@ class XWalkPresentationServiceDelegateWin
       const RenderFrameHostId& render_frame_host_id);
   void OnSessionStarted(
       const RenderFrameHostId& id,
-      const PresentationSessionSuccessCallback& success_cb,
-      const PresentationSessionErrorCallback& error_cb,
+      const content::PresentationSessionStartedCallback& success_cb,
+      const content::PresentationSessionErrorCallback& error_cb,
       scoped_refptr<PresentationSession> session,
       const std::string& error);
 

--- a/runtime/common/android/xwalk_render_view_messages.h
+++ b/runtime/common/android/xwalk_render_view_messages.h
@@ -106,10 +106,6 @@ IPC_MESSAGE_ROUTED2(XWalkViewHostMsg_DocumentHasImagesResponse, // NOLINT(*)
 IPC_MESSAGE_ROUTED1(XWalkViewHostMsg_UpdateHitTestData, // NOLINT(*)
                     xwalk::XWalkHitTestData)
 
-// Sent whenever the page scale factor (as seen by RenderView) is changed.
-IPC_MESSAGE_ROUTED1(XWalkViewHostMsg_PageScaleFactorChanged, // NOLINT(*)
-                    float /* page_scale_factor */)
-
 // Notification that a new picture becomes available. It is only sent if
 // XWalkViewMsg_EnableCapturePictureCallback was previously enabled.
 IPC_MESSAGE_ROUTED0(XWalkViewHostMsg_PictureUpdated) // NOLINT(*)

--- a/runtime/common/xwalk_runtime_features.cc
+++ b/runtime/common/xwalk_runtime_features.cc
@@ -33,7 +33,7 @@ XWalkRuntimeFeatures::Feature::Feature(
 
 // static
 XWalkRuntimeFeatures* XWalkRuntimeFeatures::GetInstance() {
-  return Singleton<XWalkRuntimeFeatures>::get();
+  return base::Singleton<XWalkRuntimeFeatures>::get();
 }
 
 XWalkRuntimeFeatures::XWalkRuntimeFeatures()

--- a/runtime/common/xwalk_runtime_features.h
+++ b/runtime/common/xwalk_runtime_features.h
@@ -52,7 +52,7 @@ class XWalkRuntimeFeatures {
   };
 
  private:
-  friend struct DefaultSingletonTraits<XWalkRuntimeFeatures>;
+  friend struct base::DefaultSingletonTraits<XWalkRuntimeFeatures>;
 
   XWalkRuntimeFeatures();
   ~XWalkRuntimeFeatures();

--- a/runtime/renderer/android/xwalk_render_view_ext.h
+++ b/runtime/renderer/android/xwalk_render_view_ext.h
@@ -35,7 +35,6 @@ class XWalkRenderViewExt : public content::RenderViewObserver {
   void DidCommitProvisionalLoad(blink::WebLocalFrame* frame,
                                 bool is_new_navigation) override;
   void FocusedNodeChanged(const blink::WebNode& node) override;
-  void DidCommitCompositorFrame() override;
 
   void OnDocumentHasImagesRequest(int id);
 
@@ -47,13 +46,9 @@ class XWalkRenderViewExt : public content::RenderViewObserver {
 
   void OnSetInitialPageScale(double page_scale_factor);
 
-  void UpdatePageScaleFactor();
-
   void OnSetBackgroundColor(SkColor c);
 
   void OnSetTextZoomFactor(float zoom_factor);
-
-  float page_scale_factor_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkRenderViewExt);
 };

--- a/runtime/renderer/isolated_file_system.cc
+++ b/runtime/renderer/isolated_file_system.cc
@@ -15,7 +15,6 @@
 #include "third_party/WebKit/public/platform/WebFileSystemType.h"
 #include "third_party/WebKit/public/platform/WebString.h"
 #include "third_party/WebKit/public/web/WebDataSource.h"
-#include "third_party/WebKit/public/web/WebDOMError.h"
 #include "third_party/WebKit/public/web/WebDOMFileSystem.h"
 #include "third_party/WebKit/public/web/WebFrame.h"
 #include "third_party/WebKit/public/web/WebLocalFrame.h"

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -79,8 +79,7 @@ class XWalkContentRendererClient
 #endif
 
   void GetNavigationErrorStrings(
-      content::RenderView* render_view,
-      blink::WebFrame* frame,
+      content::RenderFrame* render_frame,
       const blink::WebURLRequest& failed_request,
       const blink::WebURLError& error,
       std::string* error_html,

--- a/sysapps/device_capabilities/display_info_provider_unittest.cc
+++ b/sysapps/device_capabilities/display_info_provider_unittest.cc
@@ -71,8 +71,9 @@ TEST(XWalkSysAppsDeviceCapabilitiesTest, DisplayInfoProvider) {
   provider->AddObserver(&test_observer);
   provider->RemoveObserver(&test_observer);
 
-  message_loop.PostTask(FROM_HERE, Bind(
-      &base::MessageLoop::Quit, Unretained(base::MessageLoop::current())));
+  message_loop.PostTask(FROM_HERE,
+                        Bind(&base::MessageLoop::QuitWhenIdle,
+                             Unretained(base::MessageLoop::current())));
 
   message_loop.Run();
 }

--- a/sysapps/device_capabilities/storage_info_provider_unittest.cc
+++ b/sysapps/device_capabilities/storage_info_provider_unittest.cc
@@ -56,7 +56,7 @@ void TestClosure() {
   provider->AddObserver(&test_observer);
   provider->RemoveObserver(&test_observer);
 
-  base::MessageLoop::current()->Quit();
+  base::MessageLoop::current()->QuitWhenIdle();
 }
 
 }  // namespace

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnDocumentLoadedInFrameTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnDocumentLoadedInFrameTest.java
@@ -52,7 +52,7 @@ public class OnDocumentLoadedInFrameTest extends XWalkViewTestBase {
         final String url = addPageToTestServer(mWebServer, path, pageContent);
 
         loadUrlSync(url);
-        assertEquals(1, mOnDocumentLoadedInFrameHelper.getFrameId());
+        assertTrue(mOnDocumentLoadedInFrameHelper.getFrameId() > 0);
         assertEquals(1, mOnDocumentLoadedInFrameHelper.getCallCount());
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
@@ -76,16 +76,17 @@ public class SetInitialScaleTest extends XWalkViewTestBase {
                 + "testSetInitialScale</p></body></html>";
         final float defaultScaleFactor = 0;
         final float defaultScale = 0.5f;
+        final float scaleFactor = 0.25f;
 
         assertEquals(defaultScaleFactor, getScaleFactor(), .01f);
         loadDataSync(null, page, "text/html", false);
-        assertEquals(defaultScaleFactor, getScaleFactor(), .01f);
+        assertEquals(scaleFactor, getScaleFactor(), .01f);
 
         int onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
-        setInitialScale(50);
+        setInitialScale(60);
         loadDataSync(null, page, "text/html", false);
         mOnScaleChangedHelper.waitForCallback(onScaleChangedCallCount);
-        assertEquals(0.5f, getPixelScale(), .01f);
+        assertEquals(0.6f, getPixelScale(), .01f);
 
         onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
         setInitialScale(500);

--- a/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/PresentationTest.java
+++ b/test/android/runtime_client/javatests/src/org/xwalk/runtime/client/test/PresentationTest.java
@@ -17,8 +17,12 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class PresentationTest extends XWalkRuntimeClientTestBase {
 
+    /*
     @SmallTest
     @Feature({"PresentationTest"})
+    Broken in M48: see XWALK-4646 for details.
+    */
+    @DisabledTest
     public void testPresentationDisplayAvailable() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientShellActivity>(

--- a/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PresentationTest.java
+++ b/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PresentationTest.java
@@ -17,8 +17,12 @@ import org.xwalk.test.util.RuntimeClientApiTestBase;
  */
 public class PresentationTest extends XWalkRuntimeClientTestBase {
 
+    /*
     @SmallTest
     @Feature({"PresentationTest"})
+    Broken in M48: see XWALK-4646 for details.
+    */
+    @DisabledTest
     public void testPresentationDisplayAvailable() throws Throwable {
         RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity> helper =
                 new RuntimeClientApiTestBase<XWalkRuntimeClientEmbeddedShellActivity>(

--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -131,7 +131,7 @@ void InProcessBrowserTest::OnRuntimeClosed(Runtime* runtime) {
 
   if (runtimes_.empty())
     base::MessageLoop::current()->PostTask(
-        FROM_HERE, base::MessageLoop::QuitClosure());
+        FROM_HERE, base::MessageLoop::QuitWhenIdleClosure());
 }
 
 void InProcessBrowserTest::CloseAll() {

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -735,7 +735,7 @@
         }],
         ['OS=="win"', {
           'sources': [
-            '../content/app/startup_helper_win.cc', # Needed by InitializedSandbox
+            '../content/app/sandbox_helper_win.cc', # Needed by InitializedSandbox
             'runtime/resources/xwalk.rc',
           ],
           'configurations': {


### PR DESCRIPTION
This is the latest M48 beta, which is going to be promoted to Chromium's
stable channel within the next few days.

As usual, big thanks to everyone who has contributed to this rebase:
Alexis Menard, Olli Raula, Lin Sun, Wu Hengzhi and, most importantly,
Mrunal Kapade, who did the big majority of the work on his own.

Things to note:
- The ozone-wayland repository is no longer being pulled in, as we have
  stopped maintaining the Linux Ozone-Wayland configuration for now.
- Presentation API support is currently broken and the tests have been
  temporarily disabled. The existing extension will be replaced by code
  that integrates the Chromium implementation, which has started
  shipping in M48. This is being tracked in XWALK-4646.
- When checking out Crosswalk for Android, we no longer skip downloading
  the Google Play services library pulled by the Chromium code. This was
  caused by two factors:
  1. The upstream code has become more friendly towards dowstreams like
     us and does not try to fetch files only accessible within Google's
     intranet when `CHROME_HEADLESS=1` (ie. bots).
  2. Given the above, maintaining the hacks and workarounds to avoid
     fetching that library is not worth it.
  One important consequence is that users will be prompted to accept the
  Google Play services library's EULA once, and not accepting it will
  make the build fail (a directory needed by gyp will not be present).
  Anyone willing to avoid the prompt (when automating Crosswalk's build,
  for example) needs to set the `CHROME_HEADLESS` environment variable and
  make sure it is OK to automatically accept the EULA.

Changes that deserve a proper commit message:

```
  [Android] Update XWalkContentView to track ContentView

  Move the methods for JellyBean to XWalkContentViewApi16 to imitate
  JellyBeanContentView. Move the mothods for AndroidM to
  XWalkContentViewApi23 to imitate ContentView.ContentViewApi23. All
  methods remaining in XWalkContentView is for XWalkView's usage.

  XWalkContentView is a temporary solution. We are targeting to optimize
  the hierarchy of XWalkView to make it more like WebView. This task can
  be tracked via XWALK-6118.
```

```
  [Android] M48 gardening: adapt to https://codereview.chromium.org/1408393003

  Upstream has made all of the pageScaleFactor changes to browser process,
  WebContentsObserver can observe the changed page scale factors.
  XWalkRenderViewHostExt was inherited from WebContentsObserver, so the
  changed factors were propagated to it. The previous notification has
  side effects that the scale factor's changed messages were delayed.
  Modify the test case to adapt to this change.
```

```
  [Android] Run Chromium's "sdkextras" hook as a Crosswalk hook.

  The way the src/build/android/play_services/update.py script is
  called from Crosswalk looks like this:
  -> gclient sync
   -> hook invokes fetch_deps.py
    -> fetch_deps.py invokes gclient sync --gclientfile=.gclient-xwalk

  Since we're stacking gclient on top of gclient, the process invocation
  and I/O buffering code in depot_tools gets confused and the EULA
  prompt is not shown at the right time. Users would normally just press
  Enter when shown the EULA, which is then taken as "user has not
  accepted the EULA".

  I've had to invoke the update.py script directly from DEPS.xwalk as
  hook instead. This does not cause any problems so far, we just have to
  keep in mind that the script will be invoked after all other Chromium
  hooks (in case the order becomes relevant in the future).
```

Relevant upstream CLs that caused changes in our code:
https://codereview.chromium.org/1284993005
https://codereview.chromium.org/1290243007
https://codereview.chromium.org/1295523006
https://codereview.chromium.org/1303773002
https://codereview.chromium.org/1303773002
https://codereview.chromium.org/1308823002
https://codereview.chromium.org/1308823002
https://codereview.chromium.org/1311783007
https://codereview.chromium.org/1312153003
https://codereview.chromium.org/1312153003
https://codereview.chromium.org/1312473003
https://codereview.chromium.org/1319513002
https://codereview.chromium.org/1327543004
https://codereview.chromium.org/1342833002
https://codereview.chromium.org/1342833002
https://codereview.chromium.org/1345343003
https://codereview.chromium.org/1349803002
https://codereview.chromium.org/1355063004
https://codereview.chromium.org/1356933002
https://codereview.chromium.org/1361253002
https://codereview.chromium.org/1361733002
https://codereview.chromium.org/1363483007
https://codereview.chromium.org/1363483007
https://codereview.chromium.org/1369823003
https://codereview.chromium.org/1373923005
https://codereview.chromium.org/1374453002
https://codereview.chromium.org/1375563002
https://codereview.chromium.org/1375563002
https://codereview.chromium.org/1387963006
https://codereview.chromium.org/1389743003
https://codereview.chromium.org/1390513002
https://codereview.chromium.org/1392323003
https://codereview.chromium.org/1392323003
https://codereview.chromium.org/1398473006
https://codereview.chromium.org/1405293011
https://codereview.chromium.org/1406303002
https://codereview.chromium.org/1410143006
https://codereview.chromium.org/1411203010
https://codereview.chromium.org/1412073004
https://codereview.chromium.org/1412363003
https://codereview.chromium.org/1412923008
https://codereview.chromium.org/1413683007
https://codereview.chromium.org/1419083002
https://codereview.chromium.org/1423583003
https://codereview.chromium.org/1433143002
https://codereview.chromium.org/1440573003
https://codereview.chromium.org/1458913004

Related BUG=XWALK-4646
BUG=XWALK-5749
BUG=XWALK-5948
Related BUG=XWALK-6118