### PR TITLE
[Android] Filter JARs being merged by the classes they contain.

### DIFF
--- a/build/android/merge_jars.py
+++ b/build/android/merge_jars.py
@@ -7,12 +7,16 @@
 
 """
 Given a list of JAR files passed via --jars, produced one single JAR file with
-all their contents merged. JAR files outside --build-dir are ignored.
+all their contents merged. JAR files with classes outside org.xwalk,
+org.chromium and a few others are ignored to avoid clashing with other
+packages.
 """
 
-import optparse
+import argparse
+import fnmatch
 import os
 import sys
+import zipfile
 
 GYP_ANDROID_DIR = os.path.join(os.path.dirname(__file__),
                                os.pardir, os.pardir, os.pardir,
@@ -25,20 +29,112 @@ import jar
 from util import build_utils
 
 
-def main():
-  parser = optparse.OptionParser()
-  parser.add_option('--build-dir',
-                    help='Base build directory, such as out/Release. JARs '
-                    'outside this directory will be skipped.')
-  parser.add_option('--jars', help='The jars to merge.')
-  parser.add_option('--output-jar', help='Name of the merged JAR file.')
 
-  options, _ = parser.parse_args()
-  build_dir = os.path.abspath(options.build_dir)
+# The list below contains all entries allowed in JAR files (it can contain
+# wildcards).
+# If a JAR contains an entry that does not match the white list below, it will
+# be rejected and not merged.
+JAR_ENTRY_WHITELIST = (
+  'META-INF/MANIFEST.MF',
+  'SevenZip/*.class',
+  'org/chromium/*.class',
+  'org/xwalk/*.class',
+)
+
+# These are the JAR files we are known to skip because they contain classes in
+# namespaces we do not allow -- they are either not necessary or users must
+# embed them on their own together with Crosswalk.
+KNOWN_SKIPPED_JARS = (
+  # android.support.multidex is used by BaseChromiumApplication via
+  # ChromiumMultiDexInstaller, but not in release mode. We have not needed it
+  # so far (as of Crosswalk 21).
+  'android-support-multidex.jar',
+
+  # Chromium used to depend on support-v4 code for its Background Sync
+  # implementation in the content layer, but this has not been the case since
+  # crrev.com/1324173002. The dependency remains in the build system though.
+  # See also: XWALK-5092.
+  'android-support-v13.jar',
+
+  # Annotations are not used at runtime (XWALK-6544).
+  'jsr_305_javalib.jar',
+
+  # WebVR code uses the Cardboard classes that in turn depend on protobuf.
+  # Users are expected to include it in their projects themselves. See
+  # XWALK-6597.
+  'cardboard.jar',
+  'protobuf_nano_javalib.jar',
+)
+
+
+def IsMergeableJar(jar_path):
+  """
+  Returns True if a certain JAR does not have any classes outside the
+  allowed namespaces.
+  """
+  with zipfile.ZipFile(jar_path) as zip_file:
+    for entry_name in zip_file.namelist():
+      if entry_name.endswith('/'):  # Directories are irrelevant.
+        continue
+      if any(fnmatch.fnmatchcase(entry_name, f) for f in JAR_ENTRY_WHITELIST):
+        continue
+      return False
+  return True
+
+
+def ValidateKnownSkippedJars(jar_list):
+  """
+  Returns a 2-element tuple (extra, missing), where |extra| is a set with all
+  elements in KNOWN_SKIPPED_JARS that were not detected while merging the jars
+  in |jar_list|, and |missing| has all the JARs that could not be merged but
+  were not in KNOWN_SKIPPED_JARS.
+  """
+  skipped_jars = set(os.path.basename(jar_file) for jar_file in jar_list \
+                     if not IsMergeableJar(jar_file))
+  return (set(KNOWN_SKIPPED_JARS) - skipped_jars,
+          skipped_jars - set(KNOWN_SKIPPED_JARS))
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--jars', help='The jars to merge.')
+  parser.add_argument('--output-jar', help='Name of the merged JAR file.')
+  parser.add_argument('--validate-skipped-jars-list', action='store_true',
+                      help='Whether to validate KNOWN_SKIPPED_JARS by making '
+                      'sure it matches all the jars passed in --jars that are '
+                      'being skipped.')
+
+  options = parser.parse_args()
+  options.jars = build_utils.ParseGypList(options.jars)
+
+  if options.validate_skipped_jars_list:
+    extra, missing = ValidateKnownSkippedJars(options.jars)
+    # It is fine for |extra| not to be empty: different build options may
+    # include fewer JARs. |missing| being non-empty is fatal, though, as it
+    # means there will be problems for users since we are not skipping files
+    # that we should.
+    if extra:
+      print
+      print 'merge_jars.py: The following JARs in KNOWN_SKIPPED_JARS were ' \
+            'not used:'
+      print '  %s' % ', '.join(sorted(extra))
+      print
+    if missing:
+      print
+      print 'merge_jars.py: The following JARs are not mergeable but are ' \
+            'not part of KNOWN_SKIPPED_JARS:'
+      print '  %s' % ', '.join(sorted(missing))
+      print
+      return 1
 
   with build_utils.TempDir() as temp_dir:
-    for jar_file in build_utils.ParseGypList(options.jars):
-      if not os.path.abspath(jar_file).startswith(build_dir):
+    for jar_file in options.jars:
+      # If a JAR has classes outside our allowed namespaces (mostly
+      # org.chromium and org.xwalk), we need to skip it otherwise there can be
+      # build issues when a user builds an app with Crosswalk as well as
+      # another package with one of these non-allowed namespaces (see
+      # XWALK-5092, XWALK-6597).
+      if not IsMergeableJar(jar_file):
         continue
       build_utils.ExtractAll(jar_file, path=temp_dir, pattern='*.class')
     jar.JarDirectory(temp_dir, options.output_jar)

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -226,7 +226,6 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
             '--output-jar=<(jar_final_path)',
           ],
