### PR TITLE
Fix build warning: initialize order

### DIFF
--- a/extensions/common/xwalk_external_extension.cc
+++ b/extensions/common/xwalk_external_extension.cc
@@ -24,8 +24,8 @@ XWalkExternalExtension::XWalkExternalExtension(const base::FilePath& path)
       handle_msg_callback_(NULL),
       handle_sync_msg_callback_(NULL),
       handle_binary_msg_callback_(NULL),
-      initialized_(false),
-      library_path_(path) {
+      library_path_(path),
+      initialized_(false) {
 }
 
 XWalkExternalExtension::~XWalkExternalExtension() {


### PR DESCRIPTION
warning: field 'initialized_' will be initialized after
field 'library_path_' [-Wreorder]