### PR TITLE
[Android] Fix javadoc build with JDK 1.8.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -57,7 +57,7 @@ import android.os.Bundle;
  * <p>For shared mode and download mode, you might need to edit the Android manifest to set some
  * properties. </p>
  *
- * <h5>Shared Mode</h5>
+ * <h4>Shared Mode</h4>
  *
  * <p>If you want the end-user to download Crosswalk Project runtime from specified URL instead of
  * switching to the application store, add following &lt;meta-data&gt; element inside the
@@ -79,7 +79,7 @@ import android.os.Bundle;
  * &lt;uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /&gt;
  * </pre>
  *
- * <h5>Download Mode</h5>
+ * <h4>Download Mode</h4>
  *
  * <p>Firstly, you need to add following &lt;meta-data&gt; element to enable download mode:</p>
  *

--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -169,7 +169,7 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  * <p>For shared mode and download mode, you might need to edit the Android manifest to set some
  * properties. </p>
  *
- * <h5>Shared Mode</h5>
+ * <h4>Shared Mode</h4>
  *
  * <p>If you want the end-user to download Crosswalk Project runtime from specified URL instead of
  * switching to the application store, add following &lt;meta-data&gt; element inside the
@@ -191,7 +191,7 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  * &lt;uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /&gt;
  * </pre>
  *
- * <h5>Download Mode</h5>
+ * <h4>Download Mode</h4>
  *
  * <p>Firstly, you need to add following &lt;meta-data&gt; element to enable download mode:</p>
  *

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -114,10 +114,10 @@ import org.xwalk.core.internal.extension.BuiltinXWalkExtensions;
  *   </li>
  *   <li>Use XWalkView in MainActivity.java.
  *    <pre>mXWalkView = (XWalkView) findViewById(R.id.xwalkview);</pre>
- *   </li></ul></li>
+ *   </li></ul>
  *   There is debug message on logcat according to your "animatable" values:
  *    "XWalkContent: CompositingSurfaceType is TextureView"
- *   </ol>
+ *   </li></ol>
  *
  * <p>XWalkViewInternal needs hardware acceleration to render web pages. As a result, the
  * AndroidManifest.xml of the caller's app must be appended with the attribute


### PR DESCRIPTION
Fix build errors caused by commits 5505ef4 ("[Android] Refactor download
mode") and 1c6ecad ("[Android] Implement the method to set compositing
surface type for single XWalkView"):

```
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:60: error: header used out of sequence: <H5>
 * <h5>Shared Mode</h5>
   ^
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java:172: error: header used out of sequence: <H5>
 * <h5>Shared Mode</h5>
   ^
../out/Release/gen/xwalk_core_reflection_layer/wrapper/org/xwalk/core/XWalkView.java:96: error: text not allowed in <ol> element
 *   </li></ul></li>
                    ^
```