### PR TITLE
DEPS.xwalk: Roll chromium-crosswalk (552b4b9 -> 0f31e18).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '552b4b970de78fb93015a77b57cf52c93045363d'
+chromium_crosswalk_rev = '0f31e18da1b5bfc6821ed525c5fb18b9fbc51c65'
 v8_crosswalk_rev = '28a1ef346a4778d5aa3a8090c624e1c3f90a2e32'
 
 crosswalk_git = 'https://github.com/crosswalk-project'


### PR DESCRIPTION
* 0f31e18 Merge pull request #313 from astojilj/gamepad
* b34d261 XWALK-4992 [windows] App does not support gamepad
* dce3262 Merge pull request #314 from rakuco/webcl-define-only-for-webcl-files
* 64b4265 [Blink] WebCL: Only set ENABLE_WEBCL in the relevant files.