### PR TITLE
Change scoped_ptr.Pass() to std::move(scoped_ptr)

### DIFF
--- a/extensions/browser/xwalk_extension_data.h
+++ b/extensions/browser/xwalk_extension_data.h
@@ -36,7 +36,7 @@ class XWalkExtensionData {
   }
 
   scoped_ptr<XWalkExtensionProcessHost> extension_process_host() {
-    return extension_process_host_.Pass();
+    return std::move(extension_process_host_);
   }
 
   content::RenderProcessHost* render_process_host() {

--- a/extensions/browser/xwalk_extension_function_handler.cc
+++ b/extensions/browser/xwalk_extension_function_handler.cc
@@ -16,7 +16,7 @@ XWalkExtensionFunctionInfo::XWalkExtensionFunctionInfo(
     scoped_ptr<base::ListValue> arguments,
     const PostResultCallback& post_result_cb)
   : name_(name),
-    arguments_(arguments.Pass()),
+    arguments_(std::move(arguments)),
     post_result_cb_(post_result_cb) {}
 
 XWalkExtensionFunctionInfo::~XWalkExtensionFunctionInfo() {}
@@ -69,7 +69,7 @@ void XWalkExtensionFunctionHandler::HandleMessage(scoped_ptr<base::Value> msg) {
                          : nullptr,
                      callback_id)));
 
-  if (!HandleFunction(info.Pass())) {
+  if (!HandleFunction(std::move(info))) {
     DLOG(WARNING) << "Function not registered: " << function_name;
     return;
   }
@@ -81,7 +81,7 @@ bool XWalkExtensionFunctionHandler::HandleFunction(
   if (iter == handlers_.end())
     return false;
 
-  iter->second.Run(info.Pass());
+  iter->second.Run(std::move(info));
 
   return true;
 }
@@ -119,12 +119,12 @@ void XWalkExtensionFunctionHandler::DispatchResult(
   result->Insert(0, new base::StringValue(callback_id));
 
   if (handler)
-    handler->PostMessageToInstance(result.Pass());
+    handler->PostMessageToInstance(std::move(result));
 }
 
 void XWalkExtensionFunctionHandler::PostMessageToInstance(
     scoped_ptr<base::Value> msg) {
-  instance_->PostMessageToJS(msg.Pass());
+  instance_->PostMessageToJS(std::move(msg));
 }
 
 }  // namespace extensions

