### PR TITLE
Change scoped_ptr.Pass() to std::move(scoped_ptr) part 3

### DIFF
--- a/application/common/application_file_util_unittest.cc
+++ b/application/common/application_file_util_unittest.cc
@@ -100,7 +100,7 @@ static scoped_refptr<ApplicationData> LoadApplicationManifest(
   scoped_ptr<Manifest> manifest = make_scoped_ptr(
       new Manifest(make_scoped_ptr(values->DeepCopy())));
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      manifest_dir, std::string(), location, manifest.Pass(), error);
+      manifest_dir, std::string(), location, std::move(manifest), error);
   return application;
 }
 

--- a/application/common/manifest_handlers/unittest_util.cc
+++ b/application/common/manifest_handlers/unittest_util.cc
@@ -34,7 +34,7 @@ scoped_ptr<base::DictionaryValue> CreateDefaultManifestConfig() {
   manifest->SetString(manifest_keys::kXWalkVersionKey, kDefaultManifestVersion);
   manifest->SetString(manifest_keys::kNameKey, kDefaultManifestName);
 
-  return manifest.Pass();
+  return manifest;
 }
 
 scoped_ptr<base::DictionaryValue> CreateDefaultWidgetConfig() {
@@ -46,7 +46,7 @@ scoped_ptr<base::DictionaryValue> CreateDefaultWidgetConfig() {
                       widget_keys::kWidgetNamespacePrefix);
   manifest->SetString(widget_keys::kVersionKey, kDefaultWidgetVersion);
   manifest->SetString(widget_keys::kNameKey, kDefaultWidgetName);
-  return manifest.Pass();
+  return manifest;
 }
 
 scoped_refptr<ApplicationData> CreateApplication(Manifest::Type type,

--- a/application/common/manifest_unittest.cc
+++ b/application/common/manifest_unittest.cc
@@ -38,7 +38,7 @@ class ManifestTest : public testing::Test {
       manifest_value->Set(key, value);
     else
       manifest_value->Remove(key, NULL);
-    manifest->reset(new Manifest(manifest_value.Pass()));
+    manifest->reset(new Manifest(std::move(manifest_value)));
   }
 
   std::string default_value_;
@@ -52,7 +52,7 @@ TEST_F(ManifestTest, ApplicationData) {
   manifest_value->SetString("unknown_key", "foo");
 
   scoped_ptr<Manifest> manifest(
-      new Manifest(manifest_value.Pass()));
+      new Manifest(std::move(manifest_value)));
   std::string error;
   EXPECT_TRUE(manifest->ValidateManifest(&error));
   EXPECT_TRUE(error.empty());
@@ -78,7 +78,7 @@ TEST_F(ManifestTest, ApplicationTypes) {
   value->SetString(keys::kXWalkVersionKey, "1");
 
   scoped_ptr<Manifest> manifest(
-      new Manifest(value.Pass()));
+      new Manifest(std::move(value)));
   std::string error;
   EXPECT_TRUE(manifest->ValidateManifest(&error));
   EXPECT_TRUE(error.empty());

--- a/application/test/application_testapi.cc
+++ b/application/test/application_testapi.cc
@@ -54,25 +54,25 @@ ApiTestExtensionInstance::ApiTestExtensionInstance(
 }
 
 void ApiTestExtensionInstance::HandleMessage(scoped_ptr<base::Value> msg) {
-  handler_.HandleMessage(msg.Pass());
+  handler_.HandleMessage(std::move(msg));
 }
 
 void ApiTestExtensionInstance::OnNotifyPass(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   CHECK(observer_);
-  observer_->OnTestNotificationReceived(info.Pass(), kTestNotifyPass);
+  observer_->OnTestNotificationReceived(std::move(info), kTestNotifyPass);
 }
 
 void ApiTestExtensionInstance::OnNotifyFail(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   CHECK(observer_);
-  observer_->OnTestNotificationReceived(info.Pass(), kTestNotifyFail);
+  observer_->OnTestNotificationReceived(std::move(info), kTestNotifyFail);
 }
 
 void ApiTestExtensionInstance::OnNotifyTimeout(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   CHECK(observer_);
-  observer_->OnTestNotificationReceived(info.Pass(), kTestNotifyTimeout);
+  observer_->OnTestNotificationReceived(std::move(info), kTestNotifyTimeout);
 }
 
 ApiTestRunner::ApiTestRunner()

--- a/runtime/browser/linux/xwalk_notification_manager.cc
+++ b/runtime/browser/linux/xwalk_notification_manager.cc
@@ -86,7 +86,7 @@ void XWalkNotificationManager::ShowDesktopNotification(
         nullptr);
 
     notifications_map_.set(reinterpret_cast<int64_t>(notification),
-                           delegate.Pass());
+                           std::move(delegate));
     if (!notification_data.tag.empty()) {
       notifications_replace_map_[notification_data.tag] = notification;
     }

