### PR TITLE
Allow application to make cross-origin requests with setOriginAccessW…

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -33,6 +33,7 @@ import android.widget.FrameLayout;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.Locale;
 
 import org.chromium.base.annotations.CalledByNative;
@@ -56,6 +57,7 @@ import org.chromium.content_public.browser.navigation_controller.UserAgentOverri
 import org.chromium.media.MediaPlayerBridge;
 import org.chromium.ui.base.ActivityWindowAndroid;
 import org.chromium.ui.gfx.DeviceDisplayInfo;
+import org.json.JSONArray;
 
 @JNINamespace("xwalk")
 /**
@@ -590,6 +592,19 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         mIsLoaded = true;
     }
 
+    public void setOriginAccessWhitelist(String url, String[] patterns) {
+        if (mNativeContent == 0 || TextUtils.isEmpty(url)) return;
+
+        // Reset origin access whitelists if pattern is null.
+        String matchPatterns = "";
+        if (patterns != null) {
+            JSONArray arrays = new JSONArray(Arrays.asList(patterns));
+            matchPatterns = arrays.toString();
+        }
+
+        nativeSetOriginAccessWhitelist(mNativeContent, url, matchPatterns);
+    }
+
     public XWalkNavigationHistoryInternal getNavigationHistory() {
         if (mNativeContent == 0) return null;
 
@@ -972,4 +987,6 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     private native byte[] nativeGetState(long nativeXWalkContent);
     private native boolean nativeSetState(long nativeXWalkContent, byte[] state);
     private native void nativeSetBackgroundColor(long nativeXWalkContent, int color);
+    private native void nativeSetOriginAccessWhitelist(
+            long nativeXWalkContent, String url, String patterns);
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -832,6 +832,19 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         mContent.setBackgroundColor(color);
     }
 
+    /**
+     * Set origin access whitelist.
+     * @param url the url for accesssing whitelist.
+     * @param patterns representing hosts which the application should be able to access.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void setOriginAccessWhitelist(String url, String[] patterns) {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.setOriginAccessWhitelist(url, patterns);
+    }
+
     // We can't let XWalkView's setLayerType call to this via reflection as this method
     // may be called in XWalkView constructor but the XWalkView is not ready yet and then
     // UnsupportedOperationException is thrown, see XWALK-5021/XWALK-5047.

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -559,4 +559,13 @@ void XWalkContent::SetBackgroundColor(JNIEnv* env, jobject obj, jint color) {
   render_view_host_ext_->SetBackgroundColor(color);
 }
 
+void XWalkContent::SetOriginAccessWhitelist(JNIEnv* env, jobject obj,
+                                            jstring url,
+                                            jstring match_patterns) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+  render_view_host_ext_->SetOriginAccessWhitelist(
+      base::android::ConvertJavaStringToUTF8(env, url),
+      base::android::ConvertJavaStringToUTF8(env, match_patterns));
+}
+
 }  // namespace xwalk

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -71,6 +71,9 @@ class XWalkContent {
                        jstring path,
                        jstring manifest);
   void SetBackgroundColor(JNIEnv* env, jobject obj, jint color);
+  void SetOriginAccessWhitelist(JNIEnv* env, jobject obj,
+                                jstring url,
+                                jstring match_patterns);
 
   // Geolocation API support
   void ShowGeolocationPrompt(const GURL& origin,

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetOriginAccessWhitelistTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetOriginAccessWhitelistTest.java
@@ -1,0 +1,65 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Pair;
+
+import org.chromium.base.test.util.Feature;
+import org.chromium.net.test.util.TestWebServer;
+
+/**
+ * Test suite for setOriginAccessWhitelist().
+ */
+public class SetOriginAccessWhitelistTest extends XWalkViewTestBase {
+    private static final int WAIT_XML_REQUEST = 1000;
+    private TestWebServer mWebServer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mWebServer = TestWebServer.start(4444);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        mWebServer.shutdown();
+        super.tearDown();
+    }
+
+    @SmallTest
+    @Feature({"setOriginAccessWhitelist"})
+    public void testSetOriginAccessWhitelist() throws Throwable {
+        final String loadUrl = "file:///android_asset/www/cross_origin.html";
+        final String patterns = "http://localhost:4444/*,http://localhost:3333/*";
+        // The server will be accessed by XMLHttpRequest from js.
+        final String path = "/cross_origin_xhr_test.html";
+        // The original title of the cross_origin.html.
+        final String originalTitle = "Original Title";
+        final String responseStr = "Cross-Origin XHR";
+        final String url = mWebServer.setResponse(path, responseStr, null);
+        assertEquals("http://localhost:4444/cross_origin_xhr_test.html", url);
+
+        // Test without setOriginAccessWhitelist.
+        loadUrlAsync(loadUrl);
+        Thread.sleep(WAIT_XML_REQUEST);
+        // XHR in page should be failed, and the title should be "Original Title".
+        assertEquals(originalTitle, getTitleOnUiThread());
+
+        // Test setOriginAccessWhitelist.
+        setOriginAccessWhitelist(loadUrl, patterns.split(","));
+        loadUrlAsync(loadUrl);
+        Thread.sleep(WAIT_XML_REQUEST);
+        // XHR in page should be success, and the title should be "Cross-Origin XHR".
+        assertEquals(responseStr, getTitleOnUiThread());
+
+        // Reset the Whitelist
+        setOriginAccessWhitelist(loadUrl, null);
+        loadUrlAsync(loadUrl);
+        Thread.sleep(WAIT_XML_REQUEST);
+        assertEquals(originalTitle, getTitleOnUiThread());
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -746,6 +746,15 @@ public class XWalkViewTestBase
         });
     }
 
+    protected void setOriginAccessWhitelist(final String url, final String[] patterns) {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.setOriginAccessWhitelist(url, patterns);
+            }
+        });
+    }
+
     protected double getDipScale() {
         return DeviceDisplayInfo.create(mXWalkView.getContext()).getDIPScale();
     }

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -45,6 +45,7 @@
           '<(PRODUCT_DIR)/lib/libxwalkcore.>(android_product_extension)',
         ],
         'additional_input_paths': [
+          '<(PRODUCT_DIR)/xwalk_xwview/assets/www/cross_origin.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/www/index.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/www/request_focus_left_frame.html',
           '<(PRODUCT_DIR)/xwalk_xwview/assets/www/request_focus_main.html',
@@ -76,6 +77,7 @@
             'test/android/data/request_focus_main.html',
             'test/android/data/request_focus_right_frame.html',
             'test/android/data/request_focus_right_frame1.html',
+            'test/android/data/www/cross_origin.html',
           ],
         },
         {


### PR DESCRIPTION
…hitelist API

Crosswalk provides a manifest field, xwalk_hosts, which enables an application
to make cross-origin requests using XMLHttpRequest on Android. Cordova also need
this feature, so expose the new api of setOriginAccessWhitelist.

BUG=XWALK-2994