### PR TITLE
Fix the video play issue after M51 rebase.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -114,6 +114,12 @@
         ['OS=="win"', {
           'use_rssdk%': 1,
         }],
+
+        ['OS=="android" or OS=="linux" or OS=="win" or OS=="mac"', {
+          # From src/build/common.gypi.
+          # Whether to include support for proprietary codecs..
+          'proprietary_codecs%': 1,
+        }],
       ],
     },
     # Copy conditionally-set variables out one scope.
@@ -136,10 +142,6 @@
     # Disable WebVR support. The code is still experimental and and ends up
     # pulling additional dependencies into our JARs (XWALK-6597).
     'enable_webvr%': 0,
-
-    # From src/build/common.gypi.
-    # Whether to include support for proprietary codecs..
-    'proprietary_codecs%': 1,
 
     # Whether to use a WebUI-based file picker.
     'use_webui_file_picker%': 0,


### PR DESCRIPTION
This issue was caused by https://codereview.chromium.org/1577433004
The condition of 'OS=="android"' was removed, this leads to
'proprietary_codecs' was always 0, then mp4 and other codecs could not
be added to related 'MediaFormatMappings'.

'proprietary_codecs' was defined in the condition in src/build/common.gypi,
so in src/xwalk/common.gypi, 'proprietary_codecs' should also be moved
to condition to keep same scope level.

BUG=XWALK-7032