### PR TITLE
[Android] Refine the implementation of shouldOverrideUrlLoading

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -92,9 +92,8 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
         public boolean shouldIgnoreNavigation(NavigationParams navigationParams) {
             final String url = navigationParams.url;
-            boolean ignoreNavigation = shouldOverrideUrlLoading(url) ||
-                     (mNavigationHandler != null &&
-                      mNavigationHandler.handleNavigation(navigationParams));
+            boolean ignoreNavigation = mNavigationHandler != null &&
+                     mNavigationHandler.handleNavigation(navigationParams);
 
             if (!ignoreNavigation) {
                 // Post a message to UI thread to notify the page is starting to load.
@@ -814,6 +813,12 @@ class XWalkContentsClientBridge extends XWalkContentsClient
                     XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_BEFOREUNLOAD,
                     url, message, "", result);
         }
+    }
+
+    @CalledByNative
+    private boolean shouldOverrideUrlLoading(
+            String url, boolean hasUserGesture, boolean isRedirect, boolean isMainFrame) {
+         return shouldOverrideUrlLoading(url);
     }
 
     @CalledByNative

--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -285,6 +285,20 @@ void XWalkContentsClientBridge::OnWebLayoutPageScaleFactorChanged(
       env, obj.obj(), page_scale_factor);
 }
 
+bool XWalkContentsClientBridge::ShouldOverrideUrlLoading(
+    const base::string16& url,
+    bool has_user_gesture,
+    bool is_redirect,
+    bool is_main_frame) {
+  JNIEnv* env = AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> obj = java_ref_.get(env);
+  if (obj.is_null())
+    return false;
+  ScopedJavaLocalRef<jstring> jurl = ConvertUTF16ToJavaString(env, url);
+  return Java_XWalkContentsClientBridge_shouldOverrideUrlLoading(
+      env, obj.obj(), jurl.obj(), has_user_gesture, is_redirect, is_main_frame);
+}
+
 void XWalkContentsClientBridge::ConfirmJsResult(JNIEnv* env,
                                                 jobject,
                                                 int id,

--- a/runtime/browser/android/xwalk_contents_client_bridge.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge.h
@@ -81,6 +81,10 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase ,
   bool OnReceivedHttpAuthRequest(const base::android::JavaRef<jobject>& handler,
                                  const std::string& host,
                                  const std::string& realm);
+  bool ShouldOverrideUrlLoading(const base::string16& url,
+                                bool has_user_gesture,
+                                bool is_redirect,
+                                bool is_main_frame) override;
 
   // Methods called from Java.
   void ProceedSslError(JNIEnv* env, jobject obj, jboolean proceed, jint id);

--- a/runtime/browser/android/xwalk_contents_client_bridge_base.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge_base.h
@@ -78,6 +78,10 @@ class XWalkContentsClientBridgeBase {
       base::Closure* cancel_callback)
       = 0;
   virtual void OnWebLayoutPageScaleFactorChanged(float page_scale_factor) = 0;
+  virtual bool ShouldOverrideUrlLoading(const base::string16& url,
+                                        bool has_user_gesture,
+                                        bool is_redirect,
+                                        bool is_main_frame) = 0;
 };
 
 }  // namespace xwalk

--- a/runtime/browser/xwalk_render_message_filter.cc
+++ b/runtime/browser/xwalk_render_message_filter.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Copyright (c) 2014 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -5,12 +6,15 @@
 #include "xwalk/runtime/browser/xwalk_render_message_filter.h"
 
 #if defined(OS_ANDROID)
+#include "xwalk/runtime/browser/android/xwalk_contents_client_bridge_base.h"
 #include "xwalk/runtime/browser/android/xwalk_contents_io_thread_client.h"
 #include "xwalk/runtime/common/android/xwalk_render_view_messages.h"
 #endif
 
 #include "xwalk/runtime/common/xwalk_common_messages.h"
 #include "xwalk/runtime/browser/runtime_platform_util.h"
