### PR TITLE
Intt

### DIFF
--- a/runtime/browser/android/state_serializer.cc
+++ b/runtime/browser/android/state_serializer.cc
@@ -35,7 +35,7 @@ namespace {
 // Sanity check value that we are restoring from a valid pickle.
 // This can potentially used as an actual serialization version number in the
 // future if we ever decide to support restoring from older versions.
-const uint32 AW_STATE_VERSION = 20130814;
+const uint32_t AW_STATE_VERSION = 20130814;
 
 }  // namespace
 
@@ -141,7 +141,7 @@ bool WriteHeaderToPickle(base::Pickle* pickle) {
 }
 
 bool RestoreHeaderFromPickle(base::PickleIterator* iterator) {
-  uint32 state_version = -1;
+  uint32_t state_version = -1;
   if (!iterator->ReadUInt32(&state_version))
     return false;
 
@@ -269,7 +269,7 @@ bool RestoreNavigationEntryFromPickle(base::PickleIterator* iterator,
   }
 
   {
-    int64 timestamp;
+    int64_t timestamp;
     if (!iterator->ReadInt64(&timestamp))
       return false;
     entry->SetTimestamp(base::Time::FromInternalValue(timestamp));

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -444,13 +444,13 @@ base::android::ScopedJavaLocalRef<jbyteArray> XWalkContent::GetState(
   } else {
     return base::android::ToJavaByteArray(
         env,
-        reinterpret_cast<const uint8*>(pickle.data()),
+        reinterpret_cast<const uint8_t*>(pickle.data()),
         pickle.size());
   }
 }
 
 jboolean XWalkContent::SetState(JNIEnv* env, jobject obj, jbyteArray state) {
-  std::vector<uint8> state_vector;
+  std::vector<uint8_t> state_vector;
   base::android::JavaByteArrayToByteVector(env, state, &state_vector);
 
   base::Pickle pickle(reinterpret_cast<const char*>(&state_vector[0]),

--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -111,7 +111,7 @@ void XWalkContentsClientBridge::AllowCertificateError(
     return;
   ScopedJavaLocalRef<jbyteArray> jcert = base::android::ToJavaByteArray(
       env,
-      reinterpret_cast<const uint8*>(der_string.data()),
+      reinterpret_cast<const uint8_t*>(der_string.data()),
       der_string.length());
   ScopedJavaLocalRef<jstring> jurl(ConvertUTF8ToJavaString(
       env, request_url.spec()));

--- a/runtime/browser/android/xwalk_contents_io_thread_client.h
+++ b/runtime/browser/android/xwalk_contents_io_thread_client.h
@@ -92,7 +92,7 @@ class XWalkContentsIoThreadClient {
                            const std::string& user_agent,
                            const std::string& content_disposition,
                            const std::string& mime_type,
-                           int64 content_length) = 0;
+                           int64_t content_length) = 0;
 
   // Called when a new login request is detected. See the documentation for
   // WebViewClient.onReceivedLoginRequest for arguments. Note that |account|

--- a/runtime/browser/android/xwalk_contents_io_thread_client_impl.cc
+++ b/runtime/browser/android/xwalk_contents_io_thread_client_impl.cc
@@ -357,7 +357,7 @@ void XWalkContentsIoThreadClientImpl::NewDownload(
     const string& user_agent,
     const string& content_disposition,
     const string& mime_type,
-    int64 content_length) {
+    int64_t content_length) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));
   if (java_object_.is_null())
     return;

--- a/runtime/browser/android/xwalk_contents_io_thread_client_impl.h
+++ b/runtime/browser/android/xwalk_contents_io_thread_client_impl.h
@@ -58,7 +58,7 @@ class XWalkContentsIoThreadClientImpl : public XWalkContentsIoThreadClient {
                    const std::string& user_agent,
                    const std::string& content_disposition,
                    const std::string& mime_type,
-                   int64 content_length) override;
+                   int64_t content_length) override;
   void NewLoginRequest(const std::string& realm,
                        const std::string& account,
                        const std::string& args) override;

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -168,9 +168,9 @@ void XWalkWebContentsDelegate::RendererResponsive(WebContents* source) {
 
 bool XWalkWebContentsDelegate::AddMessageToConsole(
     content::WebContents* source,
-    int32 level,
+    int32_t level,
     const base::string16& message,
-    int32 line_no,
+    int32_t line_no,
     const base::string16& source_id) {
   JNIEnv* env = AttachCurrentThread();
   ScopedJavaLocalRef<jobject> obj = GetJavaDelegate(env);

--- a/runtime/browser/android/xwalk_web_contents_delegate.h
+++ b/runtime/browser/android/xwalk_web_contents_delegate.h
@@ -43,9 +43,9 @@ class XWalkWebContentsDelegate
   void RendererResponsive(content::WebContents* source) override;
 
   bool AddMessageToConsole(content::WebContents* source,
-                           int32 level,
+                           int32_t level,
                            const base::string16& message,
-                           int32 line_no,
+                           int32_t line_no,
                            const base::string16& source_id) override;
   void HandleKeyboardEvent(
       content::WebContents* source,

--- a/runtime/browser/runtime_resource_dispatcher_host_delegate_android.cc
+++ b/runtime/browser/runtime_resource_dispatcher_host_delegate_android.cc
@@ -241,7 +241,7 @@ void RuntimeResourceDispatcherHostDelegateAndroid::DownloadStarting(
   std::string user_agent;
   std::string content_disposition;
   std::string mime_type;
-  int64 content_length = request->GetExpectedContentSize();
+  int64_t content_length = request->GetExpectedContentSize();
 
   if (!request->extra_request_headers().GetHeader(
       net::HttpRequestHeaders::kUserAgent, &user_agent))

--- a/runtime/browser/ui/taskbar_util_win.cc
+++ b/runtime/browser/ui/taskbar_util_win.cc
@@ -42,7 +42,7 @@ void ConvertHexadecimalToIDAlphabet(std::string* id) {
 // always generate the same output ID.
 void GenerateId(const std::string& input, std::string* output) {
   DCHECK(output);
-  uint8 hash[kIdSize];
+  uint8_t hash[kIdSize];
   crypto::SHA256HashString(input, hash, sizeof(hash));
   *output = base::ToLowerASCII(base::HexEncode(hash, sizeof(hash)));
   ConvertHexadecimalToIDAlphabet(output);


### PR DESCRIPTION
Change last basictybes.h ints to std versions
    
basictypes.h is removed in m49 so we need to change all old
int types to _t versions.
