### PR TITLE
application_native_module: Stop using deprecated V8 API.

### DIFF
--- a/application/renderer/application_native_module.cc
+++ b/application/renderer/application_native_module.cc
@@ -28,7 +28,7 @@ void ApplicationNativeModule::GetViewByIDCallback(
   if (info.Length() != 1 || !info[0]->IsInt32())
     return;
 
-  int main_routing_id = info[0]->ToInt32()->Value();
+  int main_routing_id = info[0]->ToInt32(info.GetIsolate())->Value();
   content::RenderView* render_view =
     content::RenderView::FromRoutingID(main_routing_id);
   if (!render_view)
@@ -63,7 +63,8 @@ ApplicationNativeModule::ApplicationNativeModule() {
       v8::External::New(isolate, this));
 
   // Register native function templates to object template here.
-  v8::Handle<v8::ObjectTemplate> object_template = v8::ObjectTemplate::New();
+  v8::Handle<v8::ObjectTemplate> object_template =
+      v8::ObjectTemplate::New(isolate);
   object_template->Set(
       isolate,
       "getViewByID",


### PR DESCRIPTION
Prepare for M49 by switching to non-deprecated versions of some V8 API
calls:

```
../../xwalk/application/renderer/application_native_module.cc: In static member function 'static void xwalk::application::ApplicationNativeModule::GetViewByIDCallback(const v8::FunctionCallbackInfo<v8::Value>&)':
../../xwalk/application/renderer/application_native_module.cc:31:42: warning: 'v8::Local<v8::Int32> v8::Value::ToInt32() const' is deprecated (declared at ../../v8/include/v8.h:7942): Use maybe version [-Wdeprecated-declarations]
   int main_routing_id = info[0]->ToInt32()->Value();
                                             ^
../../xwalk/application/renderer/application_native_module.cc: In constructor 'xwalk::application::ApplicationNativeModule::ApplicationNativeModule()':
../../xwalk/application/renderer/application_native_module.cc:66:76: warning: 'static v8::Local<v8::ObjectTemplate> v8::ObjectTemplate::New()' is deprecated (declared at ../../v8/include/v8.h:4624): Use isolate version [-Wdeprecated-declarations]
   v8::Handle<v8::ObjectTemplate> object_template = v8::ObjectTemplate::New();
                                                                            ^
```