### PR TITLE
[Android] Reset the default value of setDomStorageEnabled

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -92,7 +92,7 @@ public class XWalkSettingsInternal {
     private int mCacheMode = WebSettings.LOAD_DEFAULT;
     private boolean mSupportMultipleWindows = false;
     private boolean mAppCacheEnabled = true;
-    private boolean mDomStorageEnabled = false;
+    private boolean mDomStorageEnabled = true;
     private boolean mDatabaseEnabled = true;
     private boolean mUseWideViewport = false;
     private boolean mLoadWithOverviewMode = false;
@@ -446,6 +446,7 @@ public class XWalkSettingsInternal {
     /**
      * Tells the XWalkView to enable JavaScript execution.
      * <b>The default is true.</b>
+     * Note that the default value of this setting is different with WebView.
      *
      * @param flag true if the XWalkView should execute JavaScript
      * @since 7.0
@@ -733,7 +734,8 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * Sets whether the DOM storage API is enabled. The default value is false.
+     * Sets whether the DOM storage API is enabled. The default value is true.
+     * Note that the default value of this setting is different with WebView.
      *
      * @param flag true if the XWalkView should use the DOM storage API
      * @since 7.0

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -1784,12 +1784,12 @@ public class XWalkViewTestBase
 
         @Override
         protected Boolean getAlteredValue() {
-            return ENABLED;
+            return DISABLED;
         }
 
         @Override
         protected Boolean getInitialValue() {
-            return DISABLED;
+            return ENABLED;
         }
 
         @Override
@@ -1797,7 +1797,7 @@ public class XWalkViewTestBase
             try {
                 return getDomStorageEnabledOnUiThreadByXWalkView(mView);
             } catch (Exception e) {
-                return false;
+                return true;
             }
         }
 


### PR DESCRIPTION
As a frequently used feature, it is also enabled in Chrome in default.
And change the value may cause potential risk, so reset it to original.

BUG=XWALK-7082