### PR TITLE
[Windows] Fix application origin

### DIFF
--- a/application/browser/application_service.cc
+++ b/application/browser/application_service.cc
@@ -73,9 +73,16 @@ Application* ApplicationService::LaunchFromManifestPath(
 
   base::FilePath app_path = path.DirName();
   LOG(ERROR) << "Loading app from " << app_path.MaybeAsASCII();
-
+  std::string app_id = GenerateIdForPath(app_path);
+#if defined (OS_WIN)
+  std::string update_id;
+  if (manifest->GetString(application_manifest_keys::kXWalkWindowsUpdateID,
+                          &update_id)) {
+    app_id = GenerateId(update_id);
+  }
+#endif
   scoped_refptr<ApplicationData> application_data = ApplicationData::Create(
-      app_path, std::string(), ApplicationData::LOCAL_DIRECTORY,
+      app_path, app_id, ApplicationData::LOCAL_DIRECTORY,
       std::move(manifest), &error);
   if (!application_data.get()) {
     LOG(ERROR) << "Error occurred while trying to load application: "

--- a/application/common/application_data.h
+++ b/application/common/application_data.h
@@ -72,7 +72,7 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   };
 
   static scoped_refptr<ApplicationData> Create(const base::FilePath& app_path,
-      const std::string& explicit_id, SourceType source_type,
+      const std::string& id, SourceType source_type,
           scoped_ptr<Manifest> manifest, std::string* error_message);
 
   // Returns an absolute url to a resource inside of an application. The
@@ -138,16 +138,13 @@ class ApplicationData : public base::RefCountedThreadSafe<ApplicationData> {
   friend class base::RefCountedThreadSafe<ApplicationData>;
   friend class ApplicationStorageImpl;
 
-  ApplicationData(const base::FilePath& path,
+  ApplicationData(const base::FilePath& path, const std::string& id,
       SourceType source_type, scoped_ptr<Manifest> manifest);
   virtual ~ApplicationData();
 
   // Initialize the application from a parsed manifest.
-  bool Init(const std::string& explicit_id, base::string16* error);
+  bool Init(base::string16* error);
 
-  // Chooses the application ID for an application based on a variety of
-  // criteria. The chosen ID will be set in |manifest|.
-  bool LoadID(const std::string& explicit_id, base::string16* error);
   // The following are helpers for InitFromValue to load various features of the
   // application from the manifest.
   bool LoadName(base::string16* error);

--- a/application/common/application_file_util_unittest.cc
+++ b/application/common/application_file_util_unittest.cc
@@ -12,13 +12,11 @@
 #include "base/strings/utf_string_conversions.h"
 #include "xwalk/application/common/application_data.h"
 #include "xwalk/application/common/application_manifest_constants.h"
-#include "xwalk/application/common/manifest.h"
 #include "xwalk/application/common/constants.h"
+#include "xwalk/application/common/id_util.h"
+#include "xwalk/application/common/manifest.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/l10n/l10n_util.h"
-
-using xwalk::application::ApplicationData;
-using xwalk::application::Manifest;
 
 namespace keys = xwalk::application_manifest_keys;
 
@@ -41,7 +39,8 @@ TEST_F(ApplicationFileUtilTest, LoadApplicationWithValidPath) {
 
   std::string error;
   scoped_refptr<ApplicationData> application(LoadApplication(
-          install_dir, std::string(), ApplicationData::LOCAL_DIRECTORY,
+          install_dir, GenerateIdForPath(install_dir),
+          ApplicationData::LOCAL_DIRECTORY,
           Manifest::TYPE_MANIFEST, &error));
   ASSERT_TRUE(application.get() != NULL);
   EXPECT_EQ("The first application that I made.", application->Description());
@@ -82,7 +81,8 @@ TEST_F(ApplicationFileUtilTest,
 
   std::string error;
   scoped_refptr<ApplicationData> application(LoadApplication(
-          install_dir, std::string(), ApplicationData::LOCAL_DIRECTORY,
+          install_dir, GenerateIdForPath(install_dir),
+          ApplicationData::LOCAL_DIRECTORY,
           Manifest::TYPE_MANIFEST, &error));
   ASSERT_TRUE(application.get() == NULL);
   ASSERT_FALSE(error.empty());
@@ -100,7 +100,8 @@ static scoped_refptr<ApplicationData> LoadApplicationManifest(
   scoped_ptr<Manifest> manifest = make_scoped_ptr(
       new Manifest(make_scoped_ptr(values->DeepCopy())));
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      manifest_dir, std::string(), location, std::move(manifest), error);
+      manifest_dir, GenerateIdForPath(manifest_dir), location,
+          std::move(manifest), error);
   return application;
 }
 

--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -73,6 +73,9 @@ const char kXWalkLaunchScreenPortrait[] =
     "xwalk_launch_screen.portrait";
 const char kXWalkLaunchScreenReadyWhen[] =
     "xwalk_launch_screen.ready_when";
+
+const char kXWalkWindowsUpdateID[] = "xwalk_windows_update_id";
+
 }  // namespace application_manifest_keys
 
 // manifest keys for widget applications.

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -66,6 +66,9 @@ namespace application_manifest_keys {
   extern const char kXWalkLaunchScreenLandscape[];
   extern const char kXWalkLaunchScreenPortrait[];
   extern const char kXWalkLaunchScreenReadyWhen[];
+
+  // Windows specific:
+  extern const char kXWalkWindowsUpdateID[];
 }  // namespace application_manifest_keys
 
 namespace application_widget_keys {

--- a/application/common/manifest_handler_unittest.cc
+++ b/application/common/manifest_handler_unittest.cc
@@ -10,6 +10,7 @@
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "xwalk/application/common/application_data.h"
+#include "xwalk/application/common/id_util.h"
 #include "xwalk/application/common/manifest_handler.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -219,7 +220,7 @@ TEST_F(ManifestHandlerTest, DependentHandlers) {
   manifest.SetInteger("g", 6);
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(), std::string(),
+      base::FilePath(), GenerateId("test"),
       ApplicationData::LOCAL_DIRECTORY,
       make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
       &error);
@@ -246,7 +247,7 @@ TEST_F(ManifestHandlerTest, FailingHandlers) {
   // Succeeds when "a" is not recognized.
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(), std::string(),
+      base::FilePath(), GenerateId("test"),
       ApplicationData::LOCAL_DIRECTORY,
       make_scoped_ptr(new Manifest(make_scoped_ptr(manifest_a.DeepCopy()))),
       &error);
@@ -262,7 +263,7 @@ TEST_F(ManifestHandlerTest, FailingHandlers) {
   registry.reset(new ScopedTestingManifestHandlerRegistry(handlers));
 
   application = ApplicationData::Create(
-      base::FilePath(), std::string(),
+      base::FilePath(), GenerateId("test"),
       ApplicationData::LOCAL_DIRECTORY,
       make_scoped_ptr(new Manifest(make_scoped_ptr(manifest_a.DeepCopy()))),
       &error);
@@ -282,7 +283,7 @@ TEST_F(ManifestHandlerTest, Validate) {
   manifest.SetInteger("b", 2);
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(), std::string(),
+      base::FilePath(), GenerateId("test"),
       ApplicationData::LOCAL_DIRECTORY,
       make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
       &error);

--- a/application/common/manifest_handlers/permissions_handler_unittest.cc
+++ b/application/common/manifest_handlers/permissions_handler_unittest.cc
@@ -5,6 +5,7 @@
 #include "xwalk/application/common/manifest_handlers/permissions_handler.h"
 
 #include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/manifest_handlers/unittest_util.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace xwalk {
@@ -32,12 +33,8 @@ TEST_F(PermissionsHandlerTest, NonePermission) {
   base::DictionaryValue manifest;
   manifest.SetString(keys::kNameKey, "no name");
   manifest.SetString(keys::kXWalkVersionKey, "0");
-  std::string error;
-  scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(), std::string(),
-      ApplicationData::LOCAL_DIRECTORY,
-      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
-      &error);
+  scoped_refptr<ApplicationData> application =
+      CreateApplication(Manifest::TYPE_MANIFEST, manifest);
   EXPECT_TRUE(application.get());
   EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0);
 }
@@ -48,12 +45,8 @@ TEST_F(PermissionsHandlerTest, EmptyPermission) {
   manifest.SetString(keys::kXWalkVersionKey, "0");
   base::ListValue* permissions = new base::ListValue;
   manifest.Set(keys::kPermissionsKey, permissions);
-  std::string error;
-  scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(), std::string(),
-      ApplicationData::LOCAL_DIRECTORY,
-      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
-      &error);
+  scoped_refptr<ApplicationData> application =
+      CreateApplication(Manifest::TYPE_MANIFEST, manifest);
   EXPECT_TRUE(application.get());
   EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0);
 }
