### PR TITLE
[Android] Move IO thread's shouldOverrideUrlLoading to UI thread

### DIFF
--- a/runtime/browser/xwalk_render_message_filter.cc
+++ b/runtime/browser/xwalk_render_message_filter.cc
@@ -27,6 +27,14 @@ XWalkRenderMessageFilter::XWalkRenderMessageFilter(int process_id)
     : BrowserMessageFilter(AndroidWebViewMsgStart),
       process_id_(process_id) {
 }
+
+void XWalkRenderMessageFilter::OverrideThreadForMessage(
+    const IPC::Message& message,
+    BrowserThread::ID* thread) {
+  if (message.type() == XWalkViewHostMsg_ShouldOverrideUrlLoading::ID) {
+    *thread = BrowserThread::UI;
+  }
+}
 #endif
 
 bool XWalkRenderMessageFilter::OnMessageReceived(

--- a/runtime/browser/xwalk_render_message_filter.h
+++ b/runtime/browser/xwalk_render_message_filter.h
@@ -15,6 +15,9 @@ class XWalkRenderMessageFilter : public content::BrowserMessageFilter {
   XWalkRenderMessageFilter();
 #if defined(OS_ANDROID)
   explicit XWalkRenderMessageFilter(int process_id);
+  // BrowserMessageFilter methods.
+  void OverrideThreadForMessage(const IPC::Message& message,
+                                content::BrowserThread::ID* thread) override;
 #endif
   bool OnMessageReceived(const IPC::Message& message) override;
 


### PR DESCRIPTION
Currently shouldOverrideUrlLoading happens at the IO thread. But this
was assumed to happen at the UI thread. Also, this will lead to crash
in debug build. This commit ensures shouldOverrideUrlLoading happens
at the UI thread and avoids debug crash.

BUG=XWALK-6866