### PR TITLE
[Android] Add isFirstAttempt as part of public XWalkHttpAuthHandler API

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java
@@ -34,6 +34,7 @@ public class XWalkHttpAuthHandlerInternal implements XWalkHttpAuthInternal {
         }
     }
 
+    @XWalkAPI
     public boolean isFirstAttempt() {
          return mFirstAttempt;
     }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkHttpAuthInternal.java
@@ -19,4 +19,7 @@ public interface XWalkHttpAuthInternal {
 
     @XWalkAPI
     public void cancel();
+
+    @XWalkAPI
+    public boolean isFirstAttempt();
 }


### PR DESCRIPTION
The Android HttpAuthHandler exposes if this is the first auth attempt
through the method useHttpAuthUsernamePassword. The Crosswalk
XWalkHttpAuthHandler also has this information but it is
currently not made available to the public API.

BUG=XWALK-6389