### PR TITLE
[Android] Rewrite generate_app_packaging_tool.py.

### DIFF
--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -1,91 +1,72 @@
-#!/usr/bin/env python
-
 # Copyright (c) 2013 Intel Corporation. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-# pylint: disable=F0401
 
+import argparse
+import errno
 import os
 import shutil
 import sys
+
 from common_function import RemoveUnusedFilesInReleaseMode
 
-def Clean(dir_to_clean):
-  if os.path.isdir(dir_to_clean):
-    shutil.rmtree(dir_to_clean)
 
-
-def PrepareFromXwalk(src_dir, target_dir):
+def GenerateAppTemplate(build_dir, build_mode, output_dir, source_dir):
   """
   Prepares xwalk_app_template/, which contains files used for packaging
   Crosswalk apps. Its primary consumer is app-tools.
   """
-  # Get the dir of source code from src_dir: ../../.
-  source_code_dir = os.path.dirname(os.path.dirname(src_dir))
+  dirs = (
+    (os.path.join(source_dir, 'app/android/app_template'),
+     os.path.join(output_dir, 'template')),
+    (os.path.join(build_dir, 'xwalk_core_library'),
+     os.path.join(output_dir, 'xwalk_core_library')),
+    (os.path.join(build_dir, 'xwalk_shared_library'),
+     os.path.join(output_dir, 'xwalk_shared_library')),
+  )
+  files = (
+    (os.path.join(source_dir, 'API_VERSION'),
+     os.path.join(output_dir, 'API_VERSION')),
+    (os.path.join(source_dir, 'VERSION'),
+     os.path.join(output_dir, 'VERSION')),
+    (os.path.join(build_dir, 'lib.java', 'xwalk_app_runtime_java.jar'),
+     os.path.join(output_dir, 'libs', 'xwalk_app_runtime_java.jar')),
+  )
 
-  # The directory to copy libraries and code from.
-  jar_src_dir = os.path.join(src_dir, 'lib.java')
-  xwalk_core_library_dir = os.path.join(src_dir, 'xwalk_core_library')
-  xwalk_shared_library_dir = os.path.join(src_dir, 'xwalk_shared_library')
+  for src, dest in dirs:
+    shutil.copytree(src, dest)
+  for src, dest in files:
+    try:
+      os.makedirs(os.path.dirname(dest))
+    except OSError, e:
+      if e.errno == errno.EEXIST:
+        pass
+    shutil.copy2(src, dest)
 
-  # The directory to copy libraries, code and resources to.
-  app_target_dir = os.path.join(target_dir, 'template')
-  jar_target_dir = os.path.join(app_target_dir, 'libs')
-
-  # The source file/directory list to be copied and the target directory list.
-  source_target_list = [
-    (os.path.join(source_code_dir, 'xwalk/API_VERSION'), target_dir),
-    (os.path.join(source_code_dir, 'xwalk/VERSION'), target_dir),
-
-    # The app wrapper code. It's the template Java code.
-    (os.path.join(source_code_dir, 'xwalk/app/android/app_template'),
-     app_target_dir),
-
-    (os.path.join(jar_src_dir, 'xwalk_app_runtime_java.jar'), jar_target_dir),
-
-    # XWalk Core Library
-    (xwalk_core_library_dir, os.path.join(target_dir, 'xwalk_core_library')),
-
-    # XWalk Shared Library
-    (xwalk_shared_library_dir, os.path.join(target_dir, 'xwalk_shared_library')),
-  ]
-
-  for index in range(len(source_target_list)):
-    source_path, target_path = source_target_list[index]
-
-    # Process source.
-    if not os.path.exists(source_path):
-      print ('The source path "%s" does not exist.' % source_path)
-      continue
-
-    source_is_file = os.path.isfile(source_path)
-
-    # Process target.
-    if source_is_file and not os.path.exists(target_path):
-      os.makedirs(target_path)
-    if not source_is_file and os.path.isdir(target_path):
-      shutil.rmtree(target_path)
-
-    # Do copy.
-    if source_is_file:
-      shutil.copy(source_path, target_path)
-    else:
-      shutil.copytree(source_path, target_path)
-
-  # Remove unused files.
-  mode = os.path.basename(os.path.dirname(target_dir))
-  RemoveUnusedFilesInReleaseMode(mode, os.path.join(target_dir, 'native_libs'))
+  # Remove gdbserver from Release builds. See http://crrev.com/14200040 and
+  # Android's platform/sdk's ApkBuilder.java which do the same.
+  RemoveUnusedFilesInReleaseMode(build_mode,
+                                 os.path.join(output_dir, 'native_libs'))
 
 
-def main(args):
-  if len(args) != 1:
-    print 'You must provide only one argument: folder to update'
-    return 1
-  target_dir = args[0]
-  src_dir = os.path.dirname(target_dir)
-  Clean(target_dir)
-  PrepareFromXwalk(src_dir, target_dir)
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--build-dir', required=True,
+                      help='Build directory location.')
+  parser.add_argument('--build-mode', required=True,
+                      help='Build mode (Release, Debug etc).')
+  parser.add_argument('--output-dir', required=True,
+                      help='Directory where the app template files will be '
+                      'stored.')
+  parser.add_argument('--source-dir', required=True,
+                      help='Top-level source directory location.')
+  args = parser.parse_args()
+
+  shutil.rmtree(args.output_dir, ignore_errors=True)
+  os.makedirs(args.output_dir)
+  GenerateAppTemplate(args.build_dir, args.build_mode, args.output_dir,
+                      args.source_dir)
 
 
 if __name__ == '__main__':
-  sys.exit(main(sys.argv[1:]))
+  sys.exit(main())

--- a/xwalk_android_app.gypi
+++ b/xwalk_android_app.gypi
@@ -123,7 +123,10 @@
           ],
           'action': [
             'python', 'build/android/generate_app_packaging_tool.py',
-            '<(PRODUCT_DIR)/xwalk_app_template'
+            '--build-dir', '<(PRODUCT_DIR)',
+            '--build-mode', '<(CONFIGURATION_NAME)',
+            '--output-dir', '<(PRODUCT_DIR)/xwalk_app_template',
+            '--source-dir', '<(DEPTH)/xwalk',
           ],
         },
       ],


### PR DESCRIPTION
Simplify the script a lot by not trying to deduce if an entry is a file
or a directory. Instead, keep two separate lists with directories and
files we want to copy to the `xwalk_app_template` directory.

Also stop hardcoding some paths and let gyp pass all the directory
information to the script.