### PR TITLE
Move the variable setting logic from gyp_xwalk to build/common.gypi.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -1,41 +1,135 @@
+# This file is similar to src/build/common.gypi. It contains common variable
+# definitions and other actions that are then used in other build system files.
+#
+# The values can be overriden on the GYP command line (-D) or by setting them
+# in ~/.gyp/include.gypi.
+#
+# IMPORTANT: Like src/build/common.gypi, this file must not be included by
+# other .gyp or .gypi files, it is included automatically when gyp_xwalk is
+# called. This file is always included immediately after src/build/common.gypi
+# itself so that variables originally set there can have their values
+# overridden here.
+
 {
+  # Organization of the variables below:
+  # 1. Variables copied from inner scopes.
+  # 2. New variables defined in current scope.
+  # 3. Conditions.
+  # Some variables are new, but most come from other .gyp files and are
+  # overridden here. The default values should match the ones in the original
+  # .gyp files.
   'variables': {
-    'use_webui_file_picker%': 0,
+    # Putting a variables dict inside another variables dict looks kind of
+    # weird. This is caused by the way GYP variable expansion and evaluation
+    # works: one cannot set a variable in a scope and use it in a conditional
+    # block in the same scope level. For example, setting |mediacodecs_EULA|
+    # and using it in a conditional in the same scope does not work. Similarly,
+    # since this file is automatically included and at the root level into all
+    # other .gyp and .gypi files their own |variables| section might have a
+    # check for a variable set in a condition block below, so we need to put
+    # variables such as |enable_widevine| into an inner scope to avoid having
+    # the conditions block here be at the same level as one from another file.
+    'variables': {
+      'variables': {
+        # From src/build/common.gypi.
+        # Which target type to build most targets as.
+        'component%': 'static_library',
+
+        # This variable used to be interpreted in the gyp_xwalk script and
+        # translated into changing |ffmpeg_branding|. We keep it here for
+        # compatibility for now.
+        # TODO(rakuco): Remove this after a while.
+        'mediacodecs_EULA%': 0,
+      },
+      'component%': '<(component)',
+      'mediacodecs_EULA%': '<(mediacodecs_EULA)',
+
+      # Whether to enable WebCL support in Blink.
+      'enable_webcl%': 0,
+
+      # From src/third_party/widevine/cdm/widevine_cdm.gyp.
+      # Whether to build Crosswalk with support for the Widevine CDM.
+      'enable_widevine%': 0,
+
+      # From src/third_party/ffmpeg/ffmpeg.gyp.
+      # Whether to build the Chromium or Google Chrome version of FFmpeg (the
+      # latter contains additional codecs).
+      'ffmpeg_branding%': 'Chromium',
+
+      # From src/third_party/ffmpeg/ffmpeg.gyp.
+      # Which target type to build libffmpeg as.
+      'ffmpeg_component%': '<(component)',
+
+      # From src/build/common.gypi.
+      # Whether to include stack unwinding support for backtrace().
+      'release_unwind_tables%': 1,
+
+      # From src/build/common.gypi.
+      # Whether to use external startup data for V8.
+      'v8_use_external_startup_data%': 1,
+
+      # Whether to use the RealSense SDK (libpxc) video capture.
+      'use_rssdk%': 0,
+
+      'conditions': [
+        ['mediacodecs_EULA==1', {
+          'ffmpeg_branding%': 'Chrome',
+        }],
+
+        ['OS=="android"', {
+          'enable_webcl%': 1,
+
+          # Make release builds smaller by omitting stack unwind support for
+          # backtrace().
+          # TODO(rakuco): determine if we only want this in official builds.
+          'release_unwind_tables%': 0,
+
+          # Temporarily disable use of external snapshot files (XWALK-3516).
+          'v8_use_external_startup_data%': 0,
+        }],
+
+        ['OS=="linux"', {
+          # Since M44, ffmpeg is built as a static library by default. On Linux,
+          # keep the previous behavior or building it as a shared library while
+          # we figure out if it makes sense to switch to a static library by
+          # default.
+          'ffmpeg_component%': 'shared_library',
+        }],
+
+        ['OS=="win"', {
+          'enable_widevine%': 1,
+          'use_rssdk%': 1,
+        }],
+      ],
+    },
+    # Copy conditionally-set variables out one scope.
+    'component%': '<(component)',
+    'enable_webcl%': '<(enable_webcl)',
+    'enable_widevine%': '<(enable_widevine)',
+    'ffmpeg_branding%': '<(ffmpeg_branding)',
+    'ffmpeg_component%': '<(ffmpeg_component)',
+    'mediacodecs_EULA%': '<(mediacodecs_EULA)',
+    'release_unwind_tables%': '<(release_unwind_tables)',
+    'use_rssdk%': '<(use_rssdk)',
+    'v8_use_external_startup_data%': '<(v8_use_external_startup_data)',
+
+    # Whether to build and use Crosswalk's internal extensions (device
+    # capabilities, sysapps etc).
     'disable_bundled_extensions%': 0,
+
+    # Whether to include support for proprietary codecs..
+    'proprietary_codecs%': 1,
+
+    # Whether to use a WebUI-based file picker.
+    'use_webui_file_picker%': 0,
 
     # Name of Crosswalk Maven artifacts used to generate their
     # respective POM files.
     'xwalk_core_library_artifact_id%': 'xwalk_core_library_canary',
     'xwalk_shared_library_artifact_id%': 'xwalk_shared_library_canary',
-
-    'conditions': [
-      ['OS=="android"', {
-        # Enable WebCL by default on android.
-        'enable_webcl%': 1,
-        'v8_use_external_startup_data%': 0,
-      }, {
-        'enable_webcl%': 0,
-      }],
-      ['OS=="linux"', {
-        # Since M44, ffmpeg is built as a static library by default. On Linux,
-        # keep the previous behavior or building it as a shared library while
-        # we figure out if it makes sense to switch to a static library by
-        # default.
-        'ffmpeg_component%': 'shared_library',
-      }],
-      ['OS=="win"', {
-        # Use RSSDK for video capture by default on Windows
-        'use_rssdk%': 1,
-      }, {
-        'use_rssdk%': 0,
-      }],
-    ],
   },
+
   'target_defaults': {
-    'variables': {
-      # Whether to enable WebCL.
-      'enable_webcl%': '<(enable_webcl)',
-    },
     'conditions': [
       ['enable_webcl==1', {
         'defines': ['ENABLE_WEBCL=1'],

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -182,11 +182,11 @@ def additional_include_files(supplemental_files, args=[]):
   if os.environ.get('GYP_INCLUDE_FIRST') != None:
     AddInclude(os.path.join(chrome_src, os.environ.get('GYP_INCLUDE_FIRST')))
 
-  # Include xwalk common.gypi to effect chromium source tree.
-  AddInclude(os.path.join(xwalk_dir, 'build', 'common.gypi'))
-
   # Always include common.gypi.
   AddInclude(os.path.join(chrome_src, 'build', 'common.gypi'))
+
+  # Include xwalk common.gypi to effect chromium source tree.
+  AddInclude(os.path.join(xwalk_dir, 'build', 'common.gypi'))
 
   # Optionally add supplemental .gypi files if present.
   for supplement in supplemental_files:
@@ -217,25 +217,6 @@ def main():
   if int(os.environ.get('GYP_CHROMIUM_NO_ACTION', 0)):
     print 'Skipping gyp_chromium due to GYP_CHROMIUM_NO_ACTION env var.'
     sys.exit(0)
-
-  # Support external media types capability such as MP4/MP3.
-  args = list(set(args))
-  delist = []
-  ip_media_codecs = False # Default: no third-party codecs be build in.
-  for arg in args:
-    if arg.startswith('-Dproprietary_codecs') or arg.startswith('-Dffmpeg_branding'):
-      continue
-    elif arg == '-Dmediacodecs_EULA=1':
-      ip_media_codecs = True  # Exception: mediacodecs_EULA be enabled.
-    else:
-      delist.append(arg)
-
-  args = delist
-  args.append('-Dproprietary_codecs=1')
-
-  # Triggering media playback dynamically with third-party codecs by owner.
-  if ip_media_codecs == True:
-      args.append('-Dffmpeg_branding=Chrome')
 
   # Use the Psyco JIT if available.
   if psyco:
@@ -338,21 +319,6 @@ def main():
       ['-I' + i for i in additional_include_files(supplemental_includes, args)])
 
   args.extend(['-D', 'gyp_output_dir=' + GetOutputDirectory()])
-
-  # Enable Web Audio by default on Android x86
-  if gyp_vars_dict.get('OS') == 'android':
-    args.append('-Duse_openmax_dl_fft=1')
-
-  # Enable Aura by default on all platforms except Android and Mac.
-  if gyp_vars_dict.get('OS') != 'android' and sys.platform not in ('darwin',):
-    args.append('-Duse_aura=1')
-
-  if gyp_vars_dict.get('OS') == 'android':
-    args.append('-Dnotifications=1')
-    args.append('-Drelease_unwind_tables=0')
-
-  if sys.platform == 'win32':
-    args.append('-Denable_widevine=1')
 
   if not use_analyzer:
     print 'Updating projects from gyp files...'


### PR DESCRIPTION
Setting variables in gyp_xwalk was a historical mistake and likely came
from failures to understand GYP's bizantine scoping and evaluation
rules. Additionally, gyp_xwalk will not be used once we move to GN, so
this logic needs to be moved anyway.

The following variables were being set in gyp_xwalk to the values they
already have as default in `src/build/common.gypi` and have thus just been
removed from gyp_xwalk and not added to `src/xwalk/build/common.gypi`:
 * `notifications`
 * `use_aura`
 * `use_openmax_dl_fft`

Quick explanation about GYP's weird scoping and variable evaluation
rules: one cannot set a variable in a scope and use it in a conditional
block in the same scope level, or set it in a conditional block and use
it in another check in the same block and scope level. In other words,
both conditionals below will evaluate to false:
```python
  'variables': {
    'foo%': 1,
    'conditionals': [
      ["foo == 1", {
        'bar%': 42,
      }],
      ["bar == 42", {
        'baz%': 34,
      }],
    ],
  }
```
For it to work, we need to define some variable-within-variable blocks
so that the variables and their values are properly seen by the
conditional blocks. To complicate things further, since this .gypi file
is automatically merged into all other .gyp and .gypi files we need to
put any variables we set in a conditions block into another variables
scope to avoid the situation where another .gypi file checks for the
variable's value in the same scope we're setting it in a conditional.

A lot of comments were added to the file to make this whole mess clear
to future readers.

Also related to the above, we are now including `src/build/common.gypi`
before `src/xwalk/build/common.gypi`, so that the values we set in the
latter do not get overridden by the former.

Testing done: run gyp_xwalk without this patch, build a target like
"xwalk", apply the patch, run gyp_xwalk again. Building the target again
should do nothing (on Android it's easier to pass `-Denable_webcl=0`,
otherwise `-DENABLE_WEBCL=1` will be passed in another position in the
command line and needlessly make everything be rebuilt).

Related BUG=XWALK-3674