### PR TITLE
[Windows] Implement support for native notifications.

### DIFF
--- a/runtime/browser/runtime_notification_permission_context.cc
+++ b/runtime/browser/runtime_notification_permission_context.cc
@@ -1,0 +1,83 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/runtime_notification_permission_context.h"
+
+#include <string>
+
+#include "base/bind.h"
+#include "base/callback.h"
+#include "base/prefs/pref_service.h"
+#include "base/strings/utf_string_conversions.h"
+#include "components/url_formatter/url_formatter.h"
+#include "components/user_prefs/user_prefs.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/geolocation_provider.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/web_contents.h"
+#include "grit/xwalk_resources.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "net/base/net_util.h"
+#include "xwalk/runtime/browser/xwalk_browser_context.h"
+#include "xwalk/runtime/common/xwalk_system_locale.h"
+
+#if !defined(OS_ANDROID)
+#include "xwalk/runtime/browser/ui/desktop/xwalk_permission_dialog_manager.h"
+#endif
+
+namespace xwalk {
+
+void RuntimeNotificationPermissionContext::CancelNotificationPermissionRequest(
+    content::WebContents* web_contents,
+    const GURL& requesting_frame) {
+#if !defined(OS_ANDROID)
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+  XWalkPermissionDialogManager* permission_dialog_manager =
+      XWalkPermissionDialogManager::FromWebContents(web_contents);
+  if (!permission_dialog_manager)
+    return;
+  permission_dialog_manager->CancelPermissionRequest();
+#endif
+}
+
+RuntimeNotificationPermissionContext::~RuntimeNotificationPermissionContext() {
+}
+
+void
+RuntimeNotificationPermissionContext::RequestNotificationPermission(
+    content::WebContents* web_contents,
+    const GURL& requesting_frame,
+    const std::string& application_name,
+    base::Callback<void(bool)> result_callback) {
+#if !defined(OS_ANDROID)
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+  XWalkPermissionDialogManager* permission_dialog_manager =
+      XWalkPermissionDialogManager::GetPermissionDialogManager(web_contents);
+
+  PrefService* pref_service =
+      user_prefs::UserPrefs::Get(XWalkBrowserContext::GetDefault());
+  base::string16 text = l10n_util::GetStringFUTF16(
+      IDS_NOTIFICATIONS_DIALOG_QUESTION, base::ASCIIToUTF16(application_name));
+
+  permission_dialog_manager->RequestPermission(
+      CONTENT_SETTINGS_TYPE_NOTIFICATIONS,
+      requesting_frame, pref_service->GetString(kIntlAcceptLanguage), text,
+      base::Bind(
+          &RuntimeNotificationPermissionContext::OnPermissionRequestFinished,
+          base::Unretained(this), result_callback));
+#else
+  result_callback.Run(false);
+#endif
+}
+
+#if !defined(OS_ANDROID)
+void RuntimeNotificationPermissionContext::OnPermissionRequestFinished(
+    base::Callback<void(bool)> result_callback, bool success) {
+  result_callback.Run(success);
+}
+#endif
+
+}  // namespace xwalk

