### PR TITLE
[Android] Remove the network change notifier.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -45,7 +45,6 @@ import org.chromium.base.ApplicationStatus.ActivityStateListener;
 import org.chromium.base.ApplicationStatusManager;
 import org.chromium.base.CommandLine;
 import org.chromium.content.browser.ContentViewCore;
-import org.chromium.net.NetworkChangeNotifier;
 
 import org.xwalk.core.internal.extension.BuiltinXWalkExtensions;
 
@@ -296,11 +295,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         // Initialize the ActivityStatus. This is needed and used by many internal
         // features such as location provider to listen to activity status.
         ApplicationStatusManager.init(activity.getApplication());
-
-        // Auto detect network connectivity state.
-        // setAutoDetectConnectivityState() need to be called before activity started.
-        NetworkChangeNotifier.init(activity);
-        NetworkChangeNotifier.setAutoDetectConnectivityState(true);
 
         // We will miss activity onCreate() status in ApplicationStatusManager,
         // informActivityStarted() will simulate these callbacks.


### PR DESCRIPTION
The network change notifier should be registered with application context,
it depends on application status, but our notifier was registered with an
activity/service, it's wrong.
Upstream has fixed this issue by changing the network layer and
implementing the life cycle notifier in M48.

BUG=XWALK-5892, XWALK-6178