### PR TITLE
[Lite]Add fake APIs to make Lite-17 compatible with Cordova Plugin 1.7.0

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkExternalExtensionManagerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkExternalExtensionManagerInternal.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+/**
+ * Create an empty class in order to make Lite-17 compatible with Cordova
+ * Plugin 1.7.0(which matches Crosswalk-18)
+ */
+@XWalkAPI(createExternally = true)
+public class XWalkExternalExtensionManagerInternal {
+    @XWalkAPI
+    public XWalkExternalExtensionManagerInternal() {
+    }
+
+    /* empty function.*/
+    @XWalkAPI
+    public void loadExtension(String extensionPath) {
+        return;
+    }  
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -665,6 +665,23 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     }
 
     /**
+     * Add fake APIs to make Lite-17 compatible with Cordova-plugin 1.7.0(match Crosswalk-18)
+     * Below 2 APIs are new added since Crosswalk-18.
+     * getExtensionManager()
+     * startActivityForResult()
+    **/
+
+    @XWalkAPI
+    public XWalkExternalExtensionManagerInternal getExtensionManager() {
+        return new XWalkExternalExtensionManagerInternal();
+    }
+
+    @XWalkAPI
+    public void startActivityForResult(Intent intent, int requestCode, Bundle options) {
+        return;
+    }
+
+    /**
      * Pass through activity result to XWalkViewInternal. Many internal facilities need this
      * to handle activity result like JavaScript dialog, Crosswalk extensions, etc.
      * See <a href="http://developer.android.com/reference/android/app/Activity.html">

--- a/tools/reflection_generator/java_class.py
+++ b/tools/reflection_generator/java_class.py
@@ -430,6 +430,12 @@ class InternalJavaFileData(object):
                'INTERNAL_VAR': var if clazz == self._class_name else\
                                    '(%s) %s' % (clazz, var)}
       var = typed_var_template.substitute(value)
+    else:
+      typed_var_template = Template('(${VAR} instanceof ${BRIDGE_TYPE} ?'\
+          ' ((${BRIDGE_TYPE}) ${VAR} ) : null)')
+      value = {'VAR': var,
+               'BRIDGE_TYPE': self.GetJavaData(clazz).bridge_name}
+      var = typed_var_template.substitute(value)
     return var
 
   def UseAsInstanceInBridgeSuperCall(self, var):

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -30,6 +30,7 @@ CLASSES_TO_BE_PROCESS = [
     'XWalkCookieManagerInternal',
     'XWalkDownloadListenerInternal',
     'XWalkExtensionInternal',
+    'XWalkExternalExtensionManagerInternal',
     'XWalkGetBitmapCallbackInternal',
     'XWalkHttpAuthHandlerInternal',
     'XWalkViewInternal',


### PR DESCRIPTION
New XWALK APIs are added in Crosswalk-18, accordingly the Cordova
Plugin uses those APIs. It complains compile error because in Lite-17
those new added APIs are not exist.

So we add fake APIs into Lite-17 to make it compatible with Cordova Plugin.
This modification is not needed in Lite-19.

BUG=XWALK-6488