### PR TITLE
build: Explicitly pass -Wno-reserved-user-defined-literal.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -154,4 +154,17 @@
     'xwalk_core_library_artifact_id%': 'xwalk_core_library_canary',
     'xwalk_shared_library_artifact_id%': 'xwalk_shared_library_canary',
   },
+  'target_defaults': {
+    'conditions': [
+      # TODO(rakuco): Remove this once we stop supporting Ubuntu Precise or
+      # default to use_sysroot==1. This is only required because Precise's dbus
+      # 1.4.18 causes
+      # <https://bugs.chromium.org/p/chromium/issues/detail?id=263960#c6>.
+      ['clang==1 and use_sysroot==0', {
+        'cflags': [
+          '-Wno-reserved-user-defined-literal',
+        ],
+      }],
+    ],
+  },
 }


### PR DESCRIPTION
This is in preparation for M49 and http://crrev.com/1570193002, which
stopped passing -Wno-reserved-user-defined-literal except for ChromeOS
builds.

We need that at the moment for Linux builds that do not use
`use_sysroot==1` because at least our bots are using Ubuntu Precise,
whose dbus 1.14.18 breaks the build like this:

```
/usr/include/dbus-1.0/dbus/dbus-protocol.h:459:77: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
#define DBUS_INTROSPECT_1_0_XML_DOCTYPE_DECL_NODE "<!DOCTYPE node PUBLIC \""DBUS_INTROSPECT_1_0_XML_PUBLIC_IDENTIFIER"\"\n\""DBUS_INTROSPECT_1_0_XML_SYSTEM_IDENTIFIER"\">\n"
                                                                            ^
                                                                             
/usr/include/dbus-1.0/dbus/dbus-protocol.h:459:126: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
#define DBUS_INTROSPECT_1_0_XML_DOCTYPE_DECL_NODE "<!DOCTYPE node PUBLIC \""DBUS_INTROSPECT_1_0_XML_PUBLIC_IDENTIFIER"\"\n\""DBUS_INTROSPECT_1_0_XML_SYSTEM_IDENTIFIER"\">\n"
                                                                                                                             ^
```