### PR TITLE
native filesystem extension: Clean up the code.

### DIFF
--- a/experimental/native_file_system/native_file_system.idl
+++ b/experimental/native_file_system/native_file_system.idl
@@ -1,0 +1,15 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Native FileSystem API.
+// This does not correspond to any spec (or even the JS API we export in
+// native_file_system_api.js). This IDL is used to make it easier to parse
+// messages sent to the extension and prepare responses to the JavaScript side.
+namespace native_file_system {
+    callback RequestCallback = void (DOMString filesystem_id, DOMString error);
+
+    interface Functions {
+        static void requestNativeFileSystem(DOMString path, RequestCallback callback);
+    };
+};

--- a/experimental/native_file_system/native_file_system_api.js
+++ b/experimental/native_file_system/native_file_system_api.js
@@ -40,10 +40,6 @@ var requestNativeFileSystem = function(path, success, error) {
   postMessage(msg, get_file_system_id_success, error);
 }
 
-var getDirectoryList = function() {
-  extension.internal.sendSyncMessage("get");
-}
-
 var getRealPath = function(virtual_root) {
   var _msg = {
     cmd : "getRealPath",
@@ -55,7 +51,6 @@ var getRealPath = function(virtual_root) {
 NativeFileSystem.prototype = new Object();
 NativeFileSystem.prototype.constructor = NativeFileSystem;
 NativeFileSystem.prototype.requestNativeFileSystem = requestNativeFileSystem;
-NativeFileSystem.prototype.getDirectoryList = getDirectoryList;
 NativeFileSystem.prototype.getRealPath = getRealPath;
 
 exports = new NativeFileSystem();

--- a/experimental/native_file_system/native_file_system_api.js
+++ b/experimental/native_file_system/native_file_system_api.js
@@ -2,80 +2,38 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-var _promises = {};
-var _next_promise_id = 0;
+let isolated_fs = requireNative("isolated_file_system");
+let internal = requireNative("internal");
+internal.setupInternalExtension(extension);
 
-var Promise = requireNative('sysapps_promise').Promise;
-var IsolatedFileSystem = requireNative('isolated_file_system');
-
-var postMessage = function(msg, success, error) {
-  var p = new Promise();
-  p.then(success, error);
-
-  _promises[_next_promise_id] = p;
-  msg._promise_id = _next_promise_id.toString();
-  _next_promise_id += 1;
-
-  extension.postMessage(msg);
-};
-
-function _isFunction(fn) {
-  return !!fn && !fn.nodeName &&
-      fn.constructor != String && fn.constructor != RegExp &&
-      fn.constructor != Array && /function/i.test(fn + "");
-}
-
-var NativeFileSystem = function() {
-};
-
-var requestNativeFileSystem = function(path, success, error) {
-  var msg = new Object();
-  msg.data = new Object();
-  msg.data.virtual_root = path;
-  msg.cmd = "requestNativeFileSystem";
-  function get_file_system_id_success(data) {
-    var fs = IsolatedFileSystem.getIsolatedFileSystem(data.file_system_id);
-    success(fs);
+class NativeFileSystem {
+  // The extension side of the implementation is ugly, this function is not
+  // well-thought and the whole thing is needlessly hard to test. At the very
+  // least it should be made asynchronous, at best it should be removed
+  // altogether.
+  // It is being kept for the time being for backwards compatibility.
+  getRealPath(virtual_root) {
+    return extension.internal.sendSyncMessage({
+      'command': 'getRealPath',
+      'path': virtual_root
+    });
   }
-  postMessage(msg, get_file_system_id_success, error);
-}
 
-var getRealPath = function(virtual_root) {
-  var _msg = {
-    cmd : "getRealPath",
-    path : virtual_root
+  requestNativeFileSystem(path, success, error) {
+    if (typeof path !== "string" || !(success instanceof Function)) {
+      throw new TypeError("Wrong parameters passed to requestNativeFileSystem.");
+    }
+    error = error || (_ => {});
+
+    internal.postMessage(
+      "requestNativeFileSystem", [path],
+      (filesystem_id, error_message) => {
+        if (error_message)
+          error(new Error(error_message));
+        else
+          success(isolated_fs.getIsolatedFileSystem(filesystem_id));
+      });
   }
-  return extension.internal.sendSyncMessage(_msg);
 }
-
-NativeFileSystem.prototype = new Object();
-NativeFileSystem.prototype.constructor = NativeFileSystem;
-NativeFileSystem.prototype.requestNativeFileSystem = requestNativeFileSystem;
-NativeFileSystem.prototype.getRealPath = getRealPath;
 
 exports = new NativeFileSystem();
-
-function handlePromise(msgObj) {
-  if (msgObj.data.error) {
-    if (_isFunction(_promises[msgObj._promise_id].reject)) {
-      _promises[msgObj._promise_id].reject(msgObj.data);
-    }
-  } else {
-    if (_isFunction(_promises[msgObj._promise_id].fulfill)) {
-      _promises[msgObj._promise_id].fulfill(msgObj.data);
-    }
-  }
-  delete _promises[msgObj._promise_id];
-}
-
-extension.setMessageListener(function(msgStr) {
-  // TODO(shawngao5): This part of code should be refactored.
-  // Follow DeviceCapability extension way to implement.
-  var msgObj = JSON.parse(msgStr);
-  switch (msgObj.cmd) {
-    case "requestNativeFileSystem_ret":
-      handlePromise(msgObj);
-    default:
-      break;
-  }
-});

--- a/experimental/native_file_system/native_file_system_api_browsertest.html
+++ b/experimental/native_file_system/native_file_system_api_browsertest.html
@@ -22,8 +22,8 @@
         }
       };
 
-      function reportFail(message) {
-        console.log(message);
+      function reportFail(error) {
+        console.log(error);
         document.title = "Fail";
         document.body.innerText = "Fail";
       };
@@ -54,9 +54,9 @@
                 writer.write(blob);
                 runNextTest();
               },
-              function(e) {reportFail(JSON.stringify(e))});
+              function(e) {reportFail(e)});
             },
-          function(e) {reportFail(JSON.stringify(e))});
+          function(e) {reportFail(e)});
         });
       }
 
