### PR TITLE
[Android] Enable pull-to-refresh

### DIFF
--- a/runtime/android/core_internal/res/values/colors.xml
+++ b/runtime/android/core_internal/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2014 The Chromium Authors. All rights reserved.
+     Copyright (c) 2016 Intel Corporation. All rights reserved.
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file. -->
+
+<resources>
+    <!-- Common colors -->
+    <color name="light_active_color">#4285F4</color>
+</resources>

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/SwipeRefreshHandler.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/SwipeRefreshHandler.java
@@ -1,0 +1,185 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+import android.content.Context;
+import android.view.ViewGroup.LayoutParams;
+
+import org.chromium.base.TraceEvent;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.metrics.RecordUserAction;
+import org.chromium.content.browser.ContentViewCore;
+import org.chromium.content.browser.OverscrollRefreshHandler;
+import org.chromium.third_party.android.swiperefresh.SwipeRefreshLayout;
+
+import org.xwalk.core.internal.R;
+
+/**
+ * An overscroll handler implemented in terms a modified version of the Android
+ * compat library's SwipeRefreshLayout effect.
+ */
+@JNINamespace("xwalk")
+public class SwipeRefreshHandler implements OverscrollRefreshHandler {
+    // Synthetic delay between the {@link #didStopRefreshing()} signal and the
+    // call to stop the refresh animation.
+    private static final int STOP_REFRESH_ANIMATION_DELAY_MS = 500;
+
+    // Max allowed duration of the refresh animation after a refresh signal,
+    // guarding against cases where the page reload fails or takes too long.
+    private static final int MAX_REFRESH_ANIMATION_DURATION_MS = 7500;
+
+    // The modified AppCompat version of the refresh effect, handling all core
+    // logic, rendering and animation.
+    private final SwipeRefreshLayout mSwipeRefreshLayout;
+
+    // The ContentViewCore with which the handler is associated. The handler
+    // will set/unset itself as the default OverscrollRefreshHandler as the
+    // association changes.
+    private ContentViewCore mContentViewCore;
+
+    // Async runnable for ending the refresh animation after the page first
+    // loads a frame. This is used to provide a reasonable minimum animation time.
+    private Runnable mStopRefreshingRunnable;
+
+    // Accessibility utterance used to indicate refresh activation.
+    private String mAccessibilityRefreshString;
+
+    /**
+     * Simple constructor to use when creating an OverscrollRefresh instance from code.
+     *
+     * @param context The associated context.
+     */
+    public SwipeRefreshHandler(Context context) {
+        mSwipeRefreshLayout = new SwipeRefreshLayout(context);
+        mSwipeRefreshLayout.setLayoutParams(
+                new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+        mSwipeRefreshLayout.setColorSchemeResources(R.color.light_active_color);
+        // SwipeRefreshLayout.LARGE layouts appear broken on JellyBean.
+        mSwipeRefreshLayout.setSize(SwipeRefreshLayout.DEFAULT);
+        mSwipeRefreshLayout.setEnabled(false);
+    }
+
+    /**
+     * Pair the effect with a given ContentViewCore instance. If that instance is null,
+     * the effect will be disabled.
+     * @param contentViewCore The associated ContentViewCore instance.
+     */
+    public void setContentViewCore(final ContentViewCore contentViewCore) {
+        if (mContentViewCore == contentViewCore) return;
+
+        if (mContentViewCore != null) {
+            setEnabled(false);
+            cancelStopRefreshingRunnable();
+            mSwipeRefreshLayout.setOnRefreshListener(null);
+            mContentViewCore.setOverscrollRefreshHandler(null);
+        }
+
+        mContentViewCore = contentViewCore;
+
+        if (mContentViewCore == null) return;
+
+        setEnabled(true);
+        mSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                cancelStopRefreshingRunnable();
+                mSwipeRefreshLayout.postDelayed(
+                        getStopRefreshingRunnable(), MAX_REFRESH_ANIMATION_DURATION_MS);
+                if (mAccessibilityRefreshString == null) {
+                    int resId = R.string.accessibility_swipe_refresh;
+                    mAccessibilityRefreshString =
+                            contentViewCore.getContext().getResources().getString(resId);
+                }
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+                    mSwipeRefreshLayout.announceForAccessibility(mAccessibilityRefreshString);
+                }
+                contentViewCore.getWebContents().getNavigationController().reload(true);
+                RecordUserAction.record("MobilePullGestureReload");
+            }
+        });
+        contentViewCore.setOverscrollRefreshHandler(this);
+    }
+
+    /**
+     * Notify the SwipeRefreshLayout that a refresh action has completed.
+     * Defer the notification by a reasonable minimum to ensure sufficient
+     * visiblity of the animation.
+     */
+    public void didStopRefreshing() {
+        if (!mSwipeRefreshLayout.isRefreshing()) return;
+        cancelStopRefreshingRunnable();
+        mSwipeRefreshLayout.postDelayed(
+                getStopRefreshingRunnable(), STOP_REFRESH_ANIMATION_DELAY_MS);
+    }
+
+    @Override
+    public boolean start() {
+        attachSwipeRefreshLayoutIfNecessary();
+        return mSwipeRefreshLayout.start();
+    }
+
+    @Override
+    public void pull(float delta) {
+        TraceEvent.begin("SwipeRefreshHandler.pull");
+        mSwipeRefreshLayout.pull(delta);
+        TraceEvent.end("SwipeRefreshHandler.pull");
+    }
+
+    @Override
+    public void release(boolean allowRefresh) {
+        TraceEvent.begin("SwipeRefreshHandler.release");
+        mSwipeRefreshLayout.release(allowRefresh);
+        TraceEvent.end("SwipeRefreshHandler.release");
+    }
+
+    @Override
+    public void reset() {
+        cancelStopRefreshingRunnable();
+        mSwipeRefreshLayout.reset();
+        detachSwipeRefreshLayoutIfNecessary();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        mSwipeRefreshLayout.setEnabled(enabled);
+        if (!enabled) reset();
+    }
+
+    private void cancelStopRefreshingRunnable() {
+        if (mStopRefreshingRunnable != null) {
+            mSwipeRefreshLayout.removeCallbacks(mStopRefreshingRunnable);
+        }
+    }
+
+    private Runnable getStopRefreshingRunnable() {
+        if (mStopRefreshingRunnable == null) {
+            mStopRefreshingRunnable = new Runnable() {
+                @Override
+                public void run() {
+                    mSwipeRefreshLayout.setRefreshing(false);
+                }
+            };
+        }
+        return mStopRefreshingRunnable;
+    }
+
+    // The animation view is attached/detached on-demand to minimize overlap
+    // with composited SurfaceView content.
+    private void attachSwipeRefreshLayoutIfNecessary() {
+        if (mContentViewCore == null) return;
+        if (mSwipeRefreshLayout.getParent() == null) {
+            mContentViewCore.getContainerView().addView(mSwipeRefreshLayout);
+        }
+    }
+
+    private void detachSwipeRefreshLayoutIfNecessary() {
+        // TODO(jdduke): Also detach the effect when its animation ends.
+        if (mContentViewCore == null) return;
+        if (mSwipeRefreshLayout.getParent() != null) {
+            mContentViewCore.getContainerView().removeView(mSwipeRefreshLayout);
+        }
+    }
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -87,6 +87,8 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     private XWalkAutofillClientAndroid mXWalkAutofillClient;
     private XWalkGetBitmapCallbackInternal mXWalkGetBitmapCallbackInternal;
     private ContentBitmapCallback mGetBitmapCallback;
