### PR TITLE
[Android] Enable the wide viewport quirks mode default.

### DIFF
--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -213,6 +213,7 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
   prefs.databases_enabled = env->GetBooleanField(
       obj, field_ids_->database_enabled);
 
+  prefs.wide_viewport_quirk = true;
   prefs.double_tap_to_zoom_enabled = prefs.use_wide_viewport =
       env->GetBooleanField(obj, field_ids_->use_wide_viewport);
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/WideViewportTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/WideViewportTest.java
@@ -1,0 +1,41 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for WideViewport.
+ */
+public class WideViewportTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @SmallTest
+    @Feature({"WideViewport"})
+    public void testUseWideViewportWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        setQuirksModeByXWalkView(true, views.getView0());
+        setQuirksModeByXWalkView(true, views.getView1());
+        runPerViewSettingsTest(
+                new XWalkSettingsUseWideViewportTestHelper(views.getView0(), views.getBridge0()),
+                new XWalkSettingsUseWideViewportTestHelper(views.getView1(), views.getBridge1()));
+    }
+
+    @SmallTest
+    @Feature({"WideViewport"})
+    public void testUseWideViewportWithTwoViewsNoQuirks() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsUseWideViewportTestHelper(views.getView0(), views.getBridge0()),
+                new XWalkSettingsUseWideViewportTestHelper(views.getView1(), views.getBridge1()));
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -55,6 +55,8 @@ public class XWalkViewTestBase
     private XWalkView mXWalkView;
     private boolean mAllowSslError = true;
     final TestHelperBridge mTestHelperBridge = new TestHelperBridge();
+    private static final boolean ENABLED = true;
+    private static final boolean DISABLED = false;
 
     class TestXWalkUIClientBase extends XWalkUIClient {
         TestHelperBridge mInnerContentsClient;
@@ -1057,6 +1059,16 @@ public class XWalkViewTestBase
         });
     }
 
+    protected void setQuirksModeByXWalkView(final boolean value,
+            final XWalkView view) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                view.getSettings().setSupportQuirksMode(value);
+            }
+        });
+    }
+
     // This class provides helper methods for testing of settings related to
     // the text autosizing feature.
     abstract class XWalkSettingsTextAutosizingTestHelper<T> extends XWalkSettingsTestHelper<T> {
@@ -1171,5 +1183,76 @@ public class XWalkViewTestBase
                 return mXWalkView.getCertificate();
             }
         });
+    }
+
+    protected boolean getUseWideViewPortOnUiThreadByXWalkView(
+            final XWalkView view) throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return view.getSettings().getUseWideViewPort();
+            }
+        });
+    }
+
+    // To verify whether UseWideViewport works, we check, if the page width specified
+    // in the "meta viewport" tag is applied. When UseWideViewport is turned off, the
+    // "viewport" tag is ignored, and the layout width is set to device width in DIP pixels.
+    // We specify a very high width value to make sure that it doesn't intersect with
+    // device screen widths (in DIP pixels).
+    class XWalkSettingsUseWideViewportTestHelper extends XWalkSettingsTestHelper<Boolean> {
+        private static final String VIEWPORT_TAG_LAYOUT_WIDTH = "3000";
+        XWalkView mView;
+        TestHelperBridge mBridge;
+
+        XWalkSettingsUseWideViewportTestHelper(XWalkView view,
+                TestHelperBridge bridge) throws Throwable {
+            super(view);
+            mView = view;
+            mBridge = bridge;
+        }
+
+        @Override
+        protected Boolean getAlteredValue() {
+            return ENABLED;
+        }
+
+        @Override
+        protected Boolean getInitialValue() {
+            return DISABLED;
+        }
+
+        @Override
+        protected Boolean getCurrentValue() {
+            try {
+                return getUseWideViewPortOnUiThreadByXWalkView(mView);
+            } catch (Exception e) {
+                Log.e(TAG, "Get UseWideViewPort failed.", e);
+            }
+            return false;
+        }
+
+        @Override
+        protected void setCurrentValue(Boolean value) throws Throwable {
+            setUseWideViewPortOnUiThreadByXWalkView(value, mView);
+        }
+
+        @Override
+        protected void doEnsureSettingHasValue(Boolean value) throws Throwable {
+            loadDataSyncWithXWalkView(getData(), mView, mBridge);
+            final String bodyWidth = getTitleOnUiThreadByContent(mView);
+            if (value) {
+                assertTrue(bodyWidth, VIEWPORT_TAG_LAYOUT_WIDTH.equals(bodyWidth));
+            } else {
+                assertFalse(bodyWidth, VIEWPORT_TAG_LAYOUT_WIDTH.equals(bodyWidth));
+            }
+        }
+
+        private String getData() {
+            return "<html><head>"
+                    + "<meta name='viewport' content='width=" + VIEWPORT_TAG_LAYOUT_WIDTH + "' />"
+                    + "</head>"
+                    + "<body onload='document.title=document.body.clientWidth'></body></html>";
+        }
     }
 }


### PR DESCRIPTION
This patch is to enable wide viewport quirks mode default. Without
enabling, the page is zoom out which is different from WebView.
Porting the test case for wide viewport from Android WebView.

Please refer to https://chromiumcodereview.appspot.com/23496047

BUG=XWALK-6762