--- a/extensions/browser/xwalk_extension_function_handler.h
+++ b/extensions/browser/xwalk_extension_function_handler.h
@@ -36,7 +36,7 @@ class XWalkExtensionFunctionInfo {
   // do nothing in case the instance doesn't exist anymore. PostResult can
   // be called from any thread.
   void PostResult(scoped_ptr<base::ListValue> result) const {
-    post_result_cb_.Run(result.Pass());
+    post_result_cb_.Run(std::move(result));
   }
 
   std::string name() const {

--- a/extensions/browser/xwalk_extension_function_handler_unittest.cc
+++ b/extensions/browser/xwalk_extension_function_handler_unittest.cc
@@ -30,7 +30,7 @@ void EchoData(int* counter, scoped_ptr<XWalkExtensionFunctionInfo> info) {
   scoped_ptr<base::ListValue> result(new base::ListValue());
   result->AppendString(str);
 
-  info->PostResult(result.Pass());
+  info->PostResult(std::move(result));
 
   (*counter)++;
 }
@@ -46,13 +46,13 @@ TEST(XWalkExtensionFunctionHandlerTest, PostResult) {
 
   XWalkExtensionFunctionInfo info(
       "test",
-      make_scoped_ptr(new base::ListValue()).Pass(),
+      make_scoped_ptr(new base::ListValue()),
       base::Bind(&DispatchResult, &str));
 
   scoped_ptr<base::ListValue> data(new base::ListValue());
   data->AppendString(kTestString);
 
-  info.PostResult(data.Pass());
+  info.PostResult(std::move(data));
   EXPECT_EQ(str, kTestString);
 }
 
@@ -70,10 +70,10 @@ TEST(XWalkExtensionFunctionHandlerTest, RegisterAndHandleFunction) {
 
     scoped_ptr<XWalkExtensionFunctionInfo> info1(new XWalkExtensionFunctionInfo(
         "echoData",
-        data1.Pass(),
+        std::move(data1),
         base::Bind(&DispatchResult, &str1)));
 
-    handler.HandleFunction(info1.Pass());
+    handler.HandleFunction(std::move(info1));
     EXPECT_EQ(counter, i + 1);
     EXPECT_EQ(str1, kTestString);
   }
@@ -84,10 +84,10 @@ TEST(XWalkExtensionFunctionHandlerTest, RegisterAndHandleFunction) {
 
   scoped_ptr<XWalkExtensionFunctionInfo> info2(new XWalkExtensionFunctionInfo(
       "reset",
-      data2.Pass(),
+      std::move(data2),
       base::Bind(&DispatchResult, &str2)));
 
-  handler.HandleFunction(info2.Pass());
+  handler.HandleFunction(std::move(info2));
   EXPECT_EQ(counter, 0);
 
   // Dispatching to a non registered handler should not crash.
@@ -97,10 +97,10 @@ TEST(XWalkExtensionFunctionHandlerTest, RegisterAndHandleFunction) {
 
   scoped_ptr<XWalkExtensionFunctionInfo> info3(new XWalkExtensionFunctionInfo(
       "foobar",
-      data3.Pass(),
+      std::move(data3),
       base::Bind(&DispatchResult, &str3)));
 
-  handler.HandleFunction(info3.Pass());
+  handler.HandleFunction(std::move(info3));
 }
 
 TEST(XWalkExtensionFunctionHandlerTest, PostingResultAfterDeletingTheHandler) {
@@ -114,7 +114,7 @@ TEST(XWalkExtensionFunctionHandlerTest, PostingResultAfterDeletingTheHandler) {
   msg->AppendString("storeFunctionInfo");  // Function name.
   msg->AppendString("id");  // Callback ID.
 
-  handler->HandleMessage(msg.Pass());
+  handler->HandleMessage(std::move(msg));
   handler.reset();
 
   // Posting a result after deleting the handler should not

--- a/extensions/browser/xwalk_extension_process_host.cc
+++ b/extensions/browser/xwalk_extension_process_host.cc
@@ -67,7 +67,7 @@ class XWalkExtensionProcessHost::RenderProcessMessageFilter
   void OnGetExtensionProcessChannel(IPC::Message* reply) {
     scoped_ptr<IPC::Message> scoped_reply(reply);
     if (eph_)
-      eph_->OnGetExtensionProcessChannel(scoped_reply.Pass());
+      eph_->OnGetExtensionProcessChannel(std::move(scoped_reply));
   }
 
   ~RenderProcessMessageFilter() override {}
@@ -92,7 +92,7 @@ class ExtensionSandboxedProcessLauncherDelegate
   }
 #elif defined(OS_POSIX)
   base::ScopedFD TakeIpcFd() override {
-    return ipc_fd_.Pass();
+    return std::move(ipc_fd_);
   }
 #endif
 
@@ -122,7 +122,7 @@ XWalkExtensionProcessHost::XWalkExtensionProcessHost(
       external_extensions_path_(external_extensions_path),
       is_extension_process_channel_ready_(false),
       delegate_(delegate),
-      runtime_variables_(runtime_variables.Pass()) {
+      runtime_variables_(std::move(runtime_variables)) {
   render_process_host_->GetChannel()->AddFilter(
       render_process_message_filter_.get());
   BrowserThread::PostTask(BrowserThread::IO, FROM_HERE,
@@ -207,7 +207,7 @@ void XWalkExtensionProcessHost::StopProcess() {
 
 void XWalkExtensionProcessHost::OnGetExtensionProcessChannel(
     scoped_ptr<IPC::Message> reply) {
-  pending_reply_for_render_process_ = reply.Pass();
+  pending_reply_for_render_process_ = std::move(reply);
   ReplyChannelHandleToRenderProcess();
 }
 

--- a/extensions/common/xwalk_extension.h
+++ b/extensions/common/xwalk_extension.h
@@ -124,7 +124,7 @@ class XWalkExtensionInstance {
   // JavaScript in the renderer process. This function will take the ownership
   // of the message.
   void PostMessageToJS(scoped_ptr<base::Value> msg) {
-    post_message_.Run(msg.Pass());
+    post_message_.Run(std::move(msg));
   }
 
  protected:
@@ -132,7 +132,7 @@ class XWalkExtensionInstance {
 
   // Unblocks the renderer waiting on a SyncMessage.
   void SendSyncReplyToJS(scoped_ptr<base::Value> reply) {
-    send_sync_reply_.Run(reply.Pass());
+    send_sync_reply_.Run(std::move(reply));
   }
 
  private:

--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -103,7 +103,7 @@ void XWalkExtensionServer::OnPostMessageToNative(int64_t instance_id,
   // can be costly depending on the size of Value.
   scoped_ptr<base::Value> value;
   const_cast<base::ListValue*>(&msg)->Remove(0, &value);
-  data.instance->HandleMessage(value.Pass());
+  data.instance->HandleMessage(std::move(value));
 }
 
 void XWalkExtensionServer::Initialize(IPC::ChannelProxy* channelProxy) {
@@ -321,7 +321,7 @@ void XWalkExtensionServer::OnSendSyncMessageToNative(int64_t instance_id,
   const_cast<base::ListValue*>(&msg)->Remove(0, &value);
   XWalkExtensionInstance* instance = data.instance;
 
-  instance->HandleSyncMessage(value.Pass());
+  instance->HandleSyncMessage(std::move(value));
 }
 
 void XWalkExtensionServer::OnDestroyInstance(int64_t instance_id) {
@@ -407,7 +407,7 @@ std::vector<std::string> RegisterExternalExtensionsInDirectory(
       extension->set_permissions_delegate(server->permissions_delegate());
     if (extension->Initialize()) {
       registered_extensions.push_back(extension->name());
-      server->RegisterExtension(extension.Pass());
+      server->RegisterExtension(std::move(extension));
     } else {
       LOG(WARNING) << "Failed to initialize extension: "
                    << extension_path.AsUTF8Unsafe();

--- a/extensions/extension_process/xwalk_extension_process.cc
+++ b/extensions/extension_process/xwalk_extension_process.cc
@@ -73,7 +73,7 @@ void XWalkExtensionProcess::OnRegisterExtensions(
           browser_variables.get());
 
     RegisterExternalExtensionsInDirectory(&extensions_server_, path,
-                                          browser_variables.Pass());
+                                          std::move(browser_variables));
   }
   CreateRenderProcessChannel();
 }

--- a/extensions/renderer/xwalk_extension_client.cc
+++ b/extensions/renderer/xwalk_extension_client.cc
@@ -136,27 +136,27 @@ scoped_ptr<base::ListValue> WrapValueInList(scoped_ptr<base::Value> value) {
     return scoped_ptr<base::ListValue>();
   scoped_ptr<base::ListValue> list_value(new base::ListValue);
   list_value->Append(value.release());
-  return list_value.Pass();
+  return list_value;
 }
 
 }  // namespace
 
 void XWalkExtensionClient::PostMessageToNative(int64_t instance_id,
     scoped_ptr<base::Value> msg) {
-  scoped_ptr<base::ListValue> list_msg = WrapValueInList(msg.Pass());
+  scoped_ptr<base::ListValue> list_msg = WrapValueInList(std::move(msg));
   Send(new XWalkExtensionServerMsg_PostMessageToNative(instance_id, *list_msg));
 }
 
 scoped_ptr<base::Value> XWalkExtensionClient::SendSyncMessageToNative(
     int64_t instance_id, scoped_ptr<base::Value> msg) {
-  scoped_ptr<base::ListValue> wrapped_msg = WrapValueInList(msg.Pass());
+  scoped_ptr<base::ListValue> wrapped_msg = WrapValueInList(std::move(msg));
   base::ListValue* wrapped_reply = new base::ListValue;
   Send(new XWalkExtensionServerMsg_SendSyncMessageToNative(instance_id,
       *wrapped_msg, wrapped_reply));
 
   scoped_ptr<base::Value> reply;
   wrapped_reply->Remove(0, &reply);
-  return reply.Pass();
+  return reply;
 }
 
 void XWalkExtensionClient::Initialize(IPC::Sender* sender) {

--- a/extensions/renderer/xwalk_extension_module.cc
+++ b/extensions/renderer/xwalk_extension_module.cc
@@ -221,7 +221,7 @@ void XWalkExtensionModule::PostMessageCallback(
       module->converter_->FromV8Value(info[0], context));
 
   CHECK(module->instance_id_);
-  module->client_->PostMessageToNative(module->instance_id_, value.Pass());
+  module->client_->PostMessageToNative(module->instance_id_, std::move(value));
   result.Set(true);
 }
 
@@ -242,7 +242,7 @@ void XWalkExtensionModule::SendSyncMessageCallback(
   CHECK(module->instance_id_);
   scoped_ptr<base::Value> reply(
       module->client_->SendSyncMessageToNative(module->instance_id_,
-                                               value.Pass()));
+                                               std::move(value)));
 
   // If we tried to send a message to an instance that became invalid,
   // then reply will be NULL.

--- a/extensions/renderer/xwalk_extension_renderer_controller.cc
+++ b/extensions/renderer/xwalk_extension_renderer_controller.cc
@@ -65,7 +65,7 @@ void CreateExtensionModules(XWalkExtensionClient* client,
     scoped_ptr<XWalkExtensionModule> module(
         new XWalkExtensionModule(client, module_system,
                                  it->first, codepoint->api));
-    module_system->RegisterExtensionModule(module.Pass(),
+    module_system->RegisterExtensionModule(std::move(module),
                                            codepoint->entry_points);
   }
 }

--- a/extensions/renderer/xwalk_js_module.cc
+++ b/extensions/renderer/xwalk_js_module.cc
@@ -17,7 +17,7 @@ scoped_ptr<XWalkNativeModule> CreateJSModuleFromResource(int resource_id) {
       ResourceBundle::GetSharedInstance().GetRawDataResource(
           resource_id).as_string());
   scoped_ptr<XWalkNativeModule> module(new XWalkJSModule(js_api));
-  return module.Pass();
+  return module;
 }
 
 XWalkJSModule::XWalkJSModule(const std::string& js_code)


### PR DESCRIPTION
Scoped ptr is deprecated in M49 and it is easier to
fix them directly here. There will be most
probably another similar commit because it is easier to
find them from build failures.