### PR TITLE
Add a "_linux" suffix to xwalk_notification_manager.{cc,h}.

### DIFF
--- a/runtime/browser/xwalk_notification_manager_linux.cc
+++ b/runtime/browser/xwalk_notification_manager_linux.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "xwalk/runtime/browser/linux/xwalk_notification_manager.h"
+#include "xwalk/runtime/browser/xwalk_notification_manager_linux.h"
 
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_thread.h"

--- a/runtime/browser/xwalk_notification_manager_linux.h
+++ b/runtime/browser/xwalk_notification_manager_linux.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef XWALK_RUNTIME_BROWSER_LINUX_XWALK_NOTIFICATION_MANAGER_H_
-#define XWALK_RUNTIME_BROWSER_LINUX_XWALK_NOTIFICATION_MANAGER_H_
+#ifndef XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_MANAGER_LINUX_H_
+#define XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_MANAGER_LINUX_H_
 
 #include <libnotify/notification.h>
 #include <libnotify/notify.h>
@@ -58,4 +58,4 @@ class XWalkNotificationManager {
 
 }  // namespace xwalk
 
-#endif  // XWALK_RUNTIME_BROWSER_LINUX_XWALK_NOTIFICATION_MANAGER_H_
+#endif  // XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_MANAGER_LINUX_H_

--- a/runtime/browser/xwalk_platform_notification_service.cc
+++ b/runtime/browser/xwalk_platform_notification_service.cc
@@ -16,7 +16,7 @@
 #if defined(OS_ANDROID)
 #include "xwalk/runtime/browser/android/xwalk_contents_client_bridge.h"
 #elif defined(OS_LINUX) && defined(USE_LIBNOTIFY)
-#include "xwalk/runtime/browser/linux/xwalk_notification_manager.h"
+#include "xwalk/runtime/browser/xwalk_notification_manager_linux.h"
 #endif
 
 namespace xwalk {

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -261,12 +261,14 @@
         'runtime/browser/xwalk_autofill_manager.h',
         'runtime/browser/xwalk_content_browser_client.cc',
         'runtime/browser/xwalk_content_browser_client.h',
-        'runtime/browser/xwalk_form_database_service.cc',
-        'runtime/browser/xwalk_form_database_service.h',
-        'runtime/browser/xwalk_permission_manager.cc',
-        'runtime/browser/xwalk_permission_manager.h',
         'runtime/browser/xwalk_content_settings.cc',
         'runtime/browser/xwalk_content_settings.h',
+        'runtime/browser/xwalk_form_database_service.cc',
+        'runtime/browser/xwalk_form_database_service.h',
+        'runtime/browser/xwalk_notification_manager_linux.cc',
+        'runtime/browser/xwalk_notification_manager_linux.h',
+        'runtime/browser/xwalk_permission_manager.cc',
+        'runtime/browser/xwalk_permission_manager.h',
         'runtime/browser/xwalk_platform_notification_service.cc',
         'runtime/browser/xwalk_platform_notification_service.h',
         'runtime/browser/xwalk_pref_store.cc',
@@ -395,10 +397,6 @@
           'dependencies': [
             'build/system.gyp:libnotify',
           ],
-          'sources': [
-            'runtime/browser/linux/xwalk_notification_manager.cc',
-            'runtime/browser/linux/xwalk_notification_manager.h',
-          ]
         }],  # OS=="linux"
         ['OS=="linux"', {
           'dependencies': [


### PR DESCRIPTION
Doing that allows it to be automatically excluded from builds based on
the rules in `src/build/filename_rules.gypi`, and we do not have to add
those files to the build system in a special condition check.