### PR TITLE
Change scoped_ptr.Pass() to std::move(scoped_ptr) part 2

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -76,7 +76,7 @@ Application* ApplicationService::LaunchFromManifestPath(
 
   scoped_refptr<ApplicationData> application_data = ApplicationData::Create(
       app_path, std::string(), ApplicationData::LOCAL_DIRECTORY,
-      manifest.Pass(), &error);
+      std::move(manifest), &error);
   if (!application_data.get()) {
     LOG(ERROR) << "Error occurred while trying to load application: "
                << error;
@@ -149,12 +149,12 @@ Application* ApplicationService::LaunchHostedURL(const GURL& url) {
   settings->SetString(application_manifest_keys::kXWalkVersionKey, "0");
 
   scoped_ptr<Manifest> manifest(
-      new Manifest(settings.Pass(), Manifest::TYPE_MANIFEST));
+      new Manifest(std::move(settings), Manifest::TYPE_MANIFEST));
 
   std::string error;
   scoped_refptr<ApplicationData> app_data =
         ApplicationData::Create(base::FilePath(), app_id,
-        ApplicationData::EXTERNAL_URL, manifest.Pass(), &error);
+        ApplicationData::EXTERNAL_URL, std::move(manifest), &error);
   DCHECK(app_data.get());
 
   return Launch(app_data);