--- a/runtime/browser/runtime_notification_permission_context.h
+++ b/runtime/browser/runtime_notification_permission_context.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_RUNTIME_NOTIFICATION_PERMISSION_CONTEXT_H_
+#define XWALK_RUNTIME_BROWSER_RUNTIME_NOTIFICATION_PERMISSION_CONTEXT_H_
+
+#include <string>
+
+#include "base/callback.h"
+#include "base/memory/ref_counted.h"
+#include "base/strings/string16.h"
+#include "content/public/common/permission_status.mojom.h"
+
+class GURL;
+
+namespace content {
+class WebContents;
+}
+
+namespace xwalk {
+
+class XWalkBrowserContext;
+
+class RuntimeNotificationPermissionContext
+  : public base::RefCountedThreadSafe<RuntimeNotificationPermissionContext> {
+ public:
+  virtual void RequestNotificationPermission(
+      content::WebContents* web_contents,
+      const GURL& requesting_frame,
+      const std::string& application_name,
+      base::Callback<void(bool)> result_callback);
+  virtual void CancelNotificationPermissionRequest(
+      content::WebContents* web_contents,
+      const GURL& requesting_frame);
+
+ protected:
+  virtual ~RuntimeNotificationPermissionContext();
+  friend class base::RefCountedThreadSafe<RuntimeNotificationPermissionContext>;
+
+private:
+#if !defined(OS_ANDROID)
+  void OnPermissionRequestFinished(base::Callback<void(bool)>, bool success);
+#endif
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_RUNTIME_NOTIFICATION_PERMISSION_CONTEXT_H_

--- a/runtime/browser/xwalk_content_settings.cc
+++ b/runtime/browser/xwalk_content_settings.cc
@@ -64,8 +64,8 @@ void XWalkContentSettings::Shutdown() {
 
 ContentSetting XWalkContentSettings::GetPermission(
     ContentSettingsType type,
-  const GURL& requesting_origin,
-  const GURL& embedding_origin) {
+    const GURL& requesting_origin,
+    const GURL& embedding_origin) {
   return host_content_settings_map_->GetContentSetting(
       requesting_origin,
       embedding_origin,

--- a/runtime/browser/xwalk_notification_manager_win.cc
+++ b/runtime/browser/xwalk_notification_manager_win.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/xwalk_notification_manager_win.h"
+
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/desktop_notification_delegate.h"
+#include "content/public/common/platform_notification_data.h"
+#include "url/gurl.h"
+#include "xwalk/application/browser/application_service.h"
+#include "xwalk/application/common/application_manifest_constants.h"
+#include "xwalk/runtime/browser/xwalk_browser_context.h"
+#include "xwalk/runtime/browser/xwalk_notification_win.h"
+
+namespace xwalk {
+
+void DismissNotification(
+    XWalkNotificationWin* notification) {
+  if (notification)
+    notification->Dismiss();
+}
+
+XWalkNotificationManager::XWalkNotificationManager() {
+  initialized_ = XWalkNotificationWin::Initialize();
+}
+
+XWalkNotificationManager::~XWalkNotificationManager() {
+  for (const scoped_refptr<XWalkNotificationWin>& notification : notifications_)
+    notification->Destroy();
+}
+
+void XWalkNotificationManager::ShowDesktopNotification(
+    content::BrowserContext* browser_context,
+    const GURL& origin,
+    const content::PlatformNotificationData& notification_data,
+    const SkBitmap& icon,
+    scoped_ptr<content::DesktopNotificationDelegate> delegate,
+    base::Closure* cancel_callback) {
+  if (!initialized_)
+    return;
+
+  XWalkNotificationWin* notification = new XWalkNotificationWin(
+      this,
+      std::move(delegate));
+
+  notifications_.insert(notification);
+  notification->Show(
+      notification_data.title,
+      notification_data.body,
+      notification_data.icon,
+      icon,
+      notification_data.silent);
+  *cancel_callback = base::Bind(&DismissNotification,
+      notification);
+}
+
+void XWalkNotificationManager::RemoveNotification(
+    XWalkNotificationWin* notification)
+{
+  notification->Destroy();
+  notifications_.erase(notification);
+}
+
+}  // namespace xwalk

--- a/runtime/browser/xwalk_notification_manager_win.h
+++ b/runtime/browser/xwalk_notification_manager_win.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_MANAGER_WIN_H_
+#define XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_MANAGER_WIN_H_
+
+#include <set>
+#include <string>
+
+#include "base/callback.h"
+#include "base/memory/weak_ptr.h"
+
+class GURL;
+class SkBitmap;
+
+namespace content {
+class BrowserContext;
+class DesktopNotificationDelegate;
+struct PlatformNotificationData;
+}  // namespace content
+
+namespace xwalk {
+
+class XWalkNotificationWin;
+
+class XWalkNotificationManager {
+public:
+  XWalkNotificationManager();
+  ~XWalkNotificationManager();
+
+  // Show a desktop notification. If |cancel_callback| is non-null, it's set to
+  // a callback which can be used to cancel the notification.
+  void ShowDesktopNotification(
+      content::BrowserContext* browser_context,
+      const GURL& origin,
+      const content::PlatformNotificationData& notification_data,
+      const SkBitmap& icon,
+      scoped_ptr<content::DesktopNotificationDelegate> delegate,
+      base::Closure* cancel_callback);
+  void RemoveNotification(XWalkNotificationWin* notification);
+private:
+  bool initialized_;
+  std::set<scoped_refptr<XWalkNotificationWin>> notifications_;
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_MANAGER_WIN_H_

--- a/runtime/browser/xwalk_notification_win.cc
+++ b/runtime/browser/xwalk_notification_win.cc
@@ -1,0 +1,435 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include "xwalk/runtime/browser/xwalk_notification_win.h"
+
+#include "NotificationActivationCallback.h"
+#include "base/files/file_util.h"
+#include "base/md5.h"
+#include "base/path_service.h"
+#include "base/strings/utf_string_conversions.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/desktop_notification_delegate.h"
+#include "url/gurl.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/gfx/codec/png_codec.h"
+#include "xwalk/runtime/browser/xwalk_notification_manager_win.h"
+
+#include <shlobj.h>
+
+namespace {
+
+bool SaveIconToPath(const SkBitmap& bitmap, const base::FilePath& path) {
+  std::vector<unsigned char> png_data;
+  if (!gfx::PNGCodec::EncodeBGRASkBitmap(bitmap, false, &png_data))
+    return false;
+
+  char* data = reinterpret_cast<char*>(&png_data[0]);
+  int size = static_cast<int>(png_data.size());
+  return base::WriteFile(path, data, size) == size;
+}
+
+base::string16 GetAppUserModelId() {
+  base::string16 app_id;
+  PWSTR current_app_id;
+  if (SUCCEEDED(GetCurrentProcessExplicitAppUserModelID(&current_app_id))) {
+    app_id = base::string16(current_app_id);
+    CoTaskMemFree(current_app_id);
+  }
+  return app_id;
+}
+
+HSTRING MakeHString(const base::string16& str) {
+  HSTRING hstr;
+  if (FAILED(::WindowsCreateString(str.c_str(), static_cast<UINT32>(str.size()),
+    &hstr))) {
+    PLOG(DFATAL) << "Hstring creation failed";
+  }
+  return hstr;
+}
+
+base::string16 MakeStdWString(HSTRING hstring) {
+  const wchar_t* str;
+  UINT32 size = 0;
+  str = ::WindowsGetStringRawBuffer(hstring, &size);
+  if (!size)
+    return base::string16();
+  return base::string16(str, size);
+}
+
+} // namespace
+
+namespace xwalk {
+
+// static
+mswr::ComPtr<winui::Notifications::IToastNotificationManagerStatics>
+    XWalkNotificationWin::toast_manager_;
+
+// static
+mswr::ComPtr<winui::Notifications::IToastNotifier>
+    XWalkNotificationWin::toast_notifier_;
+
+XWalkNotificationWin::XWalkNotificationWin(
+    XWalkNotificationManager* manager,
+    scoped_ptr<content::DesktopNotificationDelegate> delegate)
+    : manager_(manager),
+      delegate_(std::move(delegate)) {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+  content::BrowserThread::PostTask(
+      content::BrowserThread::FILE, FROM_HERE,
+      base::Bind(&XWalkNotificationWin::InitTempDir, this));
+}
+
+XWalkNotificationWin::~XWalkNotificationWin() {
+}
+
+void XWalkNotificationWin::Destroy() {
+  content::BrowserThread::PostTask(
+      content::BrowserThread::FILE, FROM_HERE,
+      base::Bind(&XWalkNotificationWin::CleanupTempDir, this));
+}
+
+void XWalkNotificationWin::InitTempDir() {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::FILE));
+  temp_dir_.CreateUniqueTempDir();
+}
+
+void XWalkNotificationWin::CleanupTempDir() {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::FILE));
+  temp_dir_.Delete();
+}
+
+
+// static
+bool XWalkNotificationWin::Initialize() {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+  winfoundtn::Initialize(RO_INIT_MULTITHREADED);
+
+  if (FAILED(winfoundtn::GetActivationFactory(
+        MakeHString(
+            RuntimeClass_Windows_UI_Notifications_ToastNotificationManager),
+        &toast_manager_)))
+    return false;
+
+  base::string16 app_id = GetAppUserModelId();
+  if (app_id.empty())
+    return false;
+
+  return SUCCEEDED(
+      toast_manager_->CreateToastNotifierWithId(
+          MakeHString(app_id), &toast_notifier_));
+}
+
+bool XWalkNotificationWin::SetImageSrc(
+    const std::wstring& imagePath,
+    winxml::Dom::IXmlDocument *toastXml)
+{
+  mswr::ComPtr<winxml::Dom::IXmlNodeList> nodeList;
+  if (FAILED(toastXml->GetElementsByTagName(MakeHString(L"image"), &nodeList)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> imageNode;
+  if (FAILED(nodeList->Item(0, &imageNode)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNamedNodeMap> attributes;
+  if (FAILED(imageNode->get_Attributes(&attributes)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> srcAttribute;
+  if (FAILED(attributes->GetNamedItem(MakeHString(L"src"), &srcAttribute)))
+    return false;
+
+  std::wstringstream image_path;
+  image_path << imagePath.c_str();
+  mswr::ComPtr<winxml::Dom::IXmlText> inputText;
+  if (FAILED(toastXml->CreateTextNode(MakeHString(image_path.str()), &inputText)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> inputTextNode;
+  if (FAILED(inputText.As(&inputTextNode)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> pAppendedChild;
+  if (FAILED(srcAttribute->AppendChild(inputTextNode.Get(), &pAppendedChild)))
+    return false;
+
+  return true;
+}
+
+bool XWalkNotificationWin::SetXmlText(
+    winxml::Dom::IXmlDocument* doc, const std::wstring& text) {
+    mswr::ComPtr<winxml::Dom::IXmlNodeList> node_list;
+  if (!GetTextNodeList(doc, &node_list, 1))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> node;
+  if (FAILED(node_list->Item(0, &node)))
+    return false;
+
+  return AppendTextToXml(doc, node.Get(), text);
+}
+
+bool XWalkNotificationWin::AppendTextToXml(
+    winxml::Dom::IXmlDocument* doc,
+    winxml::Dom::IXmlNode* node,
+    const std::wstring& text) {
+  mswr::ComPtr<winxml::Dom::IXmlText> xml_text;
+  if (FAILED(doc->CreateTextNode(MakeHString(text), &xml_text)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> text_node;
+  if (FAILED(xml_text.As(&text_node)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> append_node;
+  return SUCCEEDED(node->AppendChild(text_node.Get(), &append_node));
+}
+
+
+bool XWalkNotificationWin::SetXmlText(
+    winxml::Dom::IXmlDocument* doc,
+    const std::wstring& title,
+    const std::wstring& body) {
+  mswr::ComPtr<winxml::Dom::IXmlNodeList> node_list;
+  if (!GetTextNodeList(doc, &node_list, 2))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> node;
+  if (FAILED(node_list->Item(0, &node)))
+    return false;
+
+  if (!AppendTextToXml(doc, node.Get(), title))
+    return false;
+
+  if (FAILED(node_list->Item(1, &node)))
+    return false;
+
+  return AppendTextToXml(doc, node.Get(), body);
+}
+
+bool XWalkNotificationWin::GetTextNodeList(
+    winxml::Dom::IXmlDocument* doc,
+    winxml::Dom::IXmlNodeList** node_list,
+    uint32_t req_length) {
+
+  if (FAILED(doc->GetElementsByTagName(MakeHString(L"text"), node_list)))
+    return false;
+
+  uint32_t node_length;
+  if (FAILED((*node_list)->get_Length(&node_length)))
+    return false;
+
+  return node_length >= req_length;
+}
+
+bool XWalkNotificationWin::CreateToastXml(
+    const std::wstring& title,
+    const std::wstring& body,
+    const std::wstring& icon_path,
+    const bool silent,
+    winxml::Dom::IXmlDocument** input_xml)
+{
+  winui::Notifications::ToastTemplateType template_type;
+  if (title.empty() || body.empty()) {
+    // Single line toast.
+    template_type = icon_path.empty() ?
+        winui::Notifications::ToastTemplateType_ToastText01 :
+        winui::Notifications::ToastTemplateType_ToastImageAndText01;
+    if (FAILED(toast_manager_->GetTemplateContent(template_type, input_xml)))
+      return false;
+    if (!SetXmlText(*input_xml,
+        title.empty() ? body : title))
+      return false;
+  } else {
+    // Title and body toast.
+    template_type = icon_path.empty() ?
+        winui::Notifications::ToastTemplateType_ToastText02 :
+        winui::Notifications::ToastTemplateType_ToastImageAndText02;
+    if (FAILED(toast_manager_->GetTemplateContent(template_type, input_xml)))
+      return false;
+    if (!SetXmlText(*input_xml, title, body))
+      return false;
+  }
+
+  if (silent) {
+    if (!SetXmlAudioSilent(*input_xml))
+      return false;
+  }
+
+  if (!icon_path.empty())
+    return SetImageSrc(icon_path, *input_xml);
+
+  return true;
+}
+
+bool XWalkNotificationWin::SetXmlAudioSilent(
+    winxml::Dom::IXmlDocument* doc) {
+
+  mswr::ComPtr<winxml::Dom::IXmlNodeList> node_list;
+  if (FAILED(doc->GetElementsByTagName(MakeHString(L"toast"), &node_list)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> root;
+  if (FAILED(node_list->Item(0, &root)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlElement> audio_element;
+  if (FAILED(doc->CreateElement(MakeHString(L"toast"), &audio_element)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> audio_node_tmp;
+  if (FAILED(audio_element.As(&audio_node_tmp)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> audio_node;
+  if (FAILED(root->AppendChild(audio_node_tmp.Get(), &audio_node)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNamedNodeMap> attributes;
+  if (FAILED(audio_node->get_Attributes(&attributes)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlAttribute> silent_attribute;
+  if (FAILED(doc->CreateAttribute(MakeHString(L"silent"), &silent_attribute)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> silent_attribute_node;
+  if (FAILED(silent_attribute.As(&silent_attribute_node)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlText> silent_text;
+  if (FAILED(doc->CreateTextNode(MakeHString(L"true"), &silent_text)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> silent_node;
+  if (FAILED(silent_text.As(&silent_node)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> child_node;
+  if (FAILED(silent_attribute_node->AppendChild(
+        silent_node.Get(), &child_node)))
+    return false;
+
+  mswr::ComPtr<winxml::Dom::IXmlNode> silent_attribute_pnode;
+  return SUCCEEDED(attributes.Get()->SetNamedItem(
+        silent_attribute_node.Get(), &silent_attribute_pnode));
+}
+
+void XWalkNotificationWin::SaveIconToFilesystemAndProceed(
+    const base::string16& title,
+    const base::string16& body,
+    const GURL& icon_url,
+    const SkBitmap& icon,
+    const bool silent) {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::FILE));
+  base::string16 icon_path;
+  std::string filename = base::MD5String(icon_url.spec()) + ".png";
+  base::FilePath path = temp_dir_.path().Append(base::UTF8ToUTF16(filename));
+  if (base::PathExists(path))
+    icon_path = path.value();
+  else if (SaveIconToPath(icon, path))
+    icon_path = path.value();
+  else
+    icon_path = base::UTF8ToUTF16(icon_url.spec());
+  content::BrowserThread::PostTask(
+      content::BrowserThread::UI, FROM_HERE,
+      base::Bind(&XWalkNotificationWin::ShowNotification,
+          this, title, body, icon_path, silent));
+}
+
+
+void XWalkNotificationWin::Show(
+    const base::string16& title,
+    const base::string16& body,
+    const GURL& icon_url,
+    const SkBitmap& icon,
+    const bool silent) {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+  content::BrowserThread::PostTask(
+      content::BrowserThread::FILE, FROM_HERE,
+      base::Bind(&XWalkNotificationWin::SaveIconToFilesystemAndProceed,
+          this, title, body, icon_url, icon, silent));
+}
+
+void XWalkNotificationWin::ShowNotification(
+    const base::string16& title,
+    const base::string16& body,
+    const base::string16& icon_path,
+    const bool silent) {
+  DCHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI));
+  mswr::ComPtr<winxml::Dom::IXmlDocument> toast_xml;
+  if (!CreateToastXml(title, body, icon_path, silent, &toast_xml))
+    return;
+
+  mswr::ComPtr<winui::Notifications::IToastNotificationFactory> factory;
+  if (FAILED(winfoundtn::GetActivationFactory(
+      MakeHString(RuntimeClass_Windows_UI_Notifications_ToastNotification), &factory)))
+    return;
+
+  if (FAILED(factory->CreateToastNotification(toast_xml.Get(), &toast_notification_)))
+    return;
+
+  mswr::ComPtr<NotificationEventHandlerWin> event_handler_ =
+      mswr::Make<NotificationEventHandlerWin>(this);
+  if (FAILED(toast_notification_->add_Activated(
+      event_handler_.Get(), &activated_token_)))
+    return;
+  if (FAILED(toast_notification_->add_Dismissed(
+      event_handler_.Get(), &dismissed_token_)))
+    return;
+  if (FAILED(toast_notification_->add_Failed(
+      event_handler_.Get(), &failed_token_)))
+    return;
+
+  if (FAILED(toast_notifier_->Show(toast_notification_.Get())))
+    return;
+
+  delegate_->NotificationDisplayed();
+}
+
+void XWalkNotificationWin::Dismiss() {
+  toast_notifier_->Hide(toast_notification_.Get());
+}
+
+void XWalkNotificationWin::NotificationClosed() {
+  delegate_->NotificationClosed();
+  manager_->RemoveNotification(this);
+}
+
+
+void XWalkNotificationWin::NotificationClicked() {
+  delegate_->NotificationClick();
+  manager_->RemoveNotification(this);
+}
+
+NotificationEventHandlerWin::NotificationEventHandlerWin(
+    XWalkNotificationWin* notification)
+    : notification_(notification) {
+}
+
+NotificationEventHandlerWin::~NotificationEventHandlerWin() {
+}
+
+IFACEMETHODIMP NotificationEventHandlerWin::Invoke(
+    ABI::Windows::UI::Notifications::IToastNotification* sender,
+    IInspectable* args) {
+  notification_->NotificationClicked();
+  return S_OK;
+}
+
+IFACEMETHODIMP NotificationEventHandlerWin::Invoke(
+    ABI::Windows::UI::Notifications::IToastNotification* sender,
+    ABI::Windows::UI::Notifications::IToastDismissedEventArgs* event) {
+  notification_->NotificationClosed();
+  return S_OK;
+}
+
+IFACEMETHODIMP NotificationEventHandlerWin::Invoke(
+    ABI::Windows::UI::Notifications::IToastNotification* sender,
+    ABI::Windows::UI::Notifications::IToastFailedEventArgs* event) {
+  notification_->NotificationClosed();
+  return S_OK;
+}
+
+}  // namespace xwalk

--- a/runtime/browser/xwalk_notification_win.h
+++ b/runtime/browser/xwalk_notification_win.h
@@ -1,0 +1,151 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_WIN_H_
+#define XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_WIN_H_
+
+#include <string>
+
+#include "base/callback.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/strings/string16.h"
+
+#include <windows.h>
+#include <windows.ui.notifications.h>
+#include <wrl/event.h>
+#include <wrl/implements.h>
+#include <wrl/module.h>
+#include <wrl/wrappers/corewrappers.h>
+
+namespace mswr = Microsoft::WRL;
+namespace mswrw = Microsoft::WRL::Wrappers;
+namespace winxml = ABI::Windows::Data::Xml;
+namespace winfoundtn = ABI::Windows::Foundation;
+namespace winui = ABI::Windows::UI;
+
+using NotificationActivatedEventHandler =
+    winfoundtn::ITypedEventHandler<winui::Notifications::ToastNotification*,
+    IInspectable*>;
+using NotificationDismissedEventHandler =
+    winfoundtn::ITypedEventHandler<winui::Notifications::ToastNotification*,
+    winui::Notifications::ToastDismissedEventArgs*>;
+using NotificationFailedEventHandler =
+    winfoundtn::ITypedEventHandler<winui::Notifications::ToastNotification*,
+    winui::Notifications::ToastFailedEventArgs*>;
+
+namespace content {
+class DesktopNotificationDelegate;
+}  // namespace content
+
+class GURL;
+class SkBitmap;
+
+namespace xwalk {
+
+class XWalkNotificationManager;
+
+class XWalkNotificationWin :
+    public base::RefCountedThreadSafe<XWalkNotificationWin> {
+public:
+  XWalkNotificationWin(
+      XWalkNotificationManager* manager,
+      scoped_ptr<content::DesktopNotificationDelegate> delegate);
+
+  ~XWalkNotificationWin();
+
+  static bool Initialize();
+
+  void Destroy();
+  void Show(
+    const base::string16& title,
+    const base::string16& body,
+    const GURL& icon_url,
+    const SkBitmap& icon,
+    const bool silent);
+
+  void Dismiss();
+
+private:
+  friend class NotificationEventHandlerWin;
+  void NotificationClosed();
+  void NotificationClicked();
+  void SaveIconToFilesystemAndProceed(
+      const base::string16& title,
+      const base::string16& body,
+      const GURL& icon_url,
+      const SkBitmap& icon,
+      const bool silent);
+  bool SetImageSrc(const std::wstring& imagePath,
+                   winxml::Dom::IXmlDocument *toastXml);
+  bool SetXmlText(winxml::Dom::IXmlDocument* doc, const std::wstring& text);
+  bool SetXmlText(winxml::Dom::IXmlDocument* doc,
+                  const std::wstring& title,
+                  const std::wstring& body);
+  bool SetXmlAudioSilent(winxml::Dom::IXmlDocument* doc);
+  bool GetTextNodeList(
+      winxml::Dom::IXmlDocument* doc,
+      winxml::Dom::IXmlNodeList** nodeList,
+      uint32_t reqLength);
+  bool AppendTextToXml(
+      winxml::Dom::IXmlDocument* doc,
+      winxml::Dom::IXmlNode* node,
+      const std::wstring& text);
+  bool CreateToastXml(
+      const std::wstring& title,
+      const std::wstring& body,
+      const std::wstring& icon_path,
+      const bool silent,
+      winxml::Dom::IXmlDocument** input_xml);
+
+  void ShowNotification(
+      const base::string16& title,
+      const base::string16& body,
+      const base::string16& icon_path,
+      const bool silent);
+  void InitTempDir();
+  void CleanupTempDir();
+
+  static mswr::ComPtr<winui::Notifications::IToastNotificationManagerStatics>
+        toast_manager_;
+  static mswr::ComPtr<winui::Notifications::IToastNotifier> toast_notifier_;
+
+  base::ScopedTempDir temp_dir_;
+  XWalkNotificationManager* manager_;
+  scoped_ptr<content::DesktopNotificationDelegate> delegate_;
+  EventRegistrationToken activated_token_;
+  EventRegistrationToken dismissed_token_;
+  EventRegistrationToken failed_token_;
+
+  mswr::ComPtr<NotificationEventHandlerWin> event_handler_;
+  mswr::ComPtr<winui::Notifications::IToastNotification> toast_notification_;
+
+  DISALLOW_COPY_AND_ASSIGN(XWalkNotificationWin);
+};
+
+class NotificationEventHandlerWin :
+    public mswr::RuntimeClass<mswr::RuntimeClassFlags<mswr::ClassicCom>,
+                              NotificationActivatedEventHandler,
+                              NotificationDismissedEventHandler,
+                              NotificationFailedEventHandler> {
+public:
+  NotificationEventHandlerWin(
+      XWalkNotificationWin* notification);
+  ~NotificationEventHandlerWin();
+
+  IFACEMETHODIMP Invoke(winui::Notifications::IToastNotification* sender,
+      IInspectable* args);
+  IFACEMETHODIMP Invoke(winui::Notifications::IToastNotification* sender,
+      winui::Notifications::IToastDismissedEventArgs* e);
+  IFACEMETHODIMP Invoke(winui::Notifications::IToastNotification* sender,
+      winui::Notifications::IToastFailedEventArgs* e);
+
+private:
+  XWalkNotificationWin* notification_;
+
+  DISALLOW_COPY_AND_ASSIGN(NotificationEventHandlerWin);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_BROWSER_XWALK_NOTIFICATION_WIN_H_

--- a/runtime/browser/xwalk_permission_manager.h
+++ b/runtime/browser/xwalk_permission_manager.h
@@ -14,6 +14,7 @@
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/permission_manager.h"
 #include "xwalk/runtime/browser/runtime_geolocation_permission_context.h"
+#include "xwalk/runtime/browser/runtime_notification_permission_context.h"
 
 namespace xwalk {
 
@@ -63,6 +64,9 @@ class XWalkPermissionManager : public content::PermissionManager {
   struct PendingRequest;
   using PendingRequestsMap = IDMap<PendingRequest, IDMapOwnPointer>;
 
+  void GetApplicationName(
+      content::RenderFrameHost* render_frame_host,
+      std::string* name);
   static void OnRequestResponse(
       const base::WeakPtr<XWalkPermissionManager>& manager,
       int request_id,
@@ -71,7 +75,9 @@ class XWalkPermissionManager : public content::PermissionManager {
 
   PendingRequestsMap pending_requests_;
   scoped_refptr<RuntimeGeolocationPermissionContext>
-    geolocation_permission_context_;
+      geolocation_permission_context_;
+  scoped_refptr<RuntimeNotificationPermissionContext>
+      notification_permission_context_;
   application::ApplicationService* application_service_;
   base::WeakPtrFactory<XWalkPermissionManager> weak_ptr_factory_;
   DISALLOW_COPY_AND_ASSIGN(XWalkPermissionManager);

--- a/runtime/browser/xwalk_platform_notification_service.h
+++ b/runtime/browser/xwalk_platform_notification_service.h
@@ -13,7 +13,7 @@
 #include "content/public/browser/platform_notification_service.h"
 
 namespace xwalk {
-#if defined(OS_LINUX) && defined(USE_LIBNOTIFY)
+#if defined(OS_LINUX) && defined(USE_LIBNOTIFY) || defined(OS_WIN)
 class XWalkNotificationManager;
 #endif
 
@@ -65,6 +65,9 @@ class XWalkPlatformNotificationService
 
 #if defined(OS_LINUX) && defined(USE_LIBNOTIFY)
   scoped_ptr<XWalkNotificationManager> notification_manager_linux_;
+#endif
+#if defined(OS_WIN)
+  scoped_ptr<XWalkNotificationManager> notification_manager_win_;
 #endif
 };
 

--- a/runtime/resources/xwalk_resources.grd
+++ b/runtime/resources/xwalk_resources.grd
@@ -87,6 +87,11 @@
           $1<ex>html5rocks.com</ex>
         </ph> wants to use your camera.
       </message>
+      <message name="IDS_NOTIFICATIONS_DIALOG_QUESTION" desc="Question asked on the dialog whenever URL wants to access the notification system.">
+        <ph name="URL">
+          $1<ex>maps.google.com</ex>
+        </ph> wants to show notifications.
+      </message>
       <message name="IDS_PERMISSION_ALLOW" desc="Label on button to allow a permissions request.">
         Allow
       </message>

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -181,6 +181,8 @@
         'runtime/browser/runtime_javascript_dialog_manager.h',
         'runtime/browser/runtime_network_delegate.cc',
         'runtime/browser/runtime_network_delegate.h',
+        'runtime/browser/runtime_notification_permission_context.cc',
+        'runtime/browser/runtime_notification_permission_context.h',
         'runtime/browser/runtime_platform_util.h',
         'runtime/browser/runtime_platform_util_android.cc',
         'runtime/browser/runtime_platform_util_aura.cc',
@@ -276,6 +278,10 @@
         'runtime/browser/xwalk_form_database_service.h',
         'runtime/browser/xwalk_notification_manager_linux.cc',
         'runtime/browser/xwalk_notification_manager_linux.h',
+        'runtime/browser/xwalk_notification_manager_win.cc',
+        'runtime/browser/xwalk_notification_manager_win.h',
+        'runtime/browser/xwalk_notification_win.cc',
+        'runtime/browser/xwalk_notification_win.h',
         'runtime/browser/xwalk_permission_manager.cc',
         'runtime/browser/xwalk_permission_manager.h',
         'runtime/browser/xwalk_platform_notification_service.cc',
@@ -399,6 +405,11 @@
                 },
               },
             },
+          },
+          'link_settings': {
+            'libraries': [
+              '-lruntimeobject.lib',
+            ],
           },
           # TODO(jschuh): crbug.com/167187 fix size_t to int truncations.
           'msvs_disabled_warnings': [ 4267, ],


### PR DESCRIPTION
- Ask permissions to the user (previously it was not granted). Android
will not grant permissions because it works differently.
- Hook up the notification support in content to the Windows C++ API. It
  comes with some limitation such as not being able to have URL based
  icons part of the notification. Workaround is to copy it in a temporary
  file before firing the notification.
- Windows 7 is not supported as there is no notification center.

Known limitations which I plan to fix in a following patch : persistent
support (aka it says in the notification center), activation even when
Crosswalk is closed.

BUG=XWALK-4990