### PR TITLE
[Android] Fix the resoures IDs reset in download mode

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkInternalResources.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkInternalResources.java
@@ -25,7 +25,8 @@ class XWalkInternalResources {
     // Doing org.chromium.content.R.<class>.<name> = org.xwalk.core.R.<class>.<name>
     // Use reflection to iterate over the target class is to avoid hardcode.
     private static void doResetIds(Context context) {
-        ClassLoader classLoader = context.getClassLoader();
+        // internal classes are loaded with the same classLoader of XWalkInternalResources
+        ClassLoader classLoader = XWalkInternalResources.class.getClassLoader();
         ClassLoader appClassLoader = context.getApplicationContext().getClassLoader();
         for (String resourceClass : INTERNAL_RESOURCE_CLASSES) {
             try {


### PR DESCRIPTION
The classloader used to load internal classes should be the same
as XWalkInternalResources'.

BUG=XWALK-6566
BUG=XWALK-6599