### PR TITLE
PRESUBMIT: Enable check for tabs in .grd files.

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -76,11 +76,11 @@ def CheckChangeOnUpload(input_api, output_api):
   #   cr._CheckNoProductionCodeUsingTestOnlyFunctions(input_api, output_api))
   # results.extend(cr._CheckNoBannedFunctions(input_api, output_api))
   # results.extend(cr._CheckIncludeOrder(input_api, output_api))
-  # results.extend(
-  #   input_api.canned_checks.CheckChangeHasNoTabs(
-  #     input_api,
-  #     output_api,
-  #     source_file_filter=lambda x: x.LocalPath().endswith('.grd')))
+  results.extend(
+    input_api.canned_checks.CheckChangeHasNoTabs(
+      input_api,
+      output_api,
+      source_file_filter=lambda x: x.LocalPath().endswith('.grd')))
   # results.extend(cr._CheckSpamLogging(input_api, output_api))
   # results.extend(cr._CheckNoDeprecatedJS(input_api, output_api))
   # results.extend(cr._CheckForIPCRules(input_api, output_api))

--- a/runtime/resources/xwalk_resources.grd
+++ b/runtime/resources/xwalk_resources.grd
@@ -94,8 +94,8 @@
         Block
       </message>
       <message name="IDS_FULLSCREEN_USER_ENTERED_FULLSCREEN" desc="The message in exclusive access bubble.">
-	    You have gone full screen.
-	  </message>
+        You have gone full screen.
+      </message>
       <message name="IDS_FULLSCREEN_EXIT_MODE" desc="The link text in exclusive access bubble">
         Exit full screen
       </message>


### PR DESCRIPTION
Enable the check after fixing the existing violations:

    ** Presubmit Warnings **
    Found a tab character in:
    ***************
    runtime/resources/xwalk_resources.grd:97
    runtime/resources/xwalk_resources.grd:98
    ***************