### PR TITLE
[Android] Update warning in setAcceptFileSchemeCookies's API documentation

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
@@ -123,7 +123,7 @@ public class XWalkCookieManagerInternal {
      * of cookie data can take place.
      * <p>
      * Note that calls to this method will have no effect if made after a
-     * WebView or CookieManager instance has been created.
+     * CookieManager instance has done any real work.
      * @param accept Whether accept cookies for file scheme URLs
      * @since 5.0
      */


### PR DESCRIPTION
Since M46, there is a change in upstream to match the comments
in CookieManager "Note that calls to this method will have no
effect if made after a WebView or CookieManager instance has
been created". For XWalkCookieManager, the function can't be
defined static for reflection limitation, so the comment is
not correct.

BUG=XWALK-6274