@@ -65,12 +58,8 @@ TEST_F(PermissionsHandlerTest, DeviceAPIPermission) {
   base::ListValue* permissions = new base::ListValue;
   permissions->AppendString("geolocation");
   manifest.Set(keys::kPermissionsKey, permissions);
-  std::string error;
-  scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(), std::string(),
-      ApplicationData::LOCAL_DIRECTORY,
-      make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()))),
-      &error);
+  scoped_refptr<ApplicationData> application =
+      CreateApplication(Manifest::TYPE_MANIFEST, manifest);
   EXPECT_TRUE(application.get());
   const PermissionSet& permission_list =
       GetAPIPermissionsInfo(application);

--- a/application/common/manifest_handlers/unittest_util.cc
+++ b/application/common/manifest_handlers/unittest_util.cc
@@ -5,7 +5,9 @@
 #include "xwalk/application/common/manifest_handlers/unittest_util.h"
 
 #include "base/strings/string_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
 #include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/application/common/id_util.h"
 
 namespace xwalk {
 
@@ -53,9 +55,10 @@ scoped_refptr<ApplicationData> CreateApplication(Manifest::Type type,
     const base::DictionaryValue& manifest) {
   std::string error;
   scoped_refptr<ApplicationData> application = ApplicationData::Create(
-      base::FilePath(), std::string(), ApplicationData::LOCAL_DIRECTORY,
+      base::FilePath(), GenerateId("test"), ApplicationData::LOCAL_DIRECTORY,
       make_scoped_ptr(new Manifest(make_scoped_ptr(manifest.DeepCopy()), type)),
       &error);
+  EXPECT_TRUE(error.empty()) << error;
   return application;
 }
 


### PR DESCRIPTION
Before, the application URL origin (which is used in granting API
permissions) was generated from the installation path. Instead the
URL origin must be unique and it must remain the same for the app
wherever it is installed.
Now the application origin is generated from the upgrade id
GUID that remains the same through all the application versions.

BUG=XWALK-6442