### PR TITLE
[Android] re-implement captureBitmapAsync based on WebContents

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -44,9 +44,8 @@ import org.chromium.content.browser.ContentViewCore;
 import org.chromium.content.browser.ContentViewRenderView;
 import org.chromium.content.browser.ContentViewRenderView.CompositingSurfaceType;
 import org.chromium.content.browser.ContentViewStatics;
-import org.chromium.content.browser.ContentReadbackHandler;
-import org.chromium.content.browser.ContentReadbackHandler.GetBitmapCallback;
 import org.chromium.content.common.CleanupReference;
+import org.chromium.content_public.browser.ContentBitmapCallback;
 import org.chromium.content_public.browser.JavaScriptCallback;
 import org.chromium.content_public.browser.LoadUrlParams;
 import org.chromium.content_public.browser.NavigationHistory;
@@ -84,8 +83,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     private boolean mIsLoaded = false;
     private XWalkAutofillClientAndroid mXWalkAutofillClient;
     private XWalkGetBitmapCallbackInternal mXWalkGetBitmapCallbackInternal;
-    private ContentReadbackHandler mContentReadbackHandler;
-    private GetBitmapCallback mGetBitmapCallback;
+    private ContentBitmapCallback mGetBitmapCallback;
 
     long mNativeContent;
     long mNativeWebContents;
@@ -139,8 +137,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     }
 
     private void initCaptureBitmapAsync() {
-        mContentReadbackHandler = mContentViewRenderView.getContentReadbackHandler();
-        mGetBitmapCallback = new GetBitmapCallback() {
+        mGetBitmapCallback = new ContentBitmapCallback() {
             @Override
             public void onFinishGetBitmap(Bitmap bitmap, int response) {
                 if (mXWalkGetBitmapCallbackInternal == null) return;
@@ -150,10 +147,10 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     }
 
     public void captureBitmapAsync(XWalkGetBitmapCallbackInternal callback) {
-        if (mContentReadbackHandler == null) return;
+        if (mNativeContent == 0) return;
         mXWalkGetBitmapCallbackInternal = callback;
-        mContentReadbackHandler.getContentBitmapAsync(1.0f, new Rect(), mContentViewCore,
-            Bitmap.Config.ARGB_8888, mGetBitmapCallback);
+        mWebContents.getContentBitmapAsync(Bitmap.Config.ARGB_8888, 1.0f,
+            new Rect(), mGetBitmapCallback);
     }
 
     private void setNativeContent(long newNativeContent) {


### PR DESCRIPTION
[Android] re-implement captureBitmapAsync based on WebContents

Now that upstream has moved ContentReadbackHandler related feature into WebContents.
We re-implement this api based on WebContents.
BUG= XWALK-6370
