### PR TITLE
application: Remove unused JavaScript file.

### DIFF
--- a/application/test/data/api/main.js
+++ b/application/test/data/api/main.js
@@ -1,2 +1,0 @@
-window.open("test.html");
-window.initialized = true;


### PR DESCRIPTION
`main.js` stopped being used with commit 7514f134 ('Drop "Main document"
support'), so we can remove it and get rid of an unlicensed file.