### PR TITLE
[Windows][Linux] Fix Geolocation crashing after the user accept the

### DIFF
--- a/runtime/browser/xwalk_browser_context.h
+++ b/runtime/browser/xwalk_browser_context.h
@@ -20,16 +20,13 @@
 #include "components/visitedlink/browser/visitedlink_delegate.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/content_browser_client.h"
+#include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
 #include "xwalk/runtime/browser/xwalk_form_database_service.h"
 #include "xwalk/runtime/browser/xwalk_ssl_host_state_delegate.h"
 
 #if defined(OS_ANDROID)
 #include "base/strings/string_split.h"
 #endif
-
-namespace net {
-class URLRequestContextGetter;
-}
 
 namespace content {
 class DownloadManagerDelegate;
@@ -45,7 +42,6 @@ class PrefService;
 namespace xwalk {
 
 class RuntimeDownloadManagerDelegate;
-class RuntimeURLRequestContextGetter;
 
 namespace application {
 class ApplicationService;
@@ -110,6 +106,10 @@ class XWalkBrowserContext
   void set_application_service(
       application::ApplicationService* application_service) {
     application_service_ = application_service;
+  }
+
+  net::URLRequestContextGetter* url_request_getter() const {
+      return url_request_getter_.get();
   }
 #if defined(OS_ANDROID)
   void SetCSPString(const std::string& csp);

--- a/runtime/browser/xwalk_content_browser_client.cc
+++ b/runtime/browser/xwalk_content_browser_client.cc
@@ -101,13 +101,11 @@ XWalkContentBrowserClient* XWalkContentBrowserClient::Get() {
 
 XWalkContentBrowserClient::XWalkContentBrowserClient(XWalkRunner* xwalk_runner)
     : xwalk_runner_(xwalk_runner),
-      url_request_context_getter_(nullptr),
 #if defined(OS_POSIX) && !defined(OS_MACOSX)
       v8_natives_fd_(-1),
       v8_snapshot_fd_(-1),
 #endif  // OS_POSIX && !OS_MACOSX
-      main_parts_(nullptr),
-      browser_context_(xwalk_runner->browser_context()) {
+      main_parts_(nullptr) {
   DCHECK(!g_browser_client);
   g_browser_client = this;
 }
@@ -154,7 +152,8 @@ XWalkContentBrowserClient::CreateQuotaPermissionContext() {
 }
 
 content::AccessTokenStore* XWalkContentBrowserClient::CreateAccessTokenStore() {
-  return new XWalkAccessTokenStore(url_request_context_getter_);
+  return new XWalkAccessTokenStore(
+      xwalk_runner_->browser_context()->url_request_getter());
 }
 
 content::WebContentsViewDelegate*

--- a/runtime/browser/xwalk_content_browser_client.h
+++ b/runtime/browser/xwalk_content_browser_client.h
@@ -165,7 +165,6 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
 
  private:
   XWalkRunner* xwalk_runner_;
-  net::URLRequestContextGetter* url_request_context_getter_;
   std::unique_ptr<content::ClientCertificateDelegate> delegate_;
 #if defined(OS_POSIX) && !defined(OS_MACOSX)
   base::ScopedFD v8_natives_fd_;
@@ -173,7 +172,6 @@ class XWalkContentBrowserClient : public content::ContentBrowserClient {
 #endif
 
   XWalkBrowserMainParts* main_parts_;
-  XWalkBrowserContext* browser_context_;
 
   std::unique_ptr<RuntimeResourceDispatcherHostDelegate>
       resource_dispatcher_host_delegate_;


### PR DESCRIPTION
prompt.

Bug is a regression after M51 and incorrect patch of
8d0c7a657433574edc397e2dbebe8dcc690e45c1 which removes the functions
CreateRequestContext and CreateRequestContextForStoragePartition from
XWalkContentBrowserClient as they moved to BrowserContext (so
XWalkBrowserContext). The problem is that they were setting the
url_request_context_getter_ member before calling XWalkBrowserContext.
The URL request context is then used afterwards inside xwalk to query
things like geolocation. With that accidental removal it was always null
so it was crashing/asserting later in the geolocation code. Fix is to
setup a getter from the browser context to access the URL request context
when creating the AccessTokenStore.

BUG=XWALK-7067