### PR TITLE
DEPS.xwalk: Roll chromium-crosswalk (0732335 -> b15d01e).

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '073233556d0f3a05d05151481bb8f6e172a68d2f'
+chromium_crosswalk_rev = 'b15d01ecdbaf659c7efa6328c4b49ba73236b8ea'
 v8_crosswalk_rev = '04e36ca961519430e18bf7265baffa2a8b7f1964'
 
 crosswalk_git = 'https://github.com/crosswalk-project'


### PR DESCRIPTION
* b15d01e Merge pull request #357 from rakuco/xw20-remove-dot-gclient
* 6956b58 Remove .gclient and .gclient_entries.

BUG=XWALK-6961