### PR TITLE
v8tools: Port the lifecycleTracker code to non-deprecated API.

### DIFF
--- a/extensions/test/data/test_v8tools.html
+++ b/extensions/test/data/test_v8tools.html
@@ -26,12 +26,19 @@
     var test2 = {};
     var test3;
     var test4;
+    var test5;
+    var test6;
 
     function inc_collected() {
       collected++;
     }
+    function reset_collected() {
+      collected = 0;
+    }
 
     test1 = test_v8tools.lifecycleTracker();
+    if (test1.destructor !== null)
+      return false;
     test1.destructor = inc_collected;
 
     test2.foo = test_v8tools.lifecycleTracker();
@@ -40,7 +47,25 @@
     test3 = test_v8tools.lifecycleTracker();
     test3.destructor = inc_collected;
 
+    // Setting the destructor to a value that's not a function or null raises
+    // a TypeError.
+    try {
+      test3.destructor = 42;
+    } catch (e) {
+      if (!(e instanceof TypeError))
+        return false;
+    } finally {
+      if (test3.destructor !== inc_collected)
+        return false;
+    }
+
     test4 = test3;
+
+    test5 = test_v8tools.lifecycleTracker();
+
+    test6 = test_v8tools.lifecycleTracker();
+    test6.destructor = reset_collected;
+    test6.destructor = null;
 
     // Should be collected.
     test1 = 0;
@@ -65,6 +90,20 @@
 
     // Should be collected.
     test4 = 0;
+    gc();
+
+    if (collected != 3)
+      return false;
+
+    // Should not do anything, no destructor set.
+    test5 = 0;
+    gc();
+
+    if (collected != 3)
+      return false;
+
+    // Should not do anything, the destructor was reset.
+    test6 = 0;
     gc();
 
     if (collected != 3)


### PR DESCRIPTION
V8 is deprecating its previous `v8::PersistentBase::SetWeak()` calls
that turned a persistent object into a weak reference. The new SetWeak()
API turns the handle into a phantom reference, a concept borrowed from
Java that means a callback set when calling SetWeak() will be run
_after_ the object being referenced has already been garbage-collected.
This is happening most likely due to performance reasons, as memory can
be reclaimed in one GC cycle instead of two. Relevant CLs and bugs:
 - https://bugs.chromium.org/p/v8/issues/detail?id=3246
 - https://codereview.chromium.org/687003005
 - https://codereview.chromium.org/753553002
 - https://codereview.chromium.org/989153003

For us, this means the lifecycleTracker code needs to be rewritten, as
we were relying on the referenced lifecycleTracker object still being
alive when running the cleanup callback in order to retrieve the
function associated with the object's `destructor` property.

What we do now is track the function assigned to the `destructor`
property separately at the time of the assignment and invoke it without
going through the referenced object during the cleanup.

The code gets more verbose, but I believe it makes things more clear:
- There's now a getter for the `destructor` property, which returns the
  function assigned, or null when there is none. Previously, if no
  destructor had been set accessing the property would return undefined.
- Related to this, the `destructor` property is no longer deletable.
  Users need to set it to null in order to remove a previously
  associated function. Combined with the above point, this makes it more
  explicit that `destructor` is not a regular property and is always
  present (and enumerable) in the object.
- The property's setter performs type checking on the value being
  assigned, raises a `TypeError` when an invalid type is passed and
  clears up the function if null is passed. Previously one could pass
  any type and the checking would only be done when the cleanup function
  was being run and there would be no JS error if an invalid type had
  been passed (only a debug warning in C++).

Related BUG=XWALK-6372