### PR TITLE
[Windows][Linux] Support of '*' CSP rules for applications

### DIFF
--- a/application/browser/application_security_policy.h
+++ b/application/browser/application_security_policy.h
@@ -37,18 +37,21 @@ class ApplicationSecurityPolicy {
 
  protected:
   struct WhitelistEntry {
-    WhitelistEntry(const GURL& url, bool subdomains);
-    GURL url;
+    WhitelistEntry(const GURL& dest,
+                   const std::string& dest_host,
+                   bool subdomains);
+    GURL dest;
+    std::string dest_host;
     bool subdomains;
 
-    bool operator==(const WhitelistEntry& o) const {
-      return o.url == url && o.subdomains == subdomains;
-    }
+    bool operator==(const WhitelistEntry& o) const;
   };
 
   ApplicationSecurityPolicy(scoped_refptr<ApplicationData> app_data,
                             SecurityMode mode);
-  void AddWhitelistEntry(const GURL& url, bool subdomains);
+  void AddWhitelistEntry(const GURL& url,
+                         const std::string& dest_host,
+                         bool subdomains);
 
   virtual void InitEntries() = 0;
 

--- a/runtime/common/xwalk_common_messages.h
+++ b/runtime/common/xwalk_common_messages.h
@@ -32,9 +32,10 @@ IPC_ENUM_TRAITS(xwalk::application::ApplicationSecurityPolicy::SecurityMode)
 // RenderView messages
 // These are messages sent from the browser to the renderer process.
 
-IPC_MESSAGE_CONTROL3(ViewMsg_SetAccessWhiteList,  // NOLINT
+IPC_MESSAGE_CONTROL4(ViewMsg_SetAccessWhiteList,  // NOLINT
                      GURL /* source */,
                      GURL /* dest */,
+                     std::string /*dest_host*/,
                      bool /* allow_subdomains */)
 
 IPC_MESSAGE_CONTROL2(ViewMsg_EnableSecurityMode,    // NOLINT

--- a/runtime/renderer/xwalk_render_process_observer_generic.h
+++ b/runtime/renderer/xwalk_render_process_observer_generic.h
@@ -49,12 +49,16 @@ class XWalkRenderProcessObserver : public content::RenderProcessObserver {
 
  private:
   void OnSetAccessWhiteList(
-      const GURL& source, const GURL& dest, bool allow_subdomains);
+      const GURL& source,
+      const GURL& dest,
+      const std::string& dest_host,
+      bool allow_subdomains);
   void OnEnableSecurityMode(
       const GURL& url,
       application::ApplicationSecurityPolicy::SecurityMode mode);
   void AddAccessWhiteListEntry(const GURL& source,
                                const GURL& dest,
+                               const std::string& dest_host,
                                bool allow_subdomains);
 
   bool is_blink_initialized_;


### PR DESCRIPTION
This patch enables manifest CSP rules containing '*' such as:
'http://*/' or 'https://*.example.com'.

BUG=XWALK-6745