### PR TITLE
[Android] Remove "All" target.

### DIFF
--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -993,15 +993,6 @@
         'xwalk_android_app.gypi',
         'xwalk_core_library_android.gypi',
       ],
-      'targets': [
-      {
-        'target_name': 'All',
-        'type': 'none',
-        'dependencies': [
-          'xwalk',
-        ],
-      }, # target_name: All
-    ],  # targets
     }], # OS=="android"
   ]
 }


### PR DESCRIPTION
It was added with commit 6863ff1b ("Bump crosswalk to Chromium
34.0.1809.2"), but it is not used anywhere (the `xwalk` target it
depended on does not even work on Android).