### PR TITLE
PRESUBMIT: Stop relying on cpplint.FileInfo.RepositoryName().

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -26,9 +26,13 @@ _LICENSE_HEADER_RE = (
 def _CheckChangeLintsClean(input_api, output_api):
   class PrefixedFileInfo(cpplint.FileInfo):
     def RepositoryName(self):
-      # RepositoryNames() will trim everything up to 'xwalk/'. We need to
-      # override it because 'xwalk/' is part of the path in our include guards.
-      return 'xwalk/' + super(PrefixedFileInfo, self).RepositoryName()
+      fullname = self.FullName()
+      repo_pos = fullname.find('xwalk/')
+      if repo_pos == -1:
+        # Something weird happened, bail out.
+        return [output_api.PresubmitError(
+            'Cannot find "xwalk/" in %s.' % fullname)]
+      return fullname[repo_pos:]
   input_api.cpplint.FileInfo = PrefixedFileInfo
   source_filter = lambda filename: input_api.FilterSourceFile(
     filename, white_list=(r'.+\.(cc|h)$',))


### PR DESCRIPTION
This protects us from changes in depot_tools that cause problems for us.

For example, https://codereview.chromium.org/1897153003 breaks our use
case in the Buildbot slaves: Crosswalk is checked out inside the
chromium-crosswalk directory, which is checked out inside our Buildbot
git repository. That CL makes FileInfo.RepositoryName() find the
outermost git repository, which is the Buildbot one. In the end, the
suggested include guards will be wrong and look like this:

    XWALK_SLAVE_CROSSWALK_LINUX_BUILD_SRC_XWALK_RUNTIME_BROWSER_XWALK_PRESENTATION_SERVICE_HELPER_ANDROID_H_

Since we know our repository layout, we can take a shortcut and just
return the path we want with the right prefix by doing some string
manipulation.