@@ -75,11 +75,11 @@
                   };
                   reader.readAsText(file);
                 },
-                function(e) {reportFail(JSON.stringify(e))});
+                function(e) {reportFail(e)});
             },
-            function(e) {reportFail(JSON.stringify(e))});
+            function(e) {reportFail(e)});
         },
-        function(e) {reportFail(JSON.stringify(e))});
+        function(e) {reportFail(e)});
       };
 
 
@@ -90,9 +90,9 @@
                 entry.remove(function () {
                       runNextTest();
                     },
-                    function(e) {reportFail(JSON.stringify(e))});
+                    function(e) {reportFail(e)});
               },
-              function(e) {reportFail(JSON.stringify(e))});
+              function(e) {reportFail(e)});
             }
         );
       }
@@ -103,7 +103,7 @@
               fs.root.getDirectory("/documents/justfortest", {create: true}, function (entry) {
                 runNextTest();
               },
-              function(e) {reportFail(JSON.stringify(e))});
+              function(e) {reportFail(e)});
             }
         );
       }
@@ -121,11 +121,11 @@
                       reportFail("You app home directory is empty!");
                     }
                   },
-                  function(e) {reportFail(JSON.stringify(e))}
+                  function(e) {reportFail(e)}
                 );
                 runNextTest();
               },
-              function(e) {reportFail(JSON.stringify(e))});
+              function(e) {reportFail(e)});
             }
         );
       }
@@ -135,9 +135,9 @@
             function(fs) {
               fs.root.getDirectory("/documents/justfortest", {create: false}, function (entry) {
                 entry.remove(function () {runNextTest();},
-                    function(e) {reportFail(JSON.stringify(e))});
+                    function(e) {reportFail(e)});
               },
-              function(e) {reportFail(JSON.stringify(e))});
+              function(e) {reportFail(e)});
             }
         );
       }

