### PR TITLE
[Android] Change the inteface for setting dialog manager

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -153,17 +153,16 @@ public abstract class XWalkActivity extends Activity {
     }
 
     /**
-     * Set up the dialog manager so that you can customize the dialog to be dislplayed when
-     * initializing Crosswalk Project runtime. This method must be called within onCreate(). Once
-     * onResume() is invoked, a default dialog manager will be set up and you won't be able to
-     * change it. The dialog manager is meaningless in download mode because there won't be any UI
-     * interfaction.
+     * Get the dialog manager so that you can customize the dialog to be dislplayed when
+     * initializing Crosswalk Project runtime. Please note that you should modify the dialog within
+     * onCreate(). Once onResume() is invoked, some dialog maybe already displayed. The dialog
+     * manager is meaningless in download mode because there won't be any UI interaction.
      *
-     * @param dialogManager The {@link XWalkDialogManager} to use
+     * @return the dialogManager which this activity is using
      * @since 7.0
      */
-    protected void setDialogManager(XWalkDialogManager dialogManager) {
-        mActivityDelegate.setDialogManager(dialogManager);
+    protected XWalkDialogManager getDialogManager() {
+        return mActivityDelegate.getDialogManager();
     }
 
     /**

--- a/runtime/android/core/src/org/xwalk/core/XWalkActivityDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivityDelegate.java
@@ -48,6 +48,8 @@ public class XWalkActivityDelegate
         mIsDownloadMode = enable != null
                 && (enable.equalsIgnoreCase("enable") || enable.equalsIgnoreCase("true"));
 
+        mDialogManager = new XWalkDialogManager(mActivity);
+
         XWalkLibraryLoader.prepareToInit(mActivity);
     }
 
@@ -67,19 +69,12 @@ public class XWalkActivityDelegate
         mXWalkApkUrl = url;
     }
 
-    public void setDialogManager(XWalkDialogManager dialogManager) {
-        if (mDialogManager != null) {
-            throw new RuntimeException("Dialog manager already exists");
-        }
-        mDialogManager = dialogManager;
+    public XWalkDialogManager getDialogManager() {
+        return mDialogManager;
     }
 
     public void onResume() {
         if (mIsInitializing || mIsXWalkReady) return;
-
-        if (mDialogManager == null) {
-            mDialogManager = new XWalkDialogManager(mActivity);
-        }
 
         mIsInitializing = true;
         if (XWalkLibraryLoader.isLibraryReady()) {


### PR DESCRIPTION
The user can't set external dialog manager to XWalkActivity anymore.
Instead, they can get internal manager and modify the dialog.
(cherry picked from commit a0bb1cc7655f9465767238bcf40f31775846699c)