### PR TITLE
crosswalk-20: DEPS.xwalk: Explicitly set `managed` to True in .gclient-xwalk.

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -31,6 +31,7 @@ solutions = [
   { 'name': 'src',
     'url': crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,
     'deps_file': '.DEPS.git',
+    'managed': True,
     'custom_deps': {
       'src':
         crosswalk_git + '/chromium-crosswalk.git@' + chromium_crosswalk_rev,


### PR DESCRIPTION
https://codereview.chromium.org/2099153003 has recently switched the
default value of the `managed` option to False instead of True.

Since we did not explicitly set that option in `.gclient-xwalk` before,
it means that for the last few days existing `src/` checkouts were not
being automatically updated to match `chromium_crosswalk_rev` any
longer, which was particularly bad for the bots, which were not testing
the commits they should.

(cherry picked from commit e9f19a987c604f30b46420fcbdb679e5f977fb98)