### PR TITLE
[Android] Enable the wide viewport quirk and implement APIs about loading overview mode.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -60,6 +60,7 @@ public class XWalkSettingsInternal {
     private boolean mDomStorageEnabled = true;
     private boolean mDatabaseEnabled = true;
     private boolean mUseWideViewport = false;
+    private boolean mLoadWithOverviewMode = false;
     private boolean mMediaPlaybackRequiresUserGesture = false;
     private String mDefaultVideoPosterURL;
     private final boolean mPasswordEchoEnabled;
@@ -1130,6 +1131,43 @@ public class XWalkSettingsInternal {
         return mLayoutAlgorithm == LayoutAlgorithmInternal.TEXT_AUTOSIZING;
     }
 
+    /**
+     * Sets whether the XWalkView loads pages in overview mode, that is, zooms out
+     * the content to fit on screen by width. This setting is taken into account
+     * when the content width is greater than the width of the XWalkView control,
+     * for example, when getUseWideViewPort() is enabled. The default is false.
+     * @param overview whether this XWalkView loads pages in overview mode.
+     * @since 7.0
+     */
+    @XWalkAPI
+    public void setLoadWithOverviewMode(boolean overview) {
+        synchronized (mXWalkSettingsLock) {
+            if (mLoadWithOverviewMode == overview) return;
+            mLoadWithOverviewMode = overview;
+            mEventHandler.maybeRunOnUiThreadBlocking(new Runnable() {
+                @Override
+                public void run() {
+                    if (mNativeXWalkSettings != 0) {
+                        mEventHandler.updateWebkitPreferencesLocked();
+                        nativeResetScrollAndScaleState(mNativeXWalkSettings);
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Gets whether this XWalkView loads pages in overview mode.
+     * @return whether this XWalkView loads pages in overview mode.
+     * @since 7.0
+     */
+    @XWalkAPI
+    public boolean getLoadWithOverviewMode() {
+        synchronized (mXWalkSettingsLock) {
+            return mLoadWithOverviewMode;
+        }
+    }
+
     private native long nativeInit(WebContents webContents);
 
     private native void nativeDestroy(long nativeXWalkSettings);
@@ -1147,4 +1185,6 @@ public class XWalkSettingsInternal {
     private native void nativeUpdateFormDataPreferences(long nativeXWalkSettings);
 
     private native void nativeUpdateInitialPageScale(long nativeXWalkSettings);
+
+    private native void nativeResetScrollAndScaleState(long nativeXWalkSettings);
 }

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -82,6 +82,8 @@ struct XWalkSettings::FieldIds {
         GetFieldID(env, clazz, "mSpatialNavigationEnabled", "Z");
     quirks_mode_enabled =
         GetFieldID(env, clazz, "mQuirksModeEnabled", "Z");
+    initialize_at_minimum_page_scale =
+        GetFieldID(env, clazz, "mLoadWithOverviewMode", "Z");
   }
 
   // Field ids
@@ -103,6 +105,7 @@ struct XWalkSettings::FieldIds {
   jfieldID default_fixed_font_size;
   jfieldID spatial_navigation_enabled;
   jfieldID quirks_mode_enabled;
+  jfieldID initialize_at_minimum_page_scale;
 };
 
 XWalkSettings::XWalkSettings(JNIEnv* env,
@@ -213,6 +216,8 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
   prefs.databases_enabled = env->GetBooleanField(
       obj, field_ids_->database_enabled);
 
+  prefs.initialize_at_minimum_page_scale =
+      env->GetBooleanField(obj, field_ids_->initialize_at_minimum_page_scale);
   prefs.double_tap_to_zoom_enabled = prefs.use_wide_viewport =
       env->GetBooleanField(obj, field_ids_->use_wide_viewport);
 
@@ -338,6 +343,12 @@ void XWalkSettings::UpdateInitialPageScale(JNIEnv* env, jobject obj) {
       Java_XWalkSettingsInternal_getDIPScaleLocked(env, obj));
   render_view_host_ext->SetInitialPageScale(
       initial_page_scale_percent / dip_scale / 100.0f);
+}
+
+void XWalkSettings::ResetScrollAndScaleState(JNIEnv* env, jobject obj) {
+  XWalkRenderViewHostExt* rvhe = GetXWalkRenderViewHostExt();
+  if (!rvhe) return;
+  rvhe->ResetScrollAndScaleState();
 }
 
 bool RegisterXWalkSettings(JNIEnv* env) {

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -267,6 +267,8 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
   prefs.viewport_meta_non_user_scalable_quirk = support_quirks;
   prefs.clobber_user_agent_initial_scale_quirk = support_quirks;
 
+  prefs.wide_viewport_quirk = true;
+
   render_view_host->UpdateWebkitPreferences(prefs);
 }
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadWithOverviewModeTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadWithOverviewModeTest.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for LoadWithOverviewMode.
+ */
+public class LoadWithOverviewModeTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @SmallTest
+    @Feature({"LoadWithOverviewMode"})
+    public void testLoadWithOverviewModeWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsLoadWithOverviewModeTestHelper(
+                        views.getView0(), views.getBridge0(), false),
+                new XWalkSettingsLoadWithOverviewModeTestHelper(
+                        views.getView1(), views.getBridge1(), false));
+    }
+
+    @SmallTest
+    @Feature({"LoadWithOverviewMode"})
+    public void testLoadWithOverviewModeViewportTagWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsLoadWithOverviewModeTestHelper(
+                        views.getView0(), views.getBridge0(), true),
+                new XWalkSettingsLoadWithOverviewModeTestHelper(
+                        views.getView1(), views.getBridge1(), true));
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
@@ -62,6 +62,7 @@ public class SetInitialScaleTest extends XWalkViewTestBase {
     @SmallTest
     @Feature({"setInitialScale"})
     public void testSetInitialScale2() throws Throwable {
+        setQuirksMode(false);
         CallbackHelper onPageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
 
         WindowManager wm = (WindowManager) getInstrumentation().getTargetContext()
@@ -75,12 +76,12 @@ public class SetInitialScaleTest extends XWalkViewTestBase {
                 + "<p style='height:" + height + "px;width:" + width + "px'>"
                 + "testSetInitialScale</p></body></html>";
         final float defaultScaleFactor = 0;
-        final float defaultScale = 0.5f;
-        final float scaleFactor = 0.25f;
+        final float defaultScale = getInstrumentation().getTargetContext(
+                ).getResources().getDisplayMetrics().density;
 
         assertEquals(defaultScaleFactor, getScaleFactor(), .01f);
         loadDataSync(null, page, "text/html", false);
-        assertEquals(scaleFactor, getScaleFactor(), .01f);
+        assertEquals(defaultScale, getPixelScale(), .01f);
 
         int onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
         setInitialScale(60);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/UseWideViewportTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/UseWideViewportTest.java
@@ -1,0 +1,41 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+
+import org.chromium.base.test.util.Feature;
+
+/**
+ * Test suite for UseWideViewport.
+ */
+public class UseWideViewportTest extends XWalkViewTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @SmallTest
+    @Feature({"WideViewport"})
+    public void testUseWideViewportWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        setQuirksModeByXWalkView(true, views.getView0());
+        setQuirksModeByXWalkView(true, views.getView1());
+        runPerViewSettingsTest(
+                new XWalkSettingsUseWideViewportTestHelper(views.getView0(), views.getBridge0()),
+                new XWalkSettingsUseWideViewportTestHelper(views.getView1(), views.getBridge1()));
+    }
+
+    @SmallTest
+    @Feature({"WideViewport"})
+    public void testUseWideViewportWithTwoViewsNoQuirks() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsUseWideViewportTestHelper(views.getView0(), views.getBridge0()),
+                new XWalkSettingsUseWideViewportTestHelper(views.getView1(), views.getBridge1()));
+    }
+}

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -56,6 +56,8 @@ public class XWalkViewTestBase
     private XWalkView mXWalkView;
     private boolean mAllowSslError = true;
     final TestHelperBridge mTestHelperBridge = new TestHelperBridge();
+    private static final boolean ENABLED = true;		
+    private static final boolean DISABLED = false;
 
     class TestXWalkUIClientBase extends XWalkUIClient {
         TestHelperBridge mInnerContentsClient;
@@ -1076,6 +1078,16 @@ public class XWalkViewTestBase
         });
     }
 
+    protected void setQuirksModeByXWalkView(final boolean value,
+            final XWalkView view) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                view.getSettings().setSupportQuirksMode(value);
+            }
+        });
+    }
+
     // This class provides helper methods for testing of settings related to
     // the text autosizing feature.
     abstract class XWalkSettingsTextAutosizingTestHelper<T> extends XWalkSettingsTestHelper<T> {
@@ -1208,5 +1220,76 @@ public class XWalkViewTestBase
                 mXWalkView.findNext(forward);
             }
         });
