### PR TITLE
Change scoped_ptr.Pass() to std::move(scoped_ptr) part4

### DIFF
--- a/application/browser/application_service_provider_linux.cc
+++ b/application/browser/application_service_provider_linux.cc
@@ -70,7 +70,7 @@ void OnPing(dbus::MethodCall* method_call,
       dbus::Response::FromMethodCall(method_call);
   dbus::MessageWriter writer(response.get());
   writer.AppendString("Pong");
-  response_sender.Run(response.Pass());
+  response_sender.Run(std::move(response));
 }
 
 }  // namespace

--- a/extensions/common/android/xwalk_extension_android.cc
+++ b/extensions/common/android/xwalk_extension_android.cc
@@ -210,7 +210,7 @@ void XWalkExtensionAndroidInstance::HandleSyncMessage(
 
   std::string value;
   if (!msg->GetAsString(&value)) {
-    SendSyncReplyToJS(ret_val.Pass());
+    SendSyncReplyToJS(std::move(ret_val));
     return;
   }
 
@@ -218,7 +218,7 @@ void XWalkExtensionAndroidInstance::HandleSyncMessage(
   ScopedJavaLocalRef<jobject> obj = java_ref_.get(env);
   if (obj.is_null()) {
     LOG(ERROR) << "No valid Java object is referenced for sync message routing";
-    SendSyncReplyToJS(ret_val.Pass());
+    SendSyncReplyToJS(std::move(ret_val));
     return;
   }
 
@@ -231,7 +231,7 @@ void XWalkExtensionAndroidInstance::HandleSyncMessage(
   ret_val.reset(new base::StringValue(str));
   env->ReleaseStringUTFChars(ret.obj(), str);
 
-  SendSyncReplyToJS(ret_val.Pass());
+  SendSyncReplyToJS(std::move(ret_val));
 }
 
 static jlong GetOrCreateExtension(

--- a/extensions/test/in_process_threads_browsertest.cc
+++ b/extensions/test/in_process_threads_browsertest.cc
@@ -29,7 +29,7 @@ class InProcessExtensionInstance : public XWalkExtensionInstance {
     scoped_ptr<base::ListValue> reply(new base::ListValue);
     reply->AppendBoolean(is_on_ui_thread);
 
-    return reply.Pass();
+    return std::move(reply);
   }
 
   void HandleMessage(scoped_ptr<base::Value> msg) override {

--- a/extensions/test/internal_extension_browsertest.cc
+++ b/extensions/test/internal_extension_browsertest.cc
@@ -58,7 +58,7 @@ TestExtensionInstance::TestExtensionInstance() : counter_(0), handler_(this) {
 TestExtensionInstance::~TestExtensionInstance() {}
 
 void TestExtensionInstance::HandleMessage(scoped_ptr<base::Value> msg) {
-  handler_.HandleMessage(msg.Pass());
+  handler_.HandleMessage(std::move(msg));
 }
 
 void TestExtensionInstance::OnClearDatabase(

--- a/extensions/test/xwalk_extensions_browsertest.cc
+++ b/extensions/test/xwalk_extensions_browsertest.cc
@@ -38,17 +38,17 @@ class EchoContext : public XWalkExtensionInstance {
   EchoContext() {
   }
   void HandleMessage(scoped_ptr<base::Value> msg) override {
-    PostMessageToJS(msg.Pass());
+    PostMessageToJS(std::move(msg));
   }
   void HandleSyncMessage(scoped_ptr<base::Value> msg) override {
-    SendSyncReplyToJS(msg.Pass());
+    SendSyncReplyToJS(std::move(msg));
   }
 };
 
 class DelayedEchoContext : public XWalkExtensionInstance {
  public:
   void HandleMessage(scoped_ptr<base::Value> msg) override {
-    PostMessageToJS(msg.Pass());
+    PostMessageToJS(std::move(msg));
   }
   void HandleSyncMessage(scoped_ptr<base::Value> msg) override {
     base::MessageLoop::current()->PostDelayedTask(
@@ -58,7 +58,7 @@ class DelayedEchoContext : public XWalkExtensionInstance {
   }
 
   void DelayedReply(scoped_ptr<base::Value> reply) {
-    SendSyncReplyToJS(reply.Pass());
+    SendSyncReplyToJS(std::move(reply));
   }
 };
 

--- a/extensions/xesh/xesh_main.cc
+++ b/extensions/xesh/xesh_main.cc
@@ -161,7 +161,7 @@ class ExtensionManager {
 
     std::vector<std::string> extensions =
         RegisterExternalExtensionsInDirectory(&server_, extensions_dir,
-            runtime_variables.Pass());
+            std::move(runtime_variables));
 
     fprintf(stderr, "\nExtensions Loaded:\n");
     std::vector<std::string>::const_iterator it = extensions.begin();

--- a/extensions/xesh/xesh_v8_runner.cc
+++ b/extensions/xesh/xesh_v8_runner.cc
@@ -216,7 +216,7 @@ void XEShV8Runner::CreateExtensionModules(XWalkModuleSystem* module_system) {
     scoped_ptr<XWalkExtensionModule> module(
         new XWalkExtensionModule(&client_, module_system, it->first,
                                  codepoint->api));
-    module_system->RegisterExtensionModule(module.Pass(),
+    module_system->RegisterExtensionModule(std::move(module),
                                            codepoint->entry_points);
   }
 }

--- a/runtime/browser/android/net/android_protocol_handler.cc
+++ b/runtime/browser/android/net/android_protocol_handler.cc
@@ -269,7 +269,7 @@ net::URLRequestJob* AndroidRequestInterceptorBase::MaybeInterceptRequest(
   return new AndroidStreamReaderURLRequestJob(
       request,
       network_delegate,
-      reader_delegate.Pass(),
+      std::move(reader_delegate),
       content_security_policy);
 }
 

--- a/runtime/browser/android/net/xwalk_url_request_job_factory.cc
+++ b/runtime/browser/android/net/xwalk_url_request_job_factory.cc
@@ -74,7 +74,7 @@ net::URLRequestJob* XWalkURLRequestJobFactory::MaybeInterceptResponse(
 bool XWalkURLRequestJobFactory::SetProtocolHandler(
     const std::string& scheme,
     scoped_ptr<ProtocolHandler> protocol_handler) {
-  return next_factory_->SetProtocolHandler(scheme, protocol_handler.Pass());
+  return next_factory_->SetProtocolHandler(scheme, std::move(protocol_handler));
 }
 
 bool XWalkURLRequestJobFactory::IsSafeRedirectTarget(

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -130,7 +130,7 @@ XWalkContent* XWalkContent::FromWebContents(
 }
 
 XWalkContent::XWalkContent(scoped_ptr<content::WebContents> web_contents)
-    : web_contents_(web_contents.Pass()) {
+    : web_contents_(std::move(web_contents)) {
   xwalk_autofill_manager_.reset(new XWalkAutofillManager(web_contents_.get()));
   XWalkContentLifecycleNotifier::OnXWalkViewCreated();
 }
@@ -218,7 +218,7 @@ void XWalkContent::SetPendingWebContentsForPopup(
     base::MessageLoop::current()->DeleteSoon(FROM_HERE, pending.release());
     return;
   }
-  pending_contents_.reset(new XWalkContent(pending.Pass()));
+  pending_contents_.reset(new XWalkContent(std::move(pending)));
 }
 
 jlong XWalkContent::ReleasePopupXWalkContent(JNIEnv* env, jobject obj) {
@@ -464,7 +464,7 @@ static jlong Init(JNIEnv* env, const JavaParamRef<jobject>& obj) {
   scoped_ptr<WebContents> web_contents(content::WebContents::Create(
       content::WebContents::CreateParams(
           XWalkRunner::GetInstance()->browser_context())));
-  return reinterpret_cast<intptr_t>(new XWalkContent(web_contents.Pass()));
+  return reinterpret_cast<intptr_t>(new XWalkContent(std::move(web_contents)));
 }
 
 bool RegisterXWalkContent(JNIEnv* env) {

--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -257,7 +257,7 @@ void XWalkContentsClientBridge::ShowNotification(
      jicon = gfx::ConvertToJavaBitmap(&icon);
 
   int notification_id = g_next_notification_id_++;
-  g_notification_map_.set(notification_id, delegate.Pass());
+  g_notification_map_.set(notification_id, std::move(delegate));
   Java_XWalkContentsClientBridge_showNotification(
       env, obj.obj(), jtitle.obj(), jbody.obj(),
       jreplace_id.obj(), jicon.obj(), notification_id);

--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -153,7 +153,7 @@ void XWalkDevToolsServer::Start(bool allow_debug_permission,
   scoped_ptr<devtools_http_handler::DevToolsHttpHandler::ServerSocketFactory>
       factory(new UnixDomainServerSocketFactory(socket_name_, auth_callback));
   devtools_http_handler_.reset(new devtools_http_handler::DevToolsHttpHandler(
-      factory.Pass(),
+      std::move(factory),
       base::StringPrintf(kFrontEndURL, BLINK_UPSTREAM_REVISION),
       new XWalkAndroidDevToolsHttpHandlerDelegate(),
       base::FilePath(),

--- a/runtime/browser/android/xwalk_request_interceptor.cc
+++ b/runtime/browser/android/xwalk_request_interceptor.cc
@@ -50,7 +50,7 @@ XWalkRequestInterceptor::QueryForXWalkWebResourceResponse(
   if (!io_thread_client.get())
     return scoped_ptr<XWalkWebResourceResponse>();
 
-  return io_thread_client->ShouldInterceptRequest(location, request).Pass();
+  return io_thread_client->ShouldInterceptRequest(location, request);
 }
 
 net::URLRequestJob* XWalkRequestInterceptor::MaybeInterceptRequest(
@@ -75,7 +75,7 @@ net::URLRequestJob* XWalkRequestInterceptor::MaybeInterceptRequest(
   if (!xwalk_web_resource_response)
     return nullptr;
   return XWalkWebResourceResponse::CreateJobFor(
-    xwalk_web_resource_response.Pass(), request, network_delegate);
+    std::move(xwalk_web_resource_response), request, network_delegate);
 }
 
 }  // namespace xwalk

--- a/runtime/browser/android/xwalk_web_resource_response.cc
+++ b/runtime/browser/android/xwalk_web_resource_response.cc
@@ -21,13 +21,13 @@ class StreamReaderJobDelegateImpl
  public:
   StreamReaderJobDelegateImpl(
       scoped_ptr<XWalkWebResourceResponse> xwalk_web_resource_response)
-      : xwalk_web_resource_response_(xwalk_web_resource_response.Pass()) {
+      : xwalk_web_resource_response_(std::move(xwalk_web_resource_response)) {
     DCHECK(xwalk_web_resource_response_);
   }
 
   scoped_ptr<InputStream> OpenInputStream(JNIEnv* env,
                                           const GURL& url) override {
-    return xwalk_web_resource_response_->GetInputStream(env).Pass();
+    return xwalk_web_resource_response_->GetInputStream(env);
   }
 
   void OnInputStreamOpenFailed(net::URLRequest* request,
@@ -91,9 +91,9 @@ net::URLRequestJob* XWalkWebResourceResponse::CreateJobFor(
   return new AndroidStreamReaderURLRequestJob(
       request,
       network_delegate,
-      make_scoped_ptr(
-          new StreamReaderJobDelegateImpl(xwalk_web_resource_response.Pass())),
-          content_security_policy);
+      make_scoped_ptr(new StreamReaderJobDelegateImpl(
+                      std::move(xwalk_web_resource_response))),
+      content_security_policy);
 }
 
 }  // namespace xwalk


### PR DESCRIPTION
Scoped ptr is deprecated in M49 and it is easier to
fix them directly here. There will be most
probably another similar commit because it is easier to
find them from build failures.