### PR TITLE
[Android] Add support to enable/disable theme color property

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -61,7 +61,10 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
         @Override
         public void didChangeThemeColor(int color) {
-            onDidChangeThemeColor(color);
+            boolean themecolor = XWalkPreferencesInternal.getValue(
+                    XWalkPreferencesInternal.THEME_COLOR);
+            if(themecolor)
+                onDidChangeThemeColor(color);
         }
 
         @Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPreferencesInternal.java
@@ -147,6 +147,14 @@ public class XWalkPreferencesInternal {
     @XWalkAPI
     public static final String SPATIAL_NAVIGATION = "enable-spatial-navigation";
 
+    /*
+     * The key string to enable/disable website's "theme-color" attribute.
+     * Default is true, and it only works on Android Lollipop or later.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public static final String THEME_COLOR = "theme-color";
+
     /**
      * The key string to enable/disable javascript.
      * TODO(wang16): Remove this after cordova removes its dependency.
@@ -170,6 +178,7 @@ public class XWalkPreferencesInternal {
         sPrefMap.put(ENABLE_EXTENSIONS, new PreferenceValue(true));
         sPrefMap.put(PROFILE_NAME, new PreferenceValue("Default"));
         sPrefMap.put(SPATIAL_NAVIGATION, new PreferenceValue(true));
+        sPrefMap.put(THEME_COLOR, new PreferenceValue(true));
     }
 
     /**


### PR DESCRIPTION
Starting in version 39 of Chrome for Android on Lollipop, it
can be able to use the theme-color meta tag to set the toolbar
color, and Crosswalk already support it now. However, it would
be nice if this feature can be configured.

BUG=XWALK-5024