### PR TITLE
Add gn build support for crosswalk-linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,489 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/features.gni")
+import("//build/config/ui.gni")
+import("//xwalk/build/version.gni")
+import("//xwalk/build/xwalk.gni")
+
+group("xwalk_builder") {
+  # In GN, When a target is marked "testonly = true", it must only be depended
+  # on by other test-only targets. In crosswalk project we don't need to care
+  # which targets are testonly. In order to group all targets into "xwalk_builder"
+  # we just set testonly=true.
+  testonly = true
+  deps = []
+  if (is_linux) {
+    deps += [
+      ":xwalk",
+      ":xwalk_all_tests",
+    ]
+  }
+}
+
+executable("xwalk") {
+  sources = [
+    "runtime/app/xwalk_main.cc",
+  ]
+  deps = [
+    ":xwalk_runtime",
+  ]
+}
+
+source_set("xwalk_runtime") {
+  sources = [
+    "//extensions/common/constants.cc",
+    "//extensions/common/constants.h",
+    "//extensions/common/url_pattern.cc",
+    "//extensions/common/url_pattern.h",
+    "runtime/app/android/xwalk_main_delegate_android.cc",
+    "runtime/app/android/xwalk_main_delegate_android.h",
+    "runtime/app/xwalk_main_delegate.cc",
+    "runtime/app/xwalk_main_delegate.h",
+    "runtime/browser/android/cookie_manager.cc",
+    "runtime/browser/android/cookie_manager.h",
+    "runtime/browser/android/find_helper.cc",
+    "runtime/browser/android/find_helper.h",
+    "runtime/browser/android/net/android_protocol_handler.cc",
+    "runtime/browser/android/net/android_protocol_handler.h",
+    "runtime/browser/android/net/android_stream_reader_url_request_job.cc",
+    "runtime/browser/android/net/android_stream_reader_url_request_job.h",
+    "runtime/browser/android/net/init_native_callback.h",
+    "runtime/browser/android/net/input_stream.h",
+    "runtime/browser/android/net/input_stream_impl.cc",
+    "runtime/browser/android/net/input_stream_impl.h",
+    "runtime/browser/android/net/input_stream_reader.cc",
+    "runtime/browser/android/net/input_stream_reader.h",
+    "runtime/browser/android/net/url_constants.cc",
+    "runtime/browser/android/net/url_constants.h",
+    "runtime/browser/android/net/xwalk_cookie_store_wrapper.cc",
+    "runtime/browser/android/net/xwalk_cookie_store_wrapper.h",
+    "runtime/browser/android/net/xwalk_url_request_job_factory.cc",
+    "runtime/browser/android/net/xwalk_url_request_job_factory.h",
+    "runtime/browser/android/net_disk_cache_remover.cc",
+    "runtime/browser/android/net_disk_cache_remover.h",
+    "runtime/browser/android/renderer_host/xwalk_render_view_host_ext.cc",
+    "runtime/browser/android/renderer_host/xwalk_render_view_host_ext.h",
+    "runtime/browser/android/scoped_allow_wait_for_legacy_web_view_api.h",
+    "runtime/browser/android/state_serializer.cc",
+    "runtime/browser/android/state_serializer.h",
+    "runtime/browser/android/xwalk_autofill_client_android.cc",
+    "runtime/browser/android/xwalk_autofill_client_android.h",
+    "runtime/browser/android/xwalk_content.cc",
+    "runtime/browser/android/xwalk_content.h",
+    "runtime/browser/android/xwalk_content_lifecycle_notifier.cc",
+    "runtime/browser/android/xwalk_content_lifecycle_notifier.h",
+    "runtime/browser/android/xwalk_contents_client_bridge.cc",
+    "runtime/browser/android/xwalk_contents_client_bridge.h",
+    "runtime/browser/android/xwalk_contents_client_bridge_base.cc",
+    "runtime/browser/android/xwalk_contents_client_bridge_base.h",
+    "runtime/browser/android/xwalk_contents_io_thread_client.h",
+    "runtime/browser/android/xwalk_contents_io_thread_client_impl.cc",
+    "runtime/browser/android/xwalk_contents_io_thread_client_impl.h",
+    "runtime/browser/android/xwalk_cookie_access_policy.cc",
+    "runtime/browser/android/xwalk_cookie_access_policy.h",
+    "runtime/browser/android/xwalk_dev_tools_server.cc",
+    "runtime/browser/android/xwalk_dev_tools_server.h",
+    "runtime/browser/android/xwalk_download_resource_throttle.cc",
+    "runtime/browser/android/xwalk_download_resource_throttle.h",
+    "runtime/browser/android/xwalk_http_auth_handler.cc",
+    "runtime/browser/android/xwalk_http_auth_handler.h",
+    "runtime/browser/android/xwalk_http_auth_handler_base.cc",
+    "runtime/browser/android/xwalk_http_auth_handler_base.h",
+    "runtime/browser/android/xwalk_icon_helper.cc",
+    "runtime/browser/android/xwalk_icon_helper.h",
+    "runtime/browser/android/xwalk_login_delegate.cc",
+    "runtime/browser/android/xwalk_login_delegate.h",
+    "runtime/browser/android/xwalk_path_helper.cc",
+    "runtime/browser/android/xwalk_path_helper.h",
+    "runtime/browser/android/xwalk_presentation_host.cc",
+    "runtime/browser/android/xwalk_presentation_host.h",
+    "runtime/browser/android/xwalk_request_interceptor.cc",
+    "runtime/browser/android/xwalk_request_interceptor.h",
+    "runtime/browser/android/xwalk_settings.cc",
+    "runtime/browser/android/xwalk_view_delegate.cc",
+    "runtime/browser/android/xwalk_view_delegate.h",
+    "runtime/browser/android/xwalk_web_contents_delegate.cc",
+    "runtime/browser/android/xwalk_web_contents_delegate.h",
+    "runtime/browser/android/xwalk_web_contents_view_delegate.cc",
+    "runtime/browser/android/xwalk_web_contents_view_delegate.h",
+    "runtime/browser/android/xwalk_web_resource_response.cc",
+    "runtime/browser/android/xwalk_web_resource_response.h",
+    "runtime/browser/android/xwalk_web_resource_response_impl.cc",
+    "runtime/browser/android/xwalk_web_resource_response_impl.h",
+    "runtime/browser/application_component.cc",
+    "runtime/browser/application_component.h",
+    "runtime/browser/devtools/remote_debugging_server.cc",
+    "runtime/browser/devtools/remote_debugging_server.h",
+    "runtime/browser/devtools/xwalk_devtools_manager_delegate.cc",
+    "runtime/browser/devtools/xwalk_devtools_manager_delegate.h",
+    "runtime/browser/geolocation/xwalk_access_token_store.cc",
+    "runtime/browser/geolocation/xwalk_access_token_store.h",
+    "runtime/browser/image_util.cc",
+    "runtime/browser/image_util.h",
+    "runtime/browser/media/media_capture_devices_dispatcher.cc",
+    "runtime/browser/media/media_capture_devices_dispatcher.h",
+    "runtime/browser/runtime.cc",
+    "runtime/browser/runtime.h",
+    "runtime/browser/runtime_download_manager_delegate.cc",
+    "runtime/browser/runtime_download_manager_delegate.h",
+    "runtime/browser/runtime_file_select_helper.cc",
+    "runtime/browser/runtime_file_select_helper.h",
+    "runtime/browser/runtime_geolocation_permission_context.cc",
+    "runtime/browser/runtime_geolocation_permission_context.h",
+    "runtime/browser/runtime_javascript_dialog_manager.cc",
+    "runtime/browser/runtime_javascript_dialog_manager.h",
+    "runtime/browser/runtime_network_delegate.cc",
+    "runtime/browser/runtime_network_delegate.h",
+    "runtime/browser/runtime_notification_permission_context.cc",
+    "runtime/browser/runtime_notification_permission_context.h",
+    "runtime/browser/runtime_platform_util.h",
+    "runtime/browser/runtime_platform_util_android.cc",
+    "runtime/browser/runtime_platform_util_linux.cc",
+    "runtime/browser/runtime_platform_util_mac.mm",
+    "runtime/browser/runtime_platform_util_win.cc",
+    "runtime/browser/runtime_quota_permission_context.cc",
+    "runtime/browser/runtime_quota_permission_context.h",
+    "runtime/browser/runtime_resource_dispatcher_host_delegate.cc",
+    "runtime/browser/runtime_resource_dispatcher_host_delegate.h",
+    "runtime/browser/runtime_resource_dispatcher_host_delegate_android.cc",
+    "runtime/browser/runtime_resource_dispatcher_host_delegate_android.h",
+    "runtime/browser/runtime_select_file_policy.cc",
+    "runtime/browser/runtime_select_file_policy.h",
+    "runtime/browser/runtime_ui_delegate.cc",
+    "runtime/browser/runtime_ui_delegate.h",
+    "runtime/browser/runtime_url_request_context_getter.cc",
+    "runtime/browser/runtime_url_request_context_getter.h",
+    "runtime/browser/speech/speech_recognition_manager_delegate.cc",
+    "runtime/browser/speech/speech_recognition_manager_delegate.h",
+    "runtime/browser/ssl_error_page.cc",
+    "runtime/browser/ssl_error_page.h",
+    "runtime/browser/storage_component.cc",
+    "runtime/browser/storage_component.h",
+    "runtime/browser/sysapps_component.cc",
+    "runtime/browser/sysapps_component.h",
+    "runtime/browser/ui/color_chooser.cc",
+    "runtime/browser/ui/color_chooser.h",
+    "runtime/browser/ui/color_chooser_android.cc",
+    "runtime/browser/ui/color_chooser_mac.cc",
+    "runtime/browser/ui/desktop/exclusive_access_bubble.cc",
+    "runtime/browser/ui/desktop/exclusive_access_bubble.h",
+    "runtime/browser/ui/desktop/exclusive_access_bubble_views_context.h",
+    "runtime/browser/ui/native_app_window.cc",
+    "runtime/browser/ui/native_app_window.h",
+    "runtime/browser/ui/native_app_window_android.cc",
+    "runtime/browser/ui/native_app_window_mac.h",
+    "runtime/browser/ui/native_app_window_mac.mm",
+    "runtime/browser/xwalk_app_extension_bridge.cc",
+    "runtime/browser/xwalk_app_extension_bridge.h",
+    "runtime/browser/xwalk_application_mac.h",
+    "runtime/browser/xwalk_application_mac.mm",
+    "runtime/browser/xwalk_autofill_client.cc",
+    "runtime/browser/xwalk_autofill_client.h",
+    "runtime/browser/xwalk_autofill_manager.cc",
+    "runtime/browser/xwalk_autofill_manager.h",
+    "runtime/browser/xwalk_browser_context.cc",
+    "runtime/browser/xwalk_browser_context.h",
+    "runtime/browser/xwalk_browser_main_parts.cc",
+    "runtime/browser/xwalk_browser_main_parts.h",
+    "runtime/browser/xwalk_browser_main_parts_android.cc",
+    "runtime/browser/xwalk_browser_main_parts_android.h",
+    "runtime/browser/xwalk_browser_main_parts_mac.h",
+    "runtime/browser/xwalk_browser_main_parts_mac.mm",
+    "runtime/browser/xwalk_component.h",
+    "runtime/browser/xwalk_content_browser_client.cc",
+    "runtime/browser/xwalk_content_browser_client.h",
+    "runtime/browser/xwalk_content_settings.cc",
+    "runtime/browser/xwalk_content_settings.h",
+    "runtime/browser/xwalk_form_database_service.cc",
+    "runtime/browser/xwalk_form_database_service.h",
+    "runtime/browser/xwalk_permission_manager.cc",
+    "runtime/browser/xwalk_permission_manager.h",
+    "runtime/browser/xwalk_platform_notification_service.cc",
+    "runtime/browser/xwalk_platform_notification_service.h",
+    "runtime/browser/xwalk_pref_store.cc",
+    "runtime/browser/xwalk_pref_store.h",
+    "runtime/browser/xwalk_presentation_service_delegate.cc",
+    "runtime/browser/xwalk_presentation_service_delegate.h",
+    "runtime/browser/xwalk_presentation_service_delegate_android.cc",
+    "runtime/browser/xwalk_presentation_service_delegate_android.h",
+    "runtime/browser/xwalk_presentation_service_delegate_win.cc",
+    "runtime/browser/xwalk_presentation_service_delegate_win.h",
+    "runtime/browser/xwalk_presentation_service_helper.cc",
+    "runtime/browser/xwalk_presentation_service_helper.h",
+    "runtime/browser/xwalk_presentation_service_helper_android.cc",
+    "runtime/browser/xwalk_presentation_service_helper_android.h",
+    "runtime/browser/xwalk_presentation_service_helper_win.cc",
+    "runtime/browser/xwalk_presentation_service_helper_win.h",
+    "runtime/browser/xwalk_render_message_filter.cc",
+    "runtime/browser/xwalk_render_message_filter.h",
+    "runtime/browser/xwalk_runner.cc",
+    "runtime/browser/xwalk_runner.h",
+    "runtime/browser/xwalk_runner_win.cc",
+    "runtime/browser/xwalk_runner_win.h",
+    "runtime/browser/xwalk_ssl_host_state_delegate.cc",
+    "runtime/browser/xwalk_ssl_host_state_delegate.h",
+    "runtime/common/android/xwalk_globals_android.cc",
+    "runtime/common/android/xwalk_globals_android.h",
+    "runtime/common/android/xwalk_hit_test_data.cc",
+    "runtime/common/android/xwalk_hit_test_data.h",
+    "runtime/common/android/xwalk_message_generator.cc",
+    "runtime/common/android/xwalk_message_generator.h",
+    "runtime/common/android/xwalk_render_view_messages.cc",
+    "runtime/common/android/xwalk_render_view_messages.h",
+    "runtime/common/logging_xwalk.cc",
+    "runtime/common/logging_xwalk.h",
+    "runtime/common/paths_mac.h",
+    "runtime/common/paths_mac.mm",
+    "runtime/common/xwalk_common_message_generator.cc",
+    "runtime/common/xwalk_common_message_generator.h",
+    "runtime/common/xwalk_common_messages.cc",
+    "runtime/common/xwalk_common_messages.h",
+    "runtime/common/xwalk_content_client.cc",
+    "runtime/common/xwalk_content_client.h",
+    "runtime/common/xwalk_localized_error.cc",
+    "runtime/common/xwalk_localized_error.h",
+    "runtime/common/xwalk_paths.cc",
+    "runtime/common/xwalk_paths.h",
+    "runtime/common/xwalk_resource_delegate.cc",
+    "runtime/common/xwalk_resource_delegate.h",
+    "runtime/common/xwalk_runtime_features.cc",
+    "runtime/common/xwalk_runtime_features.h",
+    "runtime/common/xwalk_switches.cc",
+    "runtime/common/xwalk_switches.h",
+    "runtime/common/xwalk_system_locale.cc",
+    "runtime/common/xwalk_system_locale.h",
+    "runtime/renderer/android/xwalk_permission_client.cc",
+    "runtime/renderer/android/xwalk_permission_client.h",
+    "runtime/renderer/android/xwalk_render_thread_observer.cc",
+    "runtime/renderer/android/xwalk_render_thread_observer.h",
+    "runtime/renderer/android/xwalk_render_view_ext.cc",
+    "runtime/renderer/android/xwalk_render_view_ext.h",
+    "runtime/renderer/isolated_file_system.cc",
+    "runtime/renderer/isolated_file_system.h",
+    "runtime/renderer/xwalk_content_renderer_client.cc",
+    "runtime/renderer/xwalk_content_renderer_client.h",
+  ]
+  if (!is_android) {
+    sources += [
+      "runtime/browser/devtools/xwalk_devtools_frontend.cc",
+      "runtime/browser/devtools/xwalk_devtools_frontend.h",
+      "runtime/browser/runtime_ui_delegate_desktop.cc",
+      "runtime/browser/runtime_ui_delegate_desktop.h",
+      "runtime/browser/ui/desktop/xwalk_autofill_popup_controller.cc",
+      "runtime/browser/ui/desktop/xwalk_autofill_popup_controller.h",
+      "runtime/browser/ui/desktop/xwalk_autofill_popup_view.cc",
+      "runtime/browser/ui/desktop/xwalk_autofill_popup_view.h",
+      "runtime/browser/ui/desktop/xwalk_permission_dialog_manager.cc",
+      "runtime/browser/ui/desktop/xwalk_permission_dialog_manager.h",
+      "runtime/browser/ui/desktop/xwalk_permission_modal_dialog.cc",
+      "runtime/browser/ui/desktop/xwalk_permission_modal_dialog.h",
+      "runtime/browser/ui/desktop/xwalk_popup_controller.cc",
+      "runtime/browser/ui/desktop/xwalk_popup_controller.h",
+      "runtime/browser/ui/native_app_window_desktop.cc",
+      "runtime/browser/ui/native_app_window_desktop.h",
+      "runtime/browser/xwalk_autofill_client_desktop.cc",
+      "runtime/browser/xwalk_autofill_client_desktop.h",
+      "runtime/renderer/xwalk_render_thread_observer_generic.cc",
+      "runtime/renderer/xwalk_render_thread_observer_generic.h",
+    ]
+  }
+  if (is_linux && !is_component_build && is_component_ffmpeg) {
+    # Set RPath for executable xwalk, xwalk_browsertest and xwalk_unittest.
+    public_configs = [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+  }
+
+  include_dirs = [ "$root_gen_dir/xwalk" ]
+  defines = [
+    "CHROME_VERSION=\"$chrome_version\"",
+    "XWALK_VERSION=\"$xwalk_version\"",
+  ]
+  deps = [
+    ":generate_upstream_blink_version",
+    "//base",
+    "//base:base_static",
+    "//base:i18n",
+    "//base/third_party/dynamic_annotations",
+    "//cc",
+    "//components/autofill/content/browser",
+    "//components/autofill/content/renderer",
+    "//components/autofill/core/browser",
+    "//components/cdm/renderer",
+    "//components/devtools_http_handler",
+    "//components/resources:components_resources",
+    "//components/strings",
+    "//components/url_formatter",
+    "//components/user_prefs",
+    "//components/visitedlink/browser",
+    "//components/visitedlink/renderer",
+    "//content",
+    "//content/public/app:both",
+    "//content/public/browser",
+    "//content/public/child",
+    "//content/public/common",
+    "//content/public/utility",
+    "//gin",
+    "//ipc",
+    "//media",
+    "//net",
+    "//net:net_resources",
+    "//skia",
+    "//storage/browser",
+    "//storage/common",
+    "//third_party/WebKit/public:blink",
+    "//third_party/boringssl",
+    "//ui/base",
+    "//ui/gl",
+    "//ui/shell_dialogs",
+    "//ui/snapshot",
+    "//url",
+    "//v8",
+    "//xwalk/application:xwalk_application_lib",
+    "//xwalk/application:xwalk_application_resources",
+    "//xwalk/experimental",
+    "//xwalk/extensions",
+    "//xwalk/resources:generate_xwalk_resources",
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+    "//xwalk/resources:xwalk_resources_200_percent_pak",
+    "//xwalk/resources:xwalk_resources_300_percent_pak",
+    "//xwalk/resources:xwalk_strings",
+    "//xwalk/sysapps",
+    "//xwalk/sysapps:xwalk_sysapps_resources",
+  ]
+
+  if (is_linux) {
+    deps += [ "//xwalk/resources:xwalk_locales" ]
+  }
+
+  # TODO(heke123): Add WebNotification for Linux
+  # WebNotification needs libgtk2ui and libnotify.
+
+  if (disable_bundled_extensions) {
+    defines += [ "DISABLE_BUNDLED_EXTENSIONS" ]
+  }
+
+  if (enable_nacl) {
+    if (is_linux) {
+      sources += [
+        "runtime/browser/nacl_host/nacl_browser_delegate_impl.cc",
+        "runtime/browser/nacl_host/nacl_browser_delegate_impl.h",
+      ]
+    }
+    deps += [
+      "//components/nacl/browser",
+      "//components/nacl/common",
+      "//components/nacl/loader",
+      "//components/nacl/loader:nacl_helper",
+      "//components/nacl/loader/sandbox_linux",
+      "//components/nacl/renderer",
+      "//components/nacl/renderer/plugin:nacl_trusted_plugin",
+      "//native_client/src/trusted/service_runtime/linux:bootstrap",
+    ]
+  }
+
+  if (enable_plugins) {
+    sources += [
+      "//chrome/renderer/pepper/pepper_flash_drm_renderer_host.cc",
+      "//chrome/renderer/pepper/pepper_flash_drm_renderer_host.h",
+      "//chrome/renderer/pepper/pepper_flash_font_file_host.cc",
+      "//chrome/renderer/pepper/pepper_flash_font_file_host.h",
+      "//chrome/renderer/pepper/pepper_flash_fullscreen_host.cc",
+      "//chrome/renderer/pepper/pepper_flash_fullscreen_host.h",
+      "//chrome/renderer/pepper/pepper_flash_menu_host.cc",
+      "//chrome/renderer/pepper/pepper_flash_menu_host.h",
+      "//chrome/renderer/pepper/pepper_flash_renderer_host.cc",
+      "//chrome/renderer/pepper/pepper_flash_renderer_host.h",
+      "runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.cc",
+      "runtime/browser/renderer_host/pepper/xwalk_browser_pepper_host_factory.h",
+      "runtime/renderer/pepper/pepper_helper.cc",
+      "runtime/renderer/pepper/pepper_helper.h",
+      "runtime/renderer/pepper/pepper_uma_host.cc",
+      "runtime/renderer/pepper/pepper_uma_host.h",
+      "runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.cc",
+      "runtime/renderer/pepper/xwalk_renderer_pepper_host_factory.h",
+    ]
+    deps += [
+      "//components/pdf/renderer",
+      "//ppapi/host",
+      "//ppapi/proxy",
+      "//ppapi/proxy:ipc",
+      "//ppapi/shared_impl",
+    ]
+  }
+
+  if (toolkit_views) {
+    sources += [
+      "runtime/browser/ui/desktop/download_views.cc",
+      "runtime/browser/ui/desktop/download_views.h",
+      "runtime/browser/ui/desktop/exclusive_access_bubble_views.cc",
+      "runtime/browser/ui/desktop/exclusive_access_bubble_views.h",
+      "runtime/browser/ui/desktop/xwalk_permission_modal_dialog_views.cc",
+      "runtime/browser/ui/desktop/xwalk_permission_modal_dialog_views.h",
+      "runtime/browser/ui/native_app_window_views.cc",
+      "runtime/browser/ui/native_app_window_views.h",
+      "runtime/browser/ui/top_view_layout_views.cc",
+      "runtime/browser/ui/top_view_layout_views.h",
+      "runtime/browser/ui/xwalk_javascript_native_dialog_factory.h",
+      "runtime/browser/ui/xwalk_javascript_native_dialog_factory_views.cc",
+      "runtime/browser/ui/xwalk_views_delegate.cc",
+      "runtime/browser/ui/xwalk_views_delegate.h",
+    ]
+    deps += [
+      "//components/app_modal",
+      "//components/constrained_window",
+      "//components/guest_view/browser",
+      "//components/ui/zoom",
+      "//ui/events",
+      "//ui/resources",
+      "//ui/strings:ui_strings",
+      "//ui/views",
+      "//ui/views/controls/webview",
+    ]
+  }
+
+  if (use_aura) {
+    sources += [
+      "runtime/browser/runtime_platform_util_aura.cc",
+      "runtime/browser/ui/color_chooser_aura.cc",
+    ]
+    deps += [
+      "//ui/aura",
+      "//ui/base/ime",
+      "//ui/wm",
+    ]
+  }
+}
+
+# While we could just call lastchange.py here and generate the header
+# directly, it would only work if there is a git checkout (ie. it does
+# not work with a tarball, for example).
+action("generate_upstream_blink_version") {
+  output_file = "$root_gen_dir/blink_upstream_version.h"
+  template = "//xwalk/runtime/browser/blink_upstream_version.h.in"
+  upstream = "//xwalk/build/UPSTREAM.blink"
+
+  outputs = [
+    "$output_file",
+  ]
+  script = "//build/util/version.py"
+  args = [
+    "-f",
+    rebase_path(upstream, root_out_dir),
+    rebase_path(template, root_out_dir),
+    rebase_path(output_file, root_out_dir),
+  ]
+}
+
+group("xwalk_all_tests") {
+  testonly = true
+  deps = [
+    "//xwalk/extensions/test:xwalk_extensions_browsertest",
+    "//xwalk/extensions/test:xwalk_extensions_unittest",
+    "//xwalk/sysapps:xwalk_sysapps_browsertest",
+    "//xwalk/sysapps:xwalk_sysapps_unittest",
+    "//xwalk/test:xwalk_browsertest",
+    "//xwalk/test:xwalk_unittest",
+  ]
+}

--- a/application/BUILD.gn
+++ b/application/BUILD.gn
@@ -1,0 +1,59 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# GYP version: xwalk_application.gypi:generate_xwalk_application_resources
+import("//tools/grit/grit_rule.gni")
+import("//tools/grit/repack.gni")
+
+source_set("xwalk_application_lib") {
+  sources = [
+    "browser/application.cc",
+    "browser/application.h",
+    "browser/application_protocols.cc",
+    "browser/application_protocols.h",
+    "browser/application_security_policy.cc",
+    "browser/application_security_policy.h",
+    "browser/application_service.cc",
+    "browser/application_service.h",
+    "browser/application_system.cc",
+    "browser/application_system.h",
+    "extension/application_runtime_extension.cc",
+    "extension/application_runtime_extension.h",
+    "extension/application_widget_extension.cc",
+    "extension/application_widget_extension.h",
+    "extension/application_widget_storage.cc",
+    "extension/application_widget_storage.h",
+    "renderer/application_native_module.cc",
+    "renderer/application_native_module.h",
+  ]
+  deps = [
+    ":xwalk_application_resources",
+    "//base",
+    "//crypto",
+    "//ipc",
+    "//third_party/WebKit/public:blink",
+    "//third_party/libxml",
+    "//third_party/zlib:zip",
+    "//ui/base",
+    "//url",
+    "//xwalk/application/common:xwalk_application_common_lib",
+  ]
+}
+
+# TODO(heke123): Remove this config by putting the files in the right place
+# in grit of grd file.
+config("xwalk_application_resources_include_dir") {
+  include_dirs = [ "$root_gen_dir/xwalk/application" ]
+}
+
+grit("xwalk_application_resources") {
+  source = "application_resources.grd"
+  outputs = [
+    "$root_gen_dir/xwalk/application/grit/xwalk_application_resources.h",
+    "$root_gen_dir/xwalk/application/xwalk_application_resources.pak",
+    "$root_gen_dir/xwalk/application/xwalk_application_resources.rc",
+  ]
+  public_configs = [ ":xwalk_application_resources_include_dir" ]
+  resource_ids = "//xwalk/resources/resource_ids"
+}

--- a/application/common/BUILD.gn
+++ b/application/common/BUILD.gn
@@ -1,0 +1,51 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("xwalk_application_common_lib") {
+  sources = [
+    "application_data.cc",
+    "application_data.h",
+    "application_file_util.cc",
+    "application_file_util.h",
+    "application_manifest_constants.cc",
+    "application_manifest_constants.h",
+    "application_resource.cc",
+    "application_resource.h",
+    "constants.cc",
+    "constants.h",
+    "id_util.cc",
+    "id_util.h",
+    "manifest.cc",
+    "manifest.h",
+    "manifest_handler.cc",
+    "manifest_handler.h",
+    "manifest_handlers/csp_handler.cc",
+    "manifest_handlers/csp_handler.h",
+    "manifest_handlers/permissions_handler.cc",
+    "manifest_handlers/permissions_handler.h",
+    "manifest_handlers/warp_handler.cc",
+    "manifest_handlers/warp_handler.h",
+    "manifest_handlers/widget_handler.cc",
+    "manifest_handlers/widget_handler.h",
+    "package/package.cc",
+    "package/package.h",
+    "package/wgt_package.cc",
+    "package/wgt_package.h",
+    "package/xpk_package.cc",
+    "package/xpk_package.h",
+    "permission_policy_manager.cc",
+    "permission_policy_manager.h",
+    "permission_types.h",
+  ]
+  deps = [
+    "//base",
+    "//base:i18n",
+    "//crypto",
+    "//net",
+    "//sql",
+    "//third_party/libxml",
+    "//third_party/zlib:zip",
+    "//url",
+  ]
+}

--- a/build/common.gni
+++ b/build/common.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file contains common build flags for building Crosswalk. Users should
+# NOT directly import this file into their build folder.
+# See //xwalk/build/linux.gni for how to import flags for Crosswalk-Linux Build
+
+root_extra_deps = [ "//xwalk:xwalk_builder" ]
+
+# From src/build/config/features.gni
+# Disable WebVR support. The code is still experimental and and ends up
+# pulling additional dependencies into our JARs (XWALK-6597).
+enable_webvr = false
+
+# From src/build/config/features.gni
+# Whether to include support for proprietary codecs.
+proprietary_codecs = true

--- a/build/linux.gni
+++ b/build/linux.gni
@@ -1,0 +1,26 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file contains feature flags for Crosswalk Linux build. Users should
+# import it into their build folder by run:
+#   echo 'import("//xwalk/build/linux.gni")' > out/your_folder/args.gn'
+# Then run:
+#   gn gen out/your_folder
+#   ninja -C out/your_folder xwalk_builder
+# to build xwalk and xwalk-test executable files.
+
+import("//xwalk/build/common.gni")
+
+# From src/third_party/ffmpeg/ffmpeg_options.gni
+# Set true to build ffmpeg as a shared library.
+# Since M44, ffmpeg is built as a static library by default. On Linux,
+# keep the previous behavior or building it as a shared library while
+# we figure out if it makes sense to switch to a static library by
+# default.
+is_component_ffmpeg = true
+
+# From //build/config/sysroot.gni.
+# Android and Windows do not use the sysroot, and we cannot use it on
+# Linux because we use libnotify that is not present there.
+use_sysroot = false

--- a/build/version.gni
+++ b/build/version.gni
@@ -1,0 +1,48 @@
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This exposes the Chrome version and Crosswalk version as GN variables for
+# use in build files.
+#
+# PREFER NOT TO USE THESE. The GYP build uses this kind of thing extensively.
+# However, it is far better to write an action (or use the process_version
+# wrapper in chrome/version.gni) to generate a file at build-time with the
+# information you need. This allows better dependency checking and GN will
+# run faster.
+#
+# These values should only be used if you REALLY need to depend on them at
+# build-time, for example, in the computation of output file names.
+
+# Give version.py a pattern that will expand to a GN scope consisting of
+# all values we need at once.
+
+_version_template = "full = \"@MAJOR@.@MINOR@.@BUILD@.@PATCH@\""
+
+# The file containing the Chrome version number.
+chrome_version_file = "//chrome/VERSION"
+
+_result = exec_script("//build/util/version.py",
+                      [
+                        "-f",
+                        rebase_path(chrome_version_file, root_build_dir),
+                        "-t",
+                        _version_template,
+                      ],
+                      "scope",
+                      [ chrome_version_file ])
+chrome_version = _result.full
+
+# The file containing the Crosswalk version number.
+xwalk_version_file = "//xwalk/VERSION"
+
+_result = exec_script("//build/util/version.py",
+                      [
+                        "-f",
+                        rebase_path(xwalk_version_file, root_build_dir),
+                        "-t",
+                        _version_template,
+                      ],
+                      "scope",
+                      [ xwalk_version_file ])
+xwalk_version = _result.full

--- a/build/xwalk.gni
+++ b/build/xwalk.gni
@@ -1,0 +1,10 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file contains Crosswalk specific build flags.
+declare_args() {
+  # Whether to build and use Crosswalk's internal extensions (device
+  # capabilities, sysapps etc).
+  disable_bundled_extensions = false
+}

--- a/experimental/BUILD.gn
+++ b/experimental/BUILD.gn
@@ -1,0 +1,58 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("experimental") {
+  sources = [
+    "$root_gen_dir/xwalk/experimental/native_file_system/native_file_system.cc",
+    "$root_gen_dir/xwalk/experimental/native_file_system/native_file_system.h",
+    "native_file_system/native_file_system.idl",
+    "native_file_system/native_file_system_extension.cc",
+    "native_file_system/native_file_system_extension.h",
+    "native_file_system/virtual_root_provider.cc",
+    "native_file_system/virtual_root_provider.h",
+    "native_file_system/virtual_root_provider_android.cc",
+    "native_file_system/virtual_root_provider_linux.cc",
+    "native_file_system/virtual_root_provider_mac.cc",
+    "native_file_system/virtual_root_provider_win.cc",
+  ]
+  include_dirs = [ "$root_gen_dir/xwalk/experimental" ]
+  deps = [
+    ":generate_jsapi_file_system",
+    "//xwalk/resources:generate_xwalk_resources",
+  ]
+}
+
+action_foreach("generate_jsapi_file_system") {
+  outputs = [
+    "$root_gen_dir/xwalk/experimental/native_file_system/{{source_name_part}}.h",
+    "$root_gen_dir/xwalk/experimental/native_file_system/{{source_name_part}}.cc",
+  ]
+  sources = [
+    "//xwalk/experimental/native_file_system/native_file_system.idl",
+  ]
+  inputs = [
+    "//tools/json_schema_compiler/cc_generator.py",
+    "//tools/json_schema_compiler/code.py",
+    "//tools/json_schema_compiler/compiler.py",
+    "//tools/json_schema_compiler/cpp_generator.py",
+    "//tools/json_schema_compiler/cpp_type_generator.py",
+    "//tools/json_schema_compiler/cpp_util.py",
+    "//tools/json_schema_compiler/h_generator.py",
+    "//tools/json_schema_compiler/idl_schema.py",
+    "//tools/json_schema_compiler/model.py",
+    "//tools/json_schema_compiler/util.cc",
+    "//tools/json_schema_compiler/util.h",
+    "//tools/json_schema_compiler/util_cc_helper.py",
+  ]
+  idl_path = rebase_path("//xwalk/experimental", "$root_out_dir")
+  gen_path = rebase_path("$root_gen_dir", "$root_out_dir")
+  script = "//tools/json_schema_compiler/compiler.py"
+  args = [
+    "$idl_path/native_file_system/{{source_name_part}}.idl",
+    "--root=$idl_path",
+    "--destdir=$gen_path/xwalk/experimental",
+    "--namespace=xwalk::jsapi::native_file_system",
+    "--generator=cpp",
+  ]
+}

--- a/extensions/BUILD.gn
+++ b/extensions/BUILD.gn
@@ -1,0 +1,87 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//tools/grit/grit_rule.gni")
+
+source_set("extensions") {
+  sources = [
+    "browser/xwalk_extension_data.cc",
+    "browser/xwalk_extension_data.h",
+    "browser/xwalk_extension_function_handler.cc",
+    "browser/xwalk_extension_function_handler.h",
+    "browser/xwalk_extension_process_host.cc",
+    "browser/xwalk_extension_process_host.h",
+    "browser/xwalk_extension_service.cc",
+    "browser/xwalk_extension_service.h",
+    "common/android/xwalk_extension_android.cc",
+    "common/android/xwalk_extension_android.h",
+    "common/android/xwalk_native_extension_loader_android.cc",
+    "common/android/xwalk_native_extension_loader_android.h",
+    "common/xwalk_extension.cc",
+    "common/xwalk_extension.h",
+    "common/xwalk_extension_messages.cc",
+    "common/xwalk_extension_messages.h",
+    "common/xwalk_extension_permission_types.h",
+    "common/xwalk_extension_server.cc",
+    "common/xwalk_extension_server.h",
+    "common/xwalk_extension_switches.cc",
+    "common/xwalk_extension_switches.h",
+    "common/xwalk_extension_vector.h",
+    "common/xwalk_external_adapter.cc",
+    "common/xwalk_external_adapter.h",
+    "common/xwalk_external_extension.cc",
+    "common/xwalk_external_extension.h",
+    "common/xwalk_external_instance.cc",
+    "common/xwalk_external_instance.h",
+    "extension_process/xwalk_extension_process.cc",
+    "extension_process/xwalk_extension_process.h",
+    "extension_process/xwalk_extension_process_main.cc",
+    "extension_process/xwalk_extension_process_main.h",
+    "public/XW_Extension.h",
+    "public/XW_Extension_Message_2.h",
+    "public/XW_Extension_Permissions.h",
+    "public/XW_Extension_SyncMessage.h",
+    "renderer/xwalk_extension_client.cc",
+    "renderer/xwalk_extension_client.h",
+    "renderer/xwalk_extension_module.cc",
+    "renderer/xwalk_extension_module.h",
+    "renderer/xwalk_extension_renderer_controller.cc",
+    "renderer/xwalk_extension_renderer_controller.h",
+    "renderer/xwalk_internal_api.js",
+    "renderer/xwalk_js_module.cc",
+    "renderer/xwalk_js_module.h",
+    "renderer/xwalk_module_system.cc",
+    "renderer/xwalk_module_system.h",
+    "renderer/xwalk_v8_utils.cc",
+    "renderer/xwalk_v8_utils.h",
+    "renderer/xwalk_v8tools_module.cc",
+    "renderer/xwalk_v8tools_module.h",
+  ]
+  deps = [
+    ":xwalk_extensions_resources",
+    "//base",
+    "//content",
+    "//ipc",
+    "//third_party/WebKit/public:blink_headers",
+    "//url",
+    "//v8",
+  ]
+}
+
+# TODO(heke123): Remove this config by putting the files in the right place
+# in grit of grd file.
+config("xwalk_extensions_resources_include_dir") {
+  include_dirs = [ "$root_gen_dir/xwalk/extensions" ]
+}
+
+grit("xwalk_extensions_resources") {
+  source = "extensions_resources.grd"
+  outputs = [
+    "$root_gen_dir/xwalk/extensions/grit/xwalk_extensions_resources.h",
+    "$root_gen_dir/xwalk/extensions/xwalk_extensions_resources.rc",
+    "$root_gen_dir/xwalk/extensions/xwalk_extensions_resources.pak",
+  ]
+  public_configs = [ ":xwalk_extensions_resources_include_dir" ]
+  resource_ids = "//xwalk/resources/resource_ids"
+}

--- a/extensions/test/BUILD.gn
+++ b/extensions/test/BUILD.gn
@@ -1,0 +1,157 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+executable("xwalk_extensions_unittest") {
+  testonly = true
+  sources = [
+    "//xwalk/extensions/browser/xwalk_extension_function_handler_unittest.cc",
+    "//xwalk/extensions/common/xwalk_extension_server_unittest.cc",
+  ]
+  deps = [
+    "//base",
+    "//base/test:run_all_unittests",
+    "//testing/gtest",
+    "//xwalk/extensions",
+  ]
+  if (is_linux && !is_component_build && is_component_ffmpeg) {
+    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+  }
+}
+
+executable("xwalk_extensions_browsertest") {
+  testonly = true
+  sources = [
+    "$root_gen_dir/xwalk/extensions/test/test.cc",
+    "$root_gen_dir/xwalk/extensions/test/test.h",
+    "bad_extension_test.cc",
+    "conflicting_entry_points.cc",
+    "context_destruction.cc",
+    "crash_extension_process.cc",
+    "export_object.cc",
+    "extension_in_iframe.cc",
+    "external_extension.cc",
+    "external_extension_multi_process.cc",
+    "in_process_threads_browsertest.cc",
+    "internal_extension_browsertest.cc",
+    "internal_extension_browsertest.h",
+    "namespace_read_only.cc",
+    "nested_namespace.cc",
+    "test.idl",
+    "v8tools_module.cc",
+    "xwalk_extensions_browsertest.cc",
+    "xwalk_extensions_test_base.cc",
+    "xwalk_extensions_test_base.h",
+  ]
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+  deps = [
+    ":bad_extension",
+    ":bulk_data_transmission",
+    ":crash_extension",
+    ":echo_extension",
+    ":echo_extension_messaging_2",
+    ":generate_jsapi_extensions_test",
+    ":get_runtime_variable",
+    ":multiple_entry_points_extension",
+    "//base",
+    "//content/public/browser",
+    "//content/test:test_support",
+    "//net",
+    "//skia",
+    "//testing/gtest",
+    "//xwalk:xwalk_runtime",
+    "//xwalk/extensions",
+    "//xwalk/extensions:xwalk_extensions_resources",
+    "//xwalk/test/base:test_support",
+  ]
+  if (is_linux && !is_component_build && is_component_ffmpeg) {
+    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+  }
+}
+
+action("generate_jsapi_extensions_test") {
+  outputs = [
+    "$root_gen_dir/xwalk/extensions/test/test.h",
+    "$root_gen_dir/xwalk/extensions/test/test.cc",
+  ]
+  script = "//tools/json_schema_compiler/compiler.py"
+  inputs = [
+    "//tools/json_schema_compiler/cc_generator.py",
+    "//tools/json_schema_compiler/code.py",
+    "//tools/json_schema_compiler/compiler.py",
+    "//tools/json_schema_compiler/cpp_generator.py",
+    "//tools/json_schema_compiler/cpp_type_generator.py",
+    "//tools/json_schema_compiler/cpp_util.py",
+    "//tools/json_schema_compiler/h_generator.py",
+    "//tools/json_schema_compiler/idl_schema.py",
+    "//tools/json_schema_compiler/model.py",
+    "//tools/json_schema_compiler/util.cc",
+    "//tools/json_schema_compiler/util.h",
+    "//tools/json_schema_compiler/util_cc_helper.py",
+  ]
+  root_path = rebase_path("//xwalk/extensions", "$root_out_dir")
+  gen_path = rebase_path("$root_gen_dir", "$root_out_dir")
+  args = [
+    "$root_path/test/test.idl",
+    "--root=$root_path",
+    "--destdir=$gen_path/xwalk/extensions/",
+    "--namespace=xwalk::jsapi::test",
+    "--generator=cpp",
+  ]
+}
+
+loadable_module("echo_extension") {
+  visibility = [ ":*" ]
+  sources = [
+    "echo_extension.c",
+  ]
+  output_dir = "$root_out_dir/tests/extension/echo_extension"
+}
+
+loadable_module("echo_extension_messaging_2") {
+  visibility = [ ":*" ]
+  sources = [
+    "echo_extension_messaging_2.c",
+  ]
+  output_dir = "$root_out_dir/tests/extension/echo_extension"
+}
+
+loadable_module("bad_extension") {
+  visibility = [ ":*" ]
+  sources = [
+    "bad_extension.c",
+  ]
+  output_dir = "$root_out_dir/tests/extension/bad_extension"
+}
+
+loadable_module("get_runtime_variable") {
+  visibility = [ ":*" ]
+  sources = [
+    "get_runtime_variable.c",
+  ]
+  output_dir = "$root_out_dir/tests/extension/get_runtime_variable"
+}
+
+loadable_module("multiple_entry_points_extension") {
+  visibility = [ ":*" ]
+  sources = [
+    "multiple_entry_points_extension.c",
+  ]
+  output_dir = "$root_out_dir/tests/extension/multiple_extension"
+}
+
+loadable_module("crash_extension") {
+  visibility = [ ":*" ]
+  sources = [
+    "crash_extension.c",
+  ]
+  output_dir = "$root_out_dir/tests/extension/crash_extension"
+}
+
+loadable_module("bulk_data_transmission") {
+  visibility = [ ":*" ]
+  sources = [
+    "bulk_data_transmission.c",
+  ]
+  output_dir = "$root_out_dir/tests/extension/bulk_data_transmission"
+}

--- a/resources/BUILD.gn
+++ b/resources/BUILD.gn
@@ -1,0 +1,165 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//tools/grit/grit_rule.gni")
+import("//tools/grit/repack.gni")
+import("//xwalk/resources/locales.gni")
+
+repack("xwalk_pak") {
+  output = "$root_out_dir/xwalk.pak"
+  sources = [
+    "$root_gen_dir/blink/public/resources/blink_resources.pak",
+    "$root_gen_dir/components/components_resources.pak",
+    "$root_gen_dir/content/app/strings/content_strings_en-US.pak",
+    "$root_gen_dir/content/content_resources.pak",
+    "$root_gen_dir/net/net_resources.pak",
+    "$root_gen_dir/ui/strings/app_locale_settings_en-US.pak",
+    "$root_gen_dir/ui/strings/ui_strings_en-US.pak",
+    "$root_gen_dir/xwalk/application/xwalk_application_resources.pak",
+    "$root_gen_dir/xwalk/extensions/xwalk_extensions_resources.pak",
+    "$root_gen_dir/xwalk/resources/xwalk_resources.pak",
+    "$root_gen_dir/xwalk/sysapps/xwalk_sysapps_resources.pak",
+  ]
+  deps = [
+    ":generate_xwalk_resources",
+    "//components/resources",
+    "//content:resources",
+    "//content/app/resources",
+    "//content/app/strings",
+    "//net:net_resources",
+    "//third_party/WebKit/public:image_resources",
+    "//third_party/WebKit/public:resources",
+    "//ui/app_list/resources",
+    "//ui/resources",
+    "//ui/strings",
+    "//xwalk/application:xwalk_application_resources",
+    "//xwalk/extensions:xwalk_extensions_resources",
+    "//xwalk/sysapps:xwalk_sysapps_resources",
+  ]
+  if (is_linux) {
+    sources += [
+      "$root_gen_dir/blink/devtools_resources.pak",
+      "$root_gen_dir/components/strings/components_strings_en-US.pak",
+    ]
+    deps += [
+      "//components/strings:components_strings",
+      "//content/browser/devtools:devtools_resources",
+    ]
+  }
+  if (toolkit_views) {
+    deps += [ "//ui/views/resources" ]
+  }
+}
+
+repack("xwalk_resources_100_percent_pak") {
+  output = "$root_out_dir/xwalk_100_percent.pak"
+  sources = [
+    "$root_gen_dir/blink/public/resources/blink_image_resources_100_percent.pak",
+    "$root_gen_dir/components/components_resources_100_percent.pak",
+    "$root_gen_dir/content/app/resources/content_resources_100_percent.pak",
+    "$root_gen_dir/ui/resources/ui_resources_100_percent.pak",
+  ]
+  deps = [
+    "//components/resources",
+    "//content/app/resources",
+    "//third_party/WebKit/public:image_resources",
+    "//ui/resources",
+  ]
+  if (toolkit_views) {
+    deps += [ "//ui/views/resources:resources_grd" ]
+    sources +=
+        [ "$root_gen_dir/ui/views/resources/views_resources_100_percent.pak" ]
+  }
+}
+
+repack("xwalk_resources_200_percent_pak") {
+  output = "$root_out_dir/xwalk_200_percent.pak"
+  sources = [
+    "$root_gen_dir/blink/public/resources/blink_image_resources_200_percent.pak",
+    "$root_gen_dir/components/components_resources_200_percent.pak",
+    "$root_gen_dir/content/app/resources/content_resources_200_percent.pak",
+    "$root_gen_dir/ui/resources/ui_resources_200_percent.pak",
+  ]
+  deps = [
+    "//components/resources",
+    "//content/app/resources:resources",
+    "//third_party/WebKit/public:image_resources",
+    "//ui/resources",
+  ]
+  if (toolkit_views) {
+    sources +=
+        [ "$root_gen_dir/ui/views/resources/views_resources_200_percent.pak" ]
+    deps += [ "//ui/views/resources:resources_grd" ]
+  }
+}
+
+repack("xwalk_resources_300_percent_pak") {
+  output = "$root_out_dir/xwalk_300_percent.pak"
+  sources = [
+    "$root_gen_dir/components/components_resources_300_percent.pak",
+    "$root_gen_dir/ui/resources/ui_resources_300_percent.pak",
+  ]
+  deps = [
+    "//components/resources",
+    "//ui/resources",
+  ]
+  if (toolkit_views) {
+    sources +=
+        [ "$root_gen_dir/ui/views/resources/views_resources_300_percent.pak" ]
+    deps += [ "//ui/views/resources:resources_grd" ]
+  }
+}
+
+# TODO(heke123): Get rid of this grit+copy combination by putting the files in
+# the right places in grit of the grd file.
+grit("generate_xwalk_resources") {
+  source = "//xwalk/runtime/resources/xwalk_resources.grd"
+  resource_ids = "//xwalk/resources/resource_ids"
+  outputs = [
+    "$root_gen_dir/xwalk/resources/grit/xwalk_resources.h",
+    "$root_gen_dir/xwalk/resources/grit/xwalk_resources_map.cc",
+    "$root_gen_dir/xwalk/resources/grit/xwalk_resources_map.h",
+    "$root_gen_dir/xwalk/resources/xwalk_resources.pak",
+    "$root_gen_dir/xwalk/resources/xwalk_resources.rc",
+  ]
+}
+
+copy("xwalk_resources") {
+  sources = [
+    "$root_gen_dir/xwalk/resources/grit/xwalk_resources.h",
+    "$root_gen_dir/xwalk/resources/grit/xwalk_resources_map.cc",
+    "$root_gen_dir/xwalk/resources/grit/xwalk_resources_map.h",
+  ]
+  outputs = [
+    "$root_gen_dir/xwalk/grit/{{source_file_part}}",
+  ]
+  deps = [
+    ":generate_xwalk_resources",
+  ]
+}
+
+# TODO(heke123): Get rid of this grit+copy combination by putting the files in
+# the right places in grit of the grd file.
+grit("xwalk_strings") {
+  source = "//xwalk/runtime/resources/xwalk_strings.grd"
+  outputs = [
+    "../grit/xwalk_strings.h",
+  ]
+  outputs += locales
+  output_dir = "$root_gen_dir/xwalk/locales"
+  resource_ids = "//xwalk/resources/resource_ids"
+}
+
+copy("xwalk_locales") {
+  sources = []
+  foreach(pak, locales) {
+    sources += [ "$root_gen_dir/xwalk/locales/$pak" ]
+  }
+  outputs = [
+    "$root_out_dir/locales/xwalk/{{source_file_part}}",
+  ]
+  deps = [
+    ":xwalk_strings",
+  ]
+}

--- a/resources/locales.gni
+++ b/resources/locales.gni
@@ -1,0 +1,9 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Crosswalk locales pak files list.
+locales = [
+  "en-US.pak",
+  "zh-CN.pak",
+]

--- a/sysapps/BUILD.gn
+++ b/sysapps/BUILD.gn
@@ -1,0 +1,197 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//tools/grit/grit_rule.gni")
+
+source_set("sysapps") {
+  sources = [
+    "$root_gen_dir/xwalk/sysapps/common/common.cc",
+    "$root_gen_dir/xwalk/sysapps/common/common.h",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/raw_socket.cc",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/raw_socket.h",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/tcp_server_socket.cc",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/tcp_server_socket.h",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/tcp_socket.cc",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/tcp_socket.h",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/udp_socket.cc",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/udp_socket.h",
+    "common/binding_object.h",
+    "common/binding_object_store.cc",
+    "common/binding_object_store.h",
+    "common/common.idl",
+    "common/event_target.cc",
+    "common/event_target.h",
+    "common/sysapps_manager.cc",
+    "common/sysapps_manager.h",
+    "raw_socket/raw_socket.idl",
+    "raw_socket/raw_socket_extension.cc",
+    "raw_socket/raw_socket_extension.h",
+    "raw_socket/raw_socket_object.cc",
+    "raw_socket/raw_socket_object.h",
+    "raw_socket/tcp_server_socket.idl",
+    "raw_socket/tcp_server_socket_object.cc",
+    "raw_socket/tcp_server_socket_object.h",
+    "raw_socket/tcp_socket.idl",
+    "raw_socket/tcp_socket_object.cc",
+    "raw_socket/tcp_socket_object.h",
+    "raw_socket/udp_socket.idl",
+    "raw_socket/udp_socket_object.cc",
+    "raw_socket/udp_socket_object.h",
+  ]
+  deps = [
+    ":generate_jsapi_common",
+    ":generate_jsapi_raw_socket",
+    ":xwalk_sysapps_resources",
+    "//base",
+    "//net",
+    "//ui/base",
+    "//ui/gfx",
+    "//ui/gfx/geometry",
+    "//xwalk/extensions",
+  ]
+  if (is_linux) {
+    deps += [
+      "//components/storage_monitor",
+      "//media",
+      "//third_party/ffmpeg",
+    ]
+  }
+}
+
+# TODO(heke123): Remove this config by putting the files in the right place
+# in grit of grd file.
+config("xwalk_sysapps_resources_include_dir") {
+  include_dirs = [ "$root_gen_dir/xwalk/sysapps" ]
+}
+
+grit("xwalk_sysapps_resources") {
+  source = "//xwalk/sysapps/sysapps_resources.grd"
+  outputs = [
+    "$root_gen_dir/xwalk/sysapps/grit/xwalk_sysapps_resources.h",
+    "$root_gen_dir/xwalk/sysapps/xwalk_sysapps_resources.rc",
+    "$root_gen_dir/xwalk/sysapps/xwalk_sysapps_resources.pak",
+  ]
+  public_configs = [ ":xwalk_sysapps_resources_include_dir" ]
+  resource_ids = "//xwalk/resources/resource_ids"
+}
+
+executable("xwalk_sysapps_unittest") {
+  testonly = true
+  sources = [
+    "common/binding_object_store_unittest.cc",
+    "common/event_target_unittest.cc",
+    "common/sysapps_manager_unittest.cc",
+  ]
+  deps = [
+    ":sysapps",
+    "//base",
+    "//base/test:run_all_unittests",
+    "//content/test:test_support",
+    "//testing/gtest",
+    "//xwalk/extensions",
+  ]
+  if (is_linux && !is_component_build && is_component_ffmpeg) {
+    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+  }
+  if (use_aura) {
+    deps += [ "//ui/views" ]
+  }
+}
+
+executable("xwalk_sysapps_browsertest") {
+  testonly = true
+  sources = [
+    "common/common_api_browsertest.cc",
+    "common/common_api_browsertest.h",
+    "raw_socket/raw_socket_api_browsertest.cc",
+  ]
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+  deps = [
+    ":sysapps",
+    "//base",
+    "//content/test:test_support",
+    "//net",
+    "//skia",
+    "//testing/gtest",
+    "//xwalk:xwalk_runtime",
+    "//xwalk/extensions",
+    "//xwalk/test/base:test_support",
+  ]
+  if (is_linux && !is_component_build && is_component_ffmpeg) {
+    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+  }
+}
+
+action_foreach("generate_jsapi_raw_socket") {
+  visibility = [ ":*" ]
+  outputs = [
+    "$root_gen_dir/xwalk/sysapps/raw_socket/{{source_name_part}}.h",
+    "$root_gen_dir/xwalk/sysapps/raw_socket/{{source_name_part}}.cc",
+  ]
+  sources = [
+    "//xwalk/sysapps/raw_socket/raw_socket.idl",
+    "//xwalk/sysapps/raw_socket/tcp_server_socket.idl",
+    "//xwalk/sysapps/raw_socket/tcp_socket.idl",
+    "//xwalk/sysapps/raw_socket/udp_socket.idl",
+  ]
+  inputs = [
+    "//tools/json_schema_compiler/cc_generator.py",
+    "//tools/json_schema_compiler/code.py",
+    "//tools/json_schema_compiler/compiler.py",
+    "//tools/json_schema_compiler/cpp_generator.py",
+    "//tools/json_schema_compiler/cpp_type_generator.py",
+    "//tools/json_schema_compiler/cpp_util.py",
+    "//tools/json_schema_compiler/h_generator.py",
+    "//tools/json_schema_compiler/idl_schema.py",
+    "//tools/json_schema_compiler/model.py",
+    "//tools/json_schema_compiler/util.cc",
+    "//tools/json_schema_compiler/util.h",
+    "//tools/json_schema_compiler/util_cc_helper.py",
+  ]
+  idl_path = rebase_path("//xwalk/sysapps", "$root_out_dir")
+  gen_path = rebase_path("$root_gen_dir", "$root_out_dir")
+  script = "//tools/json_schema_compiler/compiler.py"
+  args = [
+    "$idl_path/raw_socket/{{source_name_part}}.idl",
+    "--root=$idl_path",
+    "--destdir=$gen_path/xwalk/sysapps",
+    "--namespace=xwalk::jsapi::{{source_name_part}}",
+    "--generator=cpp",
+  ]
+}
+
+action_foreach("generate_jsapi_common") {
+  visibility = [ ":*" ]
+  outputs = [
+    "$root_gen_dir/xwalk/sysapps/common/{{source_name_part}}.h",
+    "$root_gen_dir/xwalk/sysapps/common/{{source_name_part}}.cc",
+  ]
+  sources = [
+    "//xwalk/sysapps/common/common.idl",
+  ]
+  inputs = [
+    "//tools/json_schema_compiler/cc_generator.py",
+    "//tools/json_schema_compiler/code.py",
+    "//tools/json_schema_compiler/compiler.py",
+    "//tools/json_schema_compiler/cpp_generator.py",
+    "//tools/json_schema_compiler/cpp_type_generator.py",
+    "//tools/json_schema_compiler/cpp_util.py",
+    "//tools/json_schema_compiler/h_generator.py",
+    "//tools/json_schema_compiler/idl_schema.py",
+    "//tools/json_schema_compiler/model.py",
+    "//tools/json_schema_compiler/util.cc",
+    "//tools/json_schema_compiler/util.h",
+    "//tools/json_schema_compiler/util_cc_helper.py",
+  ]
+  idl_path = rebase_path("//xwalk/sysapps", "$root_out_dir")
+  gen_path = rebase_path("$root_gen_dir", "$root_out_dir")
+  script = "//tools/json_schema_compiler/compiler.py"
+  args = [
+    "$idl_path/common/{{source_name_part}}.idl",
+    "--root=$idl_path",
+    "--destdir=$gen_path/xwalk/sysapps",
+    "--namespace=xwalk::jsapi::{{source_name_part}}",
+    "--generator=cpp",
+  ]
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1,0 +1,76 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/ui.gni")
+
+executable("xwalk_browsertest") {
+  testonly = true
+  sources = [
+    "//xwalk/application/test/application_browsertest.cc",
+    "//xwalk/application/test/application_browsertest.h",
+    "//xwalk/application/test/application_test.cc",
+    "//xwalk/application/test/application_testapi.cc",
+    "//xwalk/application/test/application_testapi.h",
+    "//xwalk/application/test/application_testapi_test.cc",
+    "//xwalk/experimental/native_file_system/native_file_system_api_browsertest.cc",
+    "//xwalk/runtime/browser/devtools/xwalk_devtools_browsertest.cc",
+    "//xwalk/runtime/browser/xwalk_download_browsertest.cc",
+    "//xwalk/runtime/browser/xwalk_form_input_browsertest.cc",
+    "//xwalk/runtime/browser/xwalk_runtime_browsertest.cc",
+    "//xwalk/runtime/browser/xwalk_switches_browsertest.cc",
+  ]
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+  include_dirs = [ "$root_gen_dir/xwalk/application" ]
+  deps = [
+    "//base",
+    "//content/public/browser",
+    "//content/public/common",
+    "//content/test:test_support",
+    "//net",
+    "//skia",
+    "//testing/gmock",
+    "//testing/gtest",
+    "//third_party/libxml",
+    "//ui/base",
+    "//xwalk:xwalk_runtime",
+    "//xwalk/application:xwalk_application_lib",
+    "//xwalk/resources:xwalk_resources",
+    "//xwalk/test/base:test_support",
+  ]
+}
+
+executable("xwalk_unittest") {
+  testonly = true
+  sources = [
+    "//xwalk/application/common/application_file_util_unittest.cc",
+    "//xwalk/application/common/application_unittest.cc",
+    "//xwalk/application/common/id_util_unittest.cc",
+    "//xwalk/application/common/manifest_handler_unittest.cc",
+    "//xwalk/application/common/manifest_handlers/csp_handler_unittest.cc",
+    "//xwalk/application/common/manifest_handlers/permissions_handler_unittest.cc",
+    "//xwalk/application/common/manifest_handlers/unittest_util.cc",
+    "//xwalk/application/common/manifest_handlers/unittest_util.h",
+    "//xwalk/application/common/manifest_handlers/warp_handler_unittest.cc",
+    "//xwalk/application/common/manifest_handlers/widget_handler_unittest.cc",
+    "//xwalk/application/common/manifest_unittest.cc",
+    "//xwalk/application/common/package/package_unittest.cc",
+    "//xwalk/runtime/common/xwalk_content_client_unittest.cc",
+    "//xwalk/runtime/common/xwalk_runtime_features_unittest.cc",
+  ]
+  deps = [
+    "//base",
+    "//content/public/common",
+    "//content/test:test_support",
+    "//testing/gtest",
+    "//ui/base",
+    "//xwalk:xwalk_runtime",
+    "//xwalk/application:xwalk_application_lib",
+    "//xwalk/test/base:test_support",
+  ]
+  if (toolkit_views) {
+    sources +=
+        [ "//xwalk/runtime/browser/ui/top_view_layout_views_unittest.cc" ]
+    deps += [ "//skia" ]
+  }
+}

--- a/test/base/BUILD.gn
+++ b/test/base/BUILD.gn
@@ -1,0 +1,28 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("test_support") {
+  testonly = true
+  sources = [
+    "in_process_browser_test.cc",
+    "in_process_browser_test.h",
+    "xwalk_test_launcher.cc",
+    "xwalk_test_suite.cc",
+    "xwalk_test_suite.h",
+    "xwalk_test_utils.cc",
+    "xwalk_test_utils.h",
+  ]
+  public_deps = [
+    "//base",
+    "//base/test:test_support",
+    "//content/public/browser",
+    "//content/test:browsertest_base",
+    "//content/test:test_support",
+    "//net",
+    "//skia",
+    "//testing/gtest",
+    "//ui/base",
+    "//url",
+  ]
+}


### PR DESCRIPTION
As Chromium will deprecate GYP build system since M54, we need to enable
GN build support for Crosswalk as soon as possible.
   
This PR only implements most part of Crosswalk-Linux.
See comments in xwalk/build/linux.gni on how to build.
    
TODO: Add web_notification, installer support

BUG=XWALK-7180