### PR TITLE
[Android] Change minSdkVersion to 16

### DIFF
--- a/app/android/app_hello_world/AndroidManifest.xml
+++ b/app/android/app_hello_world/AndroidManifest.xml
@@ -23,7 +23,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.CAMERA"/>

--- a/app/android/app_template/AndroidManifest.xml
+++ b/app/android/app_template/AndroidManifest.xml
@@ -24,7 +24,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.CAMERA"/>

--- a/app/android/runtime_client_embedded_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_embedded_shell/AndroidManifest.xml
@@ -28,7 +28,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />

--- a/app/android/runtime_client_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_shell/AndroidManifest.xml
@@ -28,7 +28,7 @@
         </activity>
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />

--- a/build/android/xwalk_shared_library_template/AndroidManifest.xml
+++ b/build/android/xwalk_shared_library_template/AndroidManifest.xml
@@ -4,6 +4,6 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="14"
+        android:minSdkVersion="16"
         android:targetSdkVersion="21" />
 </manifest>

--- a/build/android/xwalkcore_library_template/AndroidManifest.xml
+++ b/build/android/xwalkcore_library_template/AndroidManifest.xml
@@ -4,6 +4,6 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="14"
+        android:minSdkVersion="16"
         android:targetSdkVersion="21" />
 </manifest>

--- a/runtime/android/core_internal_empty/AndroidManifest.xml
+++ b/runtime/android/core_internal_empty/AndroidManifest.xml
@@ -13,5 +13,5 @@
         android:label="XWalkCoreLibraryEmpty" android:hardwareAccelerated="true">
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 </manifest>

--- a/runtime/android/core_internal_shell/AndroidManifest.xml
+++ b/runtime/android/core_internal_shell/AndroidManifest.xml
@@ -31,7 +31,7 @@
             android:authorities="org.xwalk.core.internal.xwview.test.TestContentProvider" />
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -31,7 +31,7 @@
             android:authorities="org.xwalk.core.xwview.test.TestContentProvider" />
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>

--- a/runtime/android/runtime_lib/AndroidManifest.xml
+++ b/runtime/android/runtime_lib/AndroidManifest.xml
@@ -13,5 +13,5 @@
         android:label="XWalkCoreLibrary" android:hardwareAccelerated="true" android:icon="@drawable/crosswalk">
     </application>
 
-  <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 </manifest>

--- a/runtime/android/sample/AndroidManifest.xml
+++ b/runtime/android/sample/AndroidManifest.xml
@@ -13,7 +13,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="14"
+        android:minSdkVersion="16"
         android:targetSdkVersion="21" />
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/test/android/core/javatests/AndroidManifest.xml
+++ b/test/android/core/javatests/AndroidManifest.xml
@@ -12,7 +12,7 @@
         <uses-library android:name="android.test.runner" />
     </application>
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
     <instrumentation android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="org.xwalk.core.xwview.shell"
         android:label="Test for org.xwalk.core.xwview" />

--- a/test/android/core_internal/javatests/AndroidManifest.xml
+++ b/test/android/core_internal/javatests/AndroidManifest.xml
@@ -12,7 +12,7 @@
         <uses-library android:name="android.test.runner" />
     </application>
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
     <instrumentation android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="org.xwalk.core.internal.xwview.shell"
         android:label="Test for org.xwalk.core.internal.xwview" />

--- a/test/android/runtime_client/javatests/AndroidManifest.xml
+++ b/test/android/runtime_client/javatests/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:authorities="org.xwalk.runtime.client.test.TestContentProvider" />
     </application>
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
     <instrumentation android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="org.xwalk.runtime.client.shell"
         android:label="Test for org.xwalk.runtime.client" />

--- a/test/android/runtime_client_embedded/javatests/AndroidManifest.xml
+++ b/test/android/runtime_client_embedded/javatests/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:authorities="org.xwalk.runtime.client.embedded.test.TestContentProvider" />
     </application>
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
     <instrumentation android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="org.xwalk.runtime.client.embedded.shell"
         android:label="Test for org.xwalk.runtime.client.embedded" />


### PR DESCRIPTION
Since we've dropped Android 4.0 support from Crosswalk-20, change the
minSdkVersion from 14 to 16.