### PR TITLE
Remove the notification of NOTIMPLEMENTED().

### DIFF
--- a/runtime/browser/xwalk_autofill_client.cc
+++ b/runtime/browser/xwalk_autofill_client.cc
@@ -113,7 +113,6 @@ void XWalkAutofillClient::DidFillOrPreviewField(
 }
 
 void XWalkAutofillClient::OnFirstUserGestureObserved() {
-  NOTIMPLEMENTED();
 }
 
 bool XWalkAutofillClient::IsContextSecure(const GURL& form_origin) {


### PR DESCRIPTION
This patch is to remove the notification of not implemented function for
OnFirstUserGestureObserved().
The notification will be displayed in logcat when user touch in XWalkView.
It's misleading when user encounter other issues, e.g crash, features
don't work.