### PR TITLE
[Android] Fix OpenJDK 8 javadoc build after 266c02a0.

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -72,7 +72,7 @@ import android.os.Bundle;
  * <h3>Edit App Manifest</h3>
  *
  * <p>For shared mode and download mode, you might need to edit the Android manifest to set some
- * properties. </pn.>
+ * properties.</p>
  *
  * <h4>Shared Mode</h4>
  *


### PR DESCRIPTION
Commit 266c02a0 ("[Android] Refine the class description of embedding
API") broke the javadoc build again:

```
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:75: error: malformed HTML
 * properties. </pn.>
               ^
../xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java:75: error: bad use of '>'
 * properties. </pn.>
                    ^
```