### PR TITLE
[Android] Refine the error message for mismatched architecture.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
@@ -390,7 +390,11 @@ class XWalkCoreWrapper {
             }
         } catch (RuntimeException e) {
             Log.d(TAG, e.getLocalizedMessage());
-            mCoreStatus = XWalkLibraryInterface.STATUS_INCOMPLETE_LIBRARY;
+            if (e.getCause() instanceof UnsatisfiedLinkError) {
+                mCoreStatus = XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH;
+            } else {
+                mCoreStatus = XWalkLibraryInterface.STATUS_INCOMPLETE_LIBRARY;
+            }
             return false;
         }
 


### PR DESCRIPTION
If the library was packaged into wrong architecture folder, e.g. library
for x86 was put in "armeabi-v7a", it will throw "UnsatisfiedLinkError"
exception when load library, this situation belongs to mismatch status
instead of incomplete library.
Check the error cause and give the right status.

BUG=XWALK-5803

(cherry picked from commit c145065728e67d056444bd58ca3f1843e58e712d)