### PR TITLE
[Windows] Read the Google API keys from the registry to set

### DIFF
--- a/application/common/application_manifest_constants.cc
+++ b/application/common/application_manifest_constants.cc
@@ -55,6 +55,7 @@ const char kXWalkViewBackgroundColor[] = "xwalk_view.background_color";
 
 // XWalk W3C Manifest (XPK) extensions:
 
+const char kXWalkPackageId[] = "xwalk_package_id";
 const char kPermissionsKey[] = "permissions";
 const char kXWalkVersionKey[] = "xwalk_version";
 const char kXWalkDescriptionKey[] = "xwalk_description";

--- a/application/common/application_manifest_constants.h
+++ b/application/common/application_manifest_constants.h
@@ -54,6 +54,7 @@ namespace application_manifest_keys {
 
   // XWalk extensions:
 
+  extern const char kXWalkPackageId[];
   extern const char kPermissionsKey[];
   extern const char kXWalkVersionKey[];
   extern const char kXWalkDescriptionKey[];

--- a/runtime/browser/xwalk_runner.cc
+++ b/runtime/browser/xwalk_runner.cc
@@ -26,6 +26,10 @@
 #include "xwalk/runtime/common/xwalk_runtime_features.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 
+#if defined(OS_WIN)
+#include "xwalk/runtime/browser/xwalk_runner_win.h"
+#endif
+
 namespace xwalk {
 
 namespace {
@@ -156,11 +160,17 @@ void XWalkRunner::OnRenderProcessWillLaunch(content::RenderProcessHost* host) {
   main_parts->CreateInternalExtensionsForExtensionThread(
       host, &extension_thread_extensions);
 
+  InitializeEnvironmentVariablesForGoogleAPIs(host);
+
   scoped_ptr<base::ValueMap> runtime_variables(new base::ValueMap);
   InitializeRuntimeVariablesForExtensions(host, runtime_variables.get());
   extension_service_->OnRenderProcessWillLaunch(
       host, &ui_thread_extensions, &extension_thread_extensions,
       std::move(runtime_variables));
+}
+
+void XWalkRunner::InitializeEnvironmentVariablesForGoogleAPIs(
+    content::RenderProcessHost* host) {
 }
 
 void XWalkRunner::OnRenderProcessHostGone(content::RenderProcessHost* host) {
@@ -187,7 +197,11 @@ void XWalkRunner::DisableRemoteDebugging() {
 
 // static
 scoped_ptr<XWalkRunner> XWalkRunner::Create() {
+#if defined (OS_WIN)
+  return scoped_ptr<XWalkRunner>(new XWalkRunnerWin);
+#else
   return scoped_ptr<XWalkRunner>(new XWalkRunner);
+#endif
 }
 
 content::ContentBrowserClient* XWalkRunner::GetContentBrowserClient() {

--- a/runtime/browser/xwalk_runner.h
+++ b/runtime/browser/xwalk_runner.h
@@ -104,6 +104,8 @@ class XWalkRunner {
   virtual void InitializeRuntimeVariablesForExtensions(
       const content::RenderProcessHost* host,
       base::ValueMap* runtime_variables);
+  virtual void InitializeEnvironmentVariablesForGoogleAPIs(
+      content::RenderProcessHost* host);
 
  private:
   friend class XWalkMainDelegate;

--- a/runtime/browser/xwalk_runner_win.cc
+++ b/runtime/browser/xwalk_runner_win.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/xwalk_runner_win.h"
+
+#include "base/win/registry.h"
+#include "xwalk/application/browser/application.h"
+#include "xwalk/application/browser/application_service.h"
+#include "xwalk/application/browser/application_system.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+
+namespace xwalk {
+
+namespace {
+
+const auto g_google_api = L"GOOGLE_API_KEY";
+const auto g_google_default_client_id = L"GOOGLE_DEFAULT_CLIENT_ID";
+const auto g_google_default_client_secret = L"GOOGLE_DEFAULT_CLIENT_SECRET";
+
+}  // namespace
+
+XWalkRunnerWin::XWalkRunnerWin() {
+}
+
+void XWalkRunnerWin::InitializeEnvironmentVariablesForGoogleAPIs(
+  content::RenderProcessHost* host) {
+  application::Application* app =
+      app_system()->application_service()->
+          GetApplicationByRenderHostID(host->GetID());
+  if (!app)
+    return;
+  std::string app_name;
+  if (!app->data()->GetManifest()->GetString(
+          application_manifest_keys::kXWalkPackageId, &app_name))
+    return;
+  std::string vendor =
+      app_name.substr(0, app_name.find_last_of("."));
+  std::wstringstream registry_path;
+  registry_path << L"SOFTWARE\\" << vendor.c_str() << L"\\"
+                << app_name.c_str();
+  base::win::RegKey key(HKEY_CURRENT_USER,
+                        registry_path.str().c_str(),
+                        KEY_READ);
+  std::wstring google_api_key;
+  if (key.ReadValue(g_google_api,
+                    &google_api_key) != ERROR_SUCCESS)
+    return;
+  std::wstring google_default_client_id;
+  if (key.ReadValue(g_google_default_client_id,
+                    &google_default_client_id) != ERROR_SUCCESS)
+    return;
+  std::wstring google_default_client_secret;
+  if (key.ReadValue(g_google_default_client_secret,
+                    &google_default_client_secret) != ERROR_SUCCESS)
+    return;
+  SetEnvironmentVariable(g_google_api,
+                         google_api_key.c_str());
+  SetEnvironmentVariable(g_google_default_client_id,
+                         google_default_client_id.c_str());
+  SetEnvironmentVariable(g_google_default_client_secret,
+                         google_default_client_secret.c_str());
+}
+
+}  // namespace xwalk

--- a/runtime/browser/xwalk_runner_win.h
+++ b/runtime/browser/xwalk_runner_win.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_XWALK_RUNNER_WIN_H_
+#define XWALK_RUNTIME_BROWSER_XWALK_RUNNER_WIN_H_
+
+#include <string>
+
+#include "xwalk/runtime/browser/xwalk_runner.h"
+
+
+namespace xwalk {
+
+class XWalkRunnerWin : public XWalkRunner {
+ public:
+  XWalkRunnerWin();
+
+ protected:
+  void InitializeEnvironmentVariablesForGoogleAPIs(
+      content::RenderProcessHost* host) override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(XWalkRunnerWin);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_XWALK_RUNNER_WIN_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -281,6 +281,8 @@
         'runtime/browser/xwalk_render_message_filter.h',
         'runtime/browser/xwalk_runner.cc',
         'runtime/browser/xwalk_runner.h',
+        'runtime/browser/xwalk_runner_win.cc',
+        'runtime/browser/xwalk_runner_win.h',
         'runtime/browser/xwalk_ssl_host_state_delegate.cc',
         'runtime/browser/xwalk_ssl_host_state_delegate.h',
         'runtime/common/android/xwalk_globals_android.cc',


### PR DESCRIPTION
them as environment variables.

When packing a crosswalk app with app-tools and a developer provided
their keys to access the Google APIs they are going to be added
in the registry. Make sure to fetch them in Crosswalk and set them
as env variables so they can be used later on during requests (such
as geolocation.)