### PR TITLE
[Android] Fixed crash of extension manager in shared mode

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtensionManagerImpl.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtensionManagerImpl.java
@@ -53,6 +53,16 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
         super(view);
 
         mXWalkView = view;
+
+        if (getBridge() == null) {
+            Log.e(TAG, "Cannot load external extensions due to old version of runtime library");
+            mContext = null;
+            mActivity = null;
+            mLoadExternalExtensions = false;
+            mNativeExtensionLoader = null;
+            return;
+        }
+
         mContext = getViewContext();
         mActivity = getViewActivity();
         mLoadExternalExtensions = true;

--- a/tools/reflection_generator/wrapper_generator.py
+++ b/tools/reflection_generator/wrapper_generator.py
@@ -138,7 +138,7 @@ ${DOC}
     private XWalkCoreWrapper coreWrapper;
     private Object bridge;
 
-    Object getBridge() {
+    protected Object getBridge() {
         return bridge;
     }
 """


### PR DESCRIPTION
The initialization of external extension manager is embedded into the
constructor of XWalkView, but corresponding class doesn't exist in
Crosswalk versions prior to 18. So the Crosswalk apps with shared mode
will crash when running on old versions of runtime library.

BUG=XWALK-6385