### PR TITLE
[Android] Implement API: clearSslPreferences().

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -949,6 +949,11 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         client.init(mContentViewCore);
     }
 
+    public void clearSslPreferences() {
+        if (mNativeContent == 0) return;
+        mNavigationController.clearSslPreferences();
+    }
+
     private native long nativeInit();
     private static native void nativeDestroy(long nativeXWalkContent);
     private native WebContents nativeGetWebContents(long nativeXWalkContent);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1445,4 +1445,16 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         checkThreadSafety();
         mExternalExtensionManager = manager;
     }
+
+    /**
+     * Clears the SSL preferences table stored in response to proceeding with
+     * SSL certificate errors.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void clearSslPreferences() {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.clearSslPreferences();
+    }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java
@@ -1,0 +1,75 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.content.browser.test.util.CallbackHelper;
+import org.chromium.net.test.util.TestWebServer;
+
+public class ClearSslPreferenceTest extends XWalkViewTestBase {
+    private TestWebServer mWebServer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        mWebServer = TestWebServer.startSsl();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        mWebServer.shutdown();
+
+        super.tearDown();
+    }
+
+    @Feature({"ClearSslPreference"})
+    @SmallTest
+    // If the user allows the ssl error, the same ssl error will not trigger
+    // the onReceivedSslError callback; If the user denies it, the same ssl
+    // error will still trigger the onReceivedSslError callback.
+    public void testSslPreferences() throws Throwable {
+        final String pagePath = "/hello.html";
+        final String pageUrl =
+                mWebServer.setResponse(pagePath, "<html><body>hello world</body></html>", null);
+        final CallbackHelper onReceivedSslErrorHelper =
+                mTestHelperBridge.getOnReceivedSslErrorHelper();
+        int onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
+
+        loadUrlSync(pageUrl);
+
+        assertEquals(onSslErrorCallCount + 1, onReceivedSslErrorHelper.getCallCount());
+        assertEquals(1, mWebServer.getRequestCount(pagePath));
+
+        // Now load the page again. This time, we expect no ssl error, because
+        // user's decision should be remembered.
+        onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
+        loadUrlSync(pageUrl);
+        assertEquals(onSslErrorCallCount, onReceivedSslErrorHelper.getCallCount());
+
+        // Now clear the ssl preferences then load the same url again. Expect to see
+        // onReceivedSslError getting called again.
+        clearSslPreferences();
+        onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
+        loadUrlSync(pageUrl);
+        assertEquals(onSslErrorCallCount + 1, onReceivedSslErrorHelper.getCallCount());
+
+        // Now clear the stored decisions and tell the client to deny ssl errors.
+        clearSslPreferences();
+        setAllowSslError(false);
+        onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
+        loadUrlSync(pageUrl);
+        assertEquals(onSslErrorCallCount + 1, onReceivedSslErrorHelper.getCallCount());
+
+        // Now load the same page again. This time, we still expect onReceivedSslError,
+        // because we only remember user's decision if it is "allow".
+        onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
+        loadUrlSync(pageUrl);
+        assertEquals(onSslErrorCallCount + 1, onReceivedSslErrorHelper.getCallCount());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/TestHelperBridge.java
@@ -6,6 +6,7 @@
 package org.xwalk.core.xwview.test;
 
 import android.graphics.Bitmap;
+import android.net.http.SslError;
 import android.net.Uri;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -543,6 +544,7 @@ class TestHelperBridge {
     private final OnReceivedClientCertRequestHelper mOnReceivedClientCertRequestHelper;
     private final OnReceivedResponseHeadersHelper mOnReceivedResponseHeadersHelper;
     private final OnReceivedHttpAuthRequestHelper mOnReceivedHttpAuthRequestHelper;
+    private final CallbackHelper mOnReceivedSslErrorHelper;
 
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -573,6 +575,7 @@ class TestHelperBridge {
         mOnReceivedClientCertRequestHelper = new OnReceivedClientCertRequestHelper();
         mOnReceivedResponseHeadersHelper = new OnReceivedResponseHeadersHelper();
         mOnReceivedHttpAuthRequestHelper = new OnReceivedHttpAuthRequestHelper();
+        mOnReceivedSslErrorHelper = new CallbackHelper();
     }
 
     public OnPageStartedHelper getOnPageStartedHelper() {
@@ -685,6 +688,10 @@ class TestHelperBridge {
 
     public OnReceivedHttpAuthRequestHelper getOnReceivedHttpAuthRequestHelper() {
         return mOnReceivedHttpAuthRequestHelper;
+    }
+
+    public CallbackHelper getOnReceivedSslErrorHelper() {
+        return mOnReceivedSslErrorHelper;
     }
 
     public void onTitleChanged(String title) {
@@ -811,5 +818,9 @@ class TestHelperBridge {
 
     public void onReceivedHttpAuthRequest(String host) {
         mOnReceivedHttpAuthRequestHelper.notifyCalled(host);
+    }
+
+    public void onReceivedSslError(ValueCallback<Boolean> callback, SslError error) {
+        mOnReceivedSslErrorHelper.notifyCalled();
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -8,6 +8,7 @@ package org.xwalk.core.xwview.test;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.net.http.SslError;
 import android.net.Uri;
 import android.test.ActivityInstrumentationTestCase2;
 import android.util.Log;
@@ -50,6 +51,7 @@ public class XWalkViewTestBase
     private final static int CHECK_INTERVAL = 100;
     private final static String TAG = "XWalkViewTestBase";
     private XWalkView mXWalkView;
+    private boolean mAllowSslError = true;
     final TestHelperBridge mTestHelperBridge = new TestHelperBridge();
 
     class TestXWalkUIClientBase extends XWalkUIClient {
@@ -228,6 +230,13 @@ public class XWalkViewTestBase
         public void onReceivedHttpAuthRequest(XWalkView view,
                 XWalkHttpAuthHandler handler, String host, String realm) {
             mInnerContentsClient.onReceivedHttpAuthRequest(host);
+        }
+
+        @Override
+        public void onReceivedSslError(XWalkView view, ValueCallback<Boolean> callback,
+                SslError error) {
+            callback.onReceiveValue(mAllowSslError);
+            mTestHelperBridge.onReceivedSslError(callback, error);
         }
     }
 
@@ -1008,5 +1017,18 @@ public class XWalkViewTestBase
         helper.waitUntilHasValue();
         Assert.assertTrue("Failed to retrieve JavaScript evaluation results.", helper.hasValue());
         return helper.getJsonResultAndClear();
+    }
+
+    protected void setAllowSslError(boolean allow) {
+        mAllowSslError = allow;
+    }
+
+    protected void clearSslPreferences() throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.clearSslPreferences();
+            }
+        });
     }
 }


### PR DESCRIPTION
This patch is to implement the API of clearSslPreferences().
Add test case for clearSslPreferences().
Most of the code was ported from upstream.

BUG=XWALK-5080