### PR TITLE
Fix FileApiPersistent API SecurityError.

### DIFF
--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -422,6 +422,13 @@ void XWalkContentBrowserClient::GetStoragePartitionConfigForSite(
 #endif
 }
 
+void XWalkContentBrowserClient::GetAdditionalAllowedSchemesForFileSystem(
+    std::vector<std::string>* additional_schemes) {
+#if !defined(OS_ANDROID)
+  additional_schemes->push_back("app");
+#endif
+}
+
 content::PresentationServiceDelegate* XWalkContentBrowserClient::
     GetPresentationServiceDelegate(content::WebContents* web_contents) {
 #if defined(OS_WIN)

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -140,6 +140,9 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
       std::string* partition_name,
       bool* in_memory) override;
 
+  void GetAdditionalAllowedSchemesForFileSystem(
+      std::vector<std::string>* additional_schemes) override;
+
 #if defined(OS_ANDROID)
   virtual void GetAdditionalMappedFilesForChildProcess(
       const base::CommandLine& command_line,


### PR DESCRIPTION
When launched through the manifest Crosswalk apps
are using the app:// protocol so we need to add it
as part of the allowed schemes for the API.