### PR TITLE
Add a NOLINT to avoid a build/header_guard cpplint warning.

### DIFF
--- a/runtime/common/xwalk_common_message_generator.h
+++ b/runtime/common/xwalk_common_message_generator.h
@@ -3,5 +3,6 @@
 // found in the LICENSE file.
 
 // Multiply-included file, hence no include guard.
+// NOLINT(build/header_guard)
 
 #include "xwalk/runtime/common/xwalk_common_messages.h"


### PR DESCRIPTION
`xwalk_common_message_generator.h` does not have include guards, and
according to a comment there this seems to be on purpose.

Add a `NOLINT` entry to it to avoid cpplint a build/header_guard error.

RELATED BUG=XWALK-1853