--- a/application/browser/application_system.cc
+++ b/application/browser/application_system.cc
@@ -35,7 +35,7 @@ scoped_ptr<ApplicationSystem> ApplicationSystem::Create(
     XWalkBrowserContext* browser_context) {
   scoped_ptr<ApplicationSystem> app_system;
   app_system.reset(new ApplicationSystem(browser_context));
-  return app_system.Pass();
+  return app_system;
 }
 
 bool ApplicationSystem::LaunchFromCommandLine(

--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -51,7 +51,7 @@ scoped_refptr<ApplicationData> ApplicationData::Create(
     return NULL;
 
   scoped_refptr<ApplicationData> app_data =
-      new ApplicationData(path, source_type, manifest.Pass());
+      new ApplicationData(path, source_type, std::move(manifest));
   if (!app_data->Init(explicit_id, &error)) {
     *error_message = base::UTF16ToUTF8(error);
     return NULL;

--- a/application/common/application_file_util.cc
+++ b/application/common/application_file_util.cc
@@ -383,7 +383,7 @@ scoped_ptr<Manifest> LoadManifest<Manifest::TYPE_MANIFEST>(
 
   scoped_ptr<base::DictionaryValue> dv = make_scoped_ptr(
       static_cast<base::DictionaryValue*>(root.release()));
-  return make_scoped_ptr(new Manifest(dv.Pass(), Manifest::TYPE_MANIFEST));
+  return make_scoped_ptr(new Manifest(std::move(dv), Manifest::TYPE_MANIFEST));
 }
 
 template <>
@@ -403,7 +403,8 @@ scoped_ptr<Manifest> LoadManifest<Manifest::TYPE_WIDGET>(
   if (dv)
     result->Set(ToConstCharPointer(root_node->name), dv);
 
-  return make_scoped_ptr(new Manifest(result.Pass(), Manifest::TYPE_WIDGET));
+  return make_scoped_ptr(new Manifest(std::move(result),
+                                      Manifest::TYPE_WIDGET));
 }
 
 scoped_ptr<Manifest> LoadManifest(const base::FilePath& manifest_path,
@@ -447,7 +448,7 @@ scoped_refptr<ApplicationData> LoadApplication(
     return NULL;
 
   return ApplicationData::Create(
-      app_root, app_id, source_type, manifest.Pass(), error);
+      app_root, app_id, source_type, std::move(manifest), error);
 }
 
 base::FilePath ApplicationURLToRelativeFilePath(const GURL& url) {

--- a/application/common/manifest.cc
+++ b/application/common/manifest.cc
@@ -54,13 +54,13 @@ scoped_ptr<List> ExpandUserAgentLocalesList(const scoped_ptr<List>& list) {
       copy_locale = copy_locale.substr(0, position);
     } while (position != std::string::npos);
   }
-  return expansion_list.Pass();
+  return expansion_list;
 }
 
 }  // namespace
 
 Manifest::Manifest(scoped_ptr<base::DictionaryValue> value, Type type)
-    : data_(value.Pass()),
+    : data_(std::move(value)),
       i18n_data_(new base::DictionaryValue),
       type_(type) {
 

--- a/application/common/package/package.cc
+++ b/application/common/package/package.cc
@@ -32,11 +32,11 @@ Package::~Package() {
 scoped_ptr<Package> Package::Create(const base::FilePath& source_path) {
   if (source_path.MatchesExtension(FILE_PATH_LITERAL(".xpk"))) {
     scoped_ptr<Package> package(new XPKPackage(source_path));
-    return package.Pass();
+    return package;
   }
   if (source_path.MatchesExtension(FILE_PATH_LITERAL(".wgt"))) {
     scoped_ptr<Package> package(new WGTPackage(source_path));
-    return package.Pass();
+    return package;
   }
 
   LOG(ERROR) << "Invalid package type. Only .xpk/.wgt supported now";

--- a/application/common/package/wgt_package.cc
+++ b/application/common/package/wgt_package.cc
@@ -61,7 +61,7 @@ WGTPackage::WGTPackage(const base::FilePath& path)
   scoped_ptr<base::ScopedFILE> file(
       new base::ScopedFILE(base::OpenFile(path, "rb")));
 
-  file_ = file.Pass();
+  file_ = std::move(file);
 }
 
 // static

--- a/application/common/package/xpk_package.cc
+++ b/application/common/package/xpk_package.cc
@@ -33,7 +33,7 @@ XPKPackage::XPKPackage(const base::FilePath& path)
     return;
   scoped_ptr<base::ScopedFILE> file(
       new base::ScopedFILE(base::OpenFile(path, "rb")));
-  file_ = file.Pass();
+  file_ = std::move(file);
   size_t len = fread(&header_, 1, sizeof(header_), file_->get());
   is_valid_ = false;
   if (len < sizeof(header_))

--- a/application/extension/application_runtime_extension.cc
+++ b/application/extension/application_runtime_extension.cc
@@ -42,7 +42,7 @@ AppRuntimeExtensionInstance::AppRuntimeExtensionInstance(
 }
 
 void AppRuntimeExtensionInstance::HandleMessage(scoped_ptr<base::Value> msg) {
-  handler_.HandleMessage(msg.Pass());
+  handler_.HandleMessage(std::move(msg));
 }
 
 void AppRuntimeExtensionInstance::OnGetManifest(
@@ -57,7 +57,7 @@ void AppRuntimeExtensionInstance::OnGetManifest(
   else
     // Return an empty dictionary value when there's no valid manifest data.
     results->Append(new base::DictionaryValue());
-  info->PostResult(results.Pass());
+  info->PostResult(std::move(results));
 }
 
 }  // namespace application

--- a/application/extension/application_widget_extension.cc
+++ b/application/extension/application_widget_extension.cc
@@ -134,24 +134,24 @@ void AppWidgetExtensionInstance::HandleSyncMessage(
 
   scoped_ptr<base::Value> result(new base::StringValue(""));
   if (command == "GetWidgetInfo") {
-    result = GetWidgetInfo(msg.Pass());
+    result = GetWidgetInfo(std::move(msg));
   } else if (command == "SetPreferencesItem") {
-    result = SetPreferencesItem(msg.Pass());
+    result = SetPreferencesItem(std::move(msg));
   } else if (command == "RemovePreferencesItem") {
-    result = RemovePreferencesItem(msg.Pass());
+    result = RemovePreferencesItem(std::move(msg));
   } else if (command == "ClearAllItems") {
-    result = ClearAllItems(msg.Pass());
+    result = ClearAllItems(std::move(msg));
   } else if (command == "GetAllItems") {
-    result = GetAllItems(msg.Pass());
+    result = GetAllItems(std::move(msg));
   } else if (command == "GetItemValueByKey") {
-    result = GetItemValueByKey(msg.Pass());
+    result = GetItemValueByKey(std::move(msg));
   } else if (command == "KeyExists") {
-    result = KeyExists(msg.Pass());
+    result = KeyExists(std::move(msg));
   } else {
     LOG(ERROR) << command << " ASSERT NOT REACHED.";
   }
 
-  SendSyncReplyToJS(result.Pass());
+  SendSyncReplyToJS(std::move(result));
 }
 
 scoped_ptr<base::StringValue> AppWidgetExtensionInstance::GetWidgetInfo(
@@ -164,7 +164,7 @@ scoped_ptr<base::StringValue> AppWidgetExtensionInstance::GetWidgetInfo(
   if (!msg->GetAsDictionary(&dict) ||
       !dict->GetString(kWidgetAttributeKey, &key)) {
     LOG(ERROR) << "Fail to get widget attribute key.";
-    return result.Pass();
+    return result;
   }
 
   WidgetInfo* info =
@@ -173,7 +173,7 @@ scoped_ptr<base::StringValue> AppWidgetExtensionInstance::GetWidgetInfo(
   base::DictionaryValue* widget_info = info->GetWidgetInfo();
   widget_info->GetString(key, &value);
   result.reset(new base::StringValue(value));
-  return result.Pass();
+  return result;
 }
 
 scoped_ptr<base::FundamentalValue>
@@ -188,7 +188,7 @@ AppWidgetExtensionInstance::SetPreferencesItem(scoped_ptr<base::Value> msg) {
       !dict->GetString(kPreferencesItemKey, &key) ||
       !dict->GetString(kPreferencesItemValue, &value)) {
     LOG(ERROR) << "Fail to set preferences item.";
-    return result.Pass();
+    return result;
   }
 
   std::string old_value;
@@ -199,7 +199,7 @@ AppWidgetExtensionInstance::SetPreferencesItem(scoped_ptr<base::Value> msg) {
     LOG(WARNING) << "You are trying to set the same value."
                  << " Nothing will be done.";
     result.reset(new base::FundamentalValue(true));
-    return result.Pass();
+    return result;
   }
   if (widget_storage_->AddEntry(key, value, false)) {
     result.reset(new base::FundamentalValue(true));
@@ -208,10 +208,10 @@ AppWidgetExtensionInstance::SetPreferencesItem(scoped_ptr<base::Value> msg) {
     event->SetString("key", key);
     event->SetString("oldValue", old_value);
     event->SetString("newValue", value);
-    PostMessageToOtherFrames(event.Pass());
+    PostMessageToOtherFrames(std::move(event));
   }
 
-  return result.Pass();
+  return result;
 }
 
 scoped_ptr<base::FundamentalValue>
@@ -224,7 +224,7 @@ AppWidgetExtensionInstance::RemovePreferencesItem(scoped_ptr<base::Value> msg) {
   if (!msg->GetAsDictionary(&dict) ||
       !dict->GetString(kPreferencesItemKey, &key)) {
     LOG(ERROR) << "Fail to remove preferences item.";
-    return result.Pass();
+    return result;
   }
 
   std::string old_value;
@@ -232,7 +232,7 @@ AppWidgetExtensionInstance::RemovePreferencesItem(scoped_ptr<base::Value> msg) {
     LOG(WARNING) << "You are trying to remove an entry which doesn't exist."
                  << " Nothing will be done.";
     result.reset(new base::FundamentalValue(true));
-    return result.Pass();
+    return result;
   }
 
   if (widget_storage_->RemoveEntry(key)) {
@@ -242,10 +242,10 @@ AppWidgetExtensionInstance::RemovePreferencesItem(scoped_ptr<base::Value> msg) {
     event->SetString("key", key);
     event->SetString("oldValue", old_value);
     event->SetString("newValue", "");
-    PostMessageToOtherFrames(event.Pass());
+    PostMessageToOtherFrames(std::move(event));
   }
 
-  return result.Pass();
+  return result;
 }
 
 scoped_ptr<base::FundamentalValue> AppWidgetExtensionInstance::ClearAllItems(
@@ -257,7 +257,7 @@ scoped_ptr<base::FundamentalValue> AppWidgetExtensionInstance::ClearAllItems(
   widget_storage_->GetAllEntries(entries.get());
 
   if (!widget_storage_->Clear())
-    return result.Pass();
+    return result;
 
   for (base::DictionaryValue::Iterator it(*(entries.get()));
       !it.IsAtEnd(); it.Advance()) {
@@ -269,12 +269,12 @@ scoped_ptr<base::FundamentalValue> AppWidgetExtensionInstance::ClearAllItems(
       event->SetString("key", key);
       event->SetString("oldValue", old_value);
       event->SetString("newValue", "");
-      PostMessageToOtherFrames(event.Pass());
+      PostMessageToOtherFrames(std::move(event));
     }
   }
 
   result.reset(new base::FundamentalValue(true));
-  return result.Pass();
+  return result;
 }
 
 scoped_ptr<base::DictionaryValue> AppWidgetExtensionInstance::GetAllItems(
@@ -282,7 +282,7 @@ scoped_ptr<base::DictionaryValue> AppWidgetExtensionInstance::GetAllItems(
   scoped_ptr<base::DictionaryValue> result(new base::DictionaryValue());
   widget_storage_->GetAllEntries(result.get());
 
-  return result.Pass();
+  return result;
 }
 
 scoped_ptr<base::StringValue> AppWidgetExtensionInstance::GetItemValueByKey(
@@ -296,7 +296,7 @@ scoped_ptr<base::StringValue> AppWidgetExtensionInstance::GetItemValueByKey(
       !widget_storage_->GetValueByKey(key, &value))
     value = "";
   scoped_ptr<base::StringValue> result(new base::StringValue(value));
-  return result.Pass();
+  return result;
 }
 
 scoped_ptr<base::FundamentalValue> AppWidgetExtensionInstance::KeyExists(
@@ -309,13 +309,13 @@ scoped_ptr<base::FundamentalValue> AppWidgetExtensionInstance::KeyExists(
   if (!msg->GetAsDictionary(&dict) ||
       !dict->GetString(kPreferencesItemKey, &key)) {
     LOG(ERROR) << "Fail to remove preferences item.";
-    return result.Pass();
+    return result;
   }
 
   if (widget_storage_->EntryExists(key))
     result.reset(new base::FundamentalValue(true));
 
-  return result.Pass();
+  return result;
 }
 
 void AppWidgetExtensionInstance::PostMessageToOtherFrames(

--- a/experimental/native_file_system/native_file_system_extension.cc
+++ b/experimental/native_file_system/native_file_system_extension.cc
@@ -120,7 +120,7 @@ void NativeFileSystemInstance::HandleSyncMessage(
     LOG(ERROR) << command << " ASSERT NOT REACHED.";
   }
 
-  SendSyncReplyToJS(result.Pass());
+  SendSyncReplyToJS(std::move(result));
 }
 
 FileSystemChecker::FileSystemChecker(

--- a/runtime/browser/devtools/remote_debugging_server.cc
+++ b/runtime/browser/devtools/remote_debugging_server.cc
@@ -149,7 +149,7 @@ RemoteDebuggingServer::RemoteDebuggingServer(
   scoped_ptr<devtools_http_handler::DevToolsHttpHandler::ServerSocketFactory>
       factory(new TCPServerSocketFactory(ip, port, 1));
   devtools_http_handler_.reset(new devtools_http_handler::DevToolsHttpHandler(
-          factory.Pass(),
+          std::move(factory),
           frontend_url,
           new XWalkDevToolsHttpHandlerDelegate(),
           output_dir,

--- a/runtime/browser/runtime_file_select_helper.cc
+++ b/runtime/browser/runtime_file_select_helper.cc
@@ -245,7 +245,7 @@ RuntimeFileSelectHelper::GetFileTypesFromAcceptType(
       new ui::SelectFileDialog::FileTypeInfo());
   base_file_type->support_drive = true;
   if (accept_types.empty())
-    return base_file_type.Pass();
+    return base_file_type;
 
   // Create FileTypeInfo and pre-allocate for the first extension list.
   scoped_ptr<ui::SelectFileDialog::FileTypeInfo> file_type(
@@ -286,7 +286,7 @@ RuntimeFileSelectHelper::GetFileTypesFromAcceptType(
 
   // If no valid extension is added, bail out.
   if (valid_type_count == 0)
-    return base_file_type.Pass();
+    return base_file_type;
 
   // Use a generic description "Custom Files" if either of the following is
   // true:
@@ -304,7 +304,7 @@ RuntimeFileSelectHelper::GetFileTypesFromAcceptType(
         l10n_util::GetStringUTF16(description_id));
   }
 
-  return file_type.Pass();
+  return file_type;
 }
 
 // static

--- a/sysapps/common/binding_object.h
+++ b/sysapps/common/binding_object.h
@@ -26,7 +26,7 @@ class BindingObject {
   virtual ~BindingObject() {}
 
   bool HandleFunction(scoped_ptr<XWalkExtensionFunctionInfo> info) {
-    return handler_.HandleFunction(info.Pass());
+    return handler_.HandleFunction(std::move(info));
   }
 
  protected:

--- a/sysapps/common/binding_object_store.cc
+++ b/sysapps/common/binding_object_store.cc
@@ -85,10 +85,10 @@ void BindingObjectStore::OnPostMessageToObject(
   scoped_ptr<XWalkExtensionFunctionInfo> new_info(
       new XWalkExtensionFunctionInfo(
           params->name,
-          new_args.Pass(),
+          std::move(new_args),
           info->post_result_cb()));
 
-  if (!it->second->HandleFunction(new_info.Pass())) {
+  if (!it->second->HandleFunction(std::move(new_info))) {
     LOG(WARNING) << "The object with the ID " << params->object_id << " has no "
         "handler for the function " << params->name << ".";
     return;

--- a/sysapps/common/event_target.cc
+++ b/sysapps/common/event_target.cc
@@ -30,7 +30,7 @@ void EventTarget::DispatchEvent(const std::string& type,
   if (it == events_.end())
     return;
 
-  it->second.Run(data.Pass());
+  it->second.Run(std::move(data));
 }
 
 bool EventTarget::IsEventActive(const std::string& type) const {

--- a/sysapps/device_capabilities/av_codecs_provider_ffmpeg.cc
+++ b/sysapps/device_capabilities/av_codecs_provider_ffmpeg.cc
@@ -53,7 +53,7 @@ scoped_ptr<SystemAVCodecs> AVCodecsProviderFFmpeg::GetSupportedCodecs() const {
     }
   }
 
-  return av_codecs.Pass();
+  return av_codecs;
 }
 
 }  // namespace sysapps

--- a/sysapps/device_capabilities/cpu_info_provider.cc
+++ b/sysapps/device_capabilities/cpu_info_provider.cc
@@ -24,7 +24,7 @@ scoped_ptr<SystemCPU> CPUInfoProvider::cpu_info() const {
   info->arch_name = processor_architecture_;
   info->load = GetCPULoad();
 
-  return info.Pass();
+  return info;
 }
 
 }  // namespace sysapps

--- a/sysapps/device_capabilities/device_capabilities_extension.cc
+++ b/sysapps/device_capabilities/device_capabilities_extension.cc
@@ -36,7 +36,7 @@ DeviceCapabilitiesInstance::DeviceCapabilitiesInstance()
 }
 
 void DeviceCapabilitiesInstance::HandleMessage(scoped_ptr<base::Value> msg) {
-  handler_.HandleMessage(msg.Pass());
+  handler_.HandleMessage(std::move(msg));
 }
 
 void DeviceCapabilitiesInstance::OnDeviceCapabilitiesConstructor(
@@ -44,7 +44,7 @@ void DeviceCapabilitiesInstance::OnDeviceCapabilitiesConstructor(
   scoped_ptr<Params> params(Params::Create(*info->arguments()));
 
   scoped_ptr<BindingObject> obj(new DeviceCapabilitiesObject());
-  store_.AddBindingObject(params->object_id, obj.Pass());
+  store_.AddBindingObject(params->object_id, std::move(obj));
 }
 
 }  // namespace experimental

--- a/sysapps/device_capabilities/device_capabilities_object.cc
+++ b/sysapps/device_capabilities/device_capabilities_object.cc
@@ -68,7 +68,7 @@ void DeviceCapabilitiesObject::OnDisplayConnected(const DisplayUnit& display) {
   scoped_ptr<base::ListValue> eventData(new base::ListValue);
   eventData->Append(display.ToValue().release());
 
-  DispatchEvent("displayconnect", eventData.Pass());
+  DispatchEvent("displayconnect", std::move(eventData));
 }
 
 void DeviceCapabilitiesObject::OnDisplayDisconnected(
@@ -76,21 +76,21 @@ void DeviceCapabilitiesObject::OnDisplayDisconnected(
   scoped_ptr<base::ListValue> eventData(new base::ListValue);
   eventData->Append(display.ToValue().release());
 
-  DispatchEvent("displaydisconnect", eventData.Pass());
+  DispatchEvent("displaydisconnect", std::move(eventData));
 }
 
 void DeviceCapabilitiesObject::OnStorageAttached(const StorageUnit& storage) {
   scoped_ptr<base::ListValue> eventData(new base::ListValue);
   eventData->Append(storage.ToValue().release());
 
-  DispatchEvent("storageattach", eventData.Pass());
+  DispatchEvent("storageattach", std::move(eventData));
 }
 
 void DeviceCapabilitiesObject::OnStorageDetached(const StorageUnit& storage) {
   scoped_ptr<base::ListValue> eventData(new base::ListValue);
   eventData->Append(storage.ToValue().release());
 
-  DispatchEvent("storagedetach", eventData.Pass());
+  DispatchEvent("storagedetach", std::move(eventData));
 }
 
 void DeviceCapabilitiesObject::OnGetAVCodecs(

--- a/sysapps/device_capabilities/display_info_provider.cc
+++ b/sysapps/device_capabilities/display_info_provider.cc
@@ -70,7 +70,7 @@ scoped_ptr<SystemDisplay> DisplayInfoProvider::display_info() {
     info->displays.push_back(makeDisplayUnit(*it));
   }
 
-  return info.Pass();
+  return info;
 }
 
 void DisplayInfoProvider::AddObserver(Observer* observer) {

--- a/sysapps/device_capabilities/memory_info_provider.cc
+++ b/sysapps/device_capabilities/memory_info_provider.cc
@@ -21,7 +21,7 @@ scoped_ptr<SystemMemory> MemoryInfoProvider::memory_info() const {
   info->capacity = amount_of_physical_memory_;
   info->avail_capacity = base::SysInfo::AmountOfAvailablePhysicalMemory();
 
-  return info.Pass();
+  return info;
 }
 
 }  // namespace sysapps

--- a/sysapps/device_capabilities/storage_info_provider_chromium.cc
+++ b/sysapps/device_capabilities/storage_info_provider_chromium.cc
@@ -65,7 +65,7 @@ scoped_ptr<SystemStorage> StorageInfoProviderChromium::storage_info() const {
     info->storages.push_back(makeStorageUnit(*it));
   }
 
-  return info.Pass();
+  return info;
 }
 
 void StorageInfoProviderChromium::OnRemovableStorageAttached(

--- a/sysapps/raw_socket/raw_socket_extension.cc
+++ b/sysapps/raw_socket/raw_socket_extension.cc
@@ -43,12 +43,12 @@ RawSocketInstance::RawSocketInstance()
 }
 
 void RawSocketInstance::HandleMessage(scoped_ptr<base::Value> msg) {
-  handler_.HandleMessage(msg.Pass());
+  handler_.HandleMessage(std::move(msg));
 }
 
 void RawSocketInstance::AddBindingObject(const std::string& object_id,
                                          scoped_ptr<BindingObject> obj) {
-  store_.AddBindingObject(object_id, obj.Pass());
+  store_.AddBindingObject(object_id, std::move(obj));
 }
 
 void RawSocketInstance::OnTCPServerSocketConstructor(
@@ -62,7 +62,7 @@ void RawSocketInstance::OnTCPServerSocketConstructor(
   }
 
   scoped_ptr<BindingObject> obj(new TCPServerSocketObject(this));
-  store_.AddBindingObject(params->object_id, obj.Pass());
+  store_.AddBindingObject(params->object_id, std::move(obj));
 }
 
 void RawSocketInstance::OnTCPSocketConstructor(
@@ -76,7 +76,7 @@ void RawSocketInstance::OnTCPSocketConstructor(
   }
 
   scoped_ptr<BindingObject> obj(new TCPSocketObject);
-  store_.AddBindingObject(params->object_id, obj.Pass());
+  store_.AddBindingObject(params->object_id, std::move(obj));
 }
 
 void RawSocketInstance::OnUDPSocketConstructor(
@@ -90,7 +90,7 @@ void RawSocketInstance::OnUDPSocketConstructor(
   }
 
   scoped_ptr<BindingObject> obj(new UDPSocketObject);
-  store_.AddBindingObject(params->object_id, obj.Pass());
+  store_.AddBindingObject(params->object_id, std::move(obj));
 }
 
 }  // namespace sysapps

--- a/sysapps/raw_socket/raw_socket_object.cc
+++ b/sysapps/raw_socket/raw_socket_object.cc
@@ -18,7 +18,7 @@ void RawSocketObject::setReadyState(ReadyState state) {
   scoped_ptr<base::ListValue> eventData(new base::ListValue);
   eventData->AppendString(ToString(state));
 
-  DispatchEvent("readystate", eventData.Pass());
+  DispatchEvent("readystate", std::move(eventData));
 }
 
 }  // namespace sysapps

--- a/sysapps/raw_socket/tcp_server_socket_object.cc
+++ b/sysapps/raw_socket/tcp_server_socket_object.cc
@@ -120,8 +120,9 @@ void TCPServerSocketObject::OnAccept(int status) {
     options.use_secure_transport = false;
 
     std::string object_id = base::GenerateGUID();
-    scoped_ptr<BindingObject> obj(new TCPSocketObject(accepted_socket_.Pass()));
-    instance_->AddBindingObject(object_id, obj.Pass());
+    scoped_ptr<BindingObject> obj(new TCPSocketObject(
+                            std::move(accepted_socket_)));
+    instance_->AddBindingObject(object_id, std::move(obj));
 
     scoped_ptr<base::ListValue> dataList(new base::ListValue);
     dataList->AppendString(object_id);
@@ -130,7 +131,7 @@ void TCPServerSocketObject::OnAccept(int status) {
     scoped_ptr<base::ListValue> eventData(new base::ListValue);
     eventData->Append(dataList.release());
 
-    DispatchEvent("connect", eventData.Pass());
+    DispatchEvent("connect", std::move(eventData));
   } else {
     // The spec is not really clear about what to do when we get a incoming
     // connection but nobody is listening. We are just closing the socket in

--- a/sysapps/raw_socket/tcp_socket_object.cc
+++ b/sysapps/raw_socket/tcp_socket_object.cc
@@ -183,7 +183,7 @@ void TCPSocketObject::OnRead(int status) {
   // disconnected the socket.
   if (status == 0) {
     setReadyState(READY_STATE_CLOSED);
-    DispatchEvent("close", eventData.Pass());
+    DispatchEvent("close", std::move(eventData));
     return;
   }
 
@@ -193,7 +193,7 @@ void TCPSocketObject::OnRead(int status) {
   eventData->Append(data.release());
 
   if (!is_suspended_)
-    DispatchEvent("data", eventData.Pass());
+    DispatchEvent("data", std::move(eventData));
 
   DoRead();
 }

--- a/sysapps/raw_socket/udp_socket_object.cc
+++ b/sysapps/raw_socket/udp_socket_object.cc
@@ -225,7 +225,7 @@ void UDPSocketObject::OnRead(int status) {
   eventData->Append(event.ToValue().release());
 
   if (!is_suspended_)
-    DispatchEvent("message", eventData.Pass());
+    DispatchEvent("message", std::move(eventData));
 
   DoRead();
 }


### PR DESCRIPTION
Scoped ptr is deprecated in M49 and it is easier to
fix them directly here. There will be most
probably another similar commit because it is easier to
find them from build failures.