### PR TITLE
[Android] Add notification while downloading is in progress and finished

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDownloadListenerImpl.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkDownloadListenerImpl.java
@@ -51,6 +51,9 @@ class XWalkDownloadListenerImpl extends XWalkDownloadListenerInternal {
             Request request = new Request(Uri.parse(url));
             request.addRequestHeader("Cookie", mCookieManager.getCookie(url));
             request.addRequestHeader("User-Agent", userAgent);
+            request.setNotificationVisibility(
+                    DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+            request.setTitle(fileName);
             request.setDestinationInExternalPublicDir(
                     Environment.DIRECTORY_DOWNLOADS, fileName);
             getDownloadManager().enqueue(request);


### PR DESCRIPTION
When open a link to download file in XWalkView, it's better the downloading
is visible and shows in the notifications while in progress and after
completion, so the downloaded file can be opened.

BUG=XWALK-6678