### PR TITLE
[Android] Remove deprecated base/basictypes.h includes

### DIFF
--- a/runtime/browser/android/net/input_stream.h
+++ b/runtime/browser/android/net/input_stream.h
@@ -5,8 +5,6 @@
 #ifndef XWALK_RUNTIME_BROWSER_ANDROID_NET_INPUT_STREAM_H_
 #define XWALK_RUNTIME_BROWSER_ANDROID_NET_INPUT_STREAM_H_
 
-#include "base/basictypes.h"
-
 namespace net {
 class IOBuffer;
 }

--- a/runtime/browser/android/xwalk_autofill_client_android.h
+++ b/runtime/browser/android/xwalk_autofill_client_android.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/android/jni_weak_ref.h"
-#include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "xwalk/runtime/browser/xwalk_autofill_client.h"
 

--- a/runtime/browser/android/xwalk_contents_io_thread_client_impl.h
+++ b/runtime/browser/android/xwalk_contents_io_thread_client_impl.h
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "base/android/scoped_java_ref.h"
-#include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "base/memory/scoped_ptr.h"
 

--- a/runtime/browser/android/xwalk_cookie_access_policy.h
+++ b/runtime/browser/android/xwalk_cookie_access_policy.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/basictypes.h"
 #include "base/lazy_instance.h"
 #include "base/synchronization/lock.h"
 #include "net/cookies/canonical_cookie.h"

--- a/runtime/browser/android/xwalk_dev_tools_server.cc
+++ b/runtime/browser/android/xwalk_dev_tools_server.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/android/jni_string.h"
-#include "base/basictypes.h"
 #include "base/bind.h"
 #include "base/callback.h"
 #include "base/compiler_specific.h"

--- a/runtime/browser/android/xwalk_dev_tools_server.h
+++ b/runtime/browser/android/xwalk_dev_tools_server.h
@@ -7,7 +7,6 @@
 
 #include <jni.h>
 #include <string>
-#include "base/basictypes.h"
 #include "base/memory/scoped_ptr.h"
 #include "net/socket/unix_domain_server_socket_posix.h"
 

--- a/runtime/browser/android/xwalk_download_resource_throttle.h
+++ b/runtime/browser/android/xwalk_download_resource_throttle.h
@@ -5,8 +5,8 @@
 #ifndef XWALK_RUNTIME_BROWSER_ANDROID_XWALK_DOWNLOAD_RESOURCE_THROTTLE_H_
 #define XWALK_RUNTIME_BROWSER_ANDROID_XWALK_DOWNLOAD_RESOURCE_THROTTLE_H_
 
-#include "base/basictypes.h"
 #include "base/compiler_specific.h"
+#include "base/macros.h"
 #include "content/public/browser/resource_throttle.h"
 
 namespace net {

--- a/runtime/browser/ui/webui/file_picker/file_picker_ui.h
+++ b/runtime/browser/ui/webui/file_picker/file_picker_ui.h
@@ -5,7 +5,6 @@
 #ifndef XWALK_RUNTIME_BROWSER_UI_WEBUI_FILE_PICKER_FILE_PICKER_UI_H_
 #define XWALK_RUNTIME_BROWSER_UI_WEBUI_FILE_PICKER_FILE_PICKER_UI_H_
 
-#include "base/basictypes.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/web_dialogs/web_dialog_ui.h"
 

--- a/runtime/browser/ui/webui/file_picker/file_picker_web_dialog.h
+++ b/runtime/browser/ui/webui/file_picker/file_picker_web_dialog.h
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/shell_dialogs/select_file_dialog.h"

--- a/runtime/browser/ui/webui/xwalk_web_ui_controller_factory.h
+++ b/runtime/browser/ui/webui/xwalk_web_ui_controller_factory.h
@@ -6,7 +6,6 @@
 #ifndef XWALK_RUNTIME_BROWSER_UI_WEBUI_XWALK_WEB_UI_CONTROLLER_FACTORY_H_
 #define XWALK_RUNTIME_BROWSER_UI_WEBUI_XWALK_WEB_UI_CONTROLLER_FACTORY_H_
 
-#include "base/basictypes.h"
 #include "base/memory/singleton.h"
 #include "content/public/browser/web_ui.h"
 #include "content/public/browser/web_ui_controller_factory.h"

--- a/runtime/renderer/android/xwalk_render_view_ext.h
+++ b/runtime/renderer/android/xwalk_render_view_ext.h
@@ -5,7 +5,6 @@
 #ifndef XWALK_RUNTIME_RENDERER_ANDROID_XWALK_RENDER_VIEW_EXT_H_
 #define XWALK_RUNTIME_RENDERER_ANDROID_XWALK_RENDER_VIEW_EXT_H_
 
-#include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "content/public/renderer/render_view_observer.h"
 #include "third_party/skia/include/core/SkColor.h"

--- a/sysapps/common/sysapps_manager_android.cc
+++ b/sysapps/common/sysapps_manager_android.cc
@@ -4,7 +4,6 @@
 
 #include "xwalk/sysapps/common/sysapps_manager.h"
 
-#include "base/basictypes.h"
 #include "xwalk/sysapps/device_capabilities/av_codecs_provider_android.h"
 #include "xwalk/sysapps/device_capabilities/storage_info_provider_android.h"
 


### PR DESCRIPTION
base/basictypes.h is removed from Chromium in m49. Mostly it is not
needed, sometimes old types are replased with _t types. There
is still 4 mac and win uses of these.