### PR TITLE
[Windows][Linux] Limit min/max zoom from viewport meta

### DIFF
--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -39,6 +39,7 @@
 #include "xwalk/runtime/renderer/android/xwalk_render_view_ext.h"
 #else
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
+#include "third_party/WebKit/public/web/WebView.h"
 #endif
 
 #if !defined(DISABLE_NACL)
@@ -168,6 +169,14 @@ void XWalkContentRendererClient::RenderViewCreated(
     content::RenderView* render_view) {
 #if defined(OS_ANDROID)
   XWalkRenderViewExt::RenderViewCreated(render_view);
+#else
+  if (blink::WebView* webview = render_view->GetWebView()) {
+    // This sets 'user agent' values which override page min and max
+    // zoom from meta viewport tag. Thus we avoid scaling out the page
+    // layout. See XWALK-6269.
+    // NOTE: This must be re-considered after crbug.com/591326 is solved.
+    webview->setIgnoreViewportTagScaleLimits(true);
+  }
 #endif
 }
 


### PR DESCRIPTION
This patch brings 'user agent' values which override page
min and max zoom from meta viewport tag.

BUG=XWALK-6269