### PR TITLE
Fix race condition when RenderProcess or ExtensionProcess dies.

### DIFF
--- a/extensions/browser/xwalk_extension_data.cc
+++ b/extensions/browser/xwalk_extension_data.cc
@@ -6,6 +6,7 @@
 
 #include "content/public/browser/browser_thread.h"
 #include "xwalk/extensions/browser/xwalk_extension_process_host.h"
+#include "xwalk/extensions/browser/xwalk_extension_service.h"
 #include "xwalk/extensions/common/xwalk_extension_server.h"
 
 using content::BrowserThread;
@@ -14,16 +15,19 @@ namespace xwalk {
 namespace extensions {
 
 XWalkExtensionData::XWalkExtensionData()
-    : extension_thread_(NULL),
-      render_process_host_(NULL) {}
+    : extension_thread_(nullptr),
+      render_process_host_(nullptr),
+      in_process_message_filter_(nullptr) {}
 
 XWalkExtensionData::~XWalkExtensionData() {
   DCHECK(in_process_extension_thread_server_);
   DCHECK(in_process_ui_thread_server_);
+  DCHECK(in_process_message_filter_);
   DCHECK(extension_thread_);
 
   in_process_extension_thread_server_->Invalidate();
   in_process_ui_thread_server_->Invalidate();
+  in_process_message_filter_->Invalidate();
 
   extension_thread_->message_loop()->DeleteSoon(
       FROM_HERE, in_process_extension_thread_server_.release());

--- a/extensions/browser/xwalk_extension_data.h
+++ b/extensions/browser/xwalk_extension_data.h
@@ -31,7 +31,7 @@ class XWalkExtensionData {
   XWalkExtensionData();
   ~XWalkExtensionData();
 
-  XWalkExtensionServer* in_process_ui_thread_server() {
+  XWalkExtensionServer* in_process_ui_thread_server() const {
     return in_process_ui_thread_server_.get();
   }
 
@@ -39,8 +39,12 @@ class XWalkExtensionData {
     return std::move(extension_process_host_);
   }
 
-  content::RenderProcessHost* render_process_host() {
+  content::RenderProcessHost* render_process_host() const {
     return render_process_host_;
+  }
+
+  ExtensionServerMessageFilter* in_process_message_filter() const {
+    return in_process_message_filter_;
   }
 
   void set_in_process_extension_thread_server(
@@ -65,6 +69,10 @@ class XWalkExtensionData {
     render_process_host_ = rph;
   }
 
+  void set_in_process_message_filter(ExtensionServerMessageFilter* filter) {
+    in_process_message_filter_ = filter;
+  }
+
  private:
   // Extension servers living on their respective threads.
   scoped_ptr<XWalkExtensionServer> in_process_extension_thread_server_;
@@ -76,6 +84,7 @@ class XWalkExtensionData {
   base::Thread* extension_thread_;
 
   content::RenderProcessHost* render_process_host_;
+  ExtensionServerMessageFilter* in_process_message_filter_;
 };
 
 }  // namespace extensions


### PR DESCRIPTION
When either of these two processes are dying then it may be that there
are still messages being filtered in the IPC channel. If so then the filter
may have dangling pointers to the extension thread server or the ui thread
server (as those have been deleted already). The solution is to invalidate
the filter when deleting the XWalkExtensionData object. Please note that
this commit partially revert XWALK-4295 beside the call to RemoveFilter in
OnRenderProcessHostClosed which was the cause of the crash (double delete
because RemoveFilter also delete the filter).

BUG=XWALK-6856