### PR TITLE
Use std::move instead of scoped_ptr::Pass().

### DIFF
--- a/runtime/browser/ui/desktop/exclusive_access_bubble_views.cc
+++ b/runtime/browser/ui/desktop/exclusive_access_bubble_views.cc
@@ -101,7 +101,7 @@ ExclusiveAccessBubbleViews::ExclusiveAccessView::ExclusiveAccessView(
   scoped_ptr<views::BubbleBorder> bubble_border(new views::BubbleBorder(
       views::BubbleBorder::NONE, shadow_type, background_color));
   set_background(new views::BubbleBackground(bubble_border.get()));
-  SetBorder(bubble_border.Pass());
+  SetBorder(std::move(bubble_border));
   SetFocusable(false);
 
   ui::ResourceBundle& rb = ui::ResourceBundle::GetSharedInstance();


### PR DESCRIPTION
Follow-up to 44b2e8a ("Add a popup window to exit full screen mode"). In
the upcoming Chromium M49 it is not possible to use
`scoped_ptr::Pass()`. Prepare beforehand by using `std::move()` instead.