+
+using content::BrowserThread;
 
 namespace xwalk {
 
@@ -32,6 +36,8 @@ bool XWalkRenderMessageFilter::OnMessageReceived(
     IPC_MESSAGE_HANDLER(ViewMsg_OpenLinkExternal, OnOpenLinkExternal)
 #if defined(OS_ANDROID)
     IPC_MESSAGE_HANDLER(XWalkViewHostMsg_SubFrameCreated, OnSubFrameCreated)
+    IPC_MESSAGE_HANDLER(XWalkViewHostMsg_ShouldOverrideUrlLoading,
+                        OnShouldOverrideUrlLoading)
 #endif
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
@@ -49,6 +55,26 @@ void XWalkRenderMessageFilter::OnSubFrameCreated(
     int parent_render_frame_id, int child_render_frame_id) {
   XWalkContentsIoThreadClient::SubFrameCreated(
       process_id_, parent_render_frame_id, child_render_frame_id);
+}
+
+void XWalkRenderMessageFilter::OnShouldOverrideUrlLoading(
+    int render_frame_id,
+    const base::string16& url,
+    bool has_user_gesture,
+    bool is_redirect,
+    bool is_main_frame,
+    bool* ignore_navigation) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  *ignore_navigation = false;
+  XWalkContentsClientBridgeBase* client =
+      XWalkContentsClientBridgeBase::FromRenderFrameID(process_id_, render_frame_id);
+  if (client) {
+    *ignore_navigation = client->ShouldOverrideUrlLoading(
+        url, has_user_gesture, is_redirect, is_main_frame);
+  } else {
+    LOG(WARNING) << "Failed to find the associated render view host for url: "
+                 << url;
+  }
 }
 #endif
 

--- a/runtime/browser/xwalk_render_message_filter.h
+++ b/runtime/browser/xwalk_render_message_filter.h
@@ -22,6 +22,12 @@ class XWalkRenderMessageFilter : public content::BrowserMessageFilter {
   void OnOpenLinkExternal(const GURL& url);
 #if defined(OS_ANDROID)
   void OnSubFrameCreated(int parent_render_frame_id, int child_render_frame_id);
+  void OnShouldOverrideUrlLoading(int routing_id,
+                                  const base::string16& url,
+                                  bool has_user_gesture,
+                                  bool is_redirect,
+                                  bool is_main_frame,
+                                  bool* ignore_navigation);
 #endif
   ~XWalkRenderMessageFilter() override {}
 

--- a/runtime/common/android/xwalk_render_view_messages.h
+++ b/runtime/common/android/xwalk_render_view_messages.h
@@ -115,6 +115,20 @@ IPC_MESSAGE_ROUTED0(XWalkViewHostMsg_PictureUpdated) // NOLINT(*)
 IPC_MESSAGE_ROUTED1(XWalkViewHostMsg_DidActivateAcceleratedCompositing, // NOLINT(*)
                     int /* input_handler_id */)
 
+// Sent immediately before a top level navigation is initiated within Blink.
+// There are some exclusions, the most important ones are it is not sent
+// when creating a popup window, and not sent for application initiated
+// navigations. See XWalkContentRendererClient::HandleNavigation for all
+// cornercases. This is sent before updating the NavigationController state
+// or creating a URLRequest for the main frame resource.
+IPC_SYNC_MESSAGE_CONTROL5_1(XWalkViewHostMsg_ShouldOverrideUrlLoading, // NOLINT(*)
+                            int /* render_frame_id id */,
+                            base::string16 /* in - url */,
+                            bool /* in - has_user_gesture */,
+                            bool /* in - is_redirect */,
+                            bool /* in - is_main_frame */,
+                            bool /* out - result */)
+
 // Sent when a subframe is created.
 IPC_MESSAGE_CONTROL2(XWalkViewHostMsg_SubFrameCreated, // NOLINT(*)
                      int, /* parent_render_frame_id */

--- a/runtime/renderer/xwalk_content_renderer_client.cc
+++ b/runtime/renderer/xwalk_content_renderer_client.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Copyright (c) 2013 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -129,6 +130,62 @@ void XWalkContentRendererClient::RenderThreadStarted() {
   blink::WebSecurityPolicy::registerURLSchemeAsLocal(content_scheme);
 #endif
 }
+
+#if defined(OS_ANDROID)
+bool XWalkContentRendererClient::HandleNavigation(
+    content::RenderFrame* render_frame,
+    bool is_content_initiated,
+    int opener_id,
+    blink::WebFrame* frame,
+    const blink::WebURLRequest& request,
+    blink::WebNavigationType type,
+    blink::WebNavigationPolicy default_policy,
+    bool is_redirect) {
+  // Only GETs can be overridden.
+  if (!request.httpMethod().equals("GET"))
+    return false;
+
+  // Any navigation from loadUrl, and goBack/Forward are considered application-
+  // initiated and hence will not yield a shouldOverrideUrlLoading() callback.
+  // Webview classic does not consider reload application-initiated so we
+  // continue the same behavior.
+  // TODO(sgurun) is_content_initiated is normally false for cross-origin
+  // navigations but since android_webview does not swap out renderers, this
+  // works fine. This will stop working if android_webview starts swapping out
+  // renderers on navigation.
+  bool application_initiated =
+      !is_content_initiated || type == blink::WebNavigationTypeBackForward;
+
+  // Don't offer application-initiated navigations unless it's a redirect.
+  if (application_initiated && !is_redirect)
+    return false;
+
+  bool is_main_frame = !frame->parent();
+  const GURL& gurl = request.url();
+  // For HTTP schemes, only top-level navigations can be overridden. Similarly,
+  // WebView Classic lets app override only top level about:blank navigations.
+  // So we filter out non-top about:blank navigations here.
+  if (!is_main_frame &&
+      (gurl.SchemeIs(url::kHttpScheme) || gurl.SchemeIs(url::kHttpsScheme) ||
+       gurl.SchemeIs(url::kAboutScheme)))
+    return false;
+
+  // use NavigationInterception throttle to handle the call as that can
+  // be deferred until after the java side has been constructed.
+  if (opener_id != MSG_ROUTING_NONE)
+    return false;
+
+  bool ignore_navigation = false;
+  base::string16 url = request.url().string();
+  bool has_user_gesture = request.hasUserGesture();
+
+  int render_frame_id = render_frame->GetRoutingID();
+  RenderThread::Get()->Send(new XWalkViewHostMsg_ShouldOverrideUrlLoading(
+      render_frame_id, url, has_user_gesture, is_redirect, is_main_frame,
+      &ignore_navigation));
+  return ignore_navigation;
+}
+#endif
 
 void XWalkContentRendererClient::RenderFrameCreated(
     content::RenderFrame* render_frame) {

--- a/runtime/renderer/xwalk_content_renderer_client.h
+++ b/runtime/renderer/xwalk_content_renderer_client.h
@@ -62,6 +62,16 @@ class XWalkContentRendererClient
                        GURL* new_url) override;
 
   void AddKeySystems(std::vector<media::KeySystemInfo>* key_systems) override;
+#if defined(OS_ANDROID)
+  bool HandleNavigation(content::RenderFrame* render_frame,
+                        bool is_content_initiated,
+                        int opener_id,
+                        blink::WebFrame* frame,
+                        const blink::WebURLRequest& request,
+                        blink::WebNavigationType type,
+                        blink::WebNavigationPolicy default_policy,
+                        bool is_redirect) override;
+#endif
 
  protected:
   scoped_ptr<XWalkRenderProcessObserver> xwalk_render_process_observer_;

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldOverrideUrlLoadingTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldOverrideUrlLoadingTest.java
@@ -140,16 +140,16 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
 
         loadUrlSync(httpPathOnServer);
         loadUrlSync(url);
-        assertEquals(2, mShouldOverrideUrlLoadingHelper.getCallCount());
+        assertEquals(0, mShouldOverrideUrlLoadingHelper.getCallCount());
         String oldTitle = getTitleOnUiThread();
         goBackSync();
         assertFalse(oldTitle.equals(getTitleOnUiThread()));
-        assertEquals(3, mShouldOverrideUrlLoadingHelper.getCallCount());
+        assertEquals(0, mShouldOverrideUrlLoadingHelper.getCallCount());
 
         oldTitle = getTitleOnUiThread();
         goForwardSync();
         assertFalse(oldTitle.equals(getTitleOnUiThread()));
-        assertEquals(4, mShouldOverrideUrlLoadingHelper.getCallCount());
+        assertEquals(0, mShouldOverrideUrlLoadingHelper.getCallCount());
     }
 
     @SmallTest
@@ -417,7 +417,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
         // Since the targetURL was loaded from the test server it means all processing related
         // to dispatching a shouldOverrideUrlLoading callback had finished and checking the call
         // is stable.
-        assertEquals(shouldOverrideUrlLoadingCallCount + 1,
+        assertEquals(shouldOverrideUrlLoadingCallCount,
                 mShouldOverrideUrlLoadingHelper.getCallCount());
     }
 
@@ -458,6 +458,8 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
         final String pageWithIframeUrl = addPageToTestServer(mWebServer, "/iframe_intercept.html",
                 makeHtmlPageFrom("", "<iframe src=\"" + iframeRedirectUrl + "\" />"));
 
+        final int shouldOverrideUrlLoadingCallCount =
+                mShouldOverrideUrlLoadingHelper.getCallCount();
         assertEquals(0, mWebServer.getRequestCount(REDIRECT_TARGET_PATH));
         loadUrlSync(pageWithIframeUrl);
 
@@ -469,7 +471,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
             }
         });
 
