### PR TITLE
[Android] Fix a crash issue of shared mode

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -339,7 +339,11 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
                   "        removeViewAt(0);",
                   "        new org.xwalk.core.extension.XWalkExternalExtensionManagerImpl(this);"},
               postBridgeLines = {
-                  "        String animatable = (String) new ReflectField(wrapper, \"mAnimatable\").get();",
+                  "        String animatable = null;",
+                  "        try {",
+                  "            animatable = (String) new ReflectField(wrapper, \"mAnimatable\").get();",
+                  "        } catch (RuntimeException e) {",
+                  "        }",
                   "        initXWalkContent(getContext(), animatable);"})
     public XWalkViewInternal(Context context, AttributeSet attrs) {
         super(context, attrs);


### PR DESCRIPTION
The old version of XWalkView doesn't have the private member
mAnimatable. When those versions of shared app are trying to link to
newest library, XWalkViewBridge in the library side can't find the
member and will throw an exception which causes the app crash.