### PR TITLE
[Android] Start shipping VERSION in the app-template zip file again.

### DIFF
--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -35,6 +35,7 @@ def PrepareFromXwalk(src_dir, target_dir):
   # The source file/directory list to be copied and the target directory list.
   source_target_list = [
     (os.path.join(source_code_dir, 'xwalk/API_VERSION'), target_dir),
+    (os.path.join(source_code_dir, 'xwalk/VERSION'), target_dir),
 
     # The app wrapper code. It's the template Java code.
     (os.path.join(source_code_dir, 'xwalk/app/android/app_template'),


### PR DESCRIPTION
It was thought to be used only by make_apk, so we stopped putting it in
the xwalk_app_template directory (and later publishing it in the zip
file) when make_apk was removed in commit acbf950 ("[Android] Remove
make_apk and associated tests from the tree") , but app-tools can use it
as a hint deduce Crosswalk's version number.