### PR TITLE
[Android] Indicate that a malformed URL isn't accepted by XWalkCooikeManager

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
@@ -4,6 +4,11 @@
 
 package org.xwalk.core.internal;
 
+import android.util.Log;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.chromium.base.annotations.JNINamespace;
 
 /**
@@ -14,6 +19,8 @@ import org.chromium.base.annotations.JNINamespace;
 @JNINamespace("xwalk")
 @XWalkAPI(createExternally = true)
 public class XWalkCookieManagerInternal {
+    private static final String TAG = "XWalkCookieManager";
+
     /**
      * Control whether cookie is enabled or disabled
      * @param accept TRUE if accept cookie
@@ -44,7 +51,11 @@ public class XWalkCookieManagerInternal {
      */
     @XWalkAPI
     public void setCookie(final String url, final String value) {
-        nativeSetCookie(url, value);
+        try {
+            nativeSetCookie(new URL(url).toString(), value);
+        } catch (MalformedURLException e) {
+            Log.e(TAG, "Not setting cookie due to invalid URL", e);
+        }
     }
 
     /**
@@ -56,9 +67,14 @@ public class XWalkCookieManagerInternal {
      */
     @XWalkAPI
     public String getCookie(final String url) {
-        String cookie = nativeGetCookie(url.toString());
-        // Return null if the string is empty to match legacy behavior
-        return cookie == null || cookie.trim().isEmpty() ? null : cookie;
+        try {
+            String cookie = nativeGetCookie(new URL(url).toString());
+            // Return null if the string is empty to match legacy behavior
+            return cookie == null || cookie.trim().isEmpty() ? null : cookie;
+        } catch (MalformedURLException e) {
+            Log.e(TAG, "Unable to get cookies due to invalid URL", e);
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Some customers complain long debug time to know that url without scheme is invalid
when using XWalkCooikeManager, which isn't required in Android WebView.

This is because CookieManager already use WebAddress to add scheme into the url.
For the different design, xwalk will not do the same implementation, but it's better
to throw an exception to user in this case.

BUG=XWALK-6766