### PR TITLE
[Android] Change the inteface for setting dialog manager

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -153,17 +153,16 @@ public abstract class XWalkActivity extends Activity {
     }
 
     /**
-     * Set up the dialog manager so that you can customize the dialog to be dislplayed when
-     * initializing Crosswalk Project runtime. This method must be called within onCreate(). Once
-     * onResume() is invoked, a default dialog manager will be set up and you won't be able to
-     * change it. The dialog manager is meaningless in download mode because there won't be any UI
-     * interfaction.
+     * Get the dialog manager so that you can customize the dialog to be dislplayed when
+     * initializing Crosswalk Project runtime. Please note that you should modify the dialog within
+     * onCreate(). Once onResume() is invoked, some dialog maybe already displayed. The dialog
+     * manager is meaningless in download mode because there won't be any UI interaction.
      *
-     * @param dialogManager The {@link XWalkDialogManager} to use
+     * @return the dialog manager which this activity is using
      * @since 7.0
      */
-    protected void setDialogManager(XWalkDialogManager dialogManager) {
-        mActivityDelegate.setDialogManager(dialogManager);
+    protected XWalkDialogManager getDialogManager() {
+        return mActivityDelegate.getDialogManager();
     }
 
     /**

--- a/runtime/android/core/src/org/xwalk/core/XWalkActivityDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivityDelegate.java
@@ -48,6 +48,8 @@ public class XWalkActivityDelegate
         mIsDownloadMode = enable != null
                 && (enable.equalsIgnoreCase("enable") || enable.equalsIgnoreCase("true"));
 
+        mDialogManager = new XWalkDialogManager(mActivity);
+
         XWalkLibraryLoader.prepareToInit(mActivity);
     }
 
@@ -67,19 +69,12 @@ public class XWalkActivityDelegate
         mXWalkApkUrl = url;
     }
 
-    public void setDialogManager(XWalkDialogManager dialogManager) {
-        if (mDialogManager != null) {
-            throw new RuntimeException("Dialog manager already exists");
-        }
-        mDialogManager = dialogManager;
+    public XWalkDialogManager getDialogManager() {
+        return mDialogManager;
     }
 
     public void onResume() {
         if (mIsInitializing || mIsXWalkReady) return;
-
-        if (mDialogManager == null) {
-            mDialogManager = new XWalkDialogManager(mActivity);
-        }
 
         mIsInitializing = true;
         if (XWalkLibraryLoader.isLibraryReady()) {

--- a/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
  *
  * public class MainActivity extends XWalkActivity {
  *     private XWalkView mXWalkView;
- *     private XWalkDialogManager mDialogManager;
  *
  *     &#64;Override
  *     protected void onCreate(Bundle savedInstanceState) {
@@ -50,11 +49,10 @@ import java.util.ArrayList;
  *
  *         // Get default dialog and modifiy it as needed, or set a completely customized dialog.
  *
- *         mDialogManager = new XWalkDialogManager(this);
- *         AlertDialog dialog = mDialogManager.getAlertDialog(XWalkDialogManager.DIALOG_NOT_FOUND);
+ *         XWalkDialogManager dialogManager = getDialogManager();
+ *         AlertDialog dialog = dialogManager.getAlertDialog(XWalkDialogManager.DIALOG_NOT_FOUND);
  *         dialog.setTitle("TestTitle");
  *         dialog.setMessage("TestMessage");
- *         setDialogManager(mDialogManager);
  *     }
  *
  *     &#64;Override


### PR DESCRIPTION
The user can't set external dialog manager to XWalkActivity anymore.
Instead, they can get internal manager and modify the dialog.
(cherry picked from commit 69d2964ba1280a578807a951ddae8a907f0b8e15)