### PR TITLE
[Android] Fix the xwalk build target on android

### DIFF
--- a/runtime/app/xwalk_main.cc
+++ b/runtime/app/xwalk_main.cc
@@ -67,7 +67,7 @@ int main(int argc, const char** argv) {
     // Do the delegate work in xwalk_content_main to avoid having to export the
   // delegate types.
   return ::ContentMain(argc, argv);
-#else
+#elif !defined(OS_ANDROID)
   xwalk::XWalkMainDelegate delegate;
   content::ContentMainParams params(&delegate);
 


### PR DESCRIPTION
Not that important as xwalk build target is not used for Android
but I thought it's still good to fix it for Android. Without this patch
you will see following build error,

../../xwalk/runtime/app/xwalk_main.cc: In function 'int main(int, const char**)':
../../xwalk/runtime/app/xwalk_main.cc:82:10: error: 'struct content::ContentMainParams' has no member named 'argc'
   params.argc = argc;
          ^
../../xwalk/runtime/app/xwalk_main.cc:83:10: error: 'struct content::ContentMainParams' has no member named 'argv'
   params.argv = argv;
          ^
../../xwalk/runtime/app/xwalk_main.cc:85:10: error: 'ContentMain' is not a member of 'content'
   return content::ContentMain(params);
          ^
ninja: build stopped: subcommand failed.

BUG=XWALK-6531