### PR TITLE
[Android] Support the feature of proxy in Crosswalk

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -549,6 +549,11 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         nativeSetBackgroundColor(mNativeContent, color);
     }
 
+    public void updateProxyConfig(String host, int port, String pacUrl, String[] exclusionList) {
+        if (mNativeContent == 0) return;
+        nativeUpdateProxyConfig(mNativeContent, host, port, pacUrl, exclusionList);
+    }
+
     public void setNetworkAvailable(boolean networkUp) {
         if (mNativeContent == 0) return;
         nativeSetJsOnlineProperty(mNativeContent, networkUp);
@@ -1080,6 +1085,12 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     private native void nativeSetBackgroundColor(long nativeXWalkContent, int color);
     private native void nativeSetOriginAccessWhitelist(
             long nativeXWalkContent, String url, String patterns);
+    private native void nativeUpdateProxyConfig(
+            long nativeXWalkContent,
+            String host,
+            int port,
+            String pacUrl,
+            String[] exclusionList);
     private native byte[] nativeGetCertificate(long nativeXWalkContent);
     private native void nativeFindAllAsync(long nativeXWalkContent, String searchString);
     private native void nativeFindNext(long nativeXWalkContent, boolean forward);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -978,6 +978,21 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
         mContent.setOriginAccessWhitelist(url, patterns);
     }
 
+    /**
+     * Update proxy config to set proxy for images/text resources.
+     * @param host the proxy host.
+     * @param host the proxy port.
+     * @param pacUrl the pac url.
+     * @param exclusionList the exclusion list.
+     * @since 7.0
+     */
+    @XWalkAPI
+    public void updateProxyConfig(String host, int port, String pacUrl, String[] exclusionList) {
+        if (mContent == null) return;
+        checkThreadSafety();
+        mContent.updateProxyConfig(host, port, pacUrl, exclusionList);
+    }
+
     // We can't let XWalkView's setLayerType call to this via reflection as this method
     // may be called in XWalkView constructor but the XWalkView is not ready yet and then
     // UnsupportedOperationException is thrown, see XWALK-5021/XWALK-5047.

--- a/runtime/browser/android/xwalk_content.cc
+++ b/runtime/browser/android/xwalk_content.cc
@@ -425,6 +425,30 @@ jboolean XWalkContent::SetManifest(JNIEnv* env,
   return true;
 }
 
+void XWalkContent::UpdateProxyConfig(
+    JNIEnv* env, jobject obj,
+    jstring jhost,
+    jint jport,
+    jstring jpac_url,
+    jobjectArray jexclusion_list) {
+  DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+
+  std::string host = base::android::ConvertJavaStringToUTF8(env, jhost);
+
+  std::string pac_url;
+  if (jpac_url)
+    pac_url = base::android::ConvertJavaStringToUTF8(env, jpac_url);
+
+  std::vector<std::string> exclusion_list;
+      base::android::AppendJavaStringArrayToStringVector(
+          env, jexclusion_list, &exclusion_list);
+
+  XWalkBrowserContext* browser_context =
+      XWalkRunner::GetInstance()->browser_context();
+  CHECK(browser_context);
+  browser_context->UpdateProxyConfig(host, jport, pac_url, exclusion_list);
+}
+
 jint XWalkContent::GetRoutingID(JNIEnv* env, jobject obj) {
   DCHECK(web_contents_.get());
   return web_contents_->GetRoutingID();

--- a/runtime/browser/android/xwalk_content.h
+++ b/runtime/browser/android/xwalk_content.h
@@ -77,6 +77,13 @@ class XWalkContent : public FindHelper::Listener {
                                 jstring url,
                                 jstring match_patterns);
 
+  void UpdateProxyConfig(
+      JNIEnv* env, jobject obj,
+      jstring jhost,
+      jint jport,
+      jstring jpac_url,
+      jobjectArray jexclusion_list);
+
   // Geolocation API support
   void ShowGeolocationPrompt(const GURL& origin,
                              const base::Callback<void(bool)>& callback); // NOLINT

--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -306,6 +306,22 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
   return url_request_context_.get();
 }
 
+void RuntimeURLRequestContextGetter::UpdateProxyConfig(
+    const std::string& host,
+    int port,
+    const std::string& pac_url,
+    const std::vector<std::string>& exclusion_list) {
+  net::ProxyConfigServiceAndroid* android_config_service =
+      static_cast<net::ProxyConfigServiceAndroid*>(
+          url_request_context_->proxy_service()->GetProxyConfigService());
+  if (host.empty()) {
+    android_config_service->ProxySettingsChanged();
+  } else {
+    android_config_service->ProxySettingsChangedTo(
+        host, port, pac_url, exclusion_list);
+  }
+}
+
 scoped_refptr<base::SingleThreadTaskRunner>
     RuntimeURLRequestContextGetter::GetNetworkTaskRunner() const {
   return BrowserThread::GetMessageLoopProxyForThread(BrowserThread::IO);

--- a/runtime/browser/runtime_url_request_context_getter.h
+++ b/runtime/browser/runtime_url_request_context_getter.h
@@ -45,6 +45,12 @@ class RuntimeURLRequestContextGetter : public net::URLRequestContextGetter {
   scoped_refptr<base::SingleThreadTaskRunner>
       GetNetworkTaskRunner() const override;
 
+  void UpdateProxyConfig(
+      const std::string& host,
+      int port,
+      const std::string& pac_url,
+      const std::vector<std::string>& exclusion_list);
+
   net::HostResolver* host_resolver();
   void UpdateAcceptLanguages(const std::string& accept_languages);
 

--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -421,6 +421,18 @@ void XWalkBrowserContext::AddVisitedURLs(const std::vector<GURL>& urls) {
   visitedlink_master_->AddURLs(urls);
 }
 
+void XWalkBrowserContext::UpdateProxyConfig(
+    const std::string& host,
+    int port,
+    const std::string& pac_url,
+    const std::vector<std::string>& exclusion_list) {
+  RuntimeURLRequestContextGetter* url_request_context_getter =
+      url_request_getter_.get();
+  if (!url_request_context_getter)
+    return;
+  url_request_context_getter->UpdateProxyConfig(host, port, pac_url, exclusion_list);
+}
+
 void XWalkBrowserContext::RebuildTable(
     const scoped_refptr<URLEnumerator>& enumerator) {
   // XWalkView rebuilds from XWalkWebChromeClient.getVisitedHistory. The client

--- a/runtime/browser/xwalk_browser_context.h
+++ b/runtime/browser/xwalk_browser_context.h
@@ -115,6 +115,11 @@ class XWalkBrowserContext
   void SetCSPString(const std::string& csp);
   std::string GetCSPString() const;
 #endif
+  void UpdateProxyConfig(
+      const std::string& host,
+      int port,
+      const std::string& pac_url,
+      const std::vector<std::string>& exclusion_list);
   // These methods map to Add methods in visitedlink::VisitedLinkMaster.
   void AddVisitedURLs(const std::vector<GURL>& urls);
   // visitedlink::VisitedLinkDelegate implementation.


### PR DESCRIPTION
Crosswalk for android will update proxy when a PROXY_CHANGE intent is received,
but it’s need system permission to send the broadcast, there is also a workaround with
reflecting the incompatible api, but it’s too complex to maintain those codes, so
implement the new API in XWalkView to set proxy for images/text resources.

BUG=XWALK-6769