### PR TITLE
Disable viewport on desktop platforms

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts.cc
+++ b/runtime/browser/xwalk_browser_main_parts.cc
@@ -117,7 +117,6 @@ XWalkBrowserMainParts::~XWalkBrowserMainParts() {
 
 void XWalkBrowserMainParts::PreMainMessageLoopStart() {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  command_line->AppendSwitch(switches::kEnableViewport);
 
   command_line->AppendSwitch(xswitches::kEnableOverlayScrollbars);
 

--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -144,6 +144,8 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   // Disable ExtensionProcess for Android.
   // External extensions will run in the BrowserProcess (in process mode).
   command_line->AppendSwitch(switches::kXWalkDisableExtensionProcess);
+  // Enable viewport.
+  command_line->AppendSwitch(switches::kEnableViewport);
 
   // Only force to enable WebGL for Android for IA platforms because
   // we've tested the WebGL conformance test. For other platforms, just

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -39,7 +39,6 @@
 #include "xwalk/runtime/renderer/android/xwalk_render_view_ext.h"
 #else
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
-#include "third_party/WebKit/public/web/WebView.h"
 #endif
 
 #if !defined(DISABLE_NACL)
@@ -169,14 +168,6 @@ void XWalkContentRendererClient::RenderViewCreated(
     content::RenderView* render_view) {
 #if defined(OS_ANDROID)
   XWalkRenderViewExt::RenderViewCreated(render_view);
-#else
-  if (blink::WebView* webview = render_view->GetWebView()) {
-    // This sets 'user agent' values which override page min and max
-    // zoom from meta viewport tag. Thus we avoid scaling out the page
-    // layout. See XWALK-6269.
-    // NOTE: This must be re-considered after crbug.com/591326 is solved.
-    webview->setIgnoreViewportTagScaleLimits(true);
-  }
 #endif
 }
 


### PR DESCRIPTION
Viewport is not supported on desktop platforms in Chromium, there
are multiple issues with it which won't be solved (see crbug.com/591326)

BUG=XWALK-6514