### PR TITLE
[Android] Fix the crash bug of setOnTouchListener

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -1652,7 +1652,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout
     public void setOnTouchListener(OnTouchListener l) {
         if (mContent == null) return;
         checkThreadSafety();
-        this.setOnTouchListener(l);
+        super.setOnTouchListener(l);
     }
 
     @Override


### PR DESCRIPTION
The background is XWalkView has been refactored in the commit 9808ed4.

Here correct the endless loop error which will cause crash.

BUG=XWALK-7099

(cherry picked from commit 48c14352f56ab5fbd94d46c6ff414a516590495b)