### PR TITLE
Refine destroy order in XWalkContent.java

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -712,10 +712,10 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         mContentViewRenderView.setCurrentContentViewCore(null);
 
         // Destroy the native resources.
+        mCleanupReference.cleanupNow();
         mContentViewRenderView.destroy();
         mContentViewCore.destroy();
 
-        mCleanupReference.cleanupNow();
         mCleanupReference = null;
         mNativeContent = 0;
     }


### PR DESCRIPTION
BUG=XWALK-6840

XWalk would destroy contentViewRenderView first and then cleanupReference which points
other native object such as exitFullScreen, it will use contentViewRenderView
when in full screen. So app would cause crash. The correct behavior is that exit full
screen first and then destroy contentViewRenderView.