### PR TITLE
DEPS.xwalk: Roll chromium-crosswalk and v8-crosswalk.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,8 +17,8 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'f5ab3be4fb99b0ac35f9bf8f746b3bc8795b6253'
-v8_crosswalk_rev = 'f553851f901c3c696425af84ffefb7e010543a04'
+chromium_crosswalk_rev = 'd5ea4e0268b7114c7320246b8c5a990076457352'
+v8_crosswalk_rev = '78a7e24999a6f72cbda07980490e4af1eab1daf1'
 
 crosswalk_git = 'https://github.com/crosswalk-project'
 


### PR DESCRIPTION
They need to be rolled in tandem because we are reverting the XDK
patches present in both repositories.

chromium-crosswalk:
* d5ea4e0 Merge pull request #362 from rakuco/revert-xdk-bits
* 2e10ac6 Revert "[XDK] Add in-depth allocation tracker"

v8-crosswalk:
* 78a7e24 Merge pull request #157 from rakuco/fix-standalone-build
* 4e54260 Adjust coding style in files touched by e236921.
* e236921 Revert "XDK Heap Profiler collector and XDK CPUProfiler"
* fb55f85 Merge pull request #152 from chuan9/xwalk-7000
* f1292ef Add Bool32x4ExtractLane on x64 Bug=XWALK-7000

BUG=XWALK-7000
