### PR TITLE
[Android] Fix the failed android tests on M49.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -93,6 +93,7 @@ public class XWalkSettingsInternal {
     private boolean mDisplayZoomControls = true;
 
     private boolean mSpatialNavigationEnabled = true;
+    private boolean mQuirksModeEnabled = false;
 
     static class LazyDefaultUserAgent{
         private static final String sInstance = nativeGetDefaultUserAgent();
@@ -1054,6 +1055,32 @@ public class XWalkSettingsInternal {
     public boolean getSupportSpatialNavigation() {
         synchronized (mXWalkSettingsLock) {
             return mSpatialNavigationEnabled;
+        }
+    }
+
+    /**
+     * Sets whether the XWalkView should support the quirks mode.
+     * @param enable whether the XWalkView should support the quirks mode.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public void setSupportQuirksMode(boolean enable) {
+        synchronized (mXWalkSettingsLock) {
+            if (mQuirksModeEnabled == enable) return;
+            mQuirksModeEnabled = enable;
+            mEventHandler.updateWebkitPreferencesLocked();
+        }
+    }
+
+    /**
+     * Gets whether the XWalkView should support the quirks mode.
+     * @return true if XWalkView supports the quirks mode.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public boolean getSupportQuirksMode() {
+        synchronized (mXWalkSettingsLock) {
+            return mQuirksModeEnabled;
         }
     }
 

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -80,6 +80,8 @@ struct XWalkSettings::FieldIds {
         GetFieldID(env, clazz, "mDefaultFixedFontSize", "I");
     spatial_navigation_enabled =
         GetFieldID(env, clazz, "mSpatialNavigationEnabled", "Z");
+    quirks_mode_enabled =
+        GetFieldID(env, clazz, "mQuirksModeEnabled", "Z");
   }
 
   // Field ids
@@ -100,6 +102,7 @@ struct XWalkSettings::FieldIds {
   jfieldID default_font_size;
   jfieldID default_fixed_font_size;
   jfieldID spatial_navigation_enabled;
+  jfieldID quirks_mode_enabled;
 };
 
 XWalkSettings::XWalkSettings(JNIEnv* env,
@@ -255,6 +258,11 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
   int fixed_font_size = env->GetIntField(obj,
       field_ids_->default_fixed_font_size);
   prefs.default_fixed_font_size = fixed_font_size;
+
+  bool support_quirks = env->GetBooleanField(
+      obj, field_ids_->quirks_mode_enabled);
+  prefs.viewport_meta_non_user_scalable_quirk = support_quirks;
+  prefs.clobber_user_agent_initial_scale_quirk = support_quirks;
 
   render_view_host->UpdateWebkitPreferences(prefs);
 }

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -17,7 +17,9 @@
 #include "content/public/renderer/render_view.h"
 #include "grit/xwalk_application_resources.h"
 #include "grit/xwalk_sysapps_resources.h"
+#include "net/base/net_errors.h"
 #include "third_party/WebKit/public/platform/WebString.h"
+#include "third_party/WebKit/public/platform/WebURLError.h"
 #include "third_party/WebKit/public/platform/WebURLRequest.h"
 #include "third_party/WebKit/public/web/WebDocument.h"
 #include "third_party/WebKit/public/web/WebSecurityPolicy.h"
@@ -272,13 +274,13 @@ void XWalkContentRendererClient::GetNavigationErrorStrings(
     const blink::WebURLError& error,
     std::string* error_html,
     base::string16* error_description) {
-  bool is_post = base::EqualsASCII(
-      base::StringPiece16(failed_request.httpMethod()), "POST");
-
   // TODO(guangzhen): Check whether error_html is needed in xwalk runtime.
 
   if (error_description) {
-    *error_description = LocalizedError::GetErrorDetails(error, is_post);
+    if (error.localizedDescription.isEmpty())
+      *error_description = base::ASCIIToUTF16(net::ErrorToString(error.reason));
+    else
+      *error_description = error.localizedDescription;
   }
 }
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
@@ -13,7 +13,6 @@ import org.chromium.content.browser.test.util.TestCallbackHelperContainer;
 import org.chromium.net.test.util.TestWebServer;
 
 import org.xwalk.core.XWalkView;
-import org.xwalk.core.internal.XWalkClient;
 
 import java.util.concurrent.TimeUnit;
 
@@ -121,7 +120,7 @@ public class OnPageFinishedTest extends XWalkViewTestBase {
         loadJavaScriptUrl("javascript: try { console.log('foo'); } catch(e) {};");
 
         onPageFinishedHelper.waitForCallback(currentCallCount);
-        assertEquals("about:blank", onPageFinishedHelper.getUrl());
+        assertTrue(onPageFinishedHelper.getUrl().startsWith("data:text/html;"));
         // onPageFinished won't be called for javascript: url.
         assertEquals(1, onPageFinishedHelper.getCallCount());
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
@@ -30,7 +30,7 @@ public class SetInitialScaleTest extends XWalkViewTestBase {
     @SmallTest
     @Feature({"setInitialScale"})
     public void testSetInitialScale1() throws Throwable {
-
+        setQuirksMode(true);
         final String pageTemplate = "<html><head>"
                 + "<meta name='viewport' content='initial-scale=%d' />"
                 + "</head><body>"

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -1027,4 +1027,13 @@ public class XWalkViewTestBase
             }
         });
     }
+
+    protected void setQuirksMode(final boolean value) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.getSettings().setSupportQuirksMode(value);
+            }
+        });
+    }
 }


### PR DESCRIPTION
For OnReceivedErrorTest#testCacheMiss, the related resource id was
removed in
https://github.com/crosswalk-project/crosswalk/commit/29838edb08b71e49c43eff580ac02f4709d1cfaa, this leads to the description is null.

For SetInitialScaleTest#testSetInitialScale1, the clobber initial scale
should works in quirks mode, please refer to https://codereview.chromium.org/67193002,
but crosswalk has no API to set quirks mode. Meanwhile the previous
CriteriaHelper.poll* did not check the result inside function, it was fixed in
https://codereview.chromium.org/1491063002, then initial scale issue was
exposed.

For OnPageFinishedTest#testOnPageFinishedNotCalledForJavaScriptUrl, it
was caused by https://codereview.chromium.org/1304373007, the return
value of GetLoadingUrl() was reset to data url instead of unreachable
url.

BUG=XWALK-6533