### PR TITLE
[Android] Implement the embedding API: getCertificate().

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
+import android.net.http.SslCertificate;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
@@ -1031,6 +1032,11 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         mContentsClientBridge.clearClientCertPreferences(callback);
     }
 
+    public SslCertificate getCertificate() {
+        if (mNativeContent == 0) return null;
+        return SslUtil.getCertificateFromDerBytes(nativeGetCertificate(mNativeContent));
+    }
+
     private native long nativeInit();
     private static native void nativeDestroy(long nativeXWalkContent);
     private native WebContents nativeGetWebContents(long nativeXWalkContent);
@@ -1056,4 +1062,5 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     private native void nativeSetBackgroundColor(long nativeXWalkContent, int color);
     private native void nativeSetOriginAccessWhitelist(
             long nativeXWalkContent, String url, String patterns);
+    private native byte[] nativeGetCertificate(long nativeXWalkContent);
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Paint;
 import android.graphics.Rect;
+import android.net.http.SslCertificate;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
@@ -1588,5 +1589,18 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         if (mContent == null) return;
         checkThreadSafety();
         mContent.clearClientCertPreferences(callback);
+    }
+
+    /**
+     * Gets the SSL certificate for the main top-level page or null
+     * if there is no certificate (the site is not secure).
+     * @return the SSL certificate for the main top-level page.
+     * @since 6.0
+     */
+    @XWalkAPI
+    public SslCertificate getCertificate() {
+        if (mContent == null) return null;
+        checkThreadSafety();
+        return mContent.getCertificate();
     }
 }

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -15,6 +15,7 @@
 #include "content/public/common/permission_status.mojom.h"
 #include "xwalk/runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h"
 
+using base::android::JavaParamRef;
 using base::android::ScopedJavaLocalRef;
 
 namespace content {
@@ -86,6 +87,10 @@ class XWalkContent {
 
   void SetXWalkAutofillClient(jobject client);
   void SetSaveFormData(bool enabled);
+
+  base::android::ScopedJavaLocalRef<jbyteArray> GetCertificate(
+      JNIEnv* env,
+      const JavaParamRef<jobject>& obj);
 
  private:
   JavaObjectWeakGlobalRef java_ref_;

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java
@@ -41,7 +41,9 @@ public class ClearSslPreferenceTest extends XWalkViewTestBase {
                 mTestHelperBridge.getOnReceivedSslErrorHelper();
         int onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
 
+        assertNull(getCertificateOnUiThread());
         loadUrlSync(pageUrl);
+        assertNotNull(getCertificateOnUiThread());
 
         assertEquals(onSslErrorCallCount + 1, onReceivedSslErrorHelper.getCallCount());
         assertEquals(1, mWebServer.getRequestCount(pagePath));
@@ -70,6 +72,7 @@ public class ClearSslPreferenceTest extends XWalkViewTestBase {
         // because we only remember user's decision if it is "allow".
         onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
         loadUrlSync(pageUrl);
+        assertNotNull(getCertificateOnUiThread());
         assertEquals(onSslErrorCallCount + 1, onReceivedSslErrorHelper.getCallCount());
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -8,6 +8,7 @@ package org.xwalk.core.xwview.test;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.net.http.SslCertificate;
 import android.net.http.SslError;
 import android.net.Uri;
 import android.test.ActivityInstrumentationTestCase2;
@@ -1150,6 +1151,15 @@ public class XWalkViewTestBase
             @Override
             public void run() {
                 view.getSettings().setUseWideViewPort(value);
+            }
+        });
+    }
+
+    protected SslCertificate getCertificateOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<SslCertificate>() {
+            @Override
+            public SslCertificate call() throws Exception {
+                return mXWalkView.getCertificate();
             }
         });
     }


### PR DESCRIPTION
This patch is to implement the embedding api of getCertificate().
Refine the test case to cover getCertificate().

BUG=XWALK-6734