### PR TITLE
[Android] Fix xwalk_app_runtime_java.jar's location in the app template.

### DIFF
--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -30,7 +30,8 @@ def GenerateAppTemplate(build_dir, build_mode, output_dir, source_dir):
     (os.path.join(source_dir, 'VERSION'),
      os.path.join(output_dir, 'VERSION')),
     (os.path.join(build_dir, 'lib.java', 'xwalk_app_runtime_java.jar'),
-     os.path.join(output_dir, 'libs', 'xwalk_app_runtime_java.jar')),
+     os.path.join(output_dir, 'template', 'libs',
+                  'xwalk_app_runtime_java.jar')),
   )
 
   for src, dest in dirs:


### PR DESCRIPTION
Fix a regression introduced by 7209eee ("[Android] Rewrite
generate_app_packaging_tool.py") which ended up putting
`lib/xwalk_app_runtime_java.jar` into the top-level app_template
directory. It must be under `template/`.

BUG=XWALK-6744