### PR TITLE
Make sure to ask permissions when requesting camera or microphone

### DIFF
--- a/runtime/browser/media/media_capture_devices_dispatcher.h
+++ b/runtime/browser/media/media_capture_devices_dispatcher.h
@@ -16,6 +16,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/media_stream_request.h"
 
+namespace xwalk {
 // This singleton is used to receive updates about media events from the content
 // layer. Based on chrome/browser/media/media_capture_devices_dispatcher.[h|cc].
 class XWalkMediaCaptureDevicesDispatcher : public content::MediaObserver {
@@ -91,6 +92,17 @@ class XWalkMediaCaptureDevicesDispatcher : public content::MediaObserver {
   XWalkMediaCaptureDevicesDispatcher();
   ~XWalkMediaCaptureDevicesDispatcher() override;
 
+#if !defined (OS_ANDROID)
+  static void OnPermissionRequestFinished(
+      const content::MediaResponseCallback& callback,
+      const content::MediaStreamRequest& request,
+      content::WebContents* web_contents,
+      bool success);
+  static void RequestPermissionToUser(
+      content::WebContents* web_contents,
+      const content::MediaStreamRequest& request,
+      const content::MediaResponseCallback& callback);
+#endif
   // Called by the MediaObserver() functions, executed on UI thread.
   void NotifyAudioDevicesChangedOnUIThread();
   void NotifyVideoDevicesChangedOnUIThread();
@@ -110,5 +122,7 @@ class XWalkMediaCaptureDevicesDispatcher : public content::MediaObserver {
   // A list of observers for the device update notifications.
   base::ObserverList<Observer> observers_;
 };
+
+}  // namespace xwalk
 
 #endif  // XWALK_RUNTIME_BROWSER_MEDIA_MEDIA_CAPTURE_DEVICES_DISPATCHER_H_

--- a/runtime/browser/runtime_geolocation_permission_context.cc
+++ b/runtime/browser/runtime_geolocation_permission_context.cc
@@ -107,12 +107,7 @@ RuntimeGeolocationPermissionContext::RequestGeolocationPermission(
 #else
   DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
   XWalkPermissionDialogManager* permission_dialog_manager =
-      XWalkPermissionDialogManager::FromWebContents(web_contents);
-  if (!permission_dialog_manager) {
-    XWalkPermissionDialogManager::CreateForWebContents(web_contents);
-    permission_dialog_manager =
-        XWalkPermissionDialogManager::FromWebContents(web_contents);
-  }
+      XWalkPermissionDialogManager::GetPermissionDialogManager(web_contents);
 
   PrefService* pref_service =
       user_prefs::UserPrefs::Get(XWalkBrowserContext::GetDefault());

--- a/runtime/browser/ui/desktop/xwalk_permission_dialog_manager.cc
+++ b/runtime/browser/ui/desktop/xwalk_permission_dialog_manager.cc
@@ -29,6 +29,19 @@ XWalkPermissionDialogManager::~XWalkPermissionDialogManager() {
   CancelPermissionRequest();
 }
 
+XWalkPermissionDialogManager*
+    XWalkPermissionDialogManager::GetPermissionDialogManager(
+        content::WebContents* web_contents) {
+  XWalkPermissionDialogManager* permission_dialog_manager =
+      XWalkPermissionDialogManager::FromWebContents(web_contents);
+  if (!permission_dialog_manager) {
+    XWalkPermissionDialogManager::CreateForWebContents(web_contents);
+    permission_dialog_manager =
+        XWalkPermissionDialogManager::FromWebContents(web_contents);
+  }
+  return permission_dialog_manager;
+}
+
 void XWalkPermissionDialogManager::WebContentsDestroyed() {
   CancelPermissionRequest();
   web_contents_->RemoveUserData(UserDataKey());
@@ -60,10 +73,10 @@ void XWalkPermissionDialogManager::RequestPermission(
   default: {
     app_modal::AppModalDialogQueue::GetInstance()->AddDialog(
         new XWalkPermissionModalDialog(
-        web_contents_,
-        message_text,
-        base::Bind(&XWalkPermissionDialogManager::OnPermissionDialogClosed,
-        base::Unretained(this), type, origin_url, callback)));
+            web_contents_,
+            message_text,
+            base::Bind(&XWalkPermissionDialogManager::OnPermissionDialogClosed,
+            base::Unretained(this), type, origin_url, callback)));
   }
   }
 }

--- a/runtime/browser/ui/desktop/xwalk_permission_dialog_manager.h
+++ b/runtime/browser/ui/desktop/xwalk_permission_dialog_manager.h
@@ -21,6 +21,8 @@ class XWalkPermissionDialogManager
     : public content::WebContentsObserver,
       public content::WebContentsUserData<XWalkPermissionDialogManager> {
  public:
+  static XWalkPermissionDialogManager* GetPermissionDialogManager(
+      content::WebContents* web_contents);
   void RequestPermission(
       ContentSettingsType type,
       const GURL& origin_url,

--- a/runtime/browser/xwalk_browser_context.h
+++ b/runtime/browser/xwalk_browser_context.h
@@ -108,6 +108,9 @@ class XWalkBrowserContext
   void UpdateAcceptLanguages(const std::string& accept_languages);
   void set_save_form_data(bool enable) { save_form_data_ = enable; }
   bool save_form_data() const { return save_form_data_; }
+  application::ApplicationService* application_service() const {
+    return application_service_;
+  }
   void set_application_service(
       application::ApplicationService* application_service) {
     application_service_ = application_service;

--- a/runtime/resources/xwalk_resources.grd
+++ b/runtime/resources/xwalk_resources.grd
@@ -193,6 +193,21 @@
           $1<ex>maps.google.com</ex>
         </ph> wants to use your computer's location.
       </message>
+      <message name="IDS_MEDIA_CAPTURE_AUDIO_AND_VIDEO" desc="Question asked on the dialog whenever a web page requests access to the computer's microphone and camera.">
+        <ph name="HOST">
+          $1<ex>html5rocks.com</ex>
+        </ph> wants to use your camera and microphone.
+      </message>
+      <message name="IDS_MEDIA_CAPTURE_AUDIO_ONLY" desc="Question asked on the dialog whenever a web page requests access to the computer's microphone.">
+        <ph name="HOST">
+          $1<ex>html5rocks.com</ex>
+        </ph> wants to use your microphone.
+      </message>
+      <message name="IDS_MEDIA_CAPTURE_VIDEO_ONLY" desc="Question asked on the dialog whenever a web page requests access to the computer's camera.">
+        <ph name="HOST">
+          $1<ex>html5rocks.com</ex>
+        </ph> wants to use your camera.
+      </message>
       <message name="IDS_PERMISSION_ALLOW" desc="Label on button to allow a permissions request.">
         Allow
       </message>


### PR DESCRIPTION
Make sure to query the permission manager to ask permissions when
querying the APIs related to microphone and camera.

Following upstream any request originating from HTTP will be ignored.

Please note that CheckMediaAccessPermission was changed to return
false on Android (this was the default behavior before df6e38).

BUG=XWALK-6083