### PR TITLE
[Android] Fix crash when setting surface type through layout

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/ReflectField.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/ReflectField.java
@@ -35,10 +35,13 @@ class ReflectField {
         try {
             mField = mClass.getField(mName);
         } catch (NoSuchFieldException e) {
-            try {
-                mField = mClass.getDeclaredField(mName);
-                mField.setAccessible(true);
-            } catch (NoSuchFieldException e2) {
+            for (Class<?> parent = mClass; parent != null; parent = parent.getSuperclass()) {
+                try {
+                    mField = parent.getDeclaredField(mName);
+                    mField.setAccessible(true);
+                    break;
+                } catch (NoSuchFieldException e2) {
+                }
             }
         }
         return mField != null;


### PR DESCRIPTION
XWalkViewBridge will try to get the member mAnimatable from XWalkView.
But if the class type in the layout file is XWalkView's subclass, the
member can't be found and a exception is thrown. This patch will look
for the member by going up the class hierarchy.