--- a/experimental/native_file_system/native_file_system_api_browsertest.html
+++ b/experimental/native_file_system/native_file_system_api_browsertest.html
@@ -6,6 +6,7 @@
     <script>
       var current_test = 0;
       var test_list = [
+        getRealPath,
         writeFile,
         readFile,
         removeFile,
@@ -31,7 +32,19 @@
         document.title = "Pass";
         document.body.innerText = "Pass";
       };
-      
+
+      function getRealPath() {
+        var doesNotExist =
+            xwalk.experimental.native_file_system.getRealPath("invalid!");
+        if (doesNotExist !== "")
+          reportFail("getRealPath should have failed.");
+        else
+          runNextTest();
+
+        // Implementing a check for a valid path, which depends on the OS and
+        // user locale, is left as an exercise to the reader.
+      }
+
       function writeFile() {
         xwalk.experimental.native_file_system.requestNativeFileSystem("documents",
           function(fs) {

--- a/experimental/native_file_system/native_file_system_extension.cc
+++ b/experimental/native_file_system/native_file_system_extension.cc
@@ -4,9 +4,6 @@
 
 #include "xwalk/experimental/native_file_system/native_file_system_extension.h"
 
-#include <algorithm>
-#include <map>
-
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "content/public/browser/browser_thread.h"
@@ -64,14 +61,8 @@ void NativeFileSystemInstance::HandleMessage(scoped_ptr<base::Value> msg) {
     return;
   }
 
-  std::string upper_virtual_root_string = virtual_root_string;
-  std::transform(upper_virtual_root_string.begin(),
-      upper_virtual_root_string.end(),
-      upper_virtual_root_string.begin(),
-      ::toupper);
   std::string real_path =
-      VirtualRootProvider::GetInstance()->GetRealPath(
-          upper_virtual_root_string);
+      VirtualRootProvider::GetInstance()->GetRealPath(virtual_root_string);
   if (real_path.empty()) {
     const scoped_ptr<base::DictionaryValue> res(new base::DictionaryValue());
     res->SetString("_promise_id", promise_id_string);
@@ -105,16 +96,11 @@ void NativeFileSystemInstance::HandleSyncMessage(
   }
 
   scoped_ptr<base::Value> result(new base::StringValue(""));
-  std::string virtual_root_string = "";
+  std::string virtual_root_string;
   if ("getRealPath" ==  command &&
       dict->GetString("path", &virtual_root_string)) {
-    std::transform(virtual_root_string.begin(),
-                   virtual_root_string.end(),
-                   virtual_root_string.begin(),
-                   ::toupper);
     std::string real_path =
-        VirtualRootProvider::GetInstance()->GetRealPath(
-            virtual_root_string);
+        VirtualRootProvider::GetInstance()->GetRealPath(virtual_root_string);
     result.reset(new base::StringValue(real_path));
   } else {
     LOG(ERROR) << command << " ASSERT NOT REACHED.";

--- a/experimental/native_file_system/native_file_system_extension.h
+++ b/experimental/native_file_system/native_file_system_extension.h
@@ -41,33 +41,10 @@ class NativeFileSystemInstance : public XWalkExtensionInstance {
   void HandleSyncMessage(scoped_ptr<base::Value> msg) override;
 
  private:
+  void OnRequestNativeFileSystem(scoped_ptr<XWalkExtensionFunctionInfo> info);
+
   XWalkExtensionFunctionHandler handler_;
   content::RenderProcessHost* host_;
-};
-
-class FileSystemChecker
-    : public base::RefCountedThreadSafe<FileSystemChecker> {
- public:
-  FileSystemChecker(
-      int process_id,
-      const std::string& path,
-      const std::string& root_name,
-      const std::string& promise_id,
-      XWalkExtensionInstance* instance);
-  void DoTask();
-
- private:
-  friend class base::RefCountedThreadSafe<FileSystemChecker>;
-  virtual ~FileSystemChecker() {}
-  void RegisterFileSystemsAndSendResponse();
-
-  int process_id_;
-  std::string path_;
-  std::string root_name_;
-  std::string promise_id_;
-  XWalkExtensionInstance* instance_;
-
-  DISALLOW_COPY_AND_ASSIGN(FileSystemChecker);
 };
 
 }  // namespace experimental

--- a/experimental/native_file_system/virtual_root_provider.cc
+++ b/experimental/native_file_system/virtual_root_provider.cc
@@ -4,7 +4,8 @@
 
 #include "xwalk/experimental/native_file_system/virtual_root_provider.h"
 
-#include <map>
+#include <algorithm>
+#include <cctype>
 #include <string>
 
 #include "base/lazy_instance.h"
@@ -21,7 +22,10 @@ VirtualRootProvider* VirtualRootProvider::GetInstance() {
 }
 
 std::string VirtualRootProvider::GetRealPath(const std::string& virtual_root) {
-  return virtual_root_map_[virtual_root].AsUTF8Unsafe();
+  std::string uppercase_virtual_root = virtual_root;
+  std::transform(virtual_root.begin(), virtual_root.end(),
+                 uppercase_virtual_root.begin(), ::toupper);
+  return virtual_root_map_[uppercase_virtual_root].AsUTF8Unsafe();
 }
 
 VirtualRootProvider::~VirtualRootProvider() {}

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -76,6 +76,7 @@
         '../extensions/common/constants.h',
         '../extensions/common/url_pattern.cc',
         '../extensions/common/url_pattern.h',
+        'experimental/native_file_system/native_file_system.idl',
         'experimental/native_file_system/native_file_system_extension.cc',
         'experimental/native_file_system/native_file_system_extension.h',
         'experimental/native_file_system/virtual_root_provider.cc',


### PR DESCRIPTION
Oh boy, where do I even start? This extension has been pretty much
unmaintained since 2014, does not really implement any actual spec and
was using the `Promises` polyfill from the sysapps code. It was the
latter that prompted me to take a look at it, and this is what I came up
with.

All the commits but the last one are small groundwork, and the last
change is where the big cleanup is actually performed. Quoting this last
commit's commit message:

Make the code more readable and trim all the unnecessary fat from both the
C++ and the JS sides to the extent that keeping backwards compatibility
allows us (i.e. synchronous functions remain synchronous, async functions
that use callbacks instead of Promises continue doing so etc).

- Remove all the pseudo-Promises silliness: manually keeping a list of
  Promises (which were just using the sysapps polyfill instead of actual
  Promises) and manipulating it whenever a message was passed or
  received was just bonkers.

- Remove all the manual message passing code. Creating a `msg`
  dictionary with a loosely-defined syntax does not make sense, we can
  just leverage the support code from `xwalk_internal_api.js` that takes
  care of keeping track of each message, correctly forwarding all
  parameters and invoking an optional callback when a response is
  returned from the C++ side.

- Consequently, this also allows us to register a specific handler for
  the newly-introduced "requestNativeFileSystem" message instead of
  implementing a catch-all `HandleMessage()` function.

- Another consequence of this change is that we now return a simple
  error string when an error occurred instead of packing the whole thing
  into a JSON string with a lot of unnecessary additional data. This
  error message gets turned into an `Error` object. It is the only
  somewhat backwards-incompatible change in this commit. I believe the
  benefits of doing error handling more sanely outweigh the cons here.

- Add an IDL file describing the parameters we pass to
  `requestNativeFileSystem()` to avoid doing a lot of manual argument
  parsing in `OnRequestNativeFileSystem` (previously `HandleMessage`).

- Replace all the `FileSystemChecker` complication with a single,
  internal function.

With this change, the Promises polyfill in the `sysapps/` directory no
longer has any users, and can be safely removed in another commit.