### PR TITLE
Make sure to handle all the required messages in our devtools frontend

### DIFF
--- a/runtime/browser/devtools/xwalk_devtools_frontend.cc
+++ b/runtime/browser/devtools/xwalk_devtools_frontend.cc
@@ -253,6 +253,9 @@ void XWalkDevToolsFrontend::HandleMessageFromDevToolsFrontend(
     if (!params->GetString(0, &name))
       return;
     preferences_.RemoveWithoutPathExpansion(name, nullptr);
+  } else if (method == "requestFileSystems") {
+    web_contents()->GetMainFrame()->ExecuteJavaScriptForTests(
+        base::ASCIIToUTF16("DevToolsAPI.fileSystemsLoaded([]);"));
   } else {
     return;
   }


### PR DESCRIPTION
This will unbreak the inspector on desktop platforms. Note that
the message has been added back in September 2015
(https://codereview.chromium.org/1362943005) but only broke when we moved
to M48 (probably now required due to work on
https://code.google.com/p/chromium/issues/detail?id=529471).

BUG=XWALK-6307