### PR TITLE
Remove unused GetCommandLineForRelaunch

### DIFF
--- a/test/base/in_process_browser_test.cc
+++ b/test/base/in_process_browser_test.cc
@@ -43,21 +43,6 @@ namespace {
 base::LazyInstance<XWalkContentRendererClient>::Leaky
         g_xwalk_content_renderer_client = LAZY_INSTANCE_INITIALIZER;
 
-// Return a CommandLine object that is used to relaunch the browser_test
-// binary as a browser process.
-base::CommandLine GetCommandLineForRelaunch() {
-  base::CommandLine new_command_line(
-      base::CommandLine::ForCurrentProcess()->GetProgram());
-  base::CommandLine::SwitchMap switches =
-      base::CommandLine::ForCurrentProcess()->GetSwitches();
-  new_command_line.AppendSwitch(content::kLaunchAsBrowser);
-
-  for (auto iter = switches.begin(); iter != switches.end(); ++iter) {
-    new_command_line.AppendSwitchNative((*iter).first, (*iter).second);
-  }
-  return new_command_line;
-}
-
 }  // namespace
 
 InProcessBrowserTest::InProcessBrowserTest() {


### PR DESCRIPTION
It is got unused bde9fbd
"The big in-browser tests classes clean-up"