### PR TITLE
Handle URLs without seperators in CSP rules properly

### DIFF
--- a/application/browser/application_security_policy.cc
+++ b/application/browser/application_security_policy.cc
@@ -177,12 +177,14 @@ void ApplicationSecurityPolicyCSP::InitEntries() {
 
       for (const auto& directive : policies) {
         for (const auto& it : directive.second) {
-          URLPattern allowedUrl(URLPattern::SCHEME_ALL);
-          if (allowedUrl.Parse(it) != URLPattern::PARSE_SUCCESS)
-            continue;
           GURL url(it);
           if (!url.is_valid())
             continue;
+
+          URLPattern allowedUrl(URLPattern::SCHEME_ALL);
+          if (allowedUrl.Parse(url.spec()) != URLPattern::PARSE_SUCCESS)
+            continue;
+
           AddWhitelistEntry(url, allowedUrl.host(), allowedUrl.match_subdomains());
         }
       }


### PR DESCRIPTION
This PR fixes handling of URLs without separtors e.g. "frame-src https://crosswalk-project.org"

BUG=XWALK-6906