+    }
+
+    protected boolean getUseWideViewPortOnUiThreadByXWalkView(
+            final XWalkView view) throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return view.getSettings().getUseWideViewPort();
+            }
+        });
+    }
+
+    // To verify whether UseWideViewport works, we check, if the page width specified
+    // in the "meta viewport" tag is applied. When UseWideViewport is turned off, the
+    // "viewport" tag is ignored, and the layout width is set to device width in DIP pixels.
+    // We specify a very high width value to make sure that it doesn't intersect with
+    // device screen widths (in DIP pixels).
+    class XWalkSettingsUseWideViewportTestHelper extends XWalkSettingsTestHelper<Boolean> {
+        private static final String VIEWPORT_TAG_LAYOUT_WIDTH = "3000";
+        XWalkView mView;
+        TestHelperBridge mBridge;
+
+        XWalkSettingsUseWideViewportTestHelper(XWalkView view,
+                TestHelperBridge bridge) throws Throwable {
+            super(view);
+            mView = view;
+            mBridge = bridge;
+        }
+
+        @Override
+        protected Boolean getAlteredValue() {
+            return ENABLED;
+        }
+
+        @Override
+        protected Boolean getInitialValue() {
+            return DISABLED;
+        }
+
+        @Override
+        protected Boolean getCurrentValue() {
+            try {
+                return getUseWideViewPortOnUiThreadByXWalkView(mView);
+            } catch (Exception e) {
+                Log.e(TAG, "Get UseWideViewPort failed.", e);
+            }
+            return false;
+        }
+
+        @Override
+        protected void setCurrentValue(Boolean value) throws Throwable {
+            setUseWideViewPortOnUiThreadByXWalkView(value, mView);
+        }
+
+        @Override
+        protected void doEnsureSettingHasValue(Boolean value) throws Throwable {
+            loadDataSyncWithXWalkView(getData(), mView, mBridge);
+            final String bodyWidth = getTitleOnUiThreadByContent(mView);
+            if (value) {
+                assertTrue(bodyWidth, VIEWPORT_TAG_LAYOUT_WIDTH.equals(bodyWidth));
+            } else {
+                assertFalse(bodyWidth, VIEWPORT_TAG_LAYOUT_WIDTH.equals(bodyWidth));
+            }
+        }
+
+        private String getData() {
+            return "<html><head>"
+                    + "<meta name='viewport' content='width=" + VIEWPORT_TAG_LAYOUT_WIDTH + "' />"
+                    + "</head>"
+                    + "<body onload='document.title=document.body.clientWidth'></body></html>";
+        }
     }
 }

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
@@ -749,4 +749,14 @@ public class XWalkViewInternalTestBase
             }
         }, WAIT_TIMEOUT_MS, CHECK_INTERVAL);
     }
+
+    protected void setUseWideViewPortOnUiThreadByXWalkView(final boolean value,
+            final XWalkViewInternal view) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                view.getSettings().setUseWideViewPort(value);
+            }
+        });
+    }
 }

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/ZoomTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/ZoomTest.java
@@ -36,6 +36,7 @@ public class ZoomTest extends XWalkViewInternalTestBase {
     @SmallTest
     @Feature({"zoomBy, zoomIn, zoomOut"})
     public void testZoom() throws Throwable {
+        setUseWideViewPortOnUiThreadByXWalkView(true, getXWalkView());
         assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
 
         loadDataSync(null, getZoomableHtml(mPageMinimumScale), "text/html", false);


### PR DESCRIPTION
Enable the wide viewport quirk by default.
Implement embedding APIs: setLoadWithOverviewMode(), getLoadWithOverviewMode().
Patch for overview mode should be merged after enabling wide viewport quirk, otherwise will lead to one test case(testSetInitialScale2) failed.

BUG=XWALK-6762
BUG=XWALK-6859