### PR TITLE
[Android] Expose embedding apis for video fullscreen.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/CustomViewCallbackHandlerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/CustomViewCallbackHandlerInternal.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+/**
+ * A callback used by the host application to notify
+ * the current page that its custom view has been dismissed.
+ */
+@XWalkAPI(impl = CustomViewCallbackInternal.class, createInternally = true)
+public class CustomViewCallbackHandlerInternal implements CustomViewCallbackInternal {
+
+    /**
+     * Invoked when the host application dismisses the
+     * custom view.
+     * @since 7.0
+     */
+    @XWalkAPI
+    public void onCustomViewHidden() {
+    }
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/CustomViewCallbackInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/CustomViewCallbackInternal.java
@@ -1,0 +1,20 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+/**
+ * A callback interface used by the host application to notify
+ * the current page that its custom view has been dismissed.
+ */
+@XWalkAPI(instance = CustomViewCallbackHandlerInternal.class)
+public interface CustomViewCallbackInternal {
+    /**
+     * Invoked when the host application dismisses the
+     * custom view.
+     * @since 7.0
+     */
+    @XWalkAPI
+    public void onCustomViewHidden();
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
@@ -13,7 +13,6 @@ import org.chromium.base.CommandLine;
 import org.chromium.content.browser.ContentVideoView;
 import org.chromium.content.browser.ContentVideoViewEmbedder;
 import org.chromium.content.common.ContentSwitches;
-import org.xwalk.core.internal.XWalkWebChromeClient.CustomViewCallback;
 
 class XWalkContentVideoViewClient implements ContentVideoViewEmbedder {
     private XWalkContentsClient mContentsClient;
@@ -27,7 +26,7 @@ class XWalkContentVideoViewClient implements ContentVideoViewEmbedder {
     @Override
     public void enterFullscreenVideo(View view) {
         mView.setOverlayVideoMode(true);
-        mContentsClient.onShowCustomView(view, null);
+        mContentsClient.onShowCustomView(view, new CustomViewCallbackHandlerInternal());
     }
 
     @Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -231,11 +231,11 @@ abstract class XWalkContentsClient extends ContentViewClient {
     // TODO (michaelbai): Remove this method once the same method remove from
     // XWalkContentsClientAdapter.
     public abstract void onShowCustomView(View view,
-           int requestedOrientation, XWalkWebChromeClient.CustomViewCallback callback);
+           int requestedOrientation, CustomViewCallbackInternal callback);
 
     // TODO (michaelbai): This method should be abstract, having empty body here
     // makes the merge to the Android easy.
-    public void onShowCustomView(View view, XWalkWebChromeClient.CustomViewCallback callback) {
+    public void onShowCustomView(View view, CustomViewCallbackInternal callback) {
         onShowCustomView(view, ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, callback);
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -147,11 +147,12 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     public void setUIClient(XWalkUIClientInternal client) {
         // If it's null, use Crosswalk implementation.
-        if (client != null) {
+        if (client == null) {
+            mXWalkUIClient = new XWalkUIClientInternal(mXWalkView);
+        } else {
             mXWalkUIClient = client;
-            return;
         }
-        mXWalkUIClient = new XWalkUIClientInternal(mXWalkView);
+        mXWalkUIClient.setContentsClient(this);
     }
 
     public void setResourceClient(XWalkResourceClientInternal client) {
@@ -167,7 +168,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     public void setXWalkWebChromeClient(XWalkWebChromeClient client) {
         // If it's null, use Crosswalk implementation.
         if (client == null) return;
-        client.setContentsClient(this);
         mXWalkWebChromeClient = client;
     }
 
@@ -499,24 +499,24 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     @Override
-    public void onShowCustomView(View view, XWalkWebChromeClient.CustomViewCallback callback) {
-        if (mXWalkWebChromeClient != null) {
-            mXWalkWebChromeClient.onShowCustomView(view, callback);
+    public void onShowCustomView(View view, CustomViewCallbackInternal callback) {
+        if (mXWalkUIClient != null) {
+            mXWalkUIClient.onShowCustomView(view, callback);
         }
     }
 
     @Override
     public void onShowCustomView(View view, int requestedOrientation,
-            XWalkWebChromeClient.CustomViewCallback callback) {
-        if (mXWalkWebChromeClient != null) {
-            mXWalkWebChromeClient.onShowCustomView(view, requestedOrientation, callback);
+            CustomViewCallbackInternal callback) {
+        if (mXWalkUIClient != null) {
+            mXWalkUIClient.onShowCustomView(view, requestedOrientation, callback);
         }
     }
 
     @Override
     public void onHideCustomView() {
-        if (mXWalkWebChromeClient != null) {
-            mXWalkWebChromeClient.onHideCustomView();
+        if (mXWalkUIClient != null) {
+            mXWalkUIClient.onHideCustomView();
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -390,7 +390,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         setXWalkClient(new XWalkClient(this));
         // Set default XWalkWebChromeClient and DownloadListener. The default actions
         // are provided via the following clients if special actions are not needed.
-        setXWalkWebChromeClient(new XWalkWebChromeClient(this));
+        setXWalkWebChromeClient(new XWalkWebChromeClient());
 
         // Set with internal implementation. Could be overwritten by embedders'
         // setting.

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
@@ -16,19 +16,14 @@
 
 package org.xwalk.core.internal;
 
-import android.app.Activity;
 import android.content.Context;
-import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Message;
-import android.view.Gravity;
 import android.view.View;
-import android.view.ViewGroup;
 import android.webkit.WebStorage;
 import android.webkit.ConsoleMessage;
 import android.webkit.ValueCallback;
-import android.widget.FrameLayout;
 
 /**
  * It's an internal legacy class which is to handle kinds of ui related
@@ -38,23 +33,7 @@ import android.widget.FrameLayout;
  * @hide
  */
 public class XWalkWebChromeClient {
-    private Context mContext;
-    private View mCustomXWalkView;
-    private XWalkViewInternal mXWalkView;
-    private XWalkWebChromeClient.CustomViewCallback mCustomViewCallback;
-    private XWalkContentsClient mContentsClient = null;
     private long XWALK_MAX_QUOTA = 1024 * 1024 * 100;
-    private final int INVALID_ORIENTATION = -2;
-    private int mPreOrientation = INVALID_ORIENTATION;
-
-    public XWalkWebChromeClient(XWalkViewInternal view) {
-        mContext = view.getContext();
-        mXWalkView = view;
-    }
-
-    void setContentsClient(XWalkContentsClient client) {
-        mContentsClient = client;
-    }
 
     /**
      * Notify the host application of a new favicon for the current page.
@@ -62,110 +41,6 @@ public class XWalkWebChromeClient {
      * @param icon A Bitmap containing the favicon for the current page.
      */
     public void onReceivedIcon(XWalkViewInternal view, Bitmap icon) {}
-
-    /**
-     * A callback interface used by the host application to notify
-     * the current page that its custom view has been dismissed.
-     */
-    public interface CustomViewCallback {
-        /**
-         * Invoked when the host application dismisses the
-         * custom view.
-         */
-        public void onCustomViewHidden();
-    }
-
-    private Activity addContentView(View view, CustomViewCallback callback) {
-        Activity activity = null;
-        try {
-            activity = (Activity) mXWalkView.getContext();
-        } catch (ClassCastException e) {
-        }
-
-        if (mCustomXWalkView != null || activity == null) {
-            if (callback != null) callback.onCustomViewHidden();
-            return null;
-        }
-
-        mCustomXWalkView = view;
-        mCustomViewCallback = callback;
-
-        if (mContentsClient != null) {
-            mContentsClient.onToggleFullscreen(true);
-        }
-
-        // Add the video view to the activity's DecorView.
-        FrameLayout decor = (FrameLayout) activity.getWindow().getDecorView();
-        decor.addView(mCustomXWalkView, 0,
-                new FrameLayout.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        Gravity.CENTER));
-        return activity;
-    }
-
-    /**
-     * Notify the host application that the current page would
-     * like to show a custom View.
-     * @param view is the View object to be shown.
-     * @param callback is the callback to be invoked if and when the view
-     * is dismissed.
-     */
-    public void onShowCustomView(View view, CustomViewCallback callback) {
-        addContentView(view, callback);
-    }
-
-    /**
-     * Notify the host application that the current page would
-     * like to show a custom View in a particular orientation.
-     * @param view is the View object to be shown.
-     * @param requestedOrientation An orientation constant as used in
-     * {@link ActivityInfo#screenOrientation ActivityInfo.screenOrientation}.
-     * @param callback is the callback to be invoked if and when the view
-     * is dismissed.
-     */
-    public void onShowCustomView(View view, int requestedOrientation,
-            CustomViewCallback callback) {
-        Activity activity = addContentView(view, callback);
-        if (activity == null) return;
-
-        final int orientation = activity.getResources().getConfiguration().orientation;
-
-        if (requestedOrientation != orientation &&
-                requestedOrientation >= ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED &&
-                requestedOrientation <= ActivityInfo.SCREEN_ORIENTATION_LOCKED) {
-            mPreOrientation = orientation;
-            activity.setRequestedOrientation(requestedOrientation);
-        }
-    };
-
-    /**
-     * Notify the host application that the current page would
-     * like to hide its custom view.
-     */
-    public void onHideCustomView() {
-        if (mCustomXWalkView == null || !(mXWalkView.getContext() instanceof Activity)) return;
-
-        if (mContentsClient != null) {
-            mContentsClient.onToggleFullscreen(false);
-        }
-
-        Activity activity = (Activity) mXWalkView.getContext();
-        // Remove video view from activity's ContentView.
-        FrameLayout decor = (FrameLayout) activity.getWindow().getDecorView();
-        decor.removeView(mCustomXWalkView);
-        if (mCustomViewCallback != null) mCustomViewCallback.onCustomViewHidden();
-
-        if (mPreOrientation != INVALID_ORIENTATION &&
-                mPreOrientation >= ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED &&
-                mPreOrientation <= ActivityInfo.SCREEN_ORIENTATION_LOCKED) {
-            activity.setRequestedOrientation(mPreOrientation);
-            mPreOrientation = INVALID_ORIENTATION;
-        }
-
-        mCustomXWalkView = null;
-        mCustomViewCallback = null;
-    }
 
    /**
     * Tell the client that the quota has been exceeded for the Web SQL Database

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/GeolocationPermissionTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/GeolocationPermissionTest.java
@@ -39,7 +39,7 @@ public class GeolocationPermissionTest extends XWalkViewInternalTestBase {
     public void testGeolocationPermissionShowPrompt() throws Throwable {
         class TestWebChromeClient extends XWalkWebChromeClient {
             public TestWebChromeClient() {
-                super(getXWalkView());
+                super();
             }
 
             private int mCalledCount = 0;
@@ -80,7 +80,7 @@ public class GeolocationPermissionTest extends XWalkViewInternalTestBase {
     public void testGeolocationPermissionHidePrompt() throws Throwable {
         class TestWebChromeClient extends XWalkWebChromeClient {
             public TestWebChromeClient() {
-                super(getXWalkView());
+                super();
             }
 
             @Override

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/OnShowOnHideCustomViewTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/OnShowOnHideCustomViewTest.java
@@ -15,18 +15,18 @@ import org.chromium.content.browser.test.util.TouchCommon;
 import org.xwalk.core.internal.xwview.test.util.VideoTestWebServer;
 
 /**
- * Tests XWalkWebChromeClient::onShow/onHideCustomView.
+ * Tests XWalkUIClient::onShow/onHideCustomView.
  */
 public class OnShowOnHideCustomViewTest extends XWalkViewInternalTestBase {
     private VideoTestWebServer mWebServer;
-    private TestXWalkWebChromeClientBase mWebChromeClient;
+    private TestXWalkUIClientInternal mUIClient;
     private ContentViewCore mContentViewCore;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        mWebChromeClient = new TestXWalkWebChromeClientBase();
-        setXWalkWebChromeClient(mWebChromeClient);
+        mUIClient = new XWalkViewInternalTestBase.TestXWalkUIClientInternal();
+        setUIClient(mUIClient);
         mContentViewCore = getContentViewCore();
         mWebServer = new VideoTestWebServer(getInstrumentation().getContext());
     }
@@ -59,7 +59,7 @@ public class OnShowOnHideCustomViewTest extends XWalkViewInternalTestBase {
         // of the custom view. Note that we're not able to get the precise location of the
         // control since it is a shadow element, so this test might break if the location
         // ever moves.
-        TouchCommon.singleClickView(mWebChromeClient.getCustomView());
+        TouchCommon.singleClickView(mUIClient.getCustomView());
 
         DOMUtils.waitForMediaPlay(
                 mContentViewCore.getWebContents(), VideoTestWebServer.VIDEO_ID);
@@ -68,12 +68,12 @@ public class OnShowOnHideCustomViewTest extends XWalkViewInternalTestBase {
     private void doOnShowAndHideCustomViewTest(final Runnable existFullscreen) throws Throwable {
         doOnShowCustomViewTest();
         getInstrumentation().runOnMainSync(existFullscreen);
-        mWebChromeClient.waitForCustomViewHidden();
+        mUIClient.waitForCustomViewHidden();
     }
 
     private void doOnShowCustomViewTest() throws Exception {
         loadTestPageAndClickFullscreen();
-        mWebChromeClient.waitForCustomViewShown();
+        mUIClient.waitForCustomViewShown();
     }
 
     private void loadTestPageAndClickFullscreen() throws Exception {

--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -157,6 +157,7 @@ class Method(object):
     self._wrapper_params_declare_for_bridge = ''
     self._wrapper_params_pass_to_bridge = ''
     self._is_reservable = False
+    self._parameter_is_internal = False
 
     self.ParseMethodParams(params)
     self.ParseMethodAnnotation(annotation)
@@ -415,11 +416,12 @@ class Method(object):
       # the way bridge uses as the condition for whether call super or
       # call wrapper in override call
       #   XWalkViewInternal view => (view instanceof XWalkViewBridge)
-      if (is_internal_class and
-          not java_data.HasInstanceCreateInternallyAnnotation()):
-        return'(%s instanceof %s)' % (param_name, java_data.GetBridgeName())
-      else:
-        return None
+      if is_internal_class:
+        if not java_data.HasInstanceCreateInternallyAnnotation():
+          return'(%s instanceof %s)' % (param_name, java_data.GetBridgeName())
+        else:
+          self._parameter_is_internal = True
+      return None
     elif param_string_type == ParamStringType.WRAPPER_DECLARE:
       # the way wrapper declare the param
       #   XWalkViewInternal view => XWalkView view
@@ -533,9 +535,12 @@ ${POST_BRIDGE_LINES}
     return template.substitute(value)
 
   def GenerateBridgeOverrideMethod(self):
-    if not self._bridge_override_condition:
+    if not self._bridge_override_condition and not self._parameter_is_internal:
       return '    @Override'
-    template = Template("""\
+    # If _bridge_override_condition and _parameter_is_internal are True
+    # concurrently, _bridge_override_condition should be treated in priority.
+    if self._bridge_override_condition:
+      template = Template("""\
     @Override
     public ${RETURN_TYPE} ${NAME}(${PARAMS}) {
         if (${IF_CONDITION}) {
@@ -543,6 +548,13 @@ ${POST_BRIDGE_LINES}
         } else {
             ${RETURN}super.${NAME}(${PARAMS_PASSING});
         }
+    }
+""")
+    else:
+      template = Template("""\
+    @Override
+    public ${RETURN_TYPE} ${NAME}(${PARAMS}) {
+        ${RETURN}${NAME}(${BRIDGE_PARAMS_PASSING});
     }
 """)
 

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -29,6 +29,8 @@ from util import build_utils
 CLASSES_TO_BE_PROCESS = [
     'ClientCertRequestHandlerInternal',
     'ClientCertRequestInternal',
+    'CustomViewCallbackHandlerInternal',
+    'CustomViewCallbackInternal',
     'XWalkCookieManagerInternal',
     'XWalkDownloadListenerInternal',
     'XWalkExtensionInternal',


### PR DESCRIPTION
The onShow/HideCustomView() was implemented in Crosswalk by default and
not exposed, it could not be overrided by customer to implement the video
fullscreen.
This patch is to expose onShow/HideCustomView().

BUG=XWALK-6939