@@ -256,7 +255,6 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
             '--output-jar=<(jar_final_path)',
           ],
@@ -287,9 +285,12 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--build-dir=<(PRODUCT_DIR)',
             '--jars=>(input_jars_paths)',
             '--output-jar=<(jar_final_path)',
+            # This argument is important for this final JAR we are creating, as
+            # it validates that we are filtering out the right JARs when doing
+            # the merge.
+            '--validate-skipped-jars-list',
           ],
         },
       ],


### PR DESCRIPTION
This builds upon the initial work done in commit 862201b ("[Android]
Only merge JARs which we have built ourselves").

That commit filtered the JARs being merged based on whether they were
located inside our build directory. That is not enough, as we sometimes
build a few JARs that contain classes in packages that can clash with
other JARs a user may use:
* `jsr_305_javalib.jar` has classes in the `javax.annotation` package.
* `protobuf_nano_javalib.jar` has classes in the
  `com.google.protobuf.nano` package.
The latter in particular is built as a dependency for the
`cardboard.jar` blob (itself a dependency for WebVR support) and causes
conflicts with LibPhoneNumber.

So instead of filtering JARs by their location, we now inspect each JAR
and skip those with classes outside the package namespaces we allow (at
the moment, `org.xwalk`, `org.chromium` and `SevenZip`).

For WebVR support, which is what originally prompted this change, this
means users must bundle `cardboard.jar` into their projects themselves
if they want WebVR support to work -- the alternative, bundling
`cardboard.jar` ourselves, means going back to XWALK-5092 (i.e. the
build would break for users who do bundle `cardboard.jar` themselves).

We also do some extra validation when generating
`xwalk_core_library_java.jar` and make sure the list of JARs we are
known to skip is entirely correct. We still need a more automated way to
let users know which JARs they need to embed together with Crosswalk.   

BUG=XWALK-5092
BUG=XWALK-6544
BUG=XWALK-6597