### PR TITLE
[Android] Implement onOverScrolled API: Enable onOverScrolled API in XWalkView.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '9a9d4c10d0fe28a802a9f00a5b5645b5288264d0'
+chromium_crosswalk_rev = '3462d5c019bb830b6e4eb3956b59dc9415deff62'
 v8_crosswalk_rev = '5a3badc0c974e73b085539dfb4c69a84a8b9fdb7'
 
 crosswalk_git = 'https://github.com/crosswalk-project'

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
@@ -65,6 +65,10 @@ public class XWalkContentView extends ContentView {
     @Override
     public void onScrollChanged(int l, int t, int oldl, int oldt) {
         mXWalkView.onScrollChangedDelegate(l, t, oldl, oldt);
+
+        // To keep the same behaviour with WebView onOverScrolled API,
+        // call onOverScrolledDelegate here.
+        mXWalkView.onOverScrolledDelegate(l, t, false, false);
     }
 
     /**

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -247,6 +247,11 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
+    public void onOverScrolled(int scrollX, int scrollY, boolean clampedX, boolean clampedY) {
+        mXWalkView.onOverScrolledDelegate(scrollX, scrollY, clampedX, clampedY);
+    }
+
+    @Override
     public XWalkWebResourceResponseInternal shouldInterceptRequest(
             WebResourceRequestInner request) {
         if (isOwnerActivityRunning()) {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1426,6 +1426,11 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     public void onFocusChangedDelegate(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
     }
 
+    @XWalkAPI(delegate = true,
+              preWrapperLines = {"onOverScrolled(scrollX, scrollY, clampedX, clampedY);"})
+    public void onOverScrolledDelegate(int scrollX, int scrollY, boolean clampedX, boolean clampedY) {
+    }
+
     // Override XWalkView.setOnTouchListener to install the listener to ContentView
     // therefore touch event intercept through onTouchListener is available on XWalkView.
     @Override


### PR DESCRIPTION
Enable onOverScrolled API on crosswalk side. this PR is companied by [PR330#](https://github.com/crosswalk-project/chromium-crosswalk/pull/330) in chromium-crosswalk side.

BUG=XWALK-4871
BUG=XWALK-4894