### PR TITLE
DEPS.xwalk: Roll chromium-crosswalk (b15365d -> c9cd89c).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'b15365d1d214d75f0ad43371531a24893966dcb1'
+chromium_crosswalk_rev = 'c9cd89ce3f52946577be3733b460b10c592579cd'
 v8_crosswalk_rev = 'c3984c3872af2a3632f9c3c74beeb1f0d1cf3680'
 
 crosswalk_git = 'https://github.com/crosswalk-project'
@@ -36,10 +36,6 @@ solutions = [
         crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
       'src/v8':
         crosswalk_git + '/v8-crosswalk.git@' + v8_crosswalk_rev,
-
-      # Include OpenCL header files for WebCL support, target version 1.2.
-      'src/third_party/khronos/CL':
-        crosswalk_git + '/khronos-cl-api-1.2.git@6f4be98d10f03ce2b12c769cd9835c73a441c00f',
 
       # Include Intel RSSDK headers and library loader for RealSense camera
       # support.


### PR DESCRIPTION
* c9cd89c Merge pull request #337 from rakuco/backport-checkperms-fix
* 123d118 [Backport] PRESUBMIT: Determine checkperms.py's path using input_api.
* 8222364 Merge pull request #335 from darktears/build-fix
* 58751e9 [Windows] Fix build.
* 96132b6 Merge pull request #332 from pozdnyakov/web_audio
* 4a0b6c0 [Windows] Implementation of 'AudioDestinationNode.devicePosition' attribute
* 4ff4032 Merge pull request #334 from rakuco/import-opencl-headers
* 8cb422b Import Khronos' OpenCL headers into chromium-crosswalk.
* 1db0eb3 .gitignore: Stop ignoring third_party/khronos/CL.

This also includes the removal of the OpenCL headers entry in
`DEPS.xwalk`, as it is now part of chromium-crosswalk itself (see
crosswalk-project/chromium-crosswalk#334 for details).