### PR TITLE
[Android] Stop setting ENABLE_WEBCL=1 in all files.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -127,12 +127,4 @@
     'xwalk_core_library_artifact_id%': 'xwalk_core_library_canary',
     'xwalk_shared_library_artifact_id%': 'xwalk_shared_library_canary',
   },
-
-  'target_defaults': {
-    'conditions': [
-      ['enable_webcl==1', {
-        'defines': ['ENABLE_WEBCL=1'],
-      }],
-    ],
-  },
 }


### PR DESCRIPTION
With chromium-crosswalk commit 64b4265 ("[Blink] WebCL: Only set
ENABLE_WEBCL in the relevant files"), the `ENABLE_WEBCL` macro is defined
only for the relevant files in Blink.

This means we can now remove it from `target_defaults` and stop passing
it to all the 15000+ files part of Crosswalk's build since the vast
majority of them do not need to be aware of the macro at all.