+    // Controls overscroll pull-to-refresh behavior.
+    private SwipeRefreshHandler mSwipeRefreshHandler;
 
     long mNativeContent;
     long mNativeWebContents;
@@ -204,6 +206,9 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         mContentViewRenderView.setCurrentContentViewCore(mContentViewCore);
         // For addJavascriptInterface
         mContentsClientBridge.installWebContentsObserver(mWebContents);
+        // For swipe-to-refresh
+        mSwipeRefreshHandler = new SwipeRefreshHandler(mViewContext);
+        mSwipeRefreshHandler.setContentViewCore(mContentViewCore);
 
         // Set the third argument isAccessFromFileURLsGrantedByDefault to false, so that
         // the members mAllowUniversalAccessFromFileURLs and mAllowFileAccessFromFileURLs
@@ -687,6 +692,27 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         }
     }
 
+    /**
+     * Reset swipe-to-refresh handler.
+     */
+    void resetSwipeRefreshHandler() {
+        // When the dialog is visible, keeping the refresh animation active
+        // in the background is distracting and unnecessary (and likely to
+        // jank when the dialog is shown).
+        if (mSwipeRefreshHandler != null) {
+            mSwipeRefreshHandler.reset();
+        }
+    }
+
+    /**
+     * Stop swipe-to-refresh animation.
+     */
+    void stopSwipeRefreshHandler() {
+        if (mSwipeRefreshHandler != null) {
+            mSwipeRefreshHandler.didStopRefreshing();
+        }
+    }
+
     public void destroy() {
         if (mNativeContent == 0) return;
 
@@ -697,6 +723,11 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         mXWalkView.removeView(mContentView);
         mXWalkView.removeView(mContentViewRenderView);
         mContentViewRenderView.setCurrentContentViewCore(null);
+
+        if (mSwipeRefreshHandler != null) {
+            mSwipeRefreshHandler.setContentViewCore(null);
+            mSwipeRefreshHandler = null;
+        }
 
         // Destroy the native resources.
         mContentViewRenderView.destroy();

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -89,6 +89,12 @@ abstract class XWalkContentsClient extends ContentViewClient {
         }
 
         @Override
+        public void didNavigateMainFrame(String url, String baseUrl,
+                boolean isNavigationToDifferentPage, boolean isFragmentNavigation, int statusCode) {
+            stopSwipeRefreshHandler();
+        }
+
+        @Override
         public void didFinishLoad(long frameId, String validatedUrl, boolean isMainFrame) {
             // Both didStopLoading and didFinishLoad will be called once a page is finished
             // to load, but didStopLoading will also be called when user clicks "X" button
@@ -260,4 +266,8 @@ abstract class XWalkContentsClient extends ContentViewClient {
     public abstract void onNewPicture(Picture picture);
 
     public abstract boolean shouldCreateWebContents(String contentUrl);
+
+    public abstract void resetSwipeRefreshHandler();
+
+    public abstract void stopSwipeRefreshHandler();
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -651,6 +651,16 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
+    public void resetSwipeRefreshHandler() {
+        mXWalkView.resetSwipeRefreshHandler();
+    }
+
+    @Override
+    public void stopSwipeRefreshHandler() {
+        mXWalkView.stopSwipeRefreshHandler();
+    }
+
+    @Override
     public ContentVideoViewClient getContentVideoViewClient() {
         return new XWalkContentVideoViewClient(this, mXWalkView.getActivity(), mXWalkView);
     }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1554,6 +1554,18 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         mExternalExtensionManager = manager;
     }
 
+    public void resetSwipeRefreshHandler() {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.resetSwipeRefreshHandler();
+    }
+
+    public void stopSwipeRefreshHandler() {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.stopSwipeRefreshHandler();
+    }
+
     /**
      * Clears the SSL preferences table stored in response to proceeding with
      * SSL certificate errors.

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegate.java
@@ -40,6 +40,9 @@ abstract class XWalkWebContentsDelegate extends WebContentsDelegateAndroid {
             int lineNumber,String sourceId);
 
     @CalledByNative
+    public abstract void showRepostFormWarningDialog();
+
+    @CalledByNative
     public abstract boolean shouldOverrideRunFileChooser(
             int processId, int renderId, int mode,
             String acceptTypes, boolean capture);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegateAdapter.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebContentsDelegateAdapter.java
@@ -91,6 +91,12 @@ class XWalkWebContentsDelegateAdapter extends XWalkWebContentsDelegate {
     }
 
     @Override
+    public void showRepostFormWarningDialog() {
+        if (mXWalkContentsClient == null) return;
+        mXWalkContentsClient.resetSwipeRefreshHandler();
+    }
+
+    @Override
     public void toggleFullscreen(boolean enterFullscreen) {
         if (!enterFullscreen) {
             ContentVideoView videoView = ContentVideoView.getContentVideoView();

--- a/runtime/android/core_internal/strings/android_xwalk_strings.grd
+++ b/runtime/android/core_internal/strings/android_xwalk_strings.grd
@@ -2,6 +2,9 @@
 <grit current_release="1" latest_public_release="0">
   <release allow_pseudo="false" seq="1">
     <messages fallback_to_english="true">
+      <message desc="Content description for the swipe refresh action." name="IDS_ACCESSIBILITY_SWIPE_REFRESH">
+         Refreshing page
+      </message>
       <message desc="Title for the Javascript Alert dialog [CHAR-LIMIT=32]" name="IDS_JS_ALERT_TITLE">
         Javascript Alert
       </message>

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -223,6 +223,15 @@ void XWalkWebContentsDelegate::HandleKeyboardEvent(
   Java_XWalkWebContentsDelegate_handleKeyboardEvent(env, obj.obj(), key_event);
 }
 
+void XWalkWebContentsDelegate::ShowRepostFormWarningDialog(
+    WebContents* source) {
+  JNIEnv* env = AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> obj = GetJavaDelegate(env);
+  if (obj.is_null())
+    return;
+  Java_XWalkWebContentsDelegate_showRepostFormWarningDialog(env, obj.obj());
+}
+
 void XWalkWebContentsDelegate::EnterFullscreenModeForTab(
     content::WebContents* web_contents,
     const GURL&) {

--- a/runtime/browser/android/xwalk_web_contents_delegate.h
+++ b/runtime/browser/android/xwalk_web_contents_delegate.h
@@ -51,6 +51,8 @@ class XWalkWebContentsDelegate
       content::WebContents* source,
       const content::NativeWebKeyboardEvent& event) override;
 
+  void ShowRepostFormWarningDialog(content::WebContents* source) override;
+
   void EnterFullscreenModeForTab(
       content::WebContents* web_contents,
       const GURL& origin) override;

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -119,6 +119,7 @@
         '../components/components.gyp:navigation_interception_java',
         '../components/components.gyp:web_contents_delegate_android_java',
         '../content/content.gyp:content_java',
+        '../third_party/android_swipe_refresh/android_swipe_refresh.gyp:android_swipe_refresh_java',
         '../ui/android/ui_android.gyp:ui_java',
         'xwalk_core_extensions_java',
         'xwalk_core_strings',


### PR DESCRIPTION
[Android] Enable pull-to-refresh
With this enabled, when user pull from the page top, page will be reloaded.
This can be disabled by flag --disable-pull-to-refresh-effect.
Pull-to-refresh differs from edge effect. For the edge effect, it is from
android and it "performs the graphical effect used at the edges of scrollable
widgets when the user scrolls beyond the content bounds in 2D space.".
Detailed documents is here:
http://developer.android.com/reference/android/widget/EdgeEffect.html.
As to the pull-to-refresh, it is from google chrome. It means reload the page
when user vertically overscrolling content at page top.

BUG=XWALK-6277