### PR TITLE
extensions: Port away from deprecated V8 APIs.

### DIFF
--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -1,6 +1,9 @@
 {
   'targets': [
     {
+      'variables': {
+        'chromium_code': 1,
+      },
       'target_name': 'xwalk_extensions',
       'type': 'static_library',
       'dependencies': [

--- a/extensions/renderer/xwalk_extension_module.cc
+++ b/extensions/renderer/xwalk_extension_module.cc
@@ -127,7 +127,7 @@ v8::Handle<v8::Value> RunString(const std::string& code,
       v8::String::NewFromUtf8(isolate, code.c_str()));
 
   blink::WebScopedMicrotaskSuppression suppression;
-  v8::TryCatch try_catch;
+  v8::TryCatch try_catch(isolate);
   try_catch.SetVerbose(true);
 
   v8::Handle<v8::Script> script(v8::Script::Compile(v8_code));
@@ -176,7 +176,7 @@ void XWalkExtensionModule::LoadExtensionCode(
   };
 
   blink::WebScopedMicrotaskSuppression suppression;
-  v8::TryCatch try_catch;
+  v8::TryCatch try_catch(context->GetIsolate());
   try_catch.SetVerbose(true);
   callable_api_code->Call(context->Global(), argc, argv);
   if (try_catch.HasCaught()) {
@@ -199,7 +199,7 @@ void XWalkExtensionModule::HandleMessageFromNative(const base::Value& msg) {
       v8::Local<v8::Function>::New(isolate, message_listener_);;
 
   blink::WebScopedMicrotaskSuppression suppression;
-  v8::TryCatch try_catch;
+  v8::TryCatch try_catch(isolate);
   message_listener->Call(context->Global(), 1, &v8_value);
   if (try_catch.HasCaught())
     LOG(WARNING) << "Exception when running message listener: "

--- a/extensions/renderer/xwalk_js_module.cc
+++ b/extensions/renderer/xwalk_js_module.cc
@@ -44,7 +44,7 @@ v8::Handle<v8::Object> XWalkJSModule::NewInstance() {
       v8::Local<v8::Script>::New(isolate, compiled_script_);
 
   blink::WebScopedMicrotaskSuppression suppression;
-  v8::TryCatch try_catch;
+  v8::TryCatch try_catch(isolate);
   v8::Local<v8::Value> result = script->Run();
   if (try_catch.HasCaught()) {
     LOG(WARNING) << "Error during requireNative(): "
@@ -64,7 +64,7 @@ bool XWalkJSModule::Compile(v8::Isolate* isolate, std::string* error) {
       v8::String::NewFromUtf8(isolate, wrapped_js_code.c_str()));
 
   blink::WebScopedMicrotaskSuppression suppression;
-  v8::TryCatch try_catch;
+  v8::TryCatch try_catch(isolate);
   v8::Handle<v8::Script> script(v8::Script::Compile(v8_code));
   if (try_catch.HasCaught()) {
     *error = "Error compiling JS module: " + ExceptionToString(try_catch);

--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -241,7 +241,7 @@ bool XWalkModuleSystem::SetTrampolineAccessorForEntryPoint(
   params->Set(v8::Integer::New(isolate, 1), entry);
 
   // FIXME(cmarcelo): ensure that trampoline is readonly.
-  value.As<v8::Object>()->SetAccessor(
+  value.As<v8::Object>()->SetAccessor(context,
       v8::String::NewFromUtf8(isolate, basename.c_str()),
       TrampolineCallback, TrampolineSetterCallback, params);
   return true;
@@ -409,7 +409,7 @@ v8::Handle<v8::Value> XWalkModuleSystem::RefetchHolder(
 
 // static
 void XWalkModuleSystem::TrampolineCallback(
-    v8::Local<v8::String> property,
+    v8::Local<v8::Name> property,
     const v8::PropertyCallbackInfo<v8::Value>& info) {
   XWalkModuleSystem::LoadExtensionForTrampoline(info.GetIsolate(), info.Data());
   v8::Handle<v8::Value> holder = RefetchHolder(info.GetIsolate(), info.Data());
@@ -421,7 +421,7 @@ void XWalkModuleSystem::TrampolineCallback(
 
 // static
 void XWalkModuleSystem::TrampolineSetterCallback(
-    v8::Local<v8::String> property,
+    v8::Local<v8::Name> property,
     v8::Local<v8::Value> value,
     const v8::PropertyCallbackInfo<void>& info) {
   XWalkModuleSystem::LoadExtensionForTrampoline(info.GetIsolate(), info.Data());
@@ -494,9 +494,10 @@ void XWalkModuleSystem::EnsureExtensionNamespaceIsReadOnly(
 
   v8::Handle<v8::String> v8_extension_name(
       v8::String::NewFromUtf8(context->GetIsolate(), basename.c_str()));
-  value.As<v8::Object>()->ForceSet(
+  value.As<v8::Object>()->DefineOwnProperty(
+      context,
       v8_extension_name, value.As<v8::Object>()->Get(v8_extension_name),
-      v8::ReadOnly);
+      v8::ReadOnly).FromJust();
 }
 
 }  // namespace extensions

--- a/extensions/renderer/xwalk_module_system.h
+++ b/extensions/renderer/xwalk_module_system.h
@@ -86,10 +86,10 @@ class XWalkModuleSystem {
                          ExtensionModuleEntry* entry);
 
   static void TrampolineCallback(
-      v8::Local<v8::String> property,
+      v8::Local<v8::Name> property,
       const v8::PropertyCallbackInfo<v8::Value>& info);
   static void TrampolineSetterCallback(
-      v8::Local<v8::String> property,
+      v8::Local<v8::Name> property,
       v8::Local<v8::Value> value,
       const v8::PropertyCallbackInfo<void>& info);
   static void LoadExtensionForTrampoline(

--- a/extensions/renderer/xwalk_v8tools_module.cc
+++ b/extensions/renderer/xwalk_v8tools_module.cc
@@ -33,7 +33,9 @@ void ForceSetPropertyCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   if (info.Length() != 3 || !info[0]->IsObject() || !info[1]->IsString()) {
     return;
   }
-  info[0].As<v8::Object>()->ForceSet(info[1], info[2]);
+  info[0].As<v8::Object>()->DefineOwnProperty(
+      info.GetIsolate()->GetCurrentContext(),
+      info[1].As<v8::String>(), info[2]).FromJust();
 }
 
 // ================
@@ -177,7 +179,8 @@ void GetWindowObject(const v8::FunctionCallbackInfo<v8::Value>& args) {
 XWalkV8ToolsModule::XWalkV8ToolsModule() {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope handle_scope(isolate);
-  v8::Handle<v8::ObjectTemplate> object_template = v8::ObjectTemplate::New();
+  v8::Handle<v8::ObjectTemplate> object_template =
+      v8::ObjectTemplate::New(isolate);
 
   // TODO(cmarcelo): Use Template::Set() function that takes isolate, once we
   // update the Chromium (and V8) version.


### PR DESCRIPTION
In preparation for Chromium M49 (which will enable stricter compilation
flags for more code by default), port the extensions subsystem away from
deprecated V8 API calls. They will be removed soon, and it is better to
avoid being surprised late in the game.

While here, enable the `chromium_code` variable in `extensions.gyp` so
that we build all targets there (currently, only `xwalk_extensions`)
with more compiler warnings and errors so that we catch uses of
deprecated APIs earlier in the future.

Related BUG=XWALK-6276
BUG=XWALK-6372