### PR TITLE
xesh: Get it to a compilable state.

### DIFF
--- a/extensions/xesh/xesh_v8_runner.cc
+++ b/extensions/xesh/xesh_v8_runner.cc
@@ -44,10 +44,13 @@ void XEShV8Runner::Shutdown() {
   v8::V8::Dispose();
 }
 
-void XEShV8Runner::Initialize(int argc, char** argv,
-    base::MessageLoopProxy* io_loop_proxy, const IPC::ChannelHandle& handle) {
-  client_channel_ = IPC::SyncChannel::Create(handle, IPC::Channel::MODE_CLIENT,
-    &client_, io_loop_proxy, true, &shutdown_event_);
+void XEShV8Runner::Initialize(int argc,
+                              char** argv,
+                              base::SingleThreadTaskRunner* io_task_runner,
+                              const IPC::ChannelHandle& handle) {
+  client_channel_ =
+      IPC::SyncChannel::Create(handle, IPC::Channel::MODE_CLIENT, &client_,
+                               io_task_runner, true, &shutdown_event_);
 
   client_.Initialize(client_channel_.get());
 
@@ -220,4 +223,3 @@ void XEShV8Runner::CreateExtensionModules(XWalkModuleSystem* module_system) {
                                            codepoint->entry_points);
   }
 }
-

--- a/extensions/xesh/xesh_v8_runner.h
+++ b/extensions/xesh/xesh_v8_runner.h
@@ -36,8 +36,10 @@ class XEShV8Runner {
 
   ~XEShV8Runner();
 
-  void Initialize(int argc, char** argv, base::MessageLoopProxy* io_loop_proxy,
-      const IPC::ChannelHandle& handle);
+  void Initialize(int argc,
+                  char** argv,
+                  base::SingleThreadTaskRunner* io_task_runner,
+                  const IPC::ChannelHandle& handle);
   void Shutdown();
 
   // Executes a string within the current v8 context.


### PR DESCRIPTION
xesh is not been built as part of the "xwalk" or "xwalk_builder"
targets, which means it has been bitrotting for a few years.

This patch adapts the code to several changes that have happened to the
Chromium code base in the meantime (`CommandLine` needs the `base`
namespace, removal of `base::MessageLoopProxy` etc).

It is not enough to get it to run without crashing though, so someone
else needs to fix it or remove it from the tree altogether.

Related to BUG=XWALK-6219