### PR TITLE
[Android] Implement the feature about custom url scheme.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/UrlUtilities.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/UrlUtilities.java
@@ -1,0 +1,164 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Matcher;
+
+import org.chromium.base.CollectionUtil;
+
+public class UrlUtilities {
+    private static final String TAG = "UrlUtilities";
+
+    // Following codes were ported from
+    // chrome/android/java/src/org/chromium/chrome/browser/util/UrlUtilities.java
+    // Add Crosswalk specific schemes to "ACCEPTED_SCHEMES".
+    /**
+     * URI schemes that ContentView can handle.
+     */
+    private static final HashSet<String> ACCEPTED_SCHEMES = CollectionUtil.newHashSet(
+            "about", "app", "content", "data", "file", "http", "https", "javascript");
+
+    /**
+     * URI schemes that can be handled in Intent fallback navigation.
+     */
+    private static final HashSet<String> FALLBACK_VALID_SCHEMES = CollectionUtil.newHashSet(
+            "http", "https");
+
+    /**
+     * @param uri A URI.
+     *
+     * @return True if the URI is valid for Intent fallback navigation.
+     */
+    public static boolean isValidForIntentFallbackNavigation(String uri) {
+        try {
+            return isValidForIntentFallbackNavigation(new URI(uri));
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param uri A URI.
+     *
+     * @return True if the URI is valid for Intent fallback navigation.
+     */
+    public static boolean isValidForIntentFallbackNavigation(URI uri) {
+        return FALLBACK_VALID_SCHEMES.contains(uri.getScheme());
+    }
+
+    /**
+     * @param uri A URI.
+     *
+     * @return True if the URI's scheme is one that ContentView can handle.
+     */
+    public static boolean isAcceptedScheme(URI uri) {
+        return ACCEPTED_SCHEMES.contains(uri.getScheme());
+    }
+
+    /**
+     * @param uri A URI.
+     *
+     * @return True if the URI's scheme is one that ContentView can handle.
+     */
+    public static boolean isAcceptedScheme(String uri) {
+        try {
+            return isAcceptedScheme(new URI(uri));
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    // Following codes were ported from
+    // chrome/android/java/src/org/chromium/chrome/browser/util/IntentUtils.java
+    /**
+     * Just like {@link Intent#getStringExtra(String)} but doesn't throw exceptions.
+     */
+    public static String safeGetStringExtra(Intent intent, String name) {
+        try {
+            return intent.getStringExtra(name);
+        } catch (Throwable t) {
+            // Catches un-parceling exceptions.
+            Log.e(TAG, "getStringExtra failed on intent: " + intent);
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves a list of components that would handle the given intent.
+     * @param context The application context.
+     * @param intent The intent which we are interested in.
+     * @return The list of component names.
+     */
+    public static List<ComponentName> getIntentHandlers(Context context, Intent intent) {
+        List<ResolveInfo> list = context.getPackageManager().queryIntentActivities(intent, 0);
+        List<ComponentName> nameList = new ArrayList<ComponentName>();
+        for (ResolveInfo r : list) {
+            nameList.add(new ComponentName(r.activityInfo.packageName, r.activityInfo.name));
+        }
+        return nameList;
+    }
+
+    public static boolean isSpecializedHandlerAvailable(Context context, Intent intent) {
+        return isPackageSpecializedHandler(context, null, intent);
+    }
+
+    // Following codes were ported from
+    // chrome/android/java/src/org/chromium/chrome/browser/externalnav/ExternalNavigationDelegateImpl.java
+    /**
+     * Check whether the given package is a specialized handler for the given intent
+     *
+     * @param context {@link Context} to use for getting the {@link PackageManager}.
+     * @param packageName Package name to check against. Can be null or empty.
+     * @param intent The intent to resolve for.
+     * @return Whether the given package is a specialized handler for the given intent. If there is
+     *         no package name given checks whether there is any specialized handler.
+     */
+    public static boolean isPackageSpecializedHandler(
+            Context context, String packageName, Intent intent) {
+        try {
+            List<ResolveInfo> handlers = context.getPackageManager().queryIntentActivities(
+                    intent, PackageManager.GET_RESOLVED_FILTER);
+            if (handlers == null || handlers.size() == 0) return false;
+            for (ResolveInfo resolveInfo : handlers) {
+                IntentFilter filter = resolveInfo.filter;
+                if (filter == null) {
+                    // No intent filter matches this intent?
+                    // Error on the side of staying in the browser, ignore
+                    continue;
+                }
+                if (filter.countDataAuthorities() == 0 || filter.countDataPaths() == 0) {
+                    // Generic handler, skip
+                    continue;
+                }
+                if (TextUtils.isEmpty(packageName)) return true;
+                ActivityInfo activityInfo = resolveInfo.activityInfo;
+                if (activityInfo == null) continue;
+                if (!activityInfo.packageName.equals(packageName)) continue;
+                return true;
+            }
+        } catch (RuntimeException e) {
+            Log.e(TAG, "isPackageSpecializedHandler e=" + e);
+        }
+        return false;
+    }
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -96,8 +96,15 @@ class XWalkContentsClientBridge extends XWalkContentsClient
                      mNavigationHandler.handleNavigation(navigationParams);
 
             if (!ignoreNavigation) {
-                // Post a message to UI thread to notify the page is starting to load.
-                mContentsClient.getCallbackHelper().postOnPageStarted(url);
+                // Check whether the fallback url is existed for scheme: intent://.
+                final String fallbackUrl = mNavigationHandler.getFallbackUrl();
+                if (fallbackUrl != null) {
+                    mNavigationHandler.resetFallbackUrl();
+                    mXWalkView.load(fallbackUrl, null);
+                } else {
+                    // Post a message to UI thread to notify the page is starting to load.
+                    mContentsClient.getCallbackHelper().postOnPageStarted(url);
+                }
             }
 
             return ignoreNavigation;

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationHandler.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationHandler.java
@@ -14,4 +14,15 @@ interface XWalkNavigationHandler {
      * @return true if the navigation request is handled.
      */
     boolean handleNavigation(NavigationParams params);
+
+    /**
+     * Gets the fallback url for special chemes, e.g. intent://.
+     * @return the fallback url if it was specified.
+     */
+    String getFallbackUrl();
+
+    /**
+     * Resets the fallback url to null.
+     */
+    void resetFallbackUrl();
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationHandlerImpl.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNavigationHandlerImpl.java
@@ -1,3 +1,4 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
 // Copyright (c) 2013 Intel Corporation. All rights reserved
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -6,13 +7,21 @@ package org.xwalk.core.internal;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.net.Uri;
+import android.provider.Browser;
+import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
 
+import java.net.URI;
+import java.util.List;
+
 import org.chromium.components.navigation_interception.NavigationParams;
+import org.chromium.ui.base.PageTransition;
 
 import org.xwalk.core.internal.XWalkNavigationHandler;
 
@@ -32,8 +41,12 @@ public class XWalkNavigationHandlerImpl implements XWalkNavigationHandler {
     private static final String ACTION_MAIL_PREFIX = "mailto:";
     private static final String ACTION_GEO_PREFIX = "geo:";
     private static final String ACTION_MARKET_PREFIX = "market:";
+    private static final String ACTION_INTENT_PREFIX = "intent:";
 
     private Context mContext;
+
+    public static final String EXTRA_BROWSER_FALLBACK_URL = "browser_fallback_url";
+    private String mFallbackUrl;
 
     public XWalkNavigationHandlerImpl(Context context) {
         mContext = context;
@@ -42,9 +55,12 @@ public class XWalkNavigationHandlerImpl implements XWalkNavigationHandler {
     @Override
     public boolean handleNavigation(NavigationParams params) {
         final String url = params.url;
+        if (UrlUtilities.isAcceptedScheme(url)) return false;
         Intent intent = null;
         if (url.startsWith(PROTOCOL_WTAI_PREFIX)) {
             intent = createIntentForWTAI(url);
+        } else if (shouldOverrideUrlLoadingInternal(params)) {
+            return true;
         } else {
             intent = createIntentForActionUri(url);
         }
@@ -152,6 +168,197 @@ public class XWalkNavigationHandlerImpl implements XWalkNavigationHandler {
                 return false;
             return true;
         }
+        return false;
+    }
+
+    @Override
+    public String getFallbackUrl() {
+        return mFallbackUrl;
+    }
+
+    @Override
+    public void resetFallbackUrl() {
+        mFallbackUrl = null;
+    }
+
+    // Following codes were ported from
+    // chrome/android/java/src/org/chromium/chrome/browser/externalnav/ExternalNavigationHandler.java
+    // Removed the Chrome specific codes.
+    private boolean shouldOverrideUrlLoadingInternal(NavigationParams params) {
+        // Perform generic parsing of the URI to turn it into an Intent.
+        Intent intent;
+        final String url = params.url;
+        try {
+            intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+        } catch (Exception ex) {
+            Log.w(TAG, "Bad URI=" + url + " ex=" + ex);
+            return false;
+        }
+        // pageTransition is a combination of an enumeration (core value) and bitmask.
+        int pageTransitionCore = params.pageTransitionType & PageTransition.CORE_MASK;
+        boolean isLink = pageTransitionCore == PageTransition.LINK;
+        boolean isFormSubmit = pageTransitionCore == PageTransition.FORM_SUBMIT;
+        boolean isFromIntent = (params.pageTransitionType & PageTransition.FROM_API) != 0;
+        boolean isForwardBackNavigation =
+                (params.pageTransitionType & PageTransition.FORWARD_BACK) != 0;
+        boolean isExternalProtocol = !UrlUtilities.isAcceptedScheme(url);
+
+        // http://crbug.com/169549 : If you type in a URL that then redirects in server side to an
+        // link that cannot be rendered by the browser, we want to show the intent picker.
+        boolean isTyped = pageTransitionCore == PageTransition.TYPED;
+        boolean typedRedirectToExternalProtocol = isTyped && params.isRedirect
+                && isExternalProtocol;
+
+        boolean hasBrowserFallbackUrl = false;
+        String browserFallbackUrl =
+                UrlUtilities.safeGetStringExtra(intent, EXTRA_BROWSER_FALLBACK_URL);
+        if (browserFallbackUrl != null
+                && UrlUtilities.isValidForIntentFallbackNavigation(browserFallbackUrl)) {
+            hasBrowserFallbackUrl = true;
+        } else {
+            browserFallbackUrl = null;
+        }
+
+        // We do not want to show the intent picker for core types typed, bookmarks, auto toplevel,
+        // generated, keyword, keyword generated. See below for exception to typed URL and
+        // redirects:
+        // - http://crbug.com/143118 : URL intercepting should not be invoked on navigations
+        //   initiated by the user in the omnibox / NTP.
+        // - http://crbug.com/159153 : Don't override http or https URLs from the NTP or bookmarks.
+        // - http://crbug.com/162106: Intent picker should not be presented on returning to a page.
+        //   This should be covered by not showing the picker if the core type is reload.
+
+        // http://crbug.com/164194 . A navigation forwards or backwards should never trigger
+        // the intent picker.
+        if (isForwardBackNavigation) {
+            return false;
+        }
+
+        // http://crbug.com/149218: We want to show the intent picker for ordinary links, providing
+        // the link is not an incoming intent from another application, unless it's a redirect (see
+        // below).
+        boolean linkNotFromIntent = isLink && !isFromIntent;
+
+        // http://crbug.com/170925: We need to show the intent picker when we receive an intent from
+        // another app that 30x redirects to a YouTube/Google Maps/Play Store/Google+ URL etc.
+        boolean incomingIntentRedirect = isLink && isFromIntent && params.isRedirect;
+
+        // http://crbug.com/181186: We need to show the intent picker when we receive a redirect
+        // following a form submit.
+        boolean isRedirectFromFormSubmit = isFormSubmit && params.isRedirect;
+
+        if (!typedRedirectToExternalProtocol) {
+            if (!linkNotFromIntent && !incomingIntentRedirect && !isRedirectFromFormSubmit) {
+                return false;
+            }
+        }
+
+        // Special case - It makes no sense to use an external application for a YouTube
+        // pairing code URL, since these match the current tab with a device (Chromecast
+        // or similar) it is supposed to be controlling. Using a different application
+        // that isn't expecting this (in particular YouTube) doesn't work.
+        if (url.matches(".*youtube\\.com.*[?&]pairingCode=.*")) {
+            return false;
+        }
+
+        List<ComponentName> resolvingComponentNames =
+                UrlUtilities.getIntentHandlers(mContext, intent);
+        boolean canResolveActivity = resolvingComponentNames.size() > 0;
+        // check whether the intent can be resolved. If not, we will see
+        // whether we can download it from the Market.
+        if (!canResolveActivity) {
+            if (hasBrowserFallbackUrl) {
+                mFallbackUrl = browserFallbackUrl;
+                return false;
+            }
+            String packagename = intent.getPackage();
+            if (packagename != null) {
+                try {
+                    intent = new Intent(Intent.ACTION_VIEW, Uri.parse(
+                            "market://details?id=" + packagename
+                            + "&referrer=" + mContext.getPackageName()));
+                    intent.addCategory(Intent.CATEGORY_BROWSABLE);
+                    intent.setPackage("com.android.vending");
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    mContext.startActivity(intent);
+                    return true;
+                } catch (ActivityNotFoundException ex) {
+                    // ignore the error on devices that does not have
+                    // play market installed.
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        if (hasBrowserFallbackUrl) {
+            intent.removeExtra(EXTRA_BROWSER_FALLBACK_URL);
+        }
+
+        // Sanitize the Intent, ensuring web pages can not bypass browser
+        // security (only access to BROWSABLE activities).
+        intent.addCategory(Intent.CATEGORY_BROWSABLE);
+        intent.setComponent(null);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+            Intent selector = intent.getSelector();
+            if (selector != null) {
+                selector.addCategory(Intent.CATEGORY_BROWSABLE);
+                selector.setComponent(null);
+            }
+        }
+
+        // Set the Browser application ID to us in case the user chooses Chrome
+        // as the app.  This will make sure the link is opened in the same tab
+        // instead of making a new one.
+        intent.putExtra(Browser.EXTRA_APPLICATION_ID, mContext.getPackageName());
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        // Make sure webkit can handle it internally before checking for specialized
+        // handlers. If webkit can't handle it internally, we need to call
+        // startActivityIfNeeded or startActivity.
+        if (!isExternalProtocol) {
+            if (!UrlUtilities.isSpecializedHandlerAvailable(mContext, intent)) {
+                return false;
+            } else if (params.referrer != null && (isLink || isFormSubmit)) {
+                // Current URL has at least one specialized handler available. For navigations
+                // within the same host, keep the navigation inside the browser unless the set of
+                // available apps to handle the new navigation is different. http://crbug.com/463138
+                URI currentUri;
+                URI previousUri;
+                try {
+                    currentUri = new URI(url);
+                    previousUri = new URI(params.referrer);
+                } catch (Exception e) {
+                    currentUri = null;
+                    previousUri = null;
+                }
+
+                if (currentUri != null && previousUri != null
+                        && TextUtils.equals(currentUri.getHost(), previousUri.getHost())) {
+                    Intent previousIntent;
+                    try {
+                        previousIntent = Intent.parseUri(
+                                params.referrer, Intent.URI_INTENT_SCHEME);
+                    } catch (Exception e) {
+                        previousIntent = null;
+                    }
+
+                    if (previousIntent != null)  {
+                        List<ComponentName> currentHandlers =
+                                UrlUtilities.getIntentHandlers(mContext, intent);
+                        List<ComponentName> previousHandlers =
+                                UrlUtilities.getIntentHandlers(mContext, previousIntent);
+
+                        if (previousHandlers.containsAll(currentHandlers)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (intent != null && startActivity(intent)) return true;
         return false;
     }
 }


### PR DESCRIPTION
This patch is to support the custom url scheme, e.g. "whatsapp://",
"intent://".
For "intent://", if the related app, e.g. Barcode Scanner, was
installed, then start the activity to launch this scanner, if it was
not installed, XWalkView will load the fallback url if it was specified.
For "whatsapp://", if whatsapp was installed, start the activity to
launch it, if it was not installed, then try to install it from market
according to the package name. If the package name is null, will report
"ERR_UNKNOWN_URL_SCHEME".

BUG=XWALK-6690