-        assertEquals(1, mShouldOverrideUrlLoadingHelper.getCallCount());
+        assertEquals(shouldOverrideUrlLoadingCallCount, mShouldOverrideUrlLoadingHelper.getCallCount());
     }
 
     /**
@@ -488,20 +490,22 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
         int directLoadCallCount = mShouldOverrideUrlLoadingHelper.getCallCount();
         loadUrlSync(redirectUrl);
 
-        mShouldOverrideUrlLoadingHelper.waitForCallback(directLoadCallCount, 2);
+        mShouldOverrideUrlLoadingHelper.waitForCallback(directLoadCallCount, 1);
         assertEquals(redirectTarget,
                 mShouldOverrideUrlLoadingHelper.getShouldOverrideUrlLoadingUrl());
 
         int indirectLoadCallCount = mShouldOverrideUrlLoadingHelper.getCallCount();
         loadUrlSync(pageWithLinkToRedirectUrl);
+        assertEquals(indirectLoadCallCount, mShouldOverrideUrlLoadingHelper.getCallCount());
 
         clickOnElementId("link", null);
 
-        mShouldOverrideUrlLoadingHelper.waitForCallback(indirectLoadCallCount, 3);
+        mShouldOverrideUrlLoadingHelper.waitForCallback(indirectLoadCallCount, 1);
+        assertEquals(redirectUrl,
+                mShouldOverrideUrlLoadingHelper.getShouldOverrideUrlLoadingUrl());
+        mShouldOverrideUrlLoadingHelper.waitForCallback(indirectLoadCallCount + 1, 1);
         assertEquals(redirectTarget,
                 mShouldOverrideUrlLoadingHelper.getShouldOverrideUrlLoadingUrl());
-        assertEquals(redirectUrl,
-                mShouldOverrideUrlLoadingHelper.getPreviousShouldOverrideUrlLoadingUrl());
     }
 
     @SmallTest


### PR DESCRIPTION
Current implementation of shouldOverrideUrlLoading has confliction
with the original design intent. In native side, handle
shouldOverrideUrlLoading should via a sync IPC instead of current
scheme, which is only used to post onPageStarted in Android WebView.

And then, the test case also need to make corresponding changes,
for example, loading "file:///android_asset" and iframe will not
trigger shouldOverrideUrlLoading.

See CreateThrottlesForNavigation in xwalk_content_browser_client.cc
and HandleNavigation in xwalk_content_renderer_client.cc for more
details.

BUG=XWALK-6630