### PR TITLE
Revert PR#3810.

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/SslUtil.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/SslUtil.java
@@ -24,7 +24,17 @@ class SslUtil {
      */
     public static SslError sslErrorFromNetErrorCode(int error, SslCertificate cert, String url) {
         assert (error >= NetError.ERR_CERT_END && error <= NetError.ERR_CERT_COMMON_NAME_INVALID);
-
+        switch(error) {
+            case NetError.ERR_CERT_COMMON_NAME_INVALID:
+                return new SslError(SslError.SSL_IDMISMATCH, cert, url);
+            case NetError.ERR_CERT_DATE_INVALID:
+                return new SslError(SslError.SSL_DATE_INVALID, cert, url);
+            case NetError.ERR_CERT_AUTHORITY_INVALID:
+                return new SslError(SslError.SSL_UNTRUSTED, cert, url);
+            default:
+                break;
+        }
+        // Map all other codes to SSL_INVALID.
         return new SslError(SslError.SSL_INVALID, cert, url);
     }
 
@@ -48,32 +58,5 @@ class SslUtil {
             Log.w(TAG, "Could not read certificate: " + e);
         }
         return null;
-    }
-
-    public static boolean shouldDenyRequest(int error) {
-        assert (error >= NetError.ERR_CERT_END && error <= NetError.ERR_CERT_COMMON_NAME_INVALID);
-        // Why deny the request for these errors, please refer to the comment in
-        // https://github.com/crosswalk-project/chromium-crosswalk/blob/master/content/browser/ssl/ssl_policy.cc#L61
-        // and https://github.com/crosswalk-project/chromium-crosswalk/blob/master/content/browser/ssl/ssl_policy.cc#L89
-        // In Chrome, please refer to https://github.com/crosswalk-project/chromium-crosswalk/blob/master/chrome/browser/chrome_content_browser_client.cc#L2019,
-        // the errors were passed to AllowCertificateError(), then display an SSL blocking page.
-        switch(error) {
-            case NetError.ERR_CERT_COMMON_NAME_INVALID:
-            case NetError.ERR_CERT_DATE_INVALID:
-            case NetError.ERR_CERT_AUTHORITY_INVALID:
-            case NetError.ERR_CERT_WEAK_SIGNATURE_ALGORITHM:
-            case NetError.ERR_CERT_WEAK_KEY:
-            case NetError.ERR_CERT_NAME_CONSTRAINT_VIOLATION:
-            case NetError.ERR_CERT_VALIDITY_TOO_LONG:
-            case NetError.ERR_CERT_CONTAINS_ERRORS:
-            case NetError.ERR_CERT_REVOKED:
-            case NetError.ERR_CERT_INVALID:
-            case NetError.ERR_SSL_WEAK_SERVER_EPHEMERAL_DH_KEY:
-            case NetError.ERR_SSL_PINNED_KEY_NOT_IN_CERT_CHAIN:
-                return true;
-            default:
-                break;
-        }
-        return false;
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -23,7 +23,6 @@ import android.view.View;
 import android.webkit.ConsoleMessage;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
-import android.widget.Toast;
 
 import java.security.cert.X509Certificate;
 import java.security.KeyStore.PrivateKeyEntry;  
@@ -674,18 +673,12 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     // If returns false, the request is immediately canceled, and any call to proceedSslError
     // has no effect. If returns true, the request should be canceled or proceeded using
     // proceedSslError().
-    // Unlike the webview classic, we do not keep a database of certificates that
+    // Unlike the webview classic, we do not keep keep a database of certificates that
     // are allowed by the user, because this functionality is already handled via
     // ssl_policy in native layers.
     @CalledByNative
     private boolean allowCertificateError(int certError, byte[] derBytes, final String url,
             final int id) {
-        boolean shouldDeny = SslUtil.shouldDenyRequest(certError);
-        if (shouldDeny) {
-            Toast.makeText(mXWalkView.getContext(), R.string.ssl_error_deny_request,
-                    Toast.LENGTH_SHORT).show();
-            return false;
-        }
         final SslCertificate cert = SslUtil.getCertificateFromDerBytes(derBytes);
         if (cert == null) {
             // if the certificate or the client is null, cancel the request

--- a/runtime/android/core_internal/strings/android_xwalk_strings.grd
+++ b/runtime/android/core_internal/strings/android_xwalk_strings.grd
@@ -41,9 +41,6 @@
       <message desc="Prompt for the http authentication login [CHAR-LIMIT=32]" name="IDS_HTTP_AUTH_LOG_IN">
         Log In
       </message>
-      <message desc="Prompt for denying request when SSL error occurred [CHAR-LIMIT=32]" name="IDS_SSL_ERROR_DENY_REQUEST">
-        Request was denied for security.
-      </message>
     </messages>
   </release>
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java
@@ -7,7 +7,6 @@ package org.xwalk.core.xwview.test;
 
 import android.test.suitebuilder.annotation.SmallTest;
 
-import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
 import org.chromium.content.browser.test.util.CallbackHelper;
 import org.chromium.net.test.util.TestWebServer;
@@ -29,16 +28,11 @@ public class ClearSslPreferenceTest extends XWalkViewTestBase {
         super.tearDown();
     }
 
-    // @Feature({"ClearSslPreference"})
-    // @SmallTest
+    @Feature({"ClearSslPreference"})
+    @SmallTest
     // If the user allows the ssl error, the same ssl error will not trigger
     // the onReceivedSslError callback; If the user denies it, the same ssl
     // error will still trigger the onReceivedSslError callback.
-    // For SSL error, if user allows it, the related host and error will be recorded.
-    // All future communications with same host and error, will accept any SSL certificate
-    // even if not valid. We deny invalid requests with some serious ssl errors that
-    // this case will be failed, so disbaled it.
-    @DisabledTest
     public void testSslPreferences() throws Throwable {
         final String pagePath = "/hello.html";
         final String pageUrl =
@@ -77,22 +71,5 @@ public class ClearSslPreferenceTest extends XWalkViewTestBase {
         onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
         loadUrlSync(pageUrl);
         assertEquals(onSslErrorCallCount + 1, onReceivedSslErrorHelper.getCallCount());
-    }
-
-    @Feature({"SslError"})
-    @SmallTest
-    public void testDeniedRequestForSslError() throws Throwable {
-        final String pagePath = "/hello.html";
-        final String pageUrl =
-                mWebServer.setResponse(pagePath, "<html><body>hello world</body></html>", null);
-        final CallbackHelper onReceivedSslErrorHelper =
-                mTestHelperBridge.getOnReceivedSslErrorHelper();
-        int onSslErrorCallCount = onReceivedSslErrorHelper.getCallCount();
-
-        assertNull(getCertificateOnUiThread());
-        loadUrlSync(pageUrl);
-        // Request was denied for ERR_CERT_COMMON_NAME_INVALID, certificate was
-        // also NULL.
-        assertNull(getCertificateOnUiThread());
     }
 }


### PR DESCRIPTION
This reverts commit 4b3000b18cb9f80b5cb41a412b0588758644834a.

The build broke:

```
test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java:92: error: cannot find symbol
        assertNull(getCertificateOnUiThread());
                   ^
  symbol:   method getCertificateOnUiThread()
  location: class ClearSslPreferenceTest
test/android/core/javatests/src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java:96: error: cannot find symbol
        assertNull(getCertificateOnUiThread());
                   ^
  symbol:   method getCertificateOnUiThread()
  location: class ClearSslPreferenceTest
```

BUG=XWALK-6986