--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -285,7 +285,7 @@ net::URLRequestContextGetter* XWalkBrowserContext::CreateRequestContext(
       GetPath(),
       BrowserThread::UnsafeGetMessageLoopForThread(BrowserThread::IO),
       BrowserThread::UnsafeGetMessageLoopForThread(BrowserThread::FILE),
-      protocol_handlers, request_interceptors.Pass());
+      protocol_handlers, std::move(request_interceptors));
   resource_context_->set_url_request_context_getter(url_request_getter_.get());
   return url_request_getter_.get();
 }
@@ -317,7 +317,7 @@ net::URLRequestContextGetter*
       partition_path,
       BrowserThread::UnsafeGetMessageLoopForThread(BrowserThread::IO),
       BrowserThread::UnsafeGetMessageLoopForThread(BrowserThread::FILE),
-      protocol_handlers, request_interceptors.Pass());
+      protocol_handlers, std::move(request_interceptors));
 
   context_getters_.insert(
       std::make_pair(partition_path.value(), context_getter));
@@ -325,7 +325,7 @@ net::URLRequestContextGetter*
   // please refer to https://crosswalk-project.org/jira/browse/XWALK-2890
   // for more details.
   if (!url_request_getter_)
-    CreateRequestContext(protocol_handlers, request_interceptors.Pass());
+    CreateRequestContext(protocol_handlers, std::move(request_interceptors));
 
   return context_getter.get();
 #endif
@@ -355,7 +355,7 @@ void XWalkBrowserContext::CreateUserPrefServiceIfNecessary() {
   base::PrefServiceFactory pref_service_factory;
   pref_service_factory.set_user_prefs(make_scoped_refptr(new XWalkPrefStore()));
   pref_service_factory.set_read_error_callback(base::Bind(&HandleReadError));
-  user_pref_service_ = pref_service_factory.Create(pref_registry).Pass();
+  user_pref_service_ = pref_service_factory.Create(pref_registry);
 
   user_prefs::UserPrefs::Set(this, user_pref_service_.get());
 }

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -136,7 +136,7 @@ net::URLRequestContextGetter* XWalkContentBrowserClient::CreateRequestContext(
     content::URLRequestInterceptorScopedVector request_interceptors) {
   url_request_context_getter_ =
       static_cast<XWalkBrowserContext*>(browser_context)->CreateRequestContext(
-          protocol_handlers, request_interceptors.Pass());
+          protocol_handlers, std::move(request_interceptors));
   return url_request_context_getter_;
 }
 
@@ -150,7 +150,7 @@ XWalkContentBrowserClient::CreateRequestContextForStoragePartition(
   return static_cast<XWalkBrowserContext*>(browser_context)->
       CreateRequestContextForStoragePartition(
           partition_path, in_memory, protocol_handlers,
-          request_interceptors.Pass());
+          std::move(request_interceptors));
 }
 
 // This allow us to append extra command line switches to the child
