### PR TITLE
[Android] Rewrite generate_version_code.py.

### DIFF
--- a/build/android/generate_version_code.py
+++ b/build/android/generate_version_code.py
@@ -1,89 +1,52 @@
 #!/usr/bin/env python
-# Copyright (c) 2009 The Chromium Authors. All rights reserved.
 # Copyright (c) 2013 Intel Corporation. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
 """
-VersionCode is needed for AndroidManifest.xml,
-
-This script will generate version code based on
-VERSION file for xwalk's runtime library apk.
+Generates a value for the android:versionCode attribute in AndroidManifest.xml.
 """
 
-import optparse
+import argparse
 import sys
 
-def fetch_values_from_file(values_dict, file_name):
-  """
-  Fetches KEYWORD=VALUE settings from the specified file.
 
-  Everything to the left of the first '=' is the keyword,
-  everything to the right is the value.  No stripping of
-  white space, so beware.
-
-  The file must exist, otherwise you get the Python exception from open().
-  """
-  for line in open(file_name, 'r').readlines():
-    key, val = line.rstrip('\r\n').split('=', 1)
-    if key in ['MAJOR', 'MINOR', 'BUILD', 'PATCH']:
-      try:
-        values_dict[key] = int(val)
-      except ValueError:
-        return False
-  return True
-
-
-def calculate_version_code(values_dict, shift):
-  """
-  Version Code is calculated based on the four version integers.
-
-  Major is for crosswalk's large update, and minor is for based chromium.
-  Major and minor will always be increasing, so use the sum of them is
-  enough.
-  For each major and minor refresh, build will reset to 0. After that,
-  the build will be increasing for 6 weeks (12 weeks if we skip one upstream
-  beta rebasing), so 100 numbers for build are enough.
-  After we branch it from trunk, the patch will be increasing for the rest of
-  this branch's life, 100 numbers are also enough since it will last for most
-  24 weeks, but the version increasing will be much less frequent after branch
-  point.
-  Shift is the last bit for different configurations we want to upload to
-  PlayStore.
-  """
-  try:
-    major = values_dict['MAJOR']
-    minor = values_dict['MINOR']
-    build = values_dict['BUILD']
-    patch = values_dict['PATCH']
-    return (major + minor) * 100000 +\
-           build * 1000 +\
-           patch * 10 +\
-           shift
-  except KeyError:
-    return 0
+# This dictionary associates a certain Android ABI name to an integer that will
+# be part of the final version code. Bigger numbers will generate a larger
+# version code that will have preference in the Play Store.
+ANDROID_ABI_KEYS = {
+  'armeabi': 1,
+  'armeabi-v7a': 2,
+  'arm64-v8a': 3,
+  'x86': 4,
+  'x86_64': 5,
+}
 
 
 def main():
-  option_parser = optparse.OptionParser()
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--abi-name', required=True,
+                      choices=sorted(ANDROID_ABI_KEYS.keys()),
+                      help='Android ABI name, as defined in '
+                      'src/build/common.gypi.')
+  parser.add_argument('--version', required=True,
+                      help='Crosswalk version number in the '
+                      'MAJOR.MINOR.BUILD.PATCH format.')
 
-  option_parser.add_option('--file', '-f', default='VERSION',
-      help='Path to the version file.')
-  option_parser.add_option('--shift', '-s', default=0, type='int',
-      help='Shift for different configurations, PlayStore '
-           'requires different version code for multiple apks')
-  options, _ = option_parser.parse_args()
+  args = parser.parse_args()
 
-  versions = {}
+  shift = ANDROID_ABI_KEYS[args.abi_name]
+  major, minor, build, patch = map(int, args.version.split('.'))
 
-  version_code = 0
-  if fetch_values_from_file(versions, options.file):
-    version_code = calculate_version_code(versions, options.shift)
-  print '%d' % version_code
-  if version_code == 0:
-    return 1
-  else:
-    return 0    
+  # We derive the version code from Crosswalk's version number plus an
+  # additional key value related to the CPU architecture being targeted.
+  # Crosswalk's major and minor version numbers are always increasing, so we
+  # use their sum in the higher order digits of the version code, followed by
+  # the build version number that increases with each canary, the patch number
+  # increased with each beta and a final value that depends on the CPU
+  # architecture (it is used to differentiate the APKs uploaded to the Play
+  # Store based on the target architecture).
+  print '%d' % ((major+minor)*100000 + build*1000 + patch*10 + shift)
 
 
 if __name__ == '__main__':

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -994,29 +994,9 @@
     }],  # OS=="mac"
     ['OS=="android"', {
       'variables': {
-        'variables': {
-          'conditions': [
-            ['android_app_abi=="armeabi"', {
-              'version_code_shift%': 1,
-            }],
-            ['android_app_abi=="armeabi-v7a"', {
-              'version_code_shift%': 2,
-            }],
-            ['android_app_abi=="arm64-v8a"', {
-              'version_code_shift%': 3,
-            }],
-            ['android_app_abi=="x86"', {
-              'version_code_shift%': 4,
-            }],
-            ['android_app_abi=="x86_64"', {
-              'version_code_shift%': 5,
-            }],
-          ], # conditions
-        },
-        'version_code_shift%': '<(version_code_shift)',
-        'xwalk_version_code': '<!(python build/android/generate_version_code.py -f VERSION -s <(version_code_shift))',
         'api_version': '<!(python ../build/util/version.py -f API_VERSION -t "@API@")',
         'min_api_version': '<!(python ../build/util/version.py -f API_VERSION -t "@MIN_API@")',
+        'xwalk_version_code': '<!(python build/android/generate_version_code.py --version <(xwalk_version) --abi-name <(android_app_abi))',
       },
       'includes': [
         'xwalk_android.gypi',


### PR DESCRIPTION
Instead of having part of the logic in xwalk.gyp and part in the Python
script, do everything in the latter, while also taking advantage of the
fact that we've already know Crosswalk's version number by the time we
invoke the script, so we do not need to read it again.

Also update the comment describing how we derive the version code
number, as it was a bit outdated (we do not reset the build number when
we bump either the major or the minor number).