### PR TITLE
[Win] Add a target to generate a Crosswalk ZIP file.

### DIFF
--- a/build/win/generate_crosswalk_zip.py
+++ b/build/win/generate_crosswalk_zip.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+This program generates a ZIP file containing Crosswalk and supporting files and
+directories with everything required to run Crosswalk on Windows.
+"""
+
+import argparse
+import os
+import sys
+import zipfile
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--build-dir', required=True,
+                      help='Top-level build directory.')
+  parser.add_argument('--dest', required=True,
+                      help='Name of the ZIP file that will be generated.')
+  parser.add_argument('--dirs', nargs='*',
+                      help='Directories to package.')
+  parser.add_argument('--files', nargs='*',
+                      help='Files to package.')
+  args = parser.parse_args()
+
+  with zipfile.ZipFile(args.dest, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+    for filename in args.files:
+      zip_file.write(filename, os.path.relpath(filename, args.build_dir))
+    for dirname in args.dirs:
+      for root, _, files in os.walk(dirname):
+        for filename in files:
+          filepath = os.path.join(root, filename)
+          zip_path = os.path.relpath(filepath, args.build_dir)
+          zip_file.write(filepath, zip_path)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -822,16 +822,17 @@
       ],
     },
     {
+      'target_name': 'generate_crosswalk_win_zip',
+      'type': 'none',
+      'includes': [
+        'xwalk_win_zip.gypi',
+      ],
+    },
+    {
       'target_name': 'xwalk_builder',
       'type': 'none',
       'conditions': [
-        ['OS!="android"', {
-          'dependencies': [
-            'xwalk',
-            'xwalk_all_tests',
-          ],
-        },
-        {
+        ['OS=="android"', {
           'dependencies': [
             # For internal testing.
             'xwalk_core_internal_shell_apk',
@@ -854,6 +855,17 @@
             'xwalk_core_sample_apk',
             'xwalk_core_library_aar',
             'xwalk_shared_library_aar',
+          ],
+        }, 'OS=="win"', {
+          'dependencies': [
+            'xwalk',
+            'xwalk_all_tests',
+            'generate_crosswalk_win_zip',
+          ],
+        }, {  # OS!="android" and OS!="win"
+          'dependencies': [
+            'xwalk',
+            'xwalk_all_tests',
           ],
         }],
       ],

--- a/xwalk_win_zip.gypi
+++ b/xwalk_win_zip.gypi
@@ -1,0 +1,57 @@
+{
+  'variables': {
+    # The files and directories will be added with the same names to the
+    # generated zip file, with <(PRODUCT_DIR)/ stripped from the beginning.
+    'directories_to_package': [
+      '<(PRODUCT_DIR)/locales',
+    ],
+    'files_to_package': [
+      '<(PRODUCT_DIR)/VERSION',
+      '<(PRODUCT_DIR)/d3dcompiler_47.dll',
+      '<(PRODUCT_DIR)/dbghelp.dll',
+      '<(PRODUCT_DIR)/icudtl.dat',
+      '<(PRODUCT_DIR)/libEGL.dll',
+      '<(PRODUCT_DIR)/libGLESv2.dll',
+      '<(PRODUCT_DIR)/natives_blob.bin',
+      '<(PRODUCT_DIR)/osmesa.dll',
+      '<(PRODUCT_DIR)/snapshot_blob.bin',
+      '<(PRODUCT_DIR)/xwalk.exe',
+      '<(PRODUCT_DIR)/xwalk.pak',
+      '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+    ],
+  },
+  # TODO(rakuco): This could be done earlier in the build for other targets to
+  # use this file instead of the one in the source tree.
+  'copies': [
+    {
+      'destination': '<(PRODUCT_DIR)',
+      'files': [
+        '<(DEPTH)/xwalk/VERSION',
+      ],
+    },
+  ],
+  'actions': [
+    {
+      'action_name': 'generate_crosswalk_win_zip',
+      'variables': {
+        'zip_script': '<(DEPTH)/xwalk/build/win/generate_crosswalk_zip.py',
+        'zip_name': '<(PRODUCT_DIR)/crosswalk_win.zip',
+      },
+      'inputs': [
+        '<(zip_script)',
+        '<@(directories_to_package)',
+        '<@(files_to_package)',
+      ],
+      'outputs': [
+        '<(zip_name)',
+      ],
+      'action': [
+        'python', '<(zip_script)',
+        '--build-dir', '<(PRODUCT_DIR)',
+        '--dest', '<(zip_name)',
+        '--dirs', '<@(directories_to_package)',
+        '--files', '<@(files_to_package)',
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
The new `generate_crosswalk_win_zip` target, built as part of the
`xwalk_builder` target on Windows, invokes a script that creates a ZIP
file (called `crosswalk_win.zip`) with everything required to run
Crosswalk on Windows. In other words, it's a zip file with the same
contents we publish on download.01.org (without a version number or
signed files, though).

Doing so helps with generating Crosswalk canaries for Windows as part of
our release building process.