### PR TITLE
[Android] Fix the potential vulnerability issue.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -23,6 +23,7 @@ import android.view.View;
 import android.webkit.ConsoleMessage;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
+import android.widget.Toast;
 
 import java.security.cert.X509Certificate;
 import java.security.KeyStore.PrivateKeyEntry;
@@ -682,12 +683,18 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     // If returns false, the request is immediately canceled, and any call to proceedSslError
     // has no effect. If returns true, the request should be canceled or proceeded using
     // proceedSslError().
-    // Unlike the webview classic, we do not keep keep a database of certificates that
+    // Unlike the webview classic, we do not keep a database of certificates that
     // are allowed by the user, because this functionality is already handled via
     // ssl_policy in native layers.
     @CalledByNative
     private boolean allowCertificateError(int certError, byte[] derBytes, final String url,
             final int id) {
+        boolean shouldDeny = SslUtil.shouldDenyRequest(certError);
+        if (shouldDeny) {
+            Toast.makeText(mXWalkView.getContext(), R.string.ssl_error_deny_request,
+                    Toast.LENGTH_SHORT).show();
+            return false;
+        }
         final SslCertificate cert = SslUtil.getCertificateFromDerBytes(derBytes);
         if (cert == null) {
             // if the certificate or the client is null, cancel the request

--- a/runtime/android/core_internal/strings/android_xwalk_strings.grd
+++ b/runtime/android/core_internal/strings/android_xwalk_strings.grd
@@ -41,6 +41,9 @@
       <message desc="Prompt for the http authentication login [CHAR-LIMIT=32]" name="IDS_HTTP_AUTH_LOG_IN">
         Log In
       </message>
+      <message desc="Prompt for denying request when SSL error occurred [CHAR-LIMIT=32]" name="IDS_SSL_ERROR_DENY_REQUEST">
+        Request was denied for security.
+      </message>
     </messages>
   </release>
 


### PR DESCRIPTION
For SSL errors, if user allows it, native layer will keep the host and
the error num, the future communications with same host and error will
not trigger the onReceivedSslError callback. Even if the certificate is
invalid, all of requests will also be passed, its vulnerable for some
serious SSL error.
Especially with MITM, the sensitive messages will be stolen, e.g.
passwords, credit cards.
Deny the invalid requests for some serious SSL error to avoid this issue.

For keeping the host and error num, please refer to
https://codereview.chromium.org/794023002
We also have the same implementation.

BUG=XWALK-6986