### PR TITLE
[Android] Fixed wrong message when run x86 apps on ARM devices

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
@@ -444,12 +444,8 @@ class XWalkCoreWrapper {
         } catch (RuntimeException e) {
             Log.d(TAG, e.getLocalizedMessage());
             if (e.getCause() instanceof UnsatisfiedLinkError) {
-                Pattern pattern = Pattern.compile(PATTERN_BIT_MISMATCH);
-                Matcher matcher = pattern.matcher(e.getLocalizedMessage());
-                if (matcher.find()) {
-                    mCoreStatus = XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH;
-                    return false;
-                }
+                mCoreStatus = XWalkLibraryInterface.STATUS_ARCHITECTURE_MISMATCH;
+                return false;
             }
             mCoreStatus = XWalkLibraryInterface.STATUS_INCOMPLETE_LIBRARY;
             return false;


### PR DESCRIPTION
The app shows the message of "mismatch of CPU architecture" once
UnsatisfiedLinkError is encountered when loading native library.
Donot distinguish the error message anymore. The message of "incomplete
library" is not used temporarily.

BUG=XWALK-6622, XWALK-6619