### PR TITLE
crosswalk-18: Build with enable_webvr=0 by default.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'd2f39946b24323c7d2ef510d1cb5451b3a30b4cc'
+chromium_crosswalk_rev = 'df737072a94b9d46b9feff57a4a59da8d020b6dd'
 v8_crosswalk_rev = 'd71b6cc1bb5d666ec67c276168ba7bdcd7fb8efd'
 
 crosswalk_git = 'https://github.com/crosswalk-project'

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -116,6 +116,10 @@
     # capabilities, sysapps etc).
     'disable_bundled_extensions%': 0,
 
+    # Disable WebVR altogether in crosswalk-18. The code is very experimental
+    # and ends up pulling additional dependencies into our JARs.
+    'enable_webvr%': 0,
+
     # Whether to include support for proprietary codecs..
     'proprietary_codecs%': 1,
 


### PR DESCRIPTION
Disable WebVR support on Android by default, since it depends on
`third_party/cardboard-java` which in turn needs
`third_party/android_protobuf`.

The dependency on `android_protobuf` means `xwalk_core_library_java.jar`
bundle Protobuf and cause build conflicts for users depending on Protobuf
themselves (or using other libraries that pull it).

The WebVR code is still in a very experimental state, even more so in M48,
so disabling it altogether is the best solution to get Crosswalk 18 out of
the door. We will try to think of a better solution for Crosswalk 19 and
above.

RELATED BUG=XWALK-6597
BUG=XWALK-6746