### PR TITLE
[Android] Fix the issue that failed to exit fullscreen.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -90,7 +90,6 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     private ContentBitmapCallback mGetBitmapCallback;
 
     long mNativeContent;
-    long mNativeWebContents;
 
     // TODO(hengzhi.wu): This should be in a global context, not per XWalkView.
     private double mDIPScale;
@@ -194,14 +193,13 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         // bind all the native->java relationships.
         mCleanupReference = new CleanupReference(this, new DestroyRunnable(mNativeContent));
 
-        WebContents webContents = nativeGetWebContents(mNativeContent);
+        mWebContents = nativeGetWebContents(mNativeContent);
 
         // Initialize ContentView.
         mContentViewCore = new ContentViewCore(mViewContext);
         mContentView = XWalkContentView.createContentView(
                 mViewContext, mContentViewCore, mXWalkView);
-        mContentViewCore.initialize(mContentView, mContentView, webContents, mWindow);
-        mWebContents = mContentViewCore.getWebContents();
+        mContentViewCore.initialize(mContentView, mContentView, mWebContents, mWindow);
         mNavigationController = mWebContents.getNavigationController();
         mXWalkView.addView(mContentView, new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
@@ -215,7 +213,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         // the members mAllowUniversalAccessFromFileURLs and mAllowFileAccessFromFileURLs
         // won't be changed from false to true at the same time in the constructor of
         // XWalkSettings class.
-        mSettings = new XWalkSettingsInternal(mViewContext, webContents, false);
+        mSettings = new XWalkSettingsInternal(mViewContext, mWebContents, false);
         // Enable AllowFileAccessFromFileURLs, so that files under file:// path could be
         // loaded by XMLHttpRequest.
         mSettings.setAllowFileAccessFromFileURLs(true);
@@ -665,7 +663,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
 
     void exitFullscreen() {
         if (hasEnteredFullscreen()) {
-            mContentsClientBridge.exitFullscreen(mNativeWebContents);
+            mWebContents.exitFullscreen();
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -843,11 +843,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         nativeCancelJsResult(mNativeContentsClientBridge, id);
     }
 
-    void exitFullscreen(long nativeWebContents) {
-        if (mNativeContentsClientBridge == 0) return;
-        nativeExitFullscreen(mNativeContentsClientBridge, nativeWebContents);
-    }
-
     public void notificationDisplayed(int id) {
         if (mNativeContentsClientBridge == 0) return;
         nativeNotificationDisplayed(mNativeContentsClientBridge, id);
@@ -918,7 +913,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     private native void nativeConfirmJsResult(long nativeXWalkContentsClientBridge, int id,
             String prompt);
     private native void nativeCancelJsResult(long nativeXWalkContentsClientBridge, int id);
-    private native void nativeExitFullscreen(long nativeXWalkContentsClientBridge, long nativeWebContents);
     private native void nativeNotificationDisplayed(long nativeXWalkContentsClientBridge, int id);
     private native void nativeNotificationClicked(long nativeXWalkContentsClientBridge, int id);
     private native void nativeNotificationClosed(long nativeXWalkContentsClientBridge, int id, boolean byUser);

--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -329,16 +329,6 @@ void XWalkContentsClientBridge::CancelJsResult(JNIEnv*, jobject, int id) {
   pending_js_dialog_callbacks_.Remove(id);
 }
 
-void XWalkContentsClientBridge::ExitFullscreen(
-    JNIEnv*, jobject, jlong j_web_contents) {
-  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
-  WebContents* web_contents = reinterpret_cast<WebContents*>(j_web_contents);
-  if (web_contents)
-    // TODO(mrunal): Instead of hardcoding the value below we can accept this
-    // as a parameter
-    web_contents->ExitFullscreen(/*will_cause_resize=*/false);
-}
-
 void XWalkContentsClientBridge::NotificationDisplayed(
     JNIEnv*, jobject, jint notification_id) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));

--- a/runtime/browser/android/xwalk_contents_client_bridge.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge.h
@@ -90,7 +90,6 @@ class XWalkContentsClientBridge : public XWalkContentsClientBridgeBase ,
   void ProceedSslError(JNIEnv* env, jobject obj, jboolean proceed, jint id);
   void ConfirmJsResult(JNIEnv*, jobject, int id, jstring prompt);
   void CancelJsResult(JNIEnv*, jobject, int id);
-  void ExitFullscreen(JNIEnv*, jobject, jlong web_contents);
   void NotificationDisplayed(JNIEnv*, jobject, jint id);
   void NotificationClicked(JNIEnv*, jobject, jint id);
   void NotificationClosed(JNIEnv*, jobject, jint id, bool by_user);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/EnterAndLeaveFullscreenTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/EnterAndLeaveFullscreenTest.java
@@ -13,6 +13,8 @@ import org.chromium.base.test.util.Feature;
  * Tests for the hasEnteredFullscreen() and leaveFullscreen() method.
  */
 public class EnterAndLeaveFullscreenTest extends XWalkViewTestBase {
+    private TestHelperBridge.OnFullscreenToggledHelper mOnFullscreenToggledHelper =
+            mTestHelperBridge.getOnFullscreenToggledHelper();
 
     @Override
     protected void setUp() throws Exception {
@@ -21,28 +23,40 @@ public class EnterAndLeaveFullscreenTest extends XWalkViewTestBase {
 
     @SmallTest
     @Feature({"XWalkView", "Fullscreen"})
-    public void testEnterAndExitFullscreen() throws Throwable {
+    public void testEnterAndExitFullscreenWithAPI() throws Throwable {
         final String name = "fullscreen_enter_exit.html";
         String fileContent = getFileContent(name);
+        int count = mOnFullscreenToggledHelper.getCallCount();
 
         loadDataSync(name, fileContent, "text/html", false);
+        assertFalse(hasEnteredFullscreen());
 
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    clickOnElementId("enter_fullscreen", null);
-                    assertTrue(getXWalkView().hasEnteredFullscreen());
-                    getXWalkView().leaveFullscreen();
-                    assertFalse(getXWalkView().hasEnteredFullscreen());
+        clickOnElementId("enter_fullscreen", null);
+        mOnFullscreenToggledHelper.waitForCallback(count);
+        assertTrue(hasEnteredFullscreen());
 
-                    clickOnElementId("enter_fullscreen", null);
-                    clickOnElementId("exit_fullscreen", null);
-                    assertFalse(getXWalkView().hasEnteredFullscreen());
-                } catch (Throwable e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        count = mOnFullscreenToggledHelper.getCallCount();
+        leaveFullscreen();
+        mOnFullscreenToggledHelper.waitForCallback(count);
+        assertFalse(hasEnteredFullscreen());
+    }
+
+    @SmallTest
+    @Feature({"XWalkView", "Fullscreen"})
+    public void testEnterAndExitFullscreenWithJS() throws Throwable {
+        final String name = "fullscreen_enter_exit.html";
+        String fileContent = getFileContent(name);
+        int count = mOnFullscreenToggledHelper.getCallCount();
+
+        loadDataSync(name, fileContent, "text/html", false);
+        assertFalse(hasEnteredFullscreen());
+
+        clickOnElementId("enter_fullscreen", null);
+        mOnFullscreenToggledHelper.waitForCallback(count);
+
+        count = mOnFullscreenToggledHelper.getCallCount();
+        clickOnElementId("exit_fullscreen", null);
+        mOnFullscreenToggledHelper.waitForCallback(count);
+        assertFalse(hasEnteredFullscreen());
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -56,7 +56,7 @@ public class XWalkViewTestBase
     private XWalkView mXWalkView;
     private boolean mAllowSslError = true;
     final TestHelperBridge mTestHelperBridge = new TestHelperBridge();
-    private static final boolean ENABLED = true;		
+    private static final boolean ENABLED = true;
     private static final boolean DISABLED = false;
 
     class TestXWalkUIClientBase extends XWalkUIClient {
@@ -1394,5 +1394,23 @@ public class XWalkViewTestBase
                     + "</head>"
                     + "<body></body></html>";
         }
+    }
+
+    protected boolean hasEnteredFullscreen() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.hasEnteredFullscreen();
+            }
+        });
+    }
+
+    protected void leaveFullscreen() throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.leaveFullscreen();
+            }
+        });
     }
 }


### PR DESCRIPTION
This issue was introduced by
https://github.com/crosswalk-project/crosswalk/commit/6761e07c3e7fa54d2766d8d94ffeafa40603b9ae
mNativeWebContents was not initialized, so it's value is invalid, can't
get the web contents from it.
Refine test case to catch this issue.

BUG=XWALK-3889

(cherry picked from commit c531e794fae3c72d6cdcf10c5202dac235d45773)