@@ -268,7 +268,7 @@ void XWalkContentBrowserClient::SelectClientCertificate(
   XWalkContentsClientBridgeBase* client =
       XWalkContentsClientBridgeBase::FromWebContents(web_contents);
   if (client) {
-    client->SelectClientCertificate(cert_request_info, delegate.Pass());
+    client->SelectClientCertificate(cert_request_info, std::move(delegate));
   } else {
     delegate->ContinueWithCertificate(nullptr);
   }
@@ -355,7 +355,7 @@ content::BrowserPpapiHost*
 #if defined(OS_ANDROID) || defined(OS_LINUX)
 void XWalkContentBrowserClient::ResourceDispatcherHostCreated() {
   resource_dispatcher_host_delegate_ =
-      (RuntimeResourceDispatcherHostDelegate::Create()).Pass();
+      (RuntimeResourceDispatcherHostDelegate::Create());
   content::ResourceDispatcherHost::Get()->SetDelegate(
       resource_dispatcher_host_delegate_.get());
 }
@@ -454,10 +454,9 @@ XWalkContentBrowserClient::CreateThrottlesForNavigation(
   if (navigation_handle->IsInMainFrame()) {
     throttles.push_back(
         navigation_interception::InterceptNavigationDelegate::CreateThrottleFor(
-            navigation_handle)
-            .Pass());
+            navigation_handle));
   }
-  return throttles.Pass();
+  return std::move(throttles);
 }
 #endif
 

--- a/runtime/browser/xwalk_platform_notification_service.cc
+++ b/runtime/browser/xwalk_platform_notification_service.cc
@@ -81,7 +81,7 @@ void XWalkPlatformNotificationService::DisplayNotification(
       continue;
     XWalkContentsClientBridgeBase* bridge =
         XWalkContentsClientBridgeBase::FromWebContents(web_contents);
-    bridge->ShowNotification(notification_data, icon, delegate.Pass(),
+    bridge->ShowNotification(notification_data, icon, std::move(delegate),
                              cancel_callback);
     return;
   }
@@ -92,7 +92,7 @@ void XWalkPlatformNotificationService::DisplayNotification(
       browser_context,
       origin,
       notification_data,
-      delegate.Pass(),
+      std::move(delegate),
       cancel_callback);
 #endif
 }

