### PR TITLE
Build fix for m52 on Linux

### DIFF
--- a/extensions/common/xwalk_extension_messages.h
+++ b/extensions/common/xwalk_extension_messages.h
@@ -78,7 +78,7 @@ IPC_MESSAGE_CONTROL2(XWalkExtensionClientMsg_PostMessageToJS,  // NOLINT(*)
 
 IPC_MESSAGE_CONTROL2(XWalkExtensionClientMsg_PostOutOfLineMessageToJS,  // NOLINT(*)
                      base::SharedMemoryHandle /* message buffer */,
-                     size_t /* buffer size */)
+                     uint64_t /* buffer size */)
 
 IPC_SYNC_MESSAGE_CONTROL2_1(XWalkExtensionServerMsg_SendSyncMessageToNative,  // NOLINT(*)
                             int64_t /* instance id */,


### PR DESCRIPTION
To fix build failure on Linux
```
../../xwalk/extensions/common/xwalk_extension_messages.h:79:1: error: [chromium-ipc] IPC tuple references banned type 'size_t'.
```