### PR TITLE
Include the right header in runtime_platform_util_aura.cc.

### DIFF
--- a/runtime/browser/runtime_platform_util_aura.cc
+++ b/runtime/browser/runtime_platform_util_aura.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "chrome/browser/platform_util.h"
+#include "xwalk/runtime/browser/runtime_platform_util.h"
 
 #include "base/logging.h"
 #include "ui/aura/window.h"


### PR DESCRIPTION
This file, contrary to the other `runtime_platform_util_*.cc` ones, was
including `chrome/browser/platform_util.h` instead of our own
`runtime/browser/runtime_platform_util.h`, leading to build failures in
M49:

```
In file included from ../../xwalk/runtime/browser/runtime_platform_util_aura.cc:5:
../../chrome/browser/platform_util.h:13:10: fatal error: 'chrome/common/features.h' file not found
```

BUG=XWALK-6287