### PR TITLE
[Android] Stop setting |enable_extensions|.

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -21,7 +21,6 @@
 #include "content/public/common/main_function_params.h"
 #include "content/public/common/url_constants.h"
 #include "content/public/common/result_codes.h"
-#include "extensions/browser/extension_system.h"
 #include "net/base/filename_util.h"
 #include "ui/gl/gl_switches.h"
 #include "xwalk/application/browser/application.h"

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -8,7 +8,6 @@
         'disable_nacl': 1,
       }],
       ['OS=="android"', {
-        'enable_extensions': 1,
         # Whether we should verify package integrity before loading Crosswalk runtime libraray in shared mode
         'verify_xwalk_apk%': 0,
       }],


### PR DESCRIPTION
We started setting it in M40 with commit b37ea05 ("Roll 40.0.2214.28"),
likely to work around Chromium change 44b9ce2 ("Cleanup: Prevent usage
of various extension headers when extensions support is not compiled
in") that would otherwise cause the build to fail like this:

```
In file included from ../../extensions/browser/extension_system.h:13:0,
                 from ../../xwalk/runtime/browser/xwalk_browser_main_parts.cc:24:
../../extensions/common/extension.h:31:2: error: #error "Extensions must be enabled"
 #error "Extensions must be enabled"
  ^
In file included from ../../xwalk/runtime/browser/xwalk_browser_main_parts.cc:24:0:
../../extensions/browser/extension_system.h:16:2: error: #error "Extensions must be enabled"
 #error "Extensions must be enabled"
  ^
```

The extension_system.h include was added in f463560 ("[Linux] Add NaCl
support"), but it is not actually required to build, so we can just
remove both the include and the variable setting.