### PR TITLE
[Android] Implement embedding API of clearClientCertPreferences()

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -958,6 +958,11 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         mNavigationController.clearSslPreferences();
     }
 
+    public void clearClientCertPreferences(Runnable callback) {
+        if (mNativeContent == 0) return;
+        mContentsClientBridge.clearClientCertPreferences(callback);
+    }
+
     private native long nativeInit();
     private static native void nativeDestroy(long nativeXWalkContent);
     private native WebContents nativeGetWebContents(long nativeXWalkContent);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -737,6 +737,22 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         }
     }
 
+    public void clearClientCertPreferences(Runnable callback) {
+        mLookupTable.clear();
+
+        if (mNativeContentsClientBridge != 0) {
+            nativeClearClientCertPreferences(mNativeContentsClientBridge, callback);
+        } else if (callback != null) {
+            callback.run();
+        }
+    }
+
+    @CalledByNative
+    private void clientCertificatesCleared(Runnable callback) {
+        if (callback == null) return;
+        callback.run();
+    }
+
     private void proceedSslError(boolean proceed, int id) {
         if (mNativeContentsClientBridge == 0) return;
         nativeProceedSslError(mNativeContentsClientBridge, proceed, id);
@@ -890,4 +906,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     private native void nativeDownloadIcon(long nativeXWalkContentsClientBridge, String url);
     private native void nativeProvideClientCertificateResponse(
             long nativeXWalkContentsClientBridge, int id, byte[][] certChain, AndroidPrivateKey androidKey);
+    private native void nativeClearClientCertPreferences(
+            long nativeXWalkContentsClientBridge, Runnable callback);
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1479,4 +1479,16 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         checkThreadSafety();
         mContent.clearSslPreferences();
     }
+
+    /**
+     * Clears the client certificate preferences stored in response to
+     * proceeding/cancelling client cert requests.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void clearClientCertPreferences(Runnable callback) {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.clearClientCertPreferences(callback);
+    }
 }

--- a/runtime/browser/android/xwalk_contents_client_bridge.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge.h
@@ -110,6 +110,14 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase ,
       scoped_ptr<content::ClientCertificateDelegate> delegate);
 
   void HandleErrorInClientCertificateResponse(int id);
+
+  void ClearClientCertPreferences(
+      JNIEnv*, jobject,
+      const base::android::JavaParamRef<jobject>& callback);
+
+  void ClientCertificatesCleared(
+      base::android::ScopedJavaGlobalRef<jobject>* callback);
+
  private:
   JavaObjectWeakGlobalRef java_ref_;
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearClientCertPreferenceTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearClientCertPreferenceTest.java
@@ -1,0 +1,39 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.content.browser.test.util.CallbackHelper;
+
+public class ClearClientCertPreferenceTest extends XWalkViewTestBase {
+    
+    private static class ClearClientCertCallbackHelper extends CallbackHelper
+            implements Runnable {
+        @Override
+        public void run() {
+            notifyCalled();
+        }
+    }
+    
+    @Feature({"ClearClientCertPreference"})
+    @SmallTest
+    public void testClearClientCertPreference() throws Throwable {
+        final ClearClientCertCallbackHelper callbackHelper = new ClearClientCertCallbackHelper();
+        int currentCallCount = callbackHelper.getCallCount();
+        runTestOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                // Make sure calling clearClientCertPreferences with null callback does not
+                // cause a crash.
+                getXWalkView().clearClientCertPreferences(null);
+                getXWalkView().clearClientCertPreferences(callbackHelper);
+            }
+        });
+        callbackHelper.waitForCallback(currentCallCount);
+    }
+}


### PR DESCRIPTION
Adding a clearClientCertPreferences method similar to the one the
Android system webview has.  When called it will clear any client
certificate preferences stored in response to proceeding/cancelling
client cert requests.

BUG=XWALK-6297