### PR TITLE
Make sure default schemes (https, http...) are allowed to store cookies.

### DIFF
--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -131,6 +131,11 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
         content::CookieStoreConfig::PERSISTANT_SESSION_COOKIES,
         NULL, NULL);
 
+    cookie_config.cookieable_schemes.insert(
+        cookie_config.cookieable_schemes.begin(),
+        net::CookieMonster::kDefaultCookieableSchemes,
+        net::CookieMonster::kDefaultCookieableSchemes +
+        net::CookieMonster::kDefaultCookieableSchemesCount);
     cookie_config.cookieable_schemes.push_back(application::kApplicationScheme);
     cookie_config.cookieable_schemes.push_back(content::kChromeDevToolsScheme);
 


### PR DESCRIPTION
This is a regression after moving to M50 and the actual refactor due
to CookieMonster being hidden as an API.

https://github.com/crosswalk-project/crosswalk/commit/e1f52c3660f3868a11cccbae67593b435672160d
landed an incorrect change.

BUG=XWALK-6934