### PR TITLE
[Android] Optimize cookie store task runner

### DIFF
--- a/runtime/browser/android/cookie_manager.cc
+++ b/runtime/browser/android/cookie_manager.cc
@@ -248,6 +248,8 @@ base::SingleThreadTaskRunner* CookieManager::GetCookieStoreTaskRunner() {
 }
 
 net::CookieStore* CookieManager::GetCookieStore() {
+  DCHECK(cookie_store_task_runner_->RunsTasksOnCurrentThread());
+
   if (!cookie_store_) {
     FilePath user_data_dir;
     GetUserDataDir(&user_data_dir);
@@ -265,8 +267,6 @@ net::CookieStore* CookieManager::GetCookieStore() {
     content::CookieStoreConfig cookie_config(
         cookie_store_path, content::CookieStoreConfig::RESTORED_SESSION_COOKIES,
         nullptr, nullptr);
-    cookie_store_task_runner_ =
-        BrowserThread::GetMessageLoopProxyForThread(BrowserThread::IO);
     cookie_config.client_task_runner = cookie_store_task_runner_;
     cookie_config.background_task_runner =
         cookie_store_backend_thread_.task_runner();


### PR DESCRIPTION
After rebaseing to M50, a cross-thread wrapper had been
implemented to around CookieStore. this patch is to correct
a rebase missing, while also fix an issue that deleted cookies
are resurrected in some cases.

BUG=XWALK-6321