### PR TITLE
[Android] Fix the NewApi warnings.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/extension/MessageInfo.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/MessageInfo.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.core.extension;
 
+import android.os.Build;
 import android.util.Log;
 
 import java.lang.Byte;
@@ -57,9 +58,11 @@ public class MessageInfo {
                 mCallbackId = mArgs.getString(1);
                 mObjectId = mArgs.getString(2);
 
-                mArgs.remove(0);
-                mArgs.remove(0);
-                mArgs.remove(0);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                    mArgs.remove(0);
+                    mArgs.remove(0);
+                    mArgs.remove(0);
+                }
             } catch (JSONException e) {
                 Log.e(TAG, e.toString());
             }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -9,6 +9,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.net.http.SslError;
+import android.os.Build;
 import android.text.InputType;
 import android.util.Log;
 import android.view.View;
@@ -374,7 +375,11 @@ public class XWalkResourceClientInternal {
         final EditText userNameEditText = new EditText(context);
         final EditText passwordEditText = new EditText(context);
         layout.setOrientation(LinearLayout.VERTICAL);
-        layout.setPaddingRelative(10, 0, 10, 20);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            layout.setPaddingRelative(10, 0, 10, 20);
+        } else {
+            layout.setPadding(10, 0, 10, 20);
+        }
         userNameEditText.setHint(R.string.http_auth_user_name);
         passwordEditText.setHint(R.string.http_auth_password);
         passwordEditText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/DisplayManagerJBMR1.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/DisplayManagerJBMR1.java
@@ -4,13 +4,16 @@
 
 package org.xwalk.core.internal.extension.api;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.hardware.display.DisplayManager;
+import android.os.Build;
 import android.view.Display;
 
 /**
  * A wrapper class for DisplayManager implementation on Android JellyBean MR1 (API Level 17).
  */
+@SuppressLint("NewApi")
 public class DisplayManagerJBMR1 extends XWalkDisplayManager implements DisplayManager.DisplayListener {
     private DisplayManager mDisplayManager;
 
@@ -26,6 +29,11 @@ public class DisplayManagerJBMR1 extends XWalkDisplayManager implements DisplayM
     @Override
     public Display[] getDisplays() {
         return mDisplayManager.getDisplays();
+    }
+
+    @Override
+    public Display[] getDisplays(String category) {
+        return mDisplayManager.getDisplays(category);
     }
 
     @Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/DisplayManagerNull.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/DisplayManagerNull.java
@@ -26,6 +26,11 @@ public class DisplayManagerNull extends XWalkDisplayManager {
     }
 
     @Override
+    public Display[] getDisplays(String category) {
+        return NO_DISPLAYS;
+    }
+
+    @Override
     public Display[] getPresentationDisplays() {
         return NO_DISPLAYS;
     }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/XWalkDisplayManager.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/XWalkDisplayManager.java
@@ -54,6 +54,11 @@ public abstract class XWalkDisplayManager {
     public abstract Display[] getDisplays();
 
     /**
+     * Gets all currently valid logical displays of the specified category.
+     */
+    public abstract Display[] getDisplays (String category);
+
+    /**
      * Get all valid secondary displays, excluding the built-in display. The returned array
      * is sorted for preference. The first display in the returned array is the most preferred
      * display for presentation show.

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/device_capabilities/DeviceCapabilitiesDisplay.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/device_capabilities/DeviceCapabilitiesDisplay.java
@@ -6,6 +6,7 @@ package org.xwalk.core.internal.extension.api.device_capabilities;
 
 import android.content.Context;
 import android.graphics.Point;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.SparseArray;
@@ -78,10 +79,12 @@ class DeviceCapabilitiesDisplay {
 
     public JSONObject convertDisplayToJSON(Display disp) {
         DisplayMetrics displayMetrics = new DisplayMetrics();
-        disp.getRealMetrics(displayMetrics);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+            disp.getRealMetrics(displayMetrics);
 
         Point realSize = new Point();
-        disp.getRealSize(realSize);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+            disp.getRealSize(realSize);
 
         Point availSize = new Point();
         disp.getSize(availSize);
@@ -89,7 +92,11 @@ class DeviceCapabilitiesDisplay {
         JSONObject out = new JSONObject();
         try {
             out.put("id", Integer.toString(disp.getDisplayId()));
-            out.put("name", disp.getName());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                out.put("name", disp.getName());
+            } else {
+                out.put("name", "");
+            }
             out.put("primary", disp.getDisplayId() == disp.DEFAULT_DISPLAY);
             out.put("external", disp.getDisplayId() != disp.DEFAULT_DISPLAY);
             out.put("deviceXDPI", (int) displayMetrics.xdpi);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/PresentationViewJBMR1.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/PresentationViewJBMR1.java
@@ -4,6 +4,7 @@
 
 package org.xwalk.core.internal.extension.api.presentation;
 
+import android.annotation.SuppressLint;
 import android.app.Presentation;
 import android.os.Build;
 import android.content.Context;
@@ -14,6 +15,7 @@ import android.view.View;
 /**
  * A wrapper class of android.app.Presentation class introduced from API level 17.
  */
+@SuppressLint("NewApi")
 public class PresentationViewJBMR1 extends PresentationView
         implements DialogInterface.OnShowListener, DialogInterface.OnDismissListener {
 


### PR DESCRIPTION
Some new APIs were used without runtime checks, app will be crashed when
it runs on lower API level devices.
Add the checks for new APIs.

BUG=XWALK-6296, XWALK-6495

(cherry picked from commit 5c5e75cf46ab6a8cc31f015913a7e964cc05d6c4)