### PR TITLE
crosswalk-20: Build with enable_webvr=0 by default.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'b15d01ecdbaf659c7efa6328c4b49ba73236b8ea'
+chromium_crosswalk_rev = 'f91b739683dd5bc8963c9c9339ef6be87bd970a0'
 v8_crosswalk_rev = '04e36ca961519430e18bf7265baffa2a8b7f1964'
 
 crosswalk_git = 'https://github.com/crosswalk-project'

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -133,6 +133,11 @@
     'disable_bundled_extensions%': 0,
 
     # From src/build/common.gypi.
+    # Disable WebVR support. The code is still experimental and and ends up
+    # pulling additional dependencies into our JARs (XWALK-6597).
+    'enable_webvr%': 0,
+
+    # From src/build/common.gypi.
     # Whether to include support for proprietary codecs..
     'proprietary_codecs%': 1,
 


### PR DESCRIPTION
**IMPORTANT**
We actually intend to fix this properly. We are cherry-picking
this commit from the crosswalk-18 branch first in order to have a stable
baseline with no WebVR support propagating from Crosswalk 21 to 20 to 19.
After that, we can start working on fixing this in 21 and 20 and, if there
is enough time, 19 too.

*From the original commit message:*

Disable WebVR support on Android by default, since it depends on
`third_party/cardboard-java` which in turn needs
`third_party/android_protobuf`.

The dependency on `android_protobuf` means `xwalk_core_library_java.jar`
bundle Protobuf and cause build conflicts for users depending on Protobuf
themselves (or using other libraries that pull it).

Related BUG=XWALK-6597