### PR TITLE
[Android] Change color of root layer to avoid white screen on startup

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'dfbc583e04cd1530d2cd6ec6721a8eea6227770c'
+chromium_crosswalk_rev = '5c3da74dd8cdf1cba7bc0d016d4ab36d689de922'
 v8_crosswalk_rev = 'fb6cbd5d3f9830261d425bdf7af94c9bc803332b'
 
 crosswalk_git = 'https://github.com/crosswalk-project'

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -523,11 +523,15 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
             });
             return;
         }
-        if (isOpaque(color) == false) {
+        if (isOpaque(color) == true) {
+            setOverlayVideoMode(false);
+            mContentViewCore.setBackgroundOpaque(true);
+        } else {
             setOverlayVideoMode(true);
-            mContentViewRenderView.setSurfaceViewBackgroundColor(color);
             mContentViewCore.setBackgroundOpaque(false);
         }
+        mContentViewCore.setBackgroundColor(color);
+        mContentViewRenderView.setSurfaceViewBackgroundColor(color);
         nativeSetBackgroundColor(mNativeContent, color);
     }
 


### PR DESCRIPTION
If set the WindowBackground of Activity to RED, and webpage page's backgroudn to RED,
when application starts or resumes after click back key, it will showup a white screen
shortly. We can change the first screen to a fix color by setting the root layer color
of ContentViewCore. This can help to avoid white screen.

BUG=XWALK-4809, XWALK-4995