### PR TITLE
Remove deprecated base/basictypes.h includes part 1

### DIFF
--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -5,7 +5,6 @@
 #include "xwalk/application/common/application_data.h"
 
 #include "base/base64.h"
-#include "base/basictypes.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"

--- a/application/common/id_util.cc
+++ b/application/common/id_util.cc
@@ -33,7 +33,7 @@ static void ConvertHexadecimalToIDAlphabet(std::string* id) {
 }
 
 std::string GenerateId(const std::string& input) {
-  uint8 hash[kIdSize];
+  uint8_t hash[kIdSize];
   crypto::SHA256HashString(input, hash, sizeof(hash));
   std::string output = base::ToLowerASCII(base::HexEncode(hash, sizeof(hash)));
   ConvertHexadecimalToIDAlphabet(&output);

--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -6,7 +6,6 @@
 
 #include <list>
 
-#include "base/basictypes.h"
 #include "base/lazy_instance.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"

--- a/application/common/package/xpk_package.cc
+++ b/application/common/package/xpk_package.cc
@@ -15,7 +15,7 @@
 namespace xwalk {
 namespace application {
 
-const uint8 kSignatureAlgorithm[15] = {
+const uint8_t kSignatureAlgorithm[15] = {
   0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
   0xf7, 0x0d, 0x01, 0x01, 0x05, 0x05, 0x00
 };
@@ -51,13 +51,13 @@ XPKPackage::XPKPackage(const base::FilePath& path)
       return;
     }
     key_.resize(header_.key_size);
-    size_t len = fread(&key_.front(), sizeof(uint8), header_.key_size,
+    size_t len = fread(&key_.front(), sizeof(uint8_t), header_.key_size,
         file_->get());
     if (len < header_.key_size)
       is_valid_ = false;
 
     signature_.resize(header_.signature_size);
-    len = fread(&signature_.front(), sizeof(uint8), header_.signature_size,
+    len = fread(&signature_.front(), sizeof(uint8_t), header_.signature_size,
         file_->get());
     if (len < header_.signature_size)
       is_valid_ = false;

--- a/application/common/package/xpk_package.h
+++ b/application/common/package/xpk_package.h
@@ -17,13 +17,13 @@ class XPKPackage : public Package {
  public:
   static const char kXPKPackageHeaderMagic[];
   static const size_t kXPKPackageHeaderMagicSize = 4;
-  static const uint32 kMaxPublicKeySize = 1 << 16;
-  static const uint32 kMaxSignatureKeySize = 1 << 16;
+  static const uint32_t kMaxPublicKeySize = 1 << 16;
+  static const uint32_t kMaxSignatureKeySize = 1 << 16;
 
   struct Header {
     char magic[kXPKPackageHeaderMagicSize];
-    uint32 key_size;
-    uint32 signature_size;
+    uint32_t key_size;
+    uint32_t signature_size;
   };
   ~XPKPackage() override;
   explicit XPKPackage(const base::FilePath& path);
@@ -34,8 +34,8 @@ class XPKPackage : public Package {
   virtual bool VerifySignature();
 
   Header header_;
-  std::vector<uint8> signature_;
-  std::vector<uint8> key_;
+  std::vector<uint8_t> signature_;
+  std::vector<uint8_t> key_;
   // It's the beginning address of the zip file
   int zip_addr_;
 };

--- a/application/common/permission_policy_manager.h
+++ b/application/common/permission_policy_manager.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/basictypes.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/permission_types.h"
 

--- a/extensions/common/xwalk_extension_server_unittest.cc
+++ b/extensions/common/xwalk_extension_server_unittest.cc
@@ -4,7 +4,6 @@
 
 #include "xwalk/extensions/common/xwalk_extension_server.h"
 
-#include "base/basictypes.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 using xwalk::extensions::ValidateExtensionNameForTesting;

--- a/runtime/browser/devtools/remote_debugging_server.h
+++ b/runtime/browser/devtools/remote_debugging_server.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/basictypes.h"
 #include "base/memory/scoped_ptr.h"
 
 namespace devtools_http_handler {

--- a/runtime/browser/devtools/xwalk_devtools_frontend.h
+++ b/runtime/browser/devtools/xwalk_devtools_frontend.h
@@ -9,7 +9,6 @@
 #include <map>
 #include <string>
 
-#include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_ptr.h"

--- a/runtime/browser/devtools/xwalk_devtools_manager_delegate.cc
+++ b/runtime/browser/devtools/xwalk_devtools_manager_delegate.cc
@@ -44,19 +44,19 @@ namespace {
 const int kBackLog = 10;
 const char kLocalHost[] = "127.0.0.1";
 
-uint16 GetInspectorPort() {
+uint16_t GetInspectorPort() {
   const base::CommandLine& command_line =
     *base::CommandLine::ForCurrentProcess();
   // See if the user specified a port on the command line (useful for
   // automation). If not, use an ephemeral port by specifying 0.
-  uint16 port = 0;
+  uint16_t port = 0;
   if (command_line.HasSwitch(switches::kRemoteDebuggingPort)) {
     int temp_port;
     std::string port_str =
       command_line.GetSwitchValueASCII(switches::kRemoteDebuggingPort);
     if (base::StringToInt(port_str, &temp_port) &&
       temp_port > 0 && temp_port < 65535) {
-      port = static_cast<uint16>(temp_port);
+      port = static_cast<uint16_t>(temp_port);
     } else {
       DLOG(WARNING) << "Invalid http debugger port number " << temp_port;
     }
@@ -67,7 +67,7 @@ uint16 GetInspectorPort() {
 class TCPServerSocketFactory
     : public DevToolsHttpHandler::ServerSocketFactory {
  public:
-  TCPServerSocketFactory(const std::string& address, uint16 port)
+  TCPServerSocketFactory(const std::string& address, uint16_t port)
       : address_(address), port_(port) {
   }
 
@@ -83,13 +83,13 @@ class TCPServerSocketFactory
   }
 
   std::string address_;
-  uint16 port_;
+  uint16_t port_;
 
   DISALLOW_COPY_AND_ASSIGN(TCPServerSocketFactory);
 };
 
 scoped_ptr<DevToolsHttpHandler::ServerSocketFactory>
-CreateSocketFactory(uint16 port) {
+CreateSocketFactory(uint16_t port) {
   return scoped_ptr<DevToolsHttpHandler::ServerSocketFactory>(
       new TCPServerSocketFactory(kLocalHost, port));
 }

--- a/runtime/browser/devtools/xwalk_devtools_manager_delegate.h
+++ b/runtime/browser/devtools/xwalk_devtools_manager_delegate.h
@@ -6,7 +6,6 @@
 #ifndef XWALK_RUNTIME_BROWSER_DEVTOOLS_XWALK_DEVTOOLS_MANAGER_DELEGATE_H_
 #define XWALK_RUNTIME_BROWSER_DEVTOOLS_XWALK_DEVTOOLS_MANAGER_DELEGATE_H_
 
-#include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "components/devtools_http_handler/devtools_http_handler_delegate.h"
 #include "content/public/browser/devtools_manager_delegate.h"

--- a/runtime/browser/runtime.h
+++ b/runtime/browser/runtime.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "base/basictypes.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "xwalk/runtime/browser/runtime_ui_delegate.h"

--- a/runtime/browser/runtime_download_manager_delegate.cc
+++ b/runtime/browser/runtime_download_manager_delegate.cc
@@ -104,12 +104,12 @@ bool RuntimeDownloadManagerDelegate::ShouldOpenDownload(
 
 void RuntimeDownloadManagerDelegate::GetNextId(
     const content::DownloadIdCallback& callback) {
-  static uint32 next_id = content::DownloadItem::kInvalidId + 1;
+  static uint32_t next_id = content::DownloadItem::kInvalidId + 1;
   callback.Run(next_id++);
 }
 
 void RuntimeDownloadManagerDelegate::GenerateFilename(
-    uint32 download_id,
+    uint32_t download_id,
     const content::DownloadTargetCallback& callback,
     const base::FilePath& generated_name,
     const base::FilePath& suggested_directory) {
@@ -130,7 +130,7 @@ void RuntimeDownloadManagerDelegate::GenerateFilename(
 }
 
 void RuntimeDownloadManagerDelegate::OnDownloadPathGenerated(
-    uint32 download_id,
+    uint32_t download_id,
     const content::DownloadTargetCallback& callback,
     const base::FilePath& suggested_path) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
@@ -147,7 +147,7 @@ void RuntimeDownloadManagerDelegate::OnDownloadPathGenerated(
 }
 
 void RuntimeDownloadManagerDelegate::ChooseDownloadPath(
-    uint32 download_id,
+    uint32_t download_id,
     const content::DownloadTargetCallback& callback,
     const base::FilePath& suggested_path) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));

--- a/runtime/browser/runtime_download_manager_delegate.h
+++ b/runtime/browser/runtime_download_manager_delegate.h
@@ -41,14 +41,14 @@ class RuntimeDownloadManagerDelegate
  private:
   friend class base::RefCountedThreadSafe<RuntimeDownloadManagerDelegate>;
 
-  void GenerateFilename(uint32 download_id,
+  void GenerateFilename(uint32_t download_id,
                         const content::DownloadTargetCallback& callback,
                         const base::FilePath& generated_name,
                         const base::FilePath& suggested_directory);
-  void OnDownloadPathGenerated(uint32 download_id,
+  void OnDownloadPathGenerated(uint32_t download_id,
                                const content::DownloadTargetCallback& callback,
                                const base::FilePath& suggested_path);
-  void ChooseDownloadPath(uint32 download_id,
+  void ChooseDownloadPath(uint32_t download_id,
                           const content::DownloadTargetCallback& callback,
                           const base::FilePath& suggested_path);
 

--- a/runtime/browser/runtime_network_delegate.h
+++ b/runtime/browser/runtime_network_delegate.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "net/base/network_delegate_impl.h"
 

--- a/runtime/browser/runtime_select_file_policy.h
+++ b/runtime/browser/runtime_select_file_policy.h
@@ -5,9 +5,9 @@
 #ifndef XWALK_RUNTIME_BROWSER_RUNTIME_SELECT_FILE_POLICY_H_
 #define XWALK_RUNTIME_BROWSER_RUNTIME_SELECT_FILE_POLICY_H_
 
-#include "base/basictypes.h"
 #include "base/callback_forward.h"
 #include "base/compiler_specific.h"
+#include "base/macros.h"
 #include "ui/shell_dialogs/select_file_policy.h"
 
 namespace content {

--- a/runtime/browser/xwalk_browser_main_parts.h
+++ b/runtime/browser/xwalk_browser_main_parts.h
@@ -6,7 +6,6 @@
 #define XWALK_RUNTIME_BROWSER_XWALK_BROWSER_MAIN_PARTS_H_
 
 #include <string>
-#include "base/basictypes.h"
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/scoped_vector.h"
 #include "content/public/browser/browser_main_parts.h"

--- a/runtime/browser/xwalk_form_database_service.h
+++ b/runtime/browser/xwalk_form_database_service.h
@@ -8,7 +8,6 @@
 
 #include <map>
 
-#include "base/basictypes.h"
 #include "base/files/file_path.h"
 #include "components/autofill/core/browser/webdata/autofill_webdata_service.h"
 #include "components/webdata/common/web_data_service_consumer.h"

--- a/sysapps/common/sysapps_manager.cc
+++ b/sysapps/common/sysapps_manager.cc
@@ -4,7 +4,6 @@
 
 #include "xwalk/sysapps/common/sysapps_manager.h"
 
-#include "base/basictypes.h"
 #include "xwalk/sysapps/device_capabilities/cpu_info_provider.h"
 #include "xwalk/sysapps/device_capabilities/device_capabilities_extension.h"
 #include "xwalk/sysapps/device_capabilities/display_info_provider.h"

--- a/sysapps/common/sysapps_manager_linux.cc
+++ b/sysapps/common/sysapps_manager_linux.cc
@@ -4,7 +4,6 @@
 
 #include "xwalk/sysapps/common/sysapps_manager.h"
 
-#include "base/basictypes.h"
 #include "xwalk/sysapps/device_capabilities/av_codecs_provider_ffmpeg.h"
 #include "xwalk/sysapps/device_capabilities/storage_info_provider_chromium.h"
 

--- a/sysapps/device_capabilities/display_info_provider.cc
+++ b/sysapps/device_capabilities/display_info_provider.cc
@@ -21,7 +21,7 @@ const float kDpi96 = 96;
 
 linked_ptr<DisplayUnit> makeDisplayUnit(const gfx::Display& display) {
   gfx::Screen* screen = gfx::Screen::GetNativeScreen();
-  const int64 primary_display_id = screen->GetPrimaryDisplay().id();
+  const int64_t primary_display_id = screen->GetPrimaryDisplay().id();
 
   linked_ptr<DisplayUnit> display_unit(new DisplayUnit);
 


### PR DESCRIPTION
base/basictypes.h is deprecated and will be removed from Chromium in m49. Mostly it is not
needed, sometimes old types are replased with _t types. This do not
indlude all of them.