### PR TITLE
Init IPC attachment broker for extension process

### DIFF
--- a/extensions/extension_process/xwalk_extension_process.cc
+++ b/extensions/extension_process/xwalk_extension_process.cc
@@ -9,6 +9,7 @@
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/message_loop/message_loop.h"
+#include "ipc/attachment_broker_privileged.h"
 #include "ipc/ipc_switches.h"
 #include "ipc/ipc_message_macros.h"
 #include "ipc/ipc_sync_channel.h"
@@ -80,6 +81,9 @@ void XWalkExtensionProcess::OnRegisterExtensions(
 
 void XWalkExtensionProcess::CreateBrowserProcessChannel(
     const IPC::ChannelHandle& channel_handle) {
+#if USE_ATTACHMENT_BROKER
+  IPC::AttachmentBrokerPrivileged::CreateBrokerIfNeeded();
+#endif  // USE_ATTACHMENT_BROKER
   if (channel_handle.name.empty()) {
     std::string channel_id =
         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(


### PR DESCRIPTION
The IPC::AttachmentBroker must be initialized within
any process that uses IPC channel, however this was not
done so far for extension process in Crosswalk.

This patch initializes the attachment brocker for extension
process with an 'AttachmentBrokerPrivileged' instance as 
extension process is privileged.

BUG=XWALK-7021