### PR TITLE
[Linux] Fix the crash in ColorChooser

### DIFF
--- a/runtime/browser/ui/color_chooser_aura.cc
+++ b/runtime/browser/ui/color_chooser_aura.cc
@@ -57,9 +57,8 @@ ColorChooserAura::ColorChooserAura(content::WebContents* web_contents,
                                    SkColor initial_color)
     : web_contents_(web_contents) {
   view_ = new views::ColorChooserView(this, initial_color);
-  widget_ = views::Widget::CreateWindowWithContext(
-      view_, web_contents->GetNativeView());
-  widget_->SetAlwaysOnTop(true);
+  widget_ = views::Widget::CreateWindowWithParent(
+      view_, web_contents->GetTopLevelNativeWindow());
   widget_->Show();
   if (IsTesting()) {
     content::BrowserThread::PostTask(content::BrowserThread::UI, FROM_HERE,


### PR DESCRIPTION
The original implementation with CreateWindowWithContext may cause
X receive a bad window parameter and the ColorChooserView is placed
at a fixed position but not bundled with the root window.

> The program 'xwalk' received an X Window System error.
This probably reflects a bug in the program.
The error was 'BadWindow (invalid Window parameter)'.
  (Details: serial 1767 error_code 3 request_code 3 minor_code 0)
  (Note to programmers: normally, X errors are reported asynchronously;
   that is, you will receive the error a while after causing it.
   To debug your program, run it with the --sync command line
   option to change this behavior. You can then get a meaningful
   backtrace from your debugger if you break on the gdk_x_error() function.)
 
Now we use CreateWindowWithParent to parent the ColorChooserView with
toplevel window to avoid the X error mentioned above and the view is
bundled with the root window and it can be moved together with the root
window.


BUG=XWALK-6958