### PR TITLE
Expose setJavaScript related APIs

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -368,7 +368,7 @@ public class XWalkSettingsInternal {
 
     /**
      * Enables or disables file access within XWalkView. File access is enabled by
-     * default.  Note that this enables or disables file system access only.
+     * default. Note that this enables or disables file system access only.
      * Assets and resources are still accessible using file:///android_asset and
      * file:///android_res.
      * @since 7.0
@@ -396,7 +396,7 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * Enables or disables content URL access within XWalkView.  Content URL
+     * Enables or disables content URL access within XWalkView. Content URL
      * access allows XWalkView to load content from a content provider installed
      * in the system. The default is enabled.
      * @since 7.0
@@ -444,8 +444,13 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#setJavaScriptEnabled}.
+     * Tells the XWalkView to enable JavaScript execution.
+     * <b>The default is true.</b>
+     *
+     * @param flag true if the XWalkView should execute JavaScript
+     * @since 7.0
      */
+    @XWalkAPI
     public void setJavaScriptEnabled(boolean flag) {
         synchronized (mXWalkSettingsLock) {
             if (mJavaScriptEnabled != flag) {
@@ -464,7 +469,6 @@ public class XWalkSettingsInternal {
      * Note that this setting affects only JavaScript access to file scheme
      * resources. Other access to such resources, for example, from image HTML
      * elements, is unaffected. The default value is true.
-     * <p>
      *
      * @param flag whether JavaScript running in the context of a file scheme
      *             URL should be allowed to access content from any origin
@@ -489,7 +493,6 @@ public class XWalkSettingsInternal {
      * Note too, that this setting affects only JavaScript access to file scheme
      * resources. Other access to such resources, for example, from image HTML
      * elements, is unaffected. The default value is true.
-     * <p>
      *
      * @param flag whether JavaScript running in the context of a file scheme
      *             URL should be allowed to access content from other file
@@ -549,8 +552,13 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#setJavaScriptEnabled}.
+     * Gets whether JavaScript is enabled.
+     *
+     * @return true if JavaScript is enabled
+     * @see #setJavaScriptEnabled
+     * @since 7.0
      */
+    @XWalkAPI
     public boolean getJavaScriptEnabled() {
         synchronized (mXWalkSettingsLock) {
             return mJavaScriptEnabled;
@@ -591,8 +599,13 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#setJavaScriptCanOpenWindowsAutomatically}.
+     * Tells JavaScript to open windows automatically. This applies to the
+     * JavaScript function window.open(). The default is true.
+     *
+     * @param flag true if JavaScript can open windows automatically
+     * @since 7.0
      */
+    @XWalkAPI
     public void setJavaScriptCanOpenWindowsAutomatically(boolean flag) {
         synchronized (mXWalkSettingsLock) {
             if (mJavaScriptCanOpenWindowsAutomatically != flag) {
@@ -602,9 +615,16 @@ public class XWalkSettingsInternal {
         }
     }
 
+
     /**
-     * See {@link android.webkit.WebSettings#getJavaScriptCanOpenWindowsAutomatically}.
+     * Gets whether JavaScript can open windows automatically.
+     *
+     * @return true if JavaScript can open windows automatically during
+     *         window.open()
+     * @see #setJavaScriptCanOpenWindowsAutomatically
+     * @since 7.0
      */
+    @XWalkAPI
     public boolean getJavaScriptCanOpenWindowsAutomatically() {
         synchronized (mXWalkSettingsLock) {
             return mJavaScriptCanOpenWindowsAutomatically;

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SettingsTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SettingsTest.java
@@ -68,7 +68,7 @@ public class SettingsTest extends XWalkViewTestBase {
     }
 
     @MediumTest
-    @Feature({"XWalkSettings", "Preferences", "Navigation"})
+    @Feature({"XWalkSettings", "Preferences"})
     // As our implementation of network loads blocking uses the same net::URLRequest settings, make
     // sure that setting cache mode doesn't accidentally enable network loads. The reference
     // behaviour is that when network loads are blocked, setting cache mode has no effect.
@@ -153,6 +153,55 @@ public class SettingsTest extends XWalkViewTestBase {
                 assertEquals(defaultvalue, settings.getSaveFormData());
             }
         });
+    }
+
+    // The test verifies that JavaScript is enabled upon XWalkView
+    // creation without accessing XWalkSettings. If the test passes,
+    // it means that XWalkView-specific web preferences configuration
+    // is applied on XWalkView creation.
+    @SmallTest
+    @Feature({"XWalkSettings", "Preferences"})
+    public void testJavaScriptEnabledByDefault() throws Throwable {
+        final String jsEnabledString = "JS has run";
+        final String jsDisabledString = "JS has not run";
+        final String testPageHtml =
+                "<html><head><title>" + jsDisabledString + "</title>"
+                + "</head><body onload=\"document.title='" + jsEnabledString
+                + "';\"></body></html>";
+
+        loadDataSync(null, testPageHtml, "text/html", false);
+        assertEquals(jsEnabledString, getTitleOnUiThread());
+    }
+
+    @SmallTest
+    @Feature({"XWalkSettings", "Preferences"})
+    public void testJavaScriptEnabledWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsJavaScriptTestHelper(views.getView0(), views.getBridge0()),
+                new XWalkSettingsJavaScriptTestHelper(views.getView1(), views.getBridge1()));
+    }
+
+    @SmallTest
+    @Feature({"XWalkSettings", "Preferences"})
+    public void testJavaScriptEnabledDynamicWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsJavaScriptDynamicTestHelper(
+                        views.getView0(), views.getBridge0()),
+                new XWalkSettingsJavaScriptDynamicTestHelper(
+                        views.getView1(), views.getBridge1()));
+    }
+
+    @SmallTest
+    @Feature({"XWalkSettings", "Preferences"})
+    public void testJavaScriptPopupsWithTwoViews() throws Throwable {
+        ViewPair views = createViews();
+        runPerViewSettingsTest(
+                new XWalkSettingsJavaScriptPopupsTestHelper(
+                        views.getView0(), views.getBridge0()),
+                new XWalkSettingsJavaScriptPopupsTestHelper(
+                        views.getView1(), views.getBridge1()));
     }
 
     @SmallTest


### PR DESCRIPTION
These APIs include set/getJavaScriptEnabled, and
set/getJavaScriptCanOpenWindowsAutomatically.

In additation, this commit also correct some mistakes in
commit b4db96745c5114fc861df9411f1a15b18f6210dd.

BUG=XWALK-7080