### PR TITLE
M51: Fix browsertests on linux

### DIFF
--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -39,8 +39,15 @@
 #include "xwalk/runtime/common/xwalk_paths.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 
+
 #if defined(OS_ANDROID)
 #include "base/strings/string_split.h"
+#elif defined(OS_WIN)
+#include "base/base_paths_win.h"
+#elif defined(OS_LINUX)
+#include "base/nix/xdg_util.h"
+#elif defined(OS_MACOSX)
+#include "base/base_paths_mac.h"
 #endif
 
 using content::BrowserThread;
@@ -121,12 +128,37 @@ XWalkBrowserContext* XWalkBrowserContext::FromWebContents(
 
 void XWalkBrowserContext::InitWhileIOAllowed() {
   base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
+  base::FilePath path;
   if (cmd_line->HasSwitch(switches::kXWalkDataPath)) {
-    base::FilePath path =
-        cmd_line->GetSwitchValuePath(switches::kXWalkDataPath);
+    path = cmd_line->GetSwitchValuePath(switches::kXWalkDataPath);
     PathService::OverrideAndCreateIfNeeded(
         DIR_DATA_PATH, path, false, true);
+    BrowserContext::Initialize(this, path);
+  } else {
+    base::FilePath::StringType xwalk_suffix;
+    xwalk_suffix = FILE_PATH_LITERAL("xwalk");
+#if defined(OS_WIN)
+    CHECK(PathService::Get(base::DIR_LOCAL_APP_DATA, &path));
+    path = path.Append(xwalk_suffix);
+#elif defined(OS_LINUX)
+    std::unique_ptr<base::Environment> env(base::Environment::Create());
+    base::FilePath config_dir(
+        base::nix::GetXDGDirectory(env.get(),
+                                   base::nix::kXdgConfigHomeEnvVar,
+                                   base::nix::kDotConfigDir));
+    path = config_dir.Append(xwalk_suffix);
+#elif defined(OS_MACOSX)
+    CHECK(PathService::Get(base::DIR_APP_DATA, &path));
+    path = path.Append(xwalk_suffix);
+#elif defined(OS_ANDROID)
+    CHECK(PathService::Get(base::DIR_ANDROID_APP_DATA, &path));
+    path = path.Append(xwalk_suffix);
+#else
+    NOTIMPLEMENTED();
+#endif
   }
+
+  BrowserContext::Initialize(this, path);
 #if !defined(OS_ANDROID)
   XWalkContentSettings::GetInstance()->Init();
 #endif


### PR DESCRIPTION
We were getting following error on all of the browsertests,
[109919:109919:0602/121714:FATAL:browser_context.cc(350)] Check failed: browser_context->GetUserData(kMojoWasInitialized). Attempting to get the mojo user id for a BrowserContext that was never Initialize()ed
becasue we were not initilizing the BrowserContext. This patch fixes it by
calling BrowserContext::Initialize() with appropriate path.

adapted from,
https://codereview.chromium.org/1741953002

BUG=XWALK-6951