--- a/runtime/browser/xwalk_pref_store.cc
+++ b/runtime/browser/xwalk_pref_store.cc
@@ -42,13 +42,13 @@ void XWalkPrefStore::SetValue(const std::string& key,
                               scoped_ptr<base::Value> value,
                               uint32_t flags) {
   DCHECK(value);
-  if (prefs_.SetValue(key, value.Pass()))
+  if (prefs_.SetValue(key, std::move(value)))
       ReportValueChanged(key, flags);
 }
 
 void XWalkPrefStore::SetValueSilently(
     const std::string& key, scoped_ptr<base::Value> value, uint32_t flags) {
-  prefs_.SetValue(key, value.Pass());
+  prefs_.SetValue(key, std::move(value));
 }
 
 void XWalkPrefStore::RemoveValue(const std::string& key, uint32_t flags) {

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -90,12 +90,12 @@ void XWalkRunner::CreateComponents() {
   // Keep a reference as some code still needs to call
   // XWalkRunner::app_system().
   app_component_ = app_component.get();
-  AddComponent(app_component.Pass());
+  AddComponent(std::move(app_component));
 
   if (XWalkRuntimeFeatures::isSysAppsEnabled())
-    AddComponent(CreateSysAppsComponent().Pass());
+    AddComponent(CreateSysAppsComponent());
   if (XWalkRuntimeFeatures::isStorageAPIEnabled())
-    AddComponent(CreateStorageComponent().Pass());
+    AddComponent(CreateStorageComponent());
 }
 
 void XWalkRunner::DestroyComponents() {
@@ -160,7 +160,7 @@ void XWalkRunner::OnRenderProcessWillLaunch(content::RenderProcessHost* host) {
   InitializeRuntimeVariablesForExtensions(host, runtime_variables.get());
   extension_service_->OnRenderProcessWillLaunch(
       host, &ui_thread_extensions, &extension_thread_extensions,
-      runtime_variables.Pass());
+      std::move(runtime_variables));
 }
 
 void XWalkRunner::OnRenderProcessHostGone(content::RenderProcessHost* host) {

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -175,11 +175,11 @@ void XWalkContentRendererClient::DidCreateModuleSystem(
     extensions::XWalkModuleSystem* module_system) {
   scoped_ptr<extensions::XWalkNativeModule> app_module(
       new application::ApplicationNativeModule());
-  module_system->RegisterNativeModule("application", app_module.Pass());
+  module_system->RegisterNativeModule("application", std::move(app_module));
   scoped_ptr<extensions::XWalkNativeModule> isolated_file_system_module(
       new extensions::IsolatedFileSystem());
   module_system->RegisterNativeModule("isolated_file_system",
-      isolated_file_system_module.Pass());
+      std::move(isolated_file_system_module));
   module_system->RegisterNativeModule("sysapps_common",
       extensions::CreateJSModuleFromResource(IDR_XWALK_SYSAPPS_COMMON_API));
   module_system->RegisterNativeModule("sysapps_promise",

--- a/sysapps/common/binding_object_store_unittest.cc
+++ b/sysapps/common/binding_object_store_unittest.cc
@@ -25,14 +25,14 @@ scoped_ptr<XWalkExtensionFunctionInfo> CreateFunctionInfo(
 
   return make_scoped_ptr(new XWalkExtensionFunctionInfo(
       name,
-      arguments.Pass(),
+      std::move(arguments),
       base::Bind(&DummyCallback)));
 }
 
 class BindingObjectTest : public BindingObject {
  public:
   static scoped_ptr<BindingObject> Create() {
-    return make_scoped_ptr(new BindingObjectTest()).Pass();
+    return make_scoped_ptr(new BindingObjectTest());
   }
 
   BindingObjectTest() : call_count_(0) {
@@ -149,8 +149,8 @@ TEST(XWalkSysAppsBindingObjectStoreTest, OnPostMessageToObject) {
   scoped_ptr<BindingObject> binding_object_ptr1(binding_object1);
   scoped_ptr<BindingObject> binding_object_ptr2(binding_object2);
 
-  store->AddBindingObject("foobar1", binding_object_ptr1.Pass());
-  store->AddBindingObject("foobar2", binding_object_ptr2.Pass());
+  store->AddBindingObject("foobar1", std::move(binding_object_ptr1));
+  store->AddBindingObject("foobar2", std::move(binding_object_ptr2));
   EXPECT_EQ(BindingObjectTest::instance_count(), 2);
 
   for (unsigned i = 0; i < 1000; ++i) {
@@ -170,10 +170,10 @@ TEST(XWalkSysAppsBindingObjectStoreTest, OnPostMessageToObject) {
     scoped_ptr<XWalkExtensionFunctionInfo> postMessageToObjectInfo(
         new XWalkExtensionFunctionInfo(
             "postMessageToObject",
-            arguments.Pass(),
+            std::move(arguments),
             base::Bind(&DummyCallback)));
 
-    EXPECT_TRUE(handler.HandleFunction(postMessageToObjectInfo.Pass()));
+    EXPECT_TRUE(handler.HandleFunction(std::move(postMessageToObjectInfo)));
     EXPECT_EQ(binding_object1->call_count(), i + 1);
   }
 

--- a/sysapps/common/common_api_browsertest.cc
+++ b/sysapps/common/common_api_browsertest.cc
@@ -70,7 +70,7 @@ SysAppsTestExtensionInstance::SysAppsTestExtensionInstance()
 }
 
 void SysAppsTestExtensionInstance::HandleMessage(scoped_ptr<base::Value> msg) {
-  handler_.HandleMessage(msg.Pass());
+  handler_.HandleMessage(std::move(msg));
 }
 
 void SysAppsTestExtensionInstance::OnSysAppsTestObjectContructor(
@@ -79,7 +79,7 @@ void SysAppsTestExtensionInstance::OnSysAppsTestObjectContructor(
   ASSERT_TRUE(info->arguments()->GetString(0, &object_id));
 
   scoped_ptr<BindingObject> obj(new SysAppsTestObject);
-  store_.AddBindingObject(object_id, obj.Pass());
+  store_.AddBindingObject(object_id, std::move(obj));
 }
 
 void SysAppsTestExtensionInstance::OnHasObject(
@@ -90,7 +90,7 @@ void SysAppsTestExtensionInstance::OnHasObject(
   scoped_ptr<base::ListValue> result(new base::ListValue());
   result->AppendBoolean(store_.HasObjectForTesting(object_id));
 
-  info->PostResult(result.Pass());
+  info->PostResult(std::move(result));
 }
 
 SysAppsTestObject::SysAppsTestObject() : is_test_event_active_(false) {
@@ -123,17 +123,17 @@ void SysAppsTestObject::OnIsTestEventActive(
   scoped_ptr<base::ListValue> result(new base::ListValue());
   result->AppendBoolean(is_test_event_active_);
 
-  info->PostResult(result.Pass());
+  info->PostResult(std::move(result));
 }
 
 void SysAppsTestObject::OnFireTestEvent(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   scoped_ptr<base::ListValue> data(new base::ListValue());
   data->AppendString("Lorem ipsum");
-  DispatchEvent("test", data.Pass());
+  DispatchEvent("test", std::move(data));
 
   scoped_ptr<base::ListValue> result(new base::ListValue());
-  info->PostResult(result.Pass());
+  info->PostResult(std::move(result));
 }
 
 void SysAppsTestObject::OnMakeFulfilledPromise(
@@ -142,7 +142,7 @@ void SysAppsTestObject::OnMakeFulfilledPromise(
   result->AppendString("Lorem ipsum");  // Data.
   result->AppendString("");  // Error, empty == no error.
 
-  info->PostResult(result.Pass());
+  info->PostResult(std::move(result));
 }
 
 void SysAppsTestObject::OnMakeRejectedPromise(
@@ -151,7 +151,7 @@ void SysAppsTestObject::OnMakeRejectedPromise(
   result->AppendString("");  // Data.
   result->AppendString("Lorem ipsum");  // Error, !empty == error.
 
-  info->PostResult(result.Pass());
+  info->PostResult(std::move(result));
 }
 
 class SysAppsCommonTest : public InProcessBrowserTest {

--- a/sysapps/common/event_target_unittest.cc
+++ b/sysapps/common/event_target_unittest.cc
@@ -24,7 +24,7 @@ scoped_ptr<XWalkExtensionFunctionInfo> CreateFunctionInfo(
 
   return make_scoped_ptr(new XWalkExtensionFunctionInfo(
       name,
-      arguments.Pass(),
+      std::move(arguments),
       base::Bind(&DummyCallback)));
 }
 
@@ -46,7 +46,7 @@ class EventTargetTest : public EventTarget {
     scoped_ptr<base::ListValue> data(new base::ListValue());
     data->AppendString(kTestString);
 
-    DispatchEvent(type, data.Pass());
+    DispatchEvent(type, std::move(data));
   }
 
   bool is_event1_active() const {
@@ -152,10 +152,10 @@ TEST(XWalkSysAppsEventTargetTest, DispatchEvent) {
   scoped_ptr<XWalkExtensionFunctionInfo> eventInfo(
       new XWalkExtensionFunctionInfo(
           "addEventListener",
-          argumentsList.Pass(),
+          std::move(argumentsList),
           base::Bind(&DispatchResult, &message_count)));
 
-  EXPECT_TRUE(target->HandleFunction(eventInfo.Pass()));
+  EXPECT_TRUE(target->HandleFunction(std::move(eventInfo)));
 
   for (unsigned i = 0; i < 1000; ++i) {
     target->InjectEvent("event1");


### PR DESCRIPTION
Scoped ptr is deprecated in M49 and it is easier to
fix them directly here. There will be most
probably another similar commit because it is easier to
find them from build failures.