### PR TITLE
[Android] Explicitly depend on target <foo> in the <foo>_aar targets.

### DIFF
--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -437,6 +437,7 @@
       'target_name': 'xwalk_core_library_aar',
       'type': 'none',
       'dependencies': [
+        'xwalk_core_library',
         'xwalk_core_empty_embedder_apk',
         'xwalk_core_library_pom_gen',
       ],
@@ -463,6 +464,7 @@
       'type': 'none',
       'dependencies': [
         'xwalk_core_empty_embedder_apk',
+        'xwalk_shared_library',
         'xwalk_shared_library_pom_gen',
       ],
       'actions': [


### PR DESCRIPTION
The `xwalk_shared_library_aar` target had a missing dependency on
`xwalk_shared_library`. If one tried to build the former, it would fail
because the latter had not been build:

    OSError: [Errno 2] No such file or directory: '../out/Release/xwalk_shared_library/AndroidManifest.xml'

Add the missing dependency between the two targets, and do the same for
`xwalk_core_library_aar`: while it is not broken because its dependency
on `xwalk_core_empty_embedder_apk` brings a dependency on
`xwalk_core_library`, it is better to be safe and explicitly depend on a
target whose output we use.