### PR TITLE
Fix a -Wreorder error after ec0720da.

### DIFF
--- a/application/common/application_data.cc
+++ b/application/common/application_data.cc
@@ -106,8 +106,8 @@ ApplicationData::ApplicationData(
     SourceType source_type,
     scoped_ptr<Manifest> manifest)
     : manifest_version_(0),
-      application_id_(id),
       path_(path),
+      application_id_(id),
       manifest_(manifest.release()),
       finished_parsing_manifest_(false),
       source_type_(source_type) {


### PR DESCRIPTION
Commit ec0720da ("[Windows] Fix application origin") introduced an
ordering issue when initializing `ApplicationData`'s members which
causes build failures with stricted compiler flags (as it happens by
default in M49):

```
../../xwalk/application/common/application_data.cc:109:7: error: field 'application_id_' will be initialized after field 'path_' [-Werror,-Wreorder]
      application_id_(id),
```