### PR TITLE
[Android] Fix audio can't play issue.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkMediaPlayerResourceLoadingFilter.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkMediaPlayerResourceLoadingFilter.java
@@ -31,6 +31,7 @@ class XWalkMediaPlayerResourceLoadingFilter extends
             uri = AndroidProtocolHandler.appUriToFileUri(uri);
         }
 
+        scheme = uri.getScheme();
         if (!scheme.equals(AndroidProtocolHandler.FILE_SCHEME)) return false;
 
         try {


### PR DESCRIPTION
For the uri of "app://", it was converted to "file://", so the scheme
should be re-got to check.

BUG=XWALK-6173