### PR TITLE
crosswalk-18: Use a standard std::string() constructor instead of base::EmptyString.

### DIFF
--- a/runtime/browser/runtime_download_manager_delegate.cc
+++ b/runtime/browser/runtime_download_manager_delegate.cc
@@ -16,8 +16,6 @@
 #include "base/command_line.h"
 #include "base/files/file_util.h"
 #include "base/logging.h"
-#include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/download_manager.h"
@@ -81,7 +79,7 @@ bool RuntimeDownloadManagerDelegate::DetermineDownloadTarget(
   base::FilePath generated_name = net::GenerateFileName(
       download->GetURL(),
       download->GetContentDisposition(),
-      base::EmptyString(),
+      std::string(),
       download->GetSuggestedFilename(),
       download->GetMimeType(),
       "download");


### PR DESCRIPTION
The former is less costly than than the latter, which requires
thread-safe access and a singleton. We just need an empty std::string()
after all.

(cherry picked from commit c1e8610f455a18574697cf73e0f902b0b8e776e3)