### PR TITLE
[Android] Update comments of set/getCookie in XWalkCooikeManager

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
@@ -38,6 +38,8 @@ public class XWalkCookieManagerInternal {
      * Set cookie for a given url. The old cookie with same host/path/name will
      * be removed. The new cookie will be added if it is not expired or it does
      * not have expiration which implies it is session cookie.
+     *
+     * Scheme[https|http] must be added as the prefix of url domain.
      * @param url The url which cookie is set for
      * @param value The value for set-cookie: in http response header
      * @since 5.0
@@ -50,6 +52,8 @@ public class XWalkCookieManagerInternal {
     /**
      * Get cookie(s) for a given url so that it can be set to "cookie:" in http
      * request header.
+     *
+     * Scheme[https|http] must be added as the prefix of url domain.
      * @param url The url needs cookie
      * @return The cookies in the format of NAME=VALUE [; NAME=VALUE]
      * @since 5.0


### PR DESCRIPTION
Some customers complain that set/getCookie of XWalkCooikeManager is invalid
without adding scheme into url domain, which isn't required in Android WebView.

This is because CookieManager already use WebAddress to add scheme into the
url, so the comments of according XWalk APIs need to be updated.

BUG=XWALK-6766