### PR TITLE
[Android] Expose some APIs in XWalkSettings

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -322,7 +322,8 @@ public class XWalkSettingsInternal {
 
     /**
      * Sets whether the XWalkView should not load resources from the network.
-     * Note that if the value of this setting is
+     * Use {@link #setBlockNetworkImage} to only avoid loading
+     * image resources. Note that if the value of this setting is
      * changed from true to false, network resources referenced by content
      * currently displayed by the XWalkView are not fetched until
      * {@link org.xwalk.core.XWalkView#reload} is called.
@@ -511,8 +512,18 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#setLoadsImagesAutomatically}.
+     * Sets whether the XWalkView should load image resources. Note that this method
+     * controls loading of all images, including those embedded using the data
+     * URI scheme. Use {@link #setBlockNetworkImage} to control loading only
+     * of images specified using network URI schemes. Note that if the value of this
+     * setting is changed from false to true, all images resources referenced
+     * by content currently displayed by the XWalkView are loaded automatically.
+     * The default is true.
+     *
+     * @param flag whether the XWalkView should load image resources
+     * @since 7.0
      */
+    @XWalkAPI
     public void setLoadsImagesAutomatically(boolean flag) {
         synchronized (mXWalkSettingsLock) {
             if (mLoadsImagesAutomatically != flag) {
@@ -523,8 +534,14 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#getLoadsImagesAutomatically}.
+     * Gets whether the XWalkView loads image resources. This includes
+     * images embedded using the data URI scheme.
+     *
+     * @return true if the XWalkView loads image resources
+     * @see #setLoadsImagesAutomatically
+     * @since 7.0
      */
+    @XWalkAPI
     public boolean getLoadsImagesAutomatically() {
         synchronized (mXWalkSettingsLock) {
             return mLoadsImagesAutomatically;
@@ -532,23 +549,42 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#setImagesEnabled}.
+     * Sets whether the XWalkView should not load image resources from the
+     * network (resources accessed via http and https URI schemes).  Note
+     * that this method has no effect unless
+     * {@link #getLoadsImagesAutomatically} returns true. Also note that
+     * disabling all network loads using {@link #setBlockNetworkLoads}
+     * will also prevent network images from loading, even if this flag is set
+     * to false. When the value of this setting is changed from true to false,
+     * network images resources referenced by content currently displayed by
+     * the XWalkView are fetched automatically. The default is false.
+     *
+     * @param flag whether the XWalkView should not load image resources from the
+     *             network
+     * @see #setBlockNetworkLoads
+     * @since 7.0
      */
-    public void setImagesEnabled(boolean flag) {
+    @XWalkAPI
+    public void setBlockNetworkImage(boolean flag) {
         synchronized (mXWalkSettingsLock) {
-            if (mImagesEnabled != flag) {
-                mImagesEnabled = flag;
+            if (mImagesEnabled == flag) {
+                mImagesEnabled = !flag;
                 mEventHandler.updateWebkitPreferencesLocked();
             }
         }
     }
 
     /**
-     * See {@link android.webkit.WebSettings#getImagesEnabled}.
+     * Gets whether the XWalkView does not load image resources from the network.
+     *
+     * @return true if the XWalkView does not load image resources from the network
+     * @see #setBlockNetworkImage
+     * @since 7.0
      */
-    public boolean getImagesEnabled() {
+    @XWalkAPI
+    public boolean getBlockNetworkImage() {
         synchronized (mXWalkSettingsLock) {
-            return mImagesEnabled;
+            return !mImagesEnabled;
         }
     }
 
@@ -633,8 +669,14 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#setSupportMultipleWindows}.
+     * Sets whether the XWalkView supports multiple windows. If set to
+     * true, {@link XWalkUIClient#onCreateWindowRequested} must be implemented
+     * by the host application. The default is false.
+     *
+     * @param support whether to suport multiple windows
+     * @since 7.0
      */
+    @XWalkAPI
     public void setSupportMultipleWindows(boolean support) {
         synchronized (mXWalkSettingsLock) {
             if (mSupportMultipleWindows != support) {
@@ -645,8 +687,13 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#supportMultipleWindows}.
+     * Gets whether the XWalkView supports multiple windows.
+     *
+     * @return true if the XWalkView supports multiple windows
+     * @see #setSupportMultipleWindows
+     * @since 7.0
      */
+    @XWalkAPI
     public boolean supportMultipleWindows() {
         synchronized (mXWalkSettingsLock) {
             return mSupportMultipleWindows;
@@ -765,8 +812,18 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#setDatabaseEnabled}.
+     * Sets whether the database storage API is enabled. The default value is
+     * true, which is different with WebView.
+     *
+     * This setting is global in effect, across all XWalkView instances in a process.
+     * Note you should only modify this setting prior to making <b>any</b> XWalkView
+     * page load within a given process, as the XWalkView implementation may ignore
+     * changes to this setting after that point.
+     *
+     * @param flag true if the XWalkView should use the database storage API
+     * @since 7.0
      */
+    @XWalkAPI
     public void setDatabaseEnabled(boolean flag) {
         synchronized (mXWalkSettingsLock) {
             if (mDatabaseEnabled != flag) {
@@ -777,8 +834,12 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#getDatabaseEnabled}.
+     * Gets whether the database storage API is enabled.
+     *
+     * @return true if the database storage API is enabled
+     * @since 7.0
      */
+    @XWalkAPI
     public boolean getDatabaseEnabled() {
        synchronized (mXWalkSettingsLock) {
            return mDatabaseEnabled;
@@ -786,8 +847,13 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#setMediaPlaybackRequiresUserGesture}.
+     * Sets whether the XWalkView requires a user gesture to play media.
+     * The default is false, which is different with WebView.
+     *
+     * @param require whether the XWalkView requires a user gesture to play media
+     * @since 7.0
      */
+    @XWalkAPI
     public void setMediaPlaybackRequiresUserGesture(boolean require) {
         synchronized (mXWalkSettingsLock) {
             if (mMediaPlaybackRequiresUserGesture != require) {
@@ -798,8 +864,13 @@ public class XWalkSettingsInternal {
     }
 
     /**
-     * See {@link android.webkit.WebSettings#getMediaPlaybackRequiresUserGesture}.
+     * Gets whether the XWalkView requires a user gesture to play media.
+     *
+     * @return true if the XWalkView requires a user gesture to play media
+     * @see #setMediaPlaybackRequiresUserGesture
+     * @since 7.0
      */
+    @XWalkAPI
     public boolean getMediaPlaybackRequiresUserGesture() {
         synchronized (mXWalkSettingsLock) {
             return mMediaPlaybackRequiresUserGesture;

--- a/runtime/browser/android/xwalk_settings.cc
+++ b/runtime/browser/android/xwalk_settings.cc
@@ -186,10 +186,12 @@ void XWalkSettings::UpdateWebkitPreferences(JNIEnv* env, jobject obj) {
   prefs.allow_scripts_to_close_windows =
       env->GetBooleanField(obj, field_ids_->allow_scripts_to_close_windows);
 
-  prefs.loads_images_automatically =
-      env->GetBooleanField(obj, field_ids_->load_images_automatically);
-
+  // Blink's LoadsImagesAutomatically and ImagesEnabled must be
+  // set cris-cross to Android's. See
+  // https://code.google.com/p/chromium/issues/detail?id=224317#c26
   prefs.images_enabled =
+      env->GetBooleanField(obj, field_ids_->load_images_automatically);
+  prefs.loads_images_automatically =
       env->GetBooleanField(obj, field_ids_->images_enabled);
 
   prefs.javascript_enabled =

--- a/runtime/renderer/android/xwalk_permission_client.cc
+++ b/runtime/renderer/android/xwalk_permission_client.cc
@@ -20,18 +20,4 @@ XWalkPermissionClient::XWalkPermissionClient(content::RenderFrame* render_frame)
 XWalkPermissionClient::~XWalkPermissionClient() {
 }
 
-bool XWalkPermissionClient::allowImage(bool enabled_per_settings,
-                                       const blink::WebURL& image_url) {
-  // Implementing setBlockNetworkImages, so allow local scheme images to be
-  // loaded.
-  if (enabled_per_settings)
-    return true;
-
-  // For compatibility, only blacklist network schemes instead of whitelisting.
-  const GURL url(image_url);
-  return !(url.SchemeIs(url::kHttpScheme) ||
-           url.SchemeIs(url::kHttpsScheme) ||
-           url.SchemeIs(url::kFtpScheme));
-}
-
 }  // namespace xwalk

--- a/runtime/renderer/android/xwalk_permission_client.h
+++ b/runtime/renderer/android/xwalk_permission_client.h
@@ -19,10 +19,6 @@ class XWalkPermissionClient : public content::RenderFrameObserver,
  private:
   ~XWalkPermissionClient() override;
 
-  // blink::WebContentSettingsClient implementation.
-  bool allowImage(bool enabledPerSettings,
-                          const blink::WebURL& imageURL) override;
-
   DISALLOW_COPY_AND_ASSIGN(XWalkPermissionClient);
 };
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnCreateWindowRequestedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnCreateWindowRequestedTest.java
@@ -42,10 +42,32 @@ public class OnCreateWindowRequestedTest extends XWalkViewTestBase {
         });
     }
 
-    public void testOnCreateWindowRequested() throws Throwable {
+    @SmallTest
+    @Feature({"OnCreateWindowRequested"})
+    public void testOnCreateWindowRequestedByPreference() throws Throwable {
         String fileContent = getFileContent("create_window_1.html");
         int count = mOnCreateWindowRequestedHelper.getCallCount();
 
+        loadDataAsync(null, fileContent, "text/html", false);
+        clickOnElementId("new_window", null);
+        mOnCreateWindowRequestedHelper.waitForCallback(count);
+        assertNotNull(mOnCreateWindowRequestedHelper.getXWalkView());
+    }
+
+    @SmallTest
+    @Feature({"OnCreateWindowRequested"})
+    public void testOnCreateWindowRequestedByAPI() throws Throwable {
+        String fileContent = getFileContent("create_window_1.html");
+        int count = mOnCreateWindowRequestedHelper.getCallCount();
+
+        setSupportMultipleWindows(false);
+        setJavaScriptCanOpenWindowsAutomatically(false);
+        loadDataAsync(null, fileContent, "text/html", false);
+        clickOnElementId("new_window", null);
+        assertNull(mOnCreateWindowRequestedHelper.getXWalkView());
+
+        setSupportMultipleWindows(true);
+        setJavaScriptCanOpenWindowsAutomatically(true);
         loadDataAsync(null, fileContent, "text/html", false);
         clickOnElementId("new_window", null);
         mOnCreateWindowRequestedHelper.waitForCallback(count);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/util/ImagePageGenerator.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/util/ImagePageGenerator.java
@@ -1,0 +1,64 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.xwview.test.util;
+
+import org.chromium.net.test.util.TestWebServer;
+
+/**
+ * The purpose of the generator is to provide a sequence of distinct images to
+ * avoid caching side-effects. As we don't need too many images, I've found it
+ * easier to hardcode image samples. It is possible to generate images on the
+ * fly, but it will require hooking up additional packages.
+ */
+public class ImagePageGenerator {
+
+    public static final String IMAGE_LOADED_STRING = "1";
+    public static final String IMAGE_NOT_LOADED_STRING = "0";
+
+    private static final String[] COLORS = {
+        "AAAAIAAc3j0Ss", "AQABIAEayS9b0", "AgACIAIQ8BmAc", "AwADIAMW5wvJE",
+        "BAAEIAQZNWRTI", "BQAFIAUfInYaQ", "BgAGIAYVG0DB4", "BwAHIAcTDFKIg",
+        "CAAIIAgXCI+Rk", "CQAJIAkRH53Y8", "CgAKIAobJqsDU", "CwALIAsdMblKM",
+        "DAAMIAwS49bQA", "DQANIA0U9MSZY", "DgAOIA4ezfJCw", "DwAPIA8Y2uALo",
+        "D+AQAA/9vaUwc", "D/AQEBANNhzkw"
+    };
+
+    private static final String IMAGE_PREFIX = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA"
+            + "6fptVAAAAAXNSR0IArs4c6QAAAA1JREFUCB0BAgD9/w";
+
+    private static final String IMAGE_SUFFIX = "AAAAASUVORK5CYII=";
+
+    private int mIndex;
+    private final boolean mAdvance;
+
+    public ImagePageGenerator(int startIndex, boolean advance) {
+        mIndex = startIndex;
+        mAdvance = advance;
+    }
+
+    public String getImageSourceNoAdvance() {
+        return IMAGE_PREFIX + COLORS[mIndex] + IMAGE_SUFFIX;
+    }
+
+    public String getPageTemplateSource(String imageSrc) {
+        return CommonResources.getOnImageLoadedHtml(imageSrc);
+    }
+
+    public String getPageSource() {
+        String result =
+                getPageTemplateSource("data:image/png;base64," + getImageSourceNoAdvance());
+        if (mAdvance) mIndex += 2;
+        return result;
+    }
+
+    public String getPageUrl(TestWebServer webServer) {
+        final String imagePath = "/image_" + mIndex + ".png";
+        final String pagePath = "/html_image_" + mIndex + ".html";
+        webServer.setResponseBase64(imagePath, getImageSourceNoAdvance(),
+                CommonResources.getImagePngHeaders(false));
+        if (mAdvance) mIndex += 2;
+        return webServer.setResponse(pagePath, getPageTemplateSource(imagePath), null);
+    }
+}


### PR DESCRIPTION
In this commit, five set APIs are exposed with their test cases.
They are set/getLoadsImagesAutomatically, set/getBlockNetworkImage,
set/getDatabaseEnabled, set/getMediaPlaybackRequiresUserGesture,
and set/getSupportMultipleWindows.

The key point is that here fix the issue of setgetLoadsImagesAutomatically
not works. The background is in crbug.com/224317.

BUG=XWALK-7054