### PR TITLE
v8tools: Run the lifecycleTracker destructor asynchronously.

### DIFF
--- a/extensions/test/data/test_v8tools.html
+++ b/extensions/test/data/test_v8tools.html
@@ -2,9 +2,43 @@
 <head>
 <title></title>
 <script>
+  /*
+   * Test helpers.
+   */
+  function failTest(errormsg) {
+    console.log(new Error(errormsg).stack);
+    document.title = "Fail";
+    // Throw an exception to stop execution and avoid running any other tests.
+    throw new Error("Stopping execution.");
+  }
+
+  function assertEqual(expected, actual) {
+    if (actual !== expected) {
+      failTest("expected '" + expected + "', but got '" + actual + "'");
+    }
+  }
+
+  function assertNotEqual(expected, actual) {
+    if (actual === expected) {
+      failTest("expected '" + expected + "', but got '" + actual + "'");
+    }
+  }
+
+  function gcAndRun(func) {
+    gc();
+
+    // We cannot call |test_function| directly in this test: the destructor
+    // function is not called synchronously when the object it refers to is
+    // garbage-collected, so we need to yield and wait for it to be run as part
+    // of the regular event loop.
+    setTimeout(func, 0);
+  }
+
+  /*
+   * Tests.
+   */
   function forceSetPropertyTest() {
     var obj = {};
-
     Object.defineProperty(obj, "prop", {
       configurable: false,
       writable: false,
@@ -14,111 +48,121 @@
     try {
       test_v8tools.forceSetProperty(obj, "prop", "Pass");
     } catch(e) {
-      return false;
+      failTest("Unable to forceSet() property 'prop'.");
     }
-
-    return true;
+    runNextTest();
   }
 
-  function lifecycleTrackerTest() {
+  function lifecycleTrackerDefaultDestructorTest() {
     var collected = 0;
-    var test1;
-    var test2 = {};
-    var test3;
-    var test4;
-    var test5;
-    var test6;
+    function inc_collected() { ++collected; }
 
-    function inc_collected() {
-      collected++;
-    }
-    function reset_collected() {
-      collected = 0;
-    }
+    var obj = test_v8tools.lifecycleTracker();
+    assertEqual(null, obj.destructor);
 
-    test1 = test_v8tools.lifecycleTracker();
-    if (test1.destructor !== null)
-      return false;
-    test1.destructor = inc_collected;
+    obj.destructor = inc_collected;
+    obj.destructor = null;
+    gcAndRun(function() {
+      assertEqual(0, collected);
+      runNextTest();
+    });
+  }
 
-    test2.foo = test_v8tools.lifecycleTracker();
-    test2.foo.destructor = inc_collected;
+  function lifecycleTrackerInvalidDestructorTest() {
+    function func() {}
 
-    test3 = test_v8tools.lifecycleTracker();
-    test3.destructor = inc_collected;
+    var obj = test_v8tools.lifecycleTracker();
+    obj.destructor = func;
 
     // Setting the destructor to a value that's not a function or null raises
     // a TypeError.
     try {
-      test3.destructor = 42;
+      obj.destructor = 42;
     } catch (e) {
-      if (!(e instanceof TypeError))
-        return false;
+      if (!(e instanceof TypeError)) {
+        failTest("lifecycleTracker returned an unexpected exception.");
+      }
     } finally {
-      if (test3.destructor !== inc_collected)
-        return false;
+      assertEqual(func, obj.destructor);
     }
+    runNextTest();
+  };
 
-    test4 = test3;
-
-    test5 = test_v8tools.lifecycleTracker();
-
-    test6 = test_v8tools.lifecycleTracker();
-    test6.destructor = reset_collected;
-    test6.destructor = null;
-
-    // Should be collected.
-    test1 = 0;
-    gc();
-
-    if (collected != 1)
-      return false;
-
-    // Should be collected.
-    test2 = 0;
-    gc();
-
-    if (collected != 2)
-      return false;
-
-    // Should not, still referenced by test4.
-    test3 = 0;
-    gc();
-
-    if (collected != 2)
-      return false;
-
-    // Should be collected.
-    test4 = 0;
-    gc();
-
-    if (collected != 3)
-      return false;
-
-    // Should not do anything, no destructor set.
-    test5 = 0;
-    gc();
-
-    if (collected != 3)
-      return false;
-
-    // Should not do anything, the destructor was reset.
-    test6 = 0;
-    gc();
-
-    if (collected != 3)
-      return false;
-
-    return true;
+  function lifecycleTrackerDeletedObjectTest() {
+    var obj1 = test_v8tools.lifecycleTracker();
+    var obj2 = test_v8tools.lifecycleTracker();
+    obj1.val = 42;
+    obj1.destructor = function() {
+      // By the time the destructor is run, the object itself must have already
+      // been destroyed.
+      assertEqual(null, obj1);
+      runNextTest();
+    };
+    obj1 = null;
+    gcAndRun(function(){});  // Just allow the destructor to be invoked.
   }
 
-  if (!forceSetPropertyTest())
-    document.title = "Fail";
-  else if(!lifecycleTrackerTest())
-    document.title = "Fail";
-  else
-    document.title = "Pass";
+  function lifecycleTrackerReferencesTest() {
+    var collected = 0;
+    function inc_collected() { ++collected; }
 
+    var obj1 = test_v8tools.lifecycleTracker();
+    obj1.destructor = inc_collected;
+    var obj2 = obj1;
+
+    obj1 = null;
+    gcAndRun(function() {
+      // |obj2| still holds a reference.
+      assertEqual(0, collected);
+      obj2 = null;
+      gcAndRun(function() {
+        assertEqual(1, collected);
+        runNextTest();
+      });
+    });
+  }
+
+  function lifecycleTrackerMultipleObjectsTest() {
+    var collected = 0;
+    function inc_collected() { ++collected; }
+
+    var obj1 = test_v8tools.lifecycleTracker();
+    obj1.destructor = inc_collected;
+    var obj2 = test_v8tools.lifecycleTracker();
+    obj2.destructor = inc_collected;
+
+    obj1 = null;
+    gcAndRun(function() {
+      assertEqual(1, collected);
+      obj2 = null;
+      gcAndRun(function() {
+        assertEqual(2, collected);
+        runNextTest();
+      });
+    });
+  }
+
+  function finishTests() {
+    document.title = "Pass";
+  }
+
+  var tests = [
+    forceSetPropertyTest,
+    lifecycleTrackerDefaultDestructorTest,
+    lifecycleTrackerInvalidDestructorTest,
+    lifecycleTrackerDeletedObjectTest,
+    lifecycleTrackerReferencesTest,
+    lifecycleTrackerMultipleObjectsTest,
+    finishTests
+  ];
+
+  function runNextTest() {
+    if (tests.length == 0)
+      return;
+    setTimeout(tests.shift(), 0);
+  }
+
+  runNextTest();
 </script>
 </head>
 </html>

--- a/sysapps/common/common_api_browsertest.html
+++ b/sysapps/common/common_api_browsertest.html
@@ -77,97 +77,139 @@
 
       function memoryManagement() {
         var garbageCollectionCount = 0;
+        var testObject;
 
-        var testObject = new api.TestObject();
-        testObject.tracker = v8tools.lifecycleTracker();
-        testObject.tracker.destructor = function() {
-          garbageCollectionCount++;
-        };
-
-        testObject = null;
-        gc();
-
-        if (garbageCollectionCount != 1) {
-          reportFail("EventTarget is leaking.");
-          return;
+        // We need to split the test into steps and make each one trigger the
+        // next because the destructor functions are called asynchronously.
+        // The tests themselves do not really depend on one another, and could
+        // be split into separate tests in the future.
+        var steps = [
+          testStep1,
+          testStep2,
+          testStep3,
+          testStep4,
+          testStep5
+        ];
+        function runNextTestStep() {
+          setTimeout(steps.shift(), 0);
         }
 
-        testObject = new api.TestObject();
-        testObject.tracker = v8tools.lifecycleTracker();
-        testObject.tracker.destructor = function() {
-          garbageCollectionCount++;
-        };
+        runNextTestStep();
 
-        // This essentially causes a leak.
-        testObject.addEventListener("test", foo);
-        testObject = null;
-        gc();
-
-        if (garbageCollectionCount != 1) {
-          reportFail("Object should not be gc'ed when listening for events.");
-          return;
-        }
-
-        testObject = new api.TestObject();
-        testObject.tracker = v8tools.lifecycleTracker();
-        testObject.tracker.destructor = function() {
-          garbageCollectionCount++;
-        };
-
-        // Another expected way of leaking an object.
-        testObject.ontest = function() {};
-        testObject = null;
-        gc();
-
-        if (garbageCollectionCount != 1) {
-          reportFail("Object should not be gc'ed when listening for events.");
-          return;
-        }
-
-        testObject = new api.TestObject();
-        testObject.tracker = v8tools.lifecycleTracker();
-        testObject.tracker.destructor = function() {
-          garbageCollectionCount++;
-        };
-
-        testObject.addEventListener("test", bar);
-        testObject.removeEventListener("test", bar);
-        testObject = null;
-        gc();
-
-        if (garbageCollectionCount != 2) {
-          reportFail("Object should be collected when listeners are removed.");
-          return;
-        }
-
-        testObject = new api.TestObject();
-        testObject.tracker = v8tools.lifecycleTracker();
-        testObject.tracker.destructor = function() {
-          garbageCollectionCount++;
-        };
-
-        // Save a reference to the id so we can verify
-        // later if it was really deleted in the backend.
-        var object_id = testObject._id;
-
-        testObject.ontest = function() {};
-        testObject.ontest = null;
-        testObject = null;
-        gc();
-
-        if (garbageCollectionCount != 3) {
-          reportFail("Object should be collected when listeners are removed.");
-          return;
-        }
-
-        api.hasObject(object_id, function(result) {
-          if (result == true) {
-            reportFail("Object not removed from the backend.");
-            return;
+        function testStep1() {
+          testObject = new api.TestObject();
+          testObject.tracker = v8tools.lifecycleTracker();
+          testObject.tracker.destructor = function() {
+            garbageCollectionCount++;
           };
 
-          runNextTest();
-        });
+          testObject = null;
+          gc();
+
+          setTimeout(function() {
+            if (garbageCollectionCount != 1) {
+              reportFail("EventTarget is leaking.");
+              return;
+            }
+            runNextTestStep();
+          }, 0);
+        }
+
+        function testStep2() {
+          testObject = new api.TestObject();
+          testObject.tracker = v8tools.lifecycleTracker();
+          testObject.tracker.destructor = function() {
+            garbageCollectionCount++;
+          };
+
+          // This essentially causes a leak.
+          testObject.addEventListener("test", foo);
+          testObject = null;
+          gc();
+
+          setTimeout(function() {
+            if (garbageCollectionCount != 1) {
+              reportFail("Object should not be gc'ed when listening for events.");
+              return;
+            }
+            runNextTestStep();
+          }, 0);
+        }
+
+        function testStep3() {
+          testObject = new api.TestObject();
+          testObject.tracker = v8tools.lifecycleTracker();
+          testObject.tracker.destructor = function() {
+            garbageCollectionCount++;
+          };
+
+          // Another expected way of leaking an object.
+          testObject.ontest = function() {};
+          testObject = null;
+          gc();
+
+          setTimeout(function() {
+            if (garbageCollectionCount != 1) {
+              reportFail("Object should not be gc'ed when listening for events.");
+              return;
+            }
+            runNextTestStep();
+          }, 0);
+        }
+
+        function testStep4() {
+          testObject = new api.TestObject();
+          testObject.tracker = v8tools.lifecycleTracker();
+          testObject.tracker.destructor = function() {
+            garbageCollectionCount++;
+          };
+
+          testObject.addEventListener("test", bar);
+          testObject.removeEventListener("test", bar);
+
+          testObject = null;
+          gc();
+
+          setTimeout(function() {
+            if (garbageCollectionCount != 2) {
+              reportFail("Object should be collected when listeners are removed.");
+              return;
+            }
+            runNextTestStep();
+          }, 0);
+         }
+
+        function testStep5() {
+          testObject = new api.TestObject();
+          testObject.tracker = v8tools.lifecycleTracker();
+          testObject.tracker.destructor = function() {
+            garbageCollectionCount++;
+          };
+
+          // Save a reference to the id so we can verify
+          // later if it was really deleted in the backend.
+          var object_id = testObject._id;
+
+          testObject.ontest = function() {};
+          testObject.ontest = null;
+          testObject = null;
+          gc();
+
+          setTimeout(function() {
+            if (garbageCollectionCount != 3) {
+              reportFail("Object should be collected when listeners are removed.");
+              return;
+            }
+            api.hasObject(object_id, function(result) {
+              if (result == true) {
+                reportFail("Object not removed from the backend.");
+                return;
+              };
+
+              runNextTest();
+            });
+          }, 0);
+        }
       };
 
       function addEventListener() {

--- a/sysapps/raw_socket/raw_socket_api_browsertest.html
+++ b/sysapps/raw_socket/raw_socket_api_browsertest.html
@@ -50,10 +50,15 @@
           gc();
           gc();
 
-          if (garbageCollectionCount != 3)
-            reportFail("TCPSocket, TCPServerSocket or UDPSocket is leaking.");
-          else
-            runNextTest();
+          // We need to use setTimeout() here because destructor callbacks are
+          // not run synchronously when the object it refers to is being
+          // garbage-collected.
+          setTimeout(function() {
+            if (garbageCollectionCount != 3)
+              reportFail("TCPSocket, TCPServerSocket or UDPSocket is leaking.");
+            else
+              runNextTest();
+          }, 0);
         };
 
         var server = new api.TCPServerSocket(


### PR DESCRIPTION
`SysAppsRawSocketTest.SysAppsRawSocket` was crashing on M49 after commit
92bdf3c ("v8tools: Port the lifecycleTracker code to non-deprecated API") when
built in debug mode.

It turns out our weak callbacks (before and after turning them into phantom
callbacks in the commit mentioned above) are run between Blink's garbage
collection prologue and epilogue. The prologue forbids script execution, and
the epilogue reenables it. In debug mode, when all asserts are on, the checks
for whether JS code is being run fail and Crosswalk crashes.

Commit d43f001 ("Fix XWalkExtensionsV8ToolsTest.V8ToolsWorks asserting in
debug") was an early indication of this issue, and was working around the issue
by somewhat blindly disabling some of those checks. That was not enough, and
doing something as simple as calling `console.log()` from the destructor
callback was enough to crash Crosswalk.

We now adopt the same solution used by Chromium's extension system and its
`GCCallback` class: instead of running the code that calls the destructor
inside the weak callback we've registered, we post a task to the message loop
and run it asynchronously _after_ the garbage collection code has run.

Some of our tests had to be rewritten to take into account the fact that the
destructor functions are no longer run synchronously, which is why this
commit got quite big (the changes to the v8tools module itself are
really small).