### PR TITLE
[Android] Decouple XWalkView from the activity

### DIFF
--- a/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
+++ b/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java
@@ -100,12 +100,6 @@ public abstract class XWalkRuntimeActivityBase extends Activity {
         if (mRuntimeView == null || !mRuntimeView.onNewIntent(intent)) super.onNewIntent(intent);
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (mRuntimeView != null) mRuntimeView.onActivityResult(requestCode, resultCode, data);
-    }
-
     private void tryLoadRuntimeView() {
         try {
             if (mUseAnimatableView) {

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkCoreProviderImpl.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkCoreProviderImpl.java
@@ -63,11 +63,6 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
     }
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        mXWalkView.onActivityResult(requestCode, resultCode, data);
-    }
-
-    @Override
     public boolean onNewIntent(Intent intent) {
         return mXWalkView.onNewIntent(intent);
     }

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeView.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeView.java
@@ -124,22 +124,10 @@ public class XWalkRuntimeView extends LinearLayout {
     }
 
     /**
-     * Tell runtime that one activity exists so that it can know the result code
-     * of the exit code.
-     *
-     * @param requestCode the request code to identify where the result is from
-     * @param resultCode the result code of the activity
-     * @param data the data to contain the result data
-     */
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        mProvider.onActivityResult(requestCode, resultCode, data);
-    }
-
-    /**
      * Tell runtime that the activity receive a new Intent to start it. It may contains
      * data that runtime want to deal with.
      * @param intent the new coming Intent.
-     * @return boolean whether runtime consumed it. 
+     * @return boolean whether runtime consumed it.
      */
     public boolean onNewIntent(Intent intent) {
         return mProvider.onNewIntent(intent);

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeViewProvider.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkRuntimeViewProvider.java
@@ -20,7 +20,6 @@ interface XWalkRuntimeViewProvider {
     public void onResume();
     public void onPause();
     public void onDestroy();
-    public void onActivityResult(int requestCode, int resultCode, Intent data);
     public boolean onNewIntent(Intent intent);
 
     // For RuntimeView APIs.

--- a/runtime/android/core/src/org/xwalk/core/XWalkActivityDelegate.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivityDelegate.java
@@ -15,7 +15,7 @@ import org.xwalk.core.XWalkUpdater.XWalkUpdateListener;
 
 public class XWalkActivityDelegate
             implements DecompressListener, ActivateListener {
-    private static final String TAG = "XWalkActivity";
+    private static final String TAG = "XWalkLib";
 
     private Activity mActivity;
     private XWalkDialogManager mDialogManager;
@@ -66,10 +66,10 @@ public class XWalkActivityDelegate
         mIsInitializing = true;
         if (XWalkLibraryLoader.isLibraryReady()) {
             Log.d(TAG, "Activate by XWalkActivity");
-            XWalkLibraryLoader.startActivate(this, mActivity);
+            XWalkLibraryLoader.startActivate(this);
         } else {
             Log.d(TAG, "Initialize by XWalkActivity");
-            XWalkLibraryLoader.startDecompress(this, mActivity);
+            XWalkLibraryLoader.startDecompress(this);
         }
     }
 
@@ -99,7 +99,7 @@ public class XWalkActivityDelegate
             mWillDecompress = false;
         }
 
-        XWalkLibraryLoader.startActivate(this, mActivity);
+        XWalkLibraryLoader.startActivate(this);
     }
 
     @Override
@@ -134,7 +134,7 @@ public class XWalkActivityDelegate
 
                         @Override
                         public void onXWalkUpdateCompleted() {
-                            XWalkLibraryLoader.startActivate(XWalkActivityDelegate.this, mActivity);
+                            XWalkLibraryLoader.startActivate(XWalkActivityDelegate.this);
                         }
                     },
                     mActivity);

--- a/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkCoreWrapper.java
@@ -4,7 +4,6 @@
 
 package org.xwalk.core;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -32,7 +31,6 @@ class XWalkCoreWrapper {
     private static final String BRIDGE_PACKAGE = "org.xwalk.core.internal";
     private static final String TAG = "XWalkLib";
     private static final String XWALK_CORE_CLASSES_DEX = "classes.dex";
-    private static final String OPTIMIZED_DEX_DIR = "dex";
 
     private static XWalkCoreWrapper sProvisionalInstance;
     private static XWalkCoreWrapper sInstance;
@@ -115,60 +113,50 @@ class XWalkCoreWrapper {
         sReservedActions.get(tag).add(new ReservedAction(method));
     }
 
-    public static void handleRuntimeError(RuntimeException e) {
-        e.printStackTrace();
-        sInstance.mCoreStatus = XWalkLibraryInterface.STATUS_OLDER_VERSION;
-        final Activity activity = (Activity) sInstance.mWrapperContext;
-        XWalkUpdater xwalkUpdater = new XWalkUpdater(
-            new XWalkUpdater.XWalkUpdateListener() {
-                @Override
-                public void onXWalkUpdateCancelled() {
-                    activity.finish();
-                }
-            },
-            activity);
-        xwalkUpdater.updateXWalkRuntime();
-    }
-
     /**
      * This method must be invoked on the UI thread.
      */
-    public static void handlePostInit(String tag) {
-        if (!sReservedActions.containsKey(tag)) return;
-        Log.d(TAG, "Post init xwalk core in " + tag);
+    public static void handlePostInit() {
+        Log.d(TAG, "Post init xwalk core");
 
-        LinkedList<ReservedAction> reservedActions = sReservedActions.get(tag);
-        for (ReservedAction action : reservedActions) {
-            if (action.mObject != null) {
-                Log.d(TAG, "Init reserved object: " + action.mObject.getClass());
-                new ReflectMethod(action.mObject, "reflectionInit").invoke();
-            } else if (action.mClass != null) {
-                Log.d(TAG, "Init reserved class: " + action.mClass.toString());
-                new ReflectMethod(action.mClass, "reflectionInit").invoke();
-            } else {
-                Log.d(TAG, "Call reserved method: " + action.mMethod.toString());
-                Object[] args = action.mArguments;
-                if (args != null) {
-                    for (int i = 0; i < args.length; ++i) {
-                        if (args[i] instanceof ReflectMethod) {
-                            args[i] = ((ReflectMethod) args[i]).invokeWithArguments();
+        for (String tag : sReservedActivities) {
+            LinkedList<ReservedAction> reservedActions = sReservedActions.get(tag);
+            for (ReservedAction action : reservedActions) {
+                if (action.mObject != null) {
+                    Log.d(TAG, "Init reserved object: " + action.mObject.getClass() + " for " + tag);
+                    new ReflectMethod(action.mObject, "reflectionInit").invoke();
+                } else if (action.mClass != null) {
+                    Log.d(TAG, "Init reserved class: " + action.mClass.toString() + " for " + tag);
+                    new ReflectMethod(action.mClass, "reflectionInit").invoke();
+                } else {
+                    Log.d(TAG, "Call reserved method: " + action.mMethod.toString() + " for " + tag);
+                    Object[] args = action.mArguments;
+                    if (args != null) {
+                        for (int i = 0; i < args.length; ++i) {
+                            if (args[i] instanceof ReflectMethod) {
+                                args[i] = ((ReflectMethod) args[i]).invokeWithArguments();
+                            }
                         }
                     }
+                    action.mMethod.invoke(args);
                 }
-                action.mMethod.invoke(args);
             }
         }
 
-        sReservedActivities.remove(tag);
-        sReservedActions.remove(tag);
+        sReservedActivities.clear();
+        sReservedActions.clear();
     }
 
-    public static int attachXWalkCore(Context context) {
+    public static void handleRuntimeError(RuntimeException e) {
+        throw new RuntimeException("The API is incompatible with the Crosswalk runtime library", e);
+    }
+
+    public static int attachXWalkCore() {
         Assert.assertFalse(sReservedActivities.isEmpty());
         Assert.assertNull(sInstance);
 
         Log.d(TAG, "Attach xwalk core");
-        sProvisionalInstance = new XWalkCoreWrapper(context, 1);
+        sProvisionalInstance = new XWalkCoreWrapper(XWalkEnvironment.getApplicationContext(), 1);
         if (sProvisionalInstance.findEmbeddedCore()) {
             return sProvisionalInstance.mCoreStatus;
         }
@@ -281,11 +269,9 @@ class XWalkCoreWrapper {
     }
 
     private boolean findDownloadedCore() {
-        String libDir = mWrapperContext.getDir(XWalkLibraryInterface.XWALK_CORE_EXTRACTED_DIR,
-                Context.MODE_PRIVATE).getAbsolutePath();
+        String libDir = XWalkEnvironment.getExtractedCoreDir();
         String dexPath = libDir + File.separator + XWALK_CORE_CLASSES_DEX;
-        String dexOutputPath = mWrapperContext.getDir(OPTIMIZED_DEX_DIR, Context.MODE_PRIVATE).
-                getAbsolutePath();
+        String dexOutputPath = XWalkEnvironment.getOptimizedDexDir();
         ClassLoader localClassLoader = ClassLoader.getSystemClassLoader();
         mBridgeLoader = new DexClassLoader(dexPath, dexOutputPath, libDir, localClassLoader);
 
@@ -363,9 +349,7 @@ class XWalkCoreWrapper {
                 }
 
                 if (!architectureMatched && mWrapperContext != null) {
-                    libDir = mWrapperContext.getDir(
-                            XWalkLibraryInterface.PRIVATE_DATA_DIRECTORY_SUFFIX,
-                            Context.MODE_PRIVATE).toString();
+                    libDir = XWalkEnvironment.getPrivateDataDir();
                     architectureMatched = (boolean) method.invoke(mBridgeContext, libDir);
                 }
             }

--- a/runtime/android/core/src/org/xwalk/core/XWalkDecompressor.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDecompressor.java
@@ -48,10 +48,10 @@ class XWalkDecompressor {
     private static final int LZMA_PROP_SIZE = 5;
     private static final int LZMA_OUTSIZE = 8;
 
-    public static boolean isLibraryCompressed(Context context) {
+    public static boolean isLibraryCompressed() {
         for (String library : MANDATORY_LIBRARIES) {
             try {
-                InputStream input = openRawResource(context, library);
+                InputStream input = openRawResource(library);
                 try {
                     input.close();
                 } catch (IOException e) {
@@ -63,9 +63,8 @@ class XWalkDecompressor {
         return true;
     }
 
-    public static boolean decompressLibrary(Context context) {
-        String libDir = context.getDir(XWalkLibraryInterface.PRIVATE_DATA_DIRECTORY_SUFFIX,
-                Context.MODE_PRIVATE).toString();
+    public static boolean decompressLibrary() {
+        String libDir = XWalkEnvironment.getPrivateDataDir();
         File f = new File(libDir);
         if (f.exists() && f.isFile()) f.delete();
         if (!f.exists() && !f.mkdirs()) return false;
@@ -74,7 +73,7 @@ class XWalkDecompressor {
         for (String library : MANDATORY_LIBRARIES) {
             try {
                 Log.d(TAG, "Decompressing " + library);
-                InputStream input = openRawResource(context, library);
+                InputStream input = openRawResource(library);
                 extractLzmaToFile(input, new File(libDir, library));
             } catch (Resources.NotFoundException e) {
                 Log.d(TAG, library + " not found");
@@ -238,8 +237,9 @@ class XWalkDecompressor {
         return resource.endsWith(".dat") || resource.endsWith(".pak");
     }
 
-    private static InputStream openRawResource(Context context, String library)
+    private static InputStream openRawResource(String library)
             throws Resources.NotFoundException {
+        Context context = XWalkEnvironment.getApplicationContext();
         Resources res = context.getResources();
         String libraryName = library.split("\\.")[0];
         int id = res.getIdentifier(libraryName, "raw", context.getPackageName());

--- a/runtime/android/core/src/org/xwalk/core/XWalkEnvironment.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkEnvironment.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.util.Log;
 
@@ -26,9 +27,11 @@ class XWalkEnvironment {
     private static final String META_XWALK_APK_URL = "xwalk_apk_url";
     private static final String META_XWALK_VERIFY = "xwalk_verify";
 
+    private static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
+    private static final String XWALK_CORE_EXTRACTED_DIR = "extracted_xwalkcore";
+    private static final String OPTIMIZED_DEX_DIR = "dex";
     private static final String PACKAGE_RE = "[a-z]+\\.[a-z0-9]+\\.[a-z0-9]+.*";
 
-    private static Context sInitializationContext;
     private static Context sApplicationContext;
 
     private static String sDeviceAbi;
@@ -41,23 +44,30 @@ class XWalkEnvironment {
     private static Boolean sIsXWalkVerify;
 
     public static void init(Context context) {
-        sInitializationContext = context;
         sApplicationContext = context.getApplicationContext();
-    }
-
-    public static void finishInit(Context context) {
-        if (context != sInitializationContext) {
-            throw new RuntimeException("The context of initialization is not consistent");
-        }
-        sInitializationContext = null;
-    }
-
-    public static Context getInitializationContext() {
-        return sInitializationContext;
     }
 
     public static Context getApplicationContext() {
         return sApplicationContext;
+    }
+
+    public static SharedPreferences getSharedPreferences() {
+        return sApplicationContext.getSharedPreferences("libxwalkcore", Context.MODE_PRIVATE);
+    }
+
+    public static String getPrivateDataDir() {
+        return sApplicationContext.getDir(PRIVATE_DATA_DIRECTORY_SUFFIX,
+                Context.MODE_PRIVATE).getAbsolutePath();
+    }
+
+    public static String getExtractedCoreDir() {
+        return sApplicationContext.getDir(XWALK_CORE_EXTRACTED_DIR,
+                Context.MODE_PRIVATE).getAbsolutePath();
+    }
+
+    public static String getOptimizedDexDir() {
+        return sApplicationContext.getDir(OPTIMIZED_DEX_DIR,
+                Context.MODE_PRIVATE).getAbsolutePath();
     }
 
     public static void setXWalkApkUrl(String url) {

--- a/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java
@@ -1,0 +1,289 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.Manifest;
+import android.net.Uri;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.util.Log;
+import android.webkit.ValueCallback;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * <p><code>XWalkFileChooser</code> is the default implementation for choosing local file to updload.
+ * This class should be used in <code>XWalkUIClient#openFileChooser</code> like below:</p>
+ *
+ * <pre>
+ * import android.app.Activity;
+ * import android.content.Intent;
+ * import android.net.Uri;
+ * import android.os.Bundle;
+ * import android.webkit.ValueCallback;
+ *
+ * import org.xwalk.core.XWalkActivity;
+ * import org.xwalk.core.XWalkFileChooser;
+ * import org.xwalk.core.XWalkUIClient;
+ * import org.xwalk.core.XWalkView;
+ *
+ * public class XWalkViewActivity extends XWalkActivity {
+ *     private XWalkView mXWalkView;
+ *     private XWalkFileChooser mXWalkFileChooser;
+ *
+ *     private class MyUIClient extends XWalkUIClient {
+ *         public MyUIClient(XWalkView view) {
+ *             super(view);
+ *         }
+ *
+ *         &#64;Override
+ *         public void openFileChooser(XWalkView view, ValueCallback&lt;Uri&gt; uploadFile,
+ *                 String acceptType, String capture) {
+ *             mXWalkFileChooser.showFileChooser(uploadFile, acceptType, capture);
+ *         }
+ *     }
+ *
+ *     &#64;Override
+ *     protected void onCreate(Bundle savedInstanceState) {
+ *         super.onCreate(savedInstanceState);
+ *
+ *         setContentView(R.layout.activity_main);
+ *
+ *         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+ *         mXWalkView.setUIClient(new MyUIClient(mXWalkView));
+ *         mXWalkFileChooser = new XWalkFileChooser(this);
+ *     }
+ *
+ *     &#64;Override
+ *     protected void onXWalkReady() {
+ *         mXWalkView.load("file:///android_asset/test.html", null);
+ *     }
+ *
+ *     &#64;Override
+ *     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+ *         mXWalkFileChooser.onActivityResult(requestCode, resultCode, data);
+ *     }
+ * }
+ * </pre>
+ */
+
+public class XWalkFileChooser {
+    private static final String IMAGE_TYPE = "image/";
+    private static final String VIDEO_TYPE = "video/";
+    private static final String AUDIO_TYPE = "audio/";
+    private static final String ALL_IMAGE_TYPES = IMAGE_TYPE + "*";
+    private static final String ALL_VIDEO_TYPES = VIDEO_TYPE + "*";
+    private static final String ALL_AUDIO_TYPES = AUDIO_TYPE + "*";
+    private static final String ANY_TYPES = "*/*";
+    private static final String SPLIT_EXPRESSION = ",";
+    private static final String PATH_PREFIX = "file:";
+    private static final String WRITE_EXTERNAL_STORAGE= "android.permission.WRITE_EXTERNAL_STORAGE";
+
+    public static final int INPUT_FILE_REQUEST_CODE = 1;
+
+    private static final String TAG = "XWalkFileChooser";
+
+    private Activity mActivity;
+    private ValueCallback<Uri> mFilePathCallback;
+    private String mCameraPhotoPath;
+
+    /**
+     * Create a file chooser using an activity.
+     */
+    public XWalkFileChooser(Activity activity) {
+        mActivity = activity;
+    }
+
+    /**
+     * Tell the client to show a file chooser.
+     * @param uploadFile the callback class to handle the result from caller. It MUST
+     *        be invoked in all cases. Leave it not invoked will block all following
+     *        requests to open file chooser.
+     * @param acceptType value of the 'accept' attribute of the input tag associated
+     *        with this file picker.
+     * @param capture value of the 'capture' attribute of the input tag associated
+     *        with this file picker
+     * @since 7.0
+     */
+    public boolean showFileChooser(ValueCallback<Uri> uploadFile, String acceptType,
+            String capture) {
+        mFilePathCallback = uploadFile;
+
+        Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        if (takePictureIntent.resolveActivity(mActivity.getPackageManager()) != null) {
+            // Create the File where the photo should go
+            File photoFile = createImageFile();
+            // Continue only if the File was successfully created
+            if (photoFile != null) {
+                mCameraPhotoPath = PATH_PREFIX + photoFile.getAbsolutePath();
+                takePictureIntent.putExtra("PhotoPath", mCameraPhotoPath);
+                takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(photoFile));
+            } else {
+                takePictureIntent = null;
+            }
+        }
+
+        Intent camcorder = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
+        Intent soundRecorder = new Intent(MediaStore.Audio.Media.RECORD_SOUND_ACTION);
+        Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
+        contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
+        ArrayList<Intent> extraIntents = new ArrayList<Intent>();
+
+        // A single mime type.
+        if (!(acceptType.contains(SPLIT_EXPRESSION) || acceptType.contains(ANY_TYPES))) {
+            if (capture.equals("true")) {
+                if (acceptType.startsWith(IMAGE_TYPE)) {
+                    if (takePictureIntent != null) {
+                        mActivity.startActivityForResult(takePictureIntent, INPUT_FILE_REQUEST_CODE);
+                        Log.d(TAG, "Started taking picture");
+                        return true;
+                    }
+                } else if (acceptType.startsWith(VIDEO_TYPE)) {
+                    mActivity.startActivityForResult(camcorder, INPUT_FILE_REQUEST_CODE);
+                    Log.d(TAG, "Started camcorder");
+                    return true;
+                } else if (acceptType.startsWith(AUDIO_TYPE)) {
+                    mActivity.startActivityForResult(soundRecorder, INPUT_FILE_REQUEST_CODE);
+                    Log.d(TAG, "Started sound recorder");
+                    return true;
+                }
+            } else {
+                if (acceptType.startsWith(IMAGE_TYPE)) {
+                    if (takePictureIntent != null) {
+                        extraIntents.add(takePictureIntent);
+                    }
+                    contentSelectionIntent.setType(ALL_IMAGE_TYPES);
+                } else if (acceptType.startsWith(VIDEO_TYPE)) {
+                    extraIntents.add(camcorder);
+                    contentSelectionIntent.setType(ALL_VIDEO_TYPES);
+                } else if (acceptType.startsWith(AUDIO_TYPE)) {
+                    extraIntents.add(soundRecorder);
+                    contentSelectionIntent.setType(ALL_AUDIO_TYPES);
+                }
+            }
+        }
+
+        // Couldn't resolve an accept type.
+        if (extraIntents.isEmpty() && canWriteExternalStorage()) {
+            if (takePictureIntent != null) {
+                extraIntents.add(takePictureIntent);
+            }
+            extraIntents.add(camcorder);
+            extraIntents.add(soundRecorder);
+            contentSelectionIntent.setType(ANY_TYPES);
+        }
+
+        Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
+        chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
+        if (!extraIntents.isEmpty()) {
+            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS,
+                    extraIntents.toArray(new Intent[] { }));
+        }
+        mActivity.startActivityForResult(chooserIntent, INPUT_FILE_REQUEST_CODE);
+        Log.d(TAG, "Started chooser");
+        return true;
+    }
+
+    /**
+     * Pass the result of your activity's onActivityResult after invoked showFileChooser.
+     * @param requestCode The integer request code originally supplied to startActivityForResult(),
+     *                    allowing you to identify who this result came from.
+     * @param resultCode The integer result code returned by the child activity through its
+     *                   setResult().
+     * @param data An Intent, which can return result data to the caller (various data can be
+     *             attached to Intent "extras").
+     * @since 7.0
+     */
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if(requestCode == INPUT_FILE_REQUEST_CODE && mFilePathCallback != null) {
+            Log.d(TAG, "Activity result: " + resultCode);
+            Uri results = null;
+
+            // Check that the response is a good one
+            if(Activity.RESULT_OK == resultCode) {
+                // In Android M, camera results return an empty Intent rather than null.
+                if(data == null || (data.getAction() == null && data.getData() == null)) {
+                    // If there is not data, then we may have taken a photo
+                    if(mCameraPhotoPath != null) {
+                        results = Uri.parse(mCameraPhotoPath);
+                    }
+                } else {
+                    String dataString = data.getDataString();
+                    if (dataString != null) {
+                        results = Uri.parse(dataString);
+                    }
+                    deleteImageFile();
+                }
+            } else if (Activity.RESULT_CANCELED == resultCode) {
+                deleteImageFile();
+            }
+
+            Log.d(TAG, "Received file: " + results.toString());
+            mFilePathCallback.onReceiveValue(results);
+            mFilePathCallback = null;
+        }
+    }
+
+    private boolean canWriteExternalStorage() {
+        try {
+            PackageManager packageManager = mActivity.getPackageManager();
+            PackageInfo packageInfo = packageManager.getPackageInfo(
+                    mActivity.getPackageName(), PackageManager.GET_PERMISSIONS);
+            return Arrays.asList(packageInfo.requestedPermissions).contains(WRITE_EXTERNAL_STORAGE);
+        } catch (NameNotFoundException | NullPointerException e) {
+            return false;
+        }
+    }
+
+    private File createImageFile() {
+        // FIXME: If the external storage state is not "MEDIA_MOUNTED", we need to get
+        // other volume paths by "getVolumePaths()" when it was exposed.
+        String state = Environment.getExternalStorageState();
+        if (!state.equals(Environment.MEDIA_MOUNTED)) {
+            Log.e(TAG, "External storage is not mounted.");
+            return null;
+        }
+
+        // Create an image file name
+        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+        String imageFileName = "JPEG_" + timeStamp + "_";
+        File storageDir = Environment.getExternalStoragePublicDirectory(
+                Environment.DIRECTORY_PICTURES);
+        if (!storageDir.exists()) {
+            storageDir.mkdirs();
+        }
+
+        try {
+            File file = File.createTempFile(imageFileName, ".jpg", storageDir);
+            Log.d(TAG, "Created image file: " +  file.getAbsolutePath());
+            return file;
+        } catch (IOException e) {
+            // Error occurred while creating the File
+            Log.e(TAG, "Unable to create Image File, " +
+                    "please make sure permission 'WRITE_EXTERNAL_STORAGE' was added.");
+            return null;
+        }
+    }
+
+    private boolean deleteImageFile() {
+        if (mCameraPhotoPath == null || !mCameraPhotoPath.contains(PATH_PREFIX)) {
+            return false;
+        }
+        String filePath = mCameraPhotoPath.split(PATH_PREFIX)[1];
+        boolean result = new File(filePath).delete();
+        Log.d(TAG, "Delete image file: " + filePath + " result: " + result);
+        return result;
+    }
+}

--- a/runtime/android/core/src/org/xwalk/core/XWalkInitializer.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkInitializer.java
@@ -4,7 +4,7 @@
 
 package org.xwalk.core;
 
-import android.app.Activity;
+import android.content.Context;
 import android.util.Log;
 
 import org.xwalk.core.XWalkLibraryLoader.ActivateListener;
@@ -12,10 +12,11 @@ import org.xwalk.core.XWalkLibraryLoader.DecompressListener;
 
 /**
  * <p><code>XWalkInitializer</code> is an alternative to {@link XWalkActivity} with the difference
- * that it provides a way of initializing Crosswalk Project runtime in background silently. Another
- * advantage is that the developer can use their own activity class directly rather than having it
- * extend {@link XWalkActivity}. However, {@link XWalkActivity} is still recommended because it
- * makes the code simpler.</p>
+ * that it provides a way of initializing Crosswalk Project runtime in background silently.
+ * <code>XWalkInitializer</code> also allows for more flexibility, the developer doesn't have to
+ * have their activity class extend {@link XWalkActivity} anymore, and the context for initializing
+ * Crosswalk environment doesn't have to be an activity either, it could be a service now. However,
+ * {@link XWalkActivity} is still recommended because it makes the code simpler.</p>
  *
  * <p>If the initialization failed, which means Crosswalk Project runtime doesn't exist or doesn't
  * match the application, you could use {@link XWalkUpdater} to download suitable Crosswalk Project
@@ -150,27 +151,27 @@ public class XWalkInitializer {
         public void onXWalkInitCompleted();
     }
 
-    private static final String TAG = "XWalkActivity";
+    private static final String TAG = "XWalkLib";
 
     private XWalkInitListener mInitListener;
-    private Activity mActivity;
+    private Context mContext;
 
     private boolean mIsInitializing;
     private boolean mIsXWalkReady;
 
     /**
-     * Create an initializer for single activity.
+     * Create an initializer
      *
      * <p>This method must be invoked on the UI thread.
      *
      * @param listener The {@link XWalkInitListener} to use.
-     * @param activity The activity which initiate the initialization
+     * @param context The context which initiate the initialization
      */
-    public XWalkInitializer(XWalkInitListener listener, Activity activity) {
+    public XWalkInitializer(XWalkInitListener listener, Context context) {
         mInitListener = listener;
-        mActivity = activity;
+        mContext = context;
 
-        XWalkLibraryLoader.prepareToInit(mActivity);
+        XWalkLibraryLoader.prepareToInit(mContext);
     }
 
     /**
@@ -188,10 +189,10 @@ public class XWalkInitializer {
         mInitListener.onXWalkInitStarted();
         if (XWalkLibraryLoader.isLibraryReady()) {
             Log.d(TAG, "Activate by XWalkInitializer");
-            XWalkLibraryLoader.startActivate(new XWalkLibraryListener(), mActivity);
+            XWalkLibraryLoader.startActivate(new XWalkLibraryListener());
         } else {
             Log.d(TAG, "Initialize by XWalkInitializer");
-            XWalkLibraryLoader.startDecompress(new XWalkLibraryListener(), mActivity);
+            XWalkLibraryLoader.startDecompress(new XWalkLibraryListener());
         }
         return true;
     }
@@ -219,7 +220,7 @@ public class XWalkInitializer {
 
         @Override
         public void onDecompressCompleted() {
-            XWalkLibraryLoader.startActivate(this, mActivity);
+            XWalkLibraryLoader.startActivate(this);
         }
 
         @Override

--- a/runtime/android/core/src/org/xwalk/core/XWalkLibraryInterface.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkLibraryInterface.java
@@ -53,9 +53,6 @@ interface XWalkLibraryInterface {
      */
     public static final int STATUS_RUNTIME_MISMATCH = 8;
 
-    public static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "xwalkcore";
-    public static final String XWALK_CORE_EXTRACTED_DIR = "extracted_xwalkcore";
-
     public static final String XWALK_CORE_PACKAGE = "org.xwalk.core";
     public static final String XWALK_CORE64_PACKAGE = "org.xwalk.core64";
     public static final String XWALK_CORE_IA_PACKAGE = "org.xwalk.core.ia";

--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -4,7 +4,6 @@
 
 package org.xwalk.core;
 
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
@@ -288,47 +287,47 @@ public class XWalkUpdater {
 
     private XWalkUpdateListener mUpdateListener;
     private XWalkBackgroundUpdateListener mBackgroundUpdateListener;
-    private Activity mActivity;
+    private Context mContext;
     private XWalkDialogManager mDialogManager;
     private Runnable mDownloadCommand;
     private Runnable mCancelCommand;
     private boolean mIsDownloading;
 
     /**
-     * Create XWalkUpdater for single activity.
+     * Create XWalkUpdater
      *
      * @param listener The {@link XWalkUpdateListener} to use
-     * @param activity The activity which initiate the update
+     * @param context The context which initiate the update
      */
-    public XWalkUpdater(XWalkUpdateListener listener, Activity activity) {
+    public XWalkUpdater(XWalkUpdateListener listener, Context context) {
         mUpdateListener = listener;
-        mActivity = activity;
-        mDialogManager = new XWalkDialogManager(activity);
+        mContext = context;
+        mDialogManager = new XWalkDialogManager(context);
     }
 
     /**
-     * Create XWalkUpdater for single activity.
+     * Create XWalkUpdater
      *
      * @param listener The {@link XWalkUpdateListener} to use
-     * @param activity The activity which initiate the update
+     * @param context The context which initiate the update
      * @param dialogManager The {@link XWalkDialogManager} to use
      */
-    public XWalkUpdater(XWalkUpdateListener listener, Activity activity,
+    public XWalkUpdater(XWalkUpdateListener listener, Context context,
             XWalkDialogManager dialogManager) {
         mUpdateListener = listener;
-        mActivity = activity;
+        mContext = context;
         mDialogManager = dialogManager;
     }
 
     /**
-     * Create XWalkUpdater for single activity. This updater will download silently.
+     * Create XWalkUpdater. This updater will download silently.
      *
      * @param listener The {@link XWalkBackgroundUpdateListener} to use
-     * @param activity The activity which initiate the update
+     * @param context The context which initiate the update
      */
-    public XWalkUpdater(XWalkBackgroundUpdateListener listener, Activity activity) {
+    public XWalkUpdater(XWalkBackgroundUpdateListener listener, Context context) {
         mBackgroundUpdateListener = listener;
-        mActivity = activity;
+        mContext = context;
     }
 
     /**
@@ -370,7 +369,7 @@ public class XWalkUpdater {
             mDialogManager.showInitializationError(status, mCancelCommand, mDownloadCommand);
         } else if (mBackgroundUpdateListener != null) {
             String url = XWalkEnvironment.getXWalkApkUrl();
-            XWalkLibraryLoader.startHttpDownload(new BackgroundListener(), mActivity, url);
+            XWalkLibraryLoader.startHttpDownload(new BackgroundListener(), mContext, url);
         } else {
             throw new IllegalArgumentException("Update listener is null");
         }
@@ -401,14 +400,14 @@ public class XWalkUpdater {
     private void downloadXWalkApk() {
         String url = XWalkEnvironment.getXWalkApkUrl();
         if (!url.isEmpty()) {
-            XWalkLibraryLoader.startDownloadManager(new ForegroundListener(), mActivity, url);
+            XWalkLibraryLoader.startDownloadManager(new ForegroundListener(), mContext, url);
             return;
         }
 
         String packageName = XWalkLibraryInterface.XWALK_CORE_PACKAGE;
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(Uri.parse(ANDROID_MARKET_DETAILS + packageName));
-        List<ResolveInfo> infos = mActivity.getPackageManager().queryIntentActivities(
+        List<ResolveInfo> infos = mContext.getPackageManager().queryIntentActivities(
                 intent, PackageManager.MATCH_ALL);
 
         StringBuilder supportedStores = new StringBuilder();
@@ -458,7 +457,7 @@ public class XWalkUpdater {
         mDialogManager.showSelectStore(new Runnable() {
             @Override
             public void run() {
-                mActivity.startActivity(storeIntent);
+                mContext.startActivity(storeIntent);
             }
         }, storeName);
     }
@@ -498,7 +497,7 @@ public class XWalkUpdater {
             Intent intent = new Intent(Intent.ACTION_VIEW);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setDataAndType(uri, "application/vnd.android.package-archive");
-            mActivity.startActivity(intent);
+            mContext.startActivity(intent);
         }
     }
 
@@ -530,8 +529,7 @@ public class XWalkUpdater {
         public void onDownloadCompleted(Uri uri) {
             mIsDownloading = false;
             final String libFile = uri.getPath();
-            final String destDir = mActivity.getDir(XWalkLibraryInterface.XWALK_CORE_EXTRACTED_DIR,
-                    Context.MODE_PRIVATE).getAbsolutePath();
+            final String destDir = XWalkEnvironment.getExtractedCoreDir();
             Log.d(TAG, "Download mode extract dir: " + destDir);
 
             new AsyncTask<Void, Void, Boolean>() {
@@ -572,7 +570,7 @@ public class XWalkUpdater {
     private boolean verifyDownloadedXWalkRuntime(String libFile) {
         // getPackageArchiveInfo also check the integrity of the downloaded runtime APK
         // besides returning the PackageInfo with signatures.
-        PackageInfo runtimePkgInfo = mActivity.getPackageManager().getPackageArchiveInfo(
+        PackageInfo runtimePkgInfo = mContext.getPackageManager().getPackageArchiveInfo(
                 libFile, PackageManager.GET_SIGNATURES);
         if (runtimePkgInfo == null) {
             Log.e(TAG, "The downloaded XWalkRuntimeLib.apk is invalid!");
@@ -581,8 +579,8 @@ public class XWalkUpdater {
 
         PackageInfo appPkgInfo = null;
         try {
-            appPkgInfo = mActivity.getPackageManager().getPackageInfo(
-                    mActivity.getPackageName(), PackageManager.GET_SIGNATURES);
+            appPkgInfo = mContext.getPackageManager().getPackageInfo(
+                    mContext.getPackageName(), PackageManager.GET_SIGNATURES);
         } catch (NameNotFoundException e) {
             return false;
         }
@@ -610,7 +608,7 @@ public class XWalkUpdater {
 
     private String getStoreName(String storePackage) {
         if (storePackage.equals(GOOGLE_PLAY_PACKAGE)) {
-            return mActivity.getString(R.string.google_play_store);
+            return mContext.getString(R.string.google_play_store);
         }
         return null;
     }

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkCoreExtensionBridge.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkCoreExtensionBridge.java
@@ -69,10 +69,6 @@ class XWalkCoreExtensionBridge extends XWalkExtension implements XWalkExternalEx
         mExtension.onNewIntent(intent);
     }
 
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        mExtension.onActivityResult(requestCode, resultCode, data);
-    }
-
     //------------------------------------------------
     // Overriden methods from XWalkExtensionAndroid
     //------------------------------------------------

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionContextClient.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionContextClient.java
@@ -60,20 +60,4 @@ public interface XWalkExtensionContextClient {
      * @return the current Android Context.
      */
     public Context getContext();
-
-    /**
-     * Get the current Android Activity.
-     * @return the current Android Activity.
-     */
-    public Activity getActivity();
-
-    /**
-     * Start another activity to get some data back.
-     * External extensions should call this function to ensure
-     * they can get their onActivityResultCallback() be called correctly.
-     * @param requestCode the request code.
-     * @param resultCode the result code.
-     * @param data the Intent data received.
-     */
-    public void startActivityForResult(Intent intent, int requestCode, Bundle options);
 }

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtension.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtension.java
@@ -150,15 +150,6 @@ public class XWalkExternalExtension {
     }
 
     /**
-     * Tell extension that one activity exists so that it can know the result
-     * of the exit code.
-     * Please call XWalkExtensionContextClient.startActivityForResult()
-     * so that this callback can be called correctly for all cases.
-     */
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-    }
-
-    /**
      * Called when a new extension instance is created.
      */
     public void onInstanceCreated(int instanceID) {
@@ -226,7 +217,7 @@ public class XWalkExternalExtension {
     public MessageHandler getMessageHandler() {
         return mHandler;
     }
-    
+
     public ReflectionHelper getTargetReflect(String cName) {
         ReflectionHelper targetReflect = mReflection.getConstructorReflection(cName);
         return (targetReflect != null) ? targetReflect : mReflection;
@@ -279,16 +270,5 @@ public class XWalkExternalExtension {
      */
     public final void broadcastMessage(String message) {
         mExtensionContext.broadcastMessage(this, message);
-    }
-
-    /**
-     * Start another activity to get some data back.
-     * Call this function then will get onActivityResult() callback.
-     * @param requestCode the request code.
-     * @param resultCode the result code.
-     * @param data the Intent data received.
-     */
-    public void startActivityForResult(Intent intent, int requestCode, Bundle options) {
-        mExtensionContext.startActivityForResult(intent, requestCode, options);
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtensionBridge.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtensionBridge.java
@@ -114,10 +114,4 @@ interface XWalkExternalExtensionBridge {
      * without creating a new activity instance.
      */
     public void onNewIntent(Intent intent);
-
-    /**
-     * Called when the extension exists if activity launched exists.
-     * TODO(hmin): Figure out if it is necessary and how to use it.
-     */
-    public void onActivityResult(int requestCode, int resultCode, Intent data);
 }

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtensionManagerImpl.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtensionManagerImpl.java
@@ -4,7 +4,6 @@
 
 package org.xwalk.core.extension;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -42,7 +41,6 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
 
     private final XWalkView mXWalkView;
     private final Context mContext;
-    private final Activity mActivity;
 
     private final HashMap<String, XWalkExternalExtensionBridge> mExtensions = new HashMap<String, XWalkExternalExtensionBridge>();
     // This variable is to set whether to load external extensions. The default is true.
@@ -57,14 +55,12 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
         if (getBridge() == null) {
             Log.e(TAG, "Cannot load external extensions due to old version of runtime library");
             mContext = null;
-            mActivity = null;
             mLoadExternalExtensions = false;
             mNativeExtensionLoader = null;
             return;
         }
 
         mContext = getViewContext();
-        mActivity = getViewActivity();
         mLoadExternalExtensions = true;
         mNativeExtensionLoader = new XWalkNativeExtensionLoader();
 
@@ -97,23 +93,10 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
         return mContext;
     }
 
-    @Override
-    public Activity getActivity() {
-        return mActivity;
-    }
-
-    // Instead of calling startActivityForResult() on mActivity directly,
-    // call on XWalkView so that XWalkView's embedder could override this behavior
-    // to do additional job.
-    @Override
-    public void startActivityForResult(Intent intent, int requestCode, Bundle options) {
-        mXWalkView.startActivityForResult(intent, requestCode, options);
-    }
-
     // Start to override XWalkExternalExtensionManager api.
     // Load one Java external extension by its folder path under assets/xwalk-extensions,
-    // the extension folder structure should be like: 
-    // ExtensionA 
+    // the extension folder structure should be like:
+    // ExtensionA
     //     ExtensionA.json
     //     ExtensionA.js(Optional)
     @Override
@@ -129,7 +112,7 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
         String jsonFile = extensionPath + File.separator + folderName + ".json";
         String jsonFileContent;
         try {
-            jsonFileContent = getFileContent(mActivity, jsonFile, false);
+            jsonFileContent = getFileContent(mContext, jsonFile, false);
         } catch (IOException e) {
             Log.w(TAG, "Failed to read json file: " + jsonFile);
             return;
@@ -149,7 +132,7 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
             String jsApi = null;
             if (jsApiFile != null && jsApiFile.length() != 0) {
                 try {
-                    jsApi = getFileContent(mActivity, jsApiFile, false);
+                    jsApi = getFileContent(mContext, jsApiFile, false);
                 } catch (IOException e) {
                     Log.w(TAG, "Failed to read the file " + jsApiFile);
                     return;
@@ -226,13 +209,6 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
         }
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        for(XWalkExternalExtensionBridge extension: mExtensions.values()) {
-            extension.onActivityResult(requestCode, resultCode, data);
-        }
-    }
-
     public void setAllowExternalExtensions(boolean load) {
         mLoadExternalExtensions = load;
     }
@@ -275,9 +251,9 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
 
     private void createExternalExtension(String name, String className, String jsApi,
             XWalkExtensionContextClient extensionContext) {
-        Activity activity = extensionContext.getActivity();
+        Context context = extensionContext.getContext();
         try {
-            Class<?> clazz = activity.getClassLoader().loadClass(className);
+            Class<?> clazz = context.getClassLoader().loadClass(className);
             Constructor<?> constructor = clazz.getConstructor(String.class,
                     String.class, XWalkExtensionContextClient.class);
             constructor.newInstance(name, jsApi, this);
@@ -302,8 +278,7 @@ public class XWalkExternalExtensionManagerImpl extends XWalkExternalExtensionMan
         String path = null;
         try {
             ApplicationInfo appInfo =
-                    mContext.getPackageManager()
-                    .getApplicationInfo(mActivity.getPackageName(), 0);
+                    mContext.getPackageManager().getApplicationInfo(mContext.getPackageName(), 0);
             path = appInfo.nativeLibraryDir;
         } catch (final NameNotFoundException e) {
         }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentVideoViewClient.java
@@ -17,12 +17,10 @@ import org.xwalk.core.internal.XWalkWebChromeClient.CustomViewCallback;
 
 class XWalkContentVideoViewClient implements ContentVideoViewEmbedder {
     private XWalkContentsClient mContentsClient;
-    private Activity mActivity;
     private XWalkViewInternal mView;
 
-    public XWalkContentVideoViewClient(XWalkContentsClient client, Activity activity, XWalkViewInternal view) {
+    public XWalkContentVideoViewClient(XWalkContentsClient client, XWalkViewInternal view) {
         mContentsClient = client;
-        mActivity = activity;
         mView = view;
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -5,7 +5,6 @@
 
 package org.xwalk.core.internal;
 
-import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.database.Cursor;
@@ -202,13 +201,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         return mInterceptNavigationDelegate;
     }
 
-    private boolean isOwnerActivityRunning() {
-        if (mXWalkView != null && mXWalkView.isOwnerActivityRunning()) {
-            return true;
-        }
-        return false;
-    }
-
     // TODO(Xingnan): All the empty functions need to be implemented.
     @Override
     public boolean shouldOverrideUrlLoading(String url) {
@@ -248,9 +240,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onProgressChanged(int progress) {
-        if (isOwnerActivityRunning()) {
-            mXWalkResourceClient.onProgressChanged(mXWalkView, progress);
-        }
+        mXWalkResourceClient.onProgressChanged(mXWalkView, progress);
     }
 
     @Override
@@ -261,69 +251,58 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     @Override
     public XWalkWebResourceResponseInternal shouldInterceptRequest(
             WebResourceRequestInner request) {
-        if (isOwnerActivityRunning()) {
-            //For compatibility with the old shouldInterceptLoadRequest.
-            WebResourceResponse response =
-                 mXWalkResourceClient.shouldInterceptLoadRequest(mXWalkView, request.url);
-            if (response == null) {
-              XWalkWebResourceResponseInternal xwalkResponse =
-                      mXWalkResourceClient.shouldInterceptLoadRequest(mXWalkView,
-                              new XWalkWebResourceRequestHandlerInternal(request));
-                if (xwalkResponse == null) return null;
+        //For compatibility with the old shouldInterceptLoadRequest.
+        WebResourceResponse response =
+             mXWalkResourceClient.shouldInterceptLoadRequest(mXWalkView, request.url);
+        if (response == null) {
+          XWalkWebResourceResponseInternal xwalkResponse =
+                  mXWalkResourceClient.shouldInterceptLoadRequest(mXWalkView,
+                          new XWalkWebResourceRequestHandlerInternal(request));
+            if (xwalkResponse == null) return null;
 
-                // XWalkWebResourceResponse should support null headers.
-                Map<String, String> responseHeaders = xwalkResponse.getResponseHeaders();
-                if (responseHeaders == null) responseHeaders = new HashMap<String, String>();
+            // XWalkWebResourceResponse should support null headers.
+            Map<String, String> responseHeaders = xwalkResponse.getResponseHeaders();
+            if (responseHeaders == null) responseHeaders = new HashMap<String, String>();
 
-                //To Investigate: return xwalkResponse directly will fail, don't know why yet.
-                return new XWalkWebResourceResponseInternal(
-                        xwalkResponse.getMimeType(),
-                        xwalkResponse.getEncoding(),
-                        xwalkResponse.getData(),
-                        xwalkResponse.getStatusCode(),
-                        xwalkResponse.getReasonPhrase(),
-                        responseHeaders);
-            } else {
-                return new XWalkWebResourceResponseInternal(
-                        response.getMimeType(),
-                        response.getEncoding(),
-                        response.getData());
-            }
+            //To Investigate: return xwalkResponse directly will fail, don't know why yet.
+            return new XWalkWebResourceResponseInternal(
+                    xwalkResponse.getMimeType(),
+                    xwalkResponse.getEncoding(),
+                    xwalkResponse.getData(),
+                    xwalkResponse.getStatusCode(),
+                    xwalkResponse.getReasonPhrase(),
+                    responseHeaders);
+        } else {
+            return new XWalkWebResourceResponseInternal(
+                    response.getMimeType(),
+                    response.getEncoding(),
+                    response.getData());
         }
-        return null;
     }
 
     @Override
     public void onDidChangeThemeColor(int color) {
-        if (isOwnerActivityRunning()) {
-            mXWalkUIClient.onDidChangeThemeColor(mXWalkView,color);
-        }
+        mXWalkUIClient.onDidChangeThemeColor(mXWalkView,color);
     }
 
     @Override
     public void onDocumentLoadedInFrame(long frameId) {
-        if (isOwnerActivityRunning()) {
-            mXWalkResourceClient.onDocumentLoadedInFrame(mXWalkView,frameId);
-        }
+         mXWalkResourceClient.onDocumentLoadedInFrame(mXWalkView,frameId);
     }
 
     @Override
     public void onResourceLoadStarted(String url) {
-        if (isOwnerActivityRunning()) {
-            mXWalkResourceClient.onLoadStarted(mXWalkView, url);
-        }
+        mXWalkResourceClient.onLoadStarted(mXWalkView, url);
     }
 
     @Override
     public void onResourceLoadFinished(String url) {
-        if (isOwnerActivityRunning()) {
-            mXWalkResourceClient.onLoadFinished(mXWalkView, url);
-        }
+        mXWalkResourceClient.onLoadFinished(mXWalkView, url);
     }
 
     @Override
     public void onLoadResource(String url) {
-        if (mXWalkClient != null && isOwnerActivityRunning()) {
+        if (mXWalkClient != null) {
             mXWalkClient.onLoadResource(mXWalkView, url);
         }
     }
@@ -359,14 +338,14 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     @CalledByNative
     public void onReceivedHttpAuthRequest(
             XWalkHttpAuthHandlerInternal handler, String host, String realm) {
-        if (mXWalkResourceClient != null && isOwnerActivityRunning()) {
+        if (mXWalkResourceClient != null) {
             mXWalkResourceClient.onReceivedHttpAuthRequest(mXWalkView, handler, host, realm);
         }
     }
 
     @Override
     public void onReceivedSslError(ValueCallback<Boolean> callback, SslError error) {
-        if (mXWalkResourceClient != null && isOwnerActivityRunning()) {
+        if (mXWalkResourceClient != null) {
             mXWalkResourceClient.onReceivedSslError(mXWalkView, callback, error);
         }
     }
@@ -377,7 +356,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onReceivedClientCertRequest(ClientCertRequestInternal handler) {
-        if (mXWalkResourceClient != null && isOwnerActivityRunning()) {
+        if (mXWalkResourceClient != null) {
             mXWalkResourceClient.onReceivedClientCertRequest(mXWalkView, handler);
         }
     }
@@ -385,7 +364,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     @Override
     public void onReceivedResponseHeaders(WebResourceRequestInner request,
             XWalkWebResourceResponseInternal response) {
-        if (mXWalkResourceClient != null && isOwnerActivityRunning()) {
+        if (mXWalkResourceClient != null) {
             mXWalkResourceClient.onReceivedResponseHeaders(mXWalkView,
                     new XWalkWebResourceRequestHandlerInternal(request), response);
         }
@@ -394,14 +373,14 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     @Override
     public void onGeolocationPermissionsShowPrompt(String origin,
             XWalkGeolocationPermissions.Callback callback) {
-        if (mXWalkWebChromeClient != null && isOwnerActivityRunning()) {
+        if (mXWalkWebChromeClient != null) {
             mXWalkWebChromeClient.onGeolocationPermissionsShowPrompt(origin, callback);
         }
     }
 
     @Override
     public void onGeolocationPermissionsHidePrompt() {
-        if (mXWalkWebChromeClient != null && isOwnerActivityRunning()) {
+        if (mXWalkWebChromeClient != null) {
             mXWalkWebChromeClient.onGeolocationPermissionsHidePrompt();
         }
     }
@@ -419,7 +398,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onPageStarted(String url) {
-        if (mXWalkUIClient != null && isOwnerActivityRunning()) {
+        if (mXWalkUIClient != null) {
             mLoadingUrl = url;
             mLoadStatus = LoadStatusInternal.FINISHED;
             mXWalkUIClient.onPageLoadStarted(mXWalkView, url);
@@ -428,7 +407,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onPageFinished(String url) {
-        if (!isOwnerActivityRunning()) return;
         if (mPageLoadListener != null) mPageLoadListener.onPageFinished(url);
         if (mXWalkUIClient != null) {
             if (mLoadStatus == LoadStatusInternal.CANCELLED && mLoadingUrl != null) {
@@ -452,24 +430,22 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onReceivedError(int errorCode, String description, String failingUrl) {
-        if (isOwnerActivityRunning()) {
-            if (mLoadingUrl != null && mLoadingUrl.equals(failingUrl)) {
-                mLoadStatus = LoadStatusInternal.FAILED;
-            }
-            mXWalkResourceClient.onReceivedLoadError(mXWalkView, errorCode, description, failingUrl);
+        if (mLoadingUrl != null && mLoadingUrl.equals(failingUrl)) {
+            mLoadStatus = LoadStatusInternal.FAILED;
         }
+        mXWalkResourceClient.onReceivedLoadError(mXWalkView, errorCode, description, failingUrl);
     }
 
     @Override
     public void onRendererUnresponsive() {
-        if (mXWalkClient != null && isOwnerActivityRunning()) {
+        if (mXWalkClient != null) {
             mXWalkClient.onRendererUnresponsive(mXWalkView);
         }
     }
 
     @Override
     public void onRendererResponsive() {
-        if (mXWalkClient != null && isOwnerActivityRunning()) {
+        if (mXWalkClient != null) {
             mXWalkClient.onRendererResponsive(mXWalkView);
         }
     }
@@ -514,21 +490,17 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onRequestFocus() {
-        if (isOwnerActivityRunning()) {
-            mXWalkUIClient.onRequestFocus(mXWalkView);
-        }
+        mXWalkUIClient.onRequestFocus(mXWalkView);
     }
 
     @Override
     public void onCloseWindow() {
-        if (isOwnerActivityRunning()) {
-            mXWalkUIClient.onJavascriptCloseWindow(mXWalkView);
-        }
+        mXWalkUIClient.onJavascriptCloseWindow(mXWalkView);
     }
 
     @Override
     public void onShowCustomView(View view, XWalkWebChromeClient.CustomViewCallback callback) {
-        if (mXWalkWebChromeClient != null && isOwnerActivityRunning()) {
+        if (mXWalkWebChromeClient != null) {
             mXWalkWebChromeClient.onShowCustomView(view, callback);
         }
     }
@@ -536,23 +508,21 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     @Override
     public void onShowCustomView(View view, int requestedOrientation,
             XWalkWebChromeClient.CustomViewCallback callback) {
-        if (mXWalkWebChromeClient != null && isOwnerActivityRunning()) {
+        if (mXWalkWebChromeClient != null) {
             mXWalkWebChromeClient.onShowCustomView(view, requestedOrientation, callback);
         }
     }
 
     @Override
     public void onHideCustomView() {
-        if (mXWalkWebChromeClient != null && isOwnerActivityRunning()) {
+        if (mXWalkWebChromeClient != null) {
             mXWalkWebChromeClient.onHideCustomView();
         }
     }
 
     @Override
     public void onScaleChangedScaled(float oldScale, float newScale) {
-        if (isOwnerActivityRunning()) {
-            mXWalkUIClient.onScaleChanged(mXWalkView, oldScale, newScale);
-        }
+        mXWalkUIClient.onScaleChanged(mXWalkView, oldScale, newScale);
     }
 
     @Override
@@ -561,17 +531,15 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @Override
     public void onTitleChanged(String title) {
-        if (mXWalkUIClient != null && isOwnerActivityRunning()) {
+        if (mXWalkUIClient != null) {
             mXWalkUIClient.onReceivedTitle(mXWalkView, title);
         }
     }
 
     @Override
     public void onToggleFullscreen(boolean enterFullscreen) {
-        if (isOwnerActivityRunning()) {
-            mIsFullscreen = enterFullscreen;
-            mXWalkUIClient.onFullscreenToggled(mXWalkView, enterFullscreen);
-        }
+        mIsFullscreen = enterFullscreen;
+        mXWalkUIClient.onFullscreenToggled(mXWalkView, enterFullscreen);
     }
 
     @Override
@@ -588,7 +556,6 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     public boolean shouldOverrideRunFileChooser(
             final int processId, final int renderId, final int modeFlags,
             String acceptTypes, boolean capture) {
-        if (!isOwnerActivityRunning()) return false;
         abstract class UriCallback implements ValueCallback<Uri> {
             boolean syncNullReceived = false;
             boolean syncCallFinished = false;
@@ -637,7 +604,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
                     } else if (ContentResolver.SCHEME_CONTENT.equals(value.getScheme())) {
                         result = value.toString();
                         displayName = resolveFileName(
-                                value, mXWalkView.getActivity().getContentResolver());
+                                value, mXWalkView.getContext().getContentResolver());
                     } else {
                         result = value.getPath();
                         displayName = value.getLastPathSegment();
@@ -651,18 +618,12 @@ class XWalkContentsClientBridge extends XWalkContentsClient
         mXWalkUIClient.openFileChooser(
                 mXWalkView, uploadFile, acceptTypes, Boolean.toString(capture));
         uploadFile.syncCallFinished = true;
-        // File chooser requires user interaction, valid derives should handle it in async process.
-        // If the ValueCallback receive a sync result with null value, it is considered the
-        // file chooser is not overridden.
-        if (uploadFile.syncNullReceived) {
-            return mXWalkView.showFileChooser(uploadFile, acceptTypes, Boolean.toString(capture));
-        }
         return !uploadFile.syncNullReceived;
     }
 
     @Override
     public ContentVideoViewEmbedder getContentVideoViewEmbedder() {
-        return new XWalkContentVideoViewClient(this, mXWalkView.getActivity(), mXWalkView);
+        return new XWalkContentVideoViewClient(this, mXWalkView);
     }
 
     public void provideClientCertificateResponse(int id, byte[][] certChain,
@@ -671,7 +632,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     }
 
     public Bitmap getFavicon() {
-        return isOwnerActivityRunning() ? mFavicon : null;
+        return mFavicon;
     }
 
     // Used by the native peer to set/reset a weak ref to the native peer.
@@ -714,7 +675,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
     @CalledByNative
     private void selectClientCertificate(final int id, final String[] keyTypes,
             byte[][] encodedPrincipals, final String host, final int port) {
-        if (mXWalkResourceClient != null && isOwnerActivityRunning()) {
+        if (mXWalkResourceClient != null) {
             assert mNativeContentsClientBridge != 0;
 
             ClientCertLookupTable.Cert cert = mLookupTable.getCertData(host, port);
@@ -780,46 +741,38 @@ class XWalkContentsClientBridge extends XWalkContentsClient
 
     @CalledByNative
     private void handleJsAlert(String url, String message, int id) {
-        if (isOwnerActivityRunning()) {
-            XWalkJavascriptResultHandlerInternal result =
-                    new XWalkJavascriptResultHandlerInternal(this, id);
-            mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
-                    XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_ALERT,
-                    url, message, "", result);
-        }
+        XWalkJavascriptResultHandlerInternal result =
+                new XWalkJavascriptResultHandlerInternal(this, id);
+        mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
+                XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_ALERT,
+                url, message, "", result);
     }
 
     @CalledByNative
     private void handleJsConfirm(String url, String message, int id) {
-        if (isOwnerActivityRunning()) {
-            XWalkJavascriptResultHandlerInternal result =
-                    new XWalkJavascriptResultHandlerInternal(this, id);
-            mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
-                    XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_CONFIRM,
-                    url, message, "", result);
-        }
+        XWalkJavascriptResultHandlerInternal result =
+                new XWalkJavascriptResultHandlerInternal(this, id);
+        mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
+                XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_CONFIRM,
+                url, message, "", result);
     }
 
     @CalledByNative
     private void handleJsPrompt(String url, String message, String defaultValue, int id) {
-        if (isOwnerActivityRunning()) {
-            XWalkJavascriptResultHandlerInternal result =
-                    new XWalkJavascriptResultHandlerInternal(this, id);
-            mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
-                    XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_PROMPT,
-                    url, message, defaultValue, result);
-        }
+        XWalkJavascriptResultHandlerInternal result =
+                new XWalkJavascriptResultHandlerInternal(this, id);
+        mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
+                XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_PROMPT,
+                url, message, defaultValue, result);
     }
 
     @CalledByNative
     private void handleJsBeforeUnload(String url, String message, int id) {
-        if (isOwnerActivityRunning()) {
-            XWalkJavascriptResultHandlerInternal result =
-                    new XWalkJavascriptResultHandlerInternal(this, id);
-            mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
-                    XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_BEFOREUNLOAD,
-                    url, message, "", result);
-        }
+        XWalkJavascriptResultHandlerInternal result =
+                new XWalkJavascriptResultHandlerInternal(this, id);
+        mXWalkUIClient.onJavascriptModalDialog(mXWalkView,
+                XWalkUIClientInternal.JavascriptMessageTypeInternal.JAVASCRIPT_BEFOREUNLOAD,
+                url, message, "", result);
     }
 
     @CalledByNative

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkExternalExtensionManagerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkExternalExtensionManagerInternal.java
@@ -47,15 +47,16 @@ public abstract class XWalkExternalExtensionManagerInternal {
 
     /**
      * Get current Activity for XWalkViewInternal.
+     * <strong>This method is no longer supported, it will always return null</strong>
      * @return the current Activity.
+     * @deprecated Not currently supported.
      */
+    @Deprecated
     @XWalkAPI
     public Activity getViewActivity() {
-        if (mXWalkView != null) {
-            return mXWalkView.getActivity();
-        }
         return null;
     }
+
 
     /**
      * Get current Context for XWalkViewInternal.
@@ -84,35 +85,39 @@ public abstract class XWalkExternalExtensionManagerInternal {
      * Extension manager should propagate to all external extensions.
      */
     @XWalkAPI
-    public abstract void onStart();
+    public void onStart() {}
 
     /**
      * Notify onResume().
      * Extension manager should propagate to all external extensions.
      */
     @XWalkAPI
-    public abstract void onResume();
+    public void onResume() {}
 
     /**
      * Notify onPause().
      * Extension manager should propagate to all external extensions.
      */
     @XWalkAPI
-    public abstract void onPause();
+    public void onPause() {}
 
     /**
      * Notify onStop().
      * Extension manager should propagate to all external extensions.
      */
     @XWalkAPI
-    public abstract void onStop();
+    public void onStop() {}
 
     /**
      * Notify onDestroy().
+     * <strong>Pleaes invoke super.onDestroy() first when you overriding this method.</strong>
      * Extension manager should propagate to all external extensions.
      */
     @XWalkAPI
-    public abstract void onDestroy();
+    public void onDestroy() {
+        mXWalkView.setExternalExtensionManager(null);
+        mXWalkView = null;
+    }
 
     /**
      * Notify onNewIntent().
@@ -125,39 +130,13 @@ public abstract class XWalkExternalExtensionManagerInternal {
     /**
      * Notify onActivityResult().
      * Extension manager should propagate to all external extensions.
+     * <strong>This method is no longer used.</strong>
      * @param requestCode the request code.
      * @param resultCode the result code.
      * @param data the Intent data received.
+     * @deprecated Not currently supported.
      */
+    @Deprecated
     @XWalkAPI
-    public abstract void onActivityResult(int requestCode, int resultCode, Intent data);
-
-    /**
-     * Get the activity state change notification from XWalkViewInternal.
-     * @hide
-     */
-    public void onActivityStateChange(Activity activity, int newState) {
-        //assert(getActivity() == activity);
-        switch (newState) {
-            case ActivityState.STARTED:
-                onStart();
-                break;
-            case ActivityState.PAUSED:
-                onPause();
-                break;
-            case ActivityState.RESUMED:
-                onResume();
-                break;
-            case ActivityState.DESTROYED:
-                onDestroy();
-                mXWalkView.setExternalExtensionManager(null);
-                mXWalkView = null;
-                break;
-            case ActivityState.STOPPED:
-                onStop();
-                break;
-            default:
-                break;
-        }
-    }
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {}
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkLaunchScreenManager.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkLaunchScreenManager.java
@@ -60,7 +60,7 @@ public class XWalkLaunchScreenManager
 
     private XWalkViewInternal mXWalkView;
     private Activity mActivity;
-    private Context mLibContext;
+    private Context mContext;
     private Dialog mLaunchScreenDialog;
     private boolean mPageLoadFinished;
     private ReadyWhenType mReadyWhen;
@@ -86,29 +86,32 @@ public class XWalkLaunchScreenManager
 
     public XWalkLaunchScreenManager(Context context, XWalkViewInternal xwView) {
         mXWalkView = xwView;
-        mLibContext = context;
-        mActivity = mXWalkView.getActivity();
-        mIntentFilterStr = mActivity.getPackageName() + ".hideLaunchScreen";
+        mContext = context;
+        try {
+            mActivity = (Activity) mContext;
+        } catch (ClassCastException e) {
+        }
+        mIntentFilterStr = mContext.getPackageName() + ".hideLaunchScreen";
     }
 
     public void displayLaunchScreen(String readyWhen, final String imageBorderList) {
-        if (mXWalkView == null) return;
+        if (mXWalkView == null || mActivity == null) return;
         setReadyWhen(readyWhen);
 
         Runnable runnable = new Runnable() {
            public void run() {
-                int bgResId = mActivity.getResources().getIdentifier(
-                        "launchscreen_bg", "drawable", mActivity.getPackageName());
+                int bgResId = mContext.getResources().getIdentifier(
+                        "launchscreen_bg", "drawable", mContext.getPackageName());
                 if (bgResId == 0) return;
                 Drawable bgDrawable = null;
                 try {
-                    bgDrawable = mActivity.getResources().getDrawable(bgResId);
+                    bgDrawable = mContext.getResources().getDrawable(bgResId);
                 } catch (OutOfMemoryError e) {
                     e.printStackTrace();
                 }
                 if (bgDrawable == null) return;
 
-                mLaunchScreenDialog = new Dialog(mLibContext,
+                mLaunchScreenDialog = new Dialog(mContext,
                                                  android.R.style.Theme_Holo_Light_NoActionBar);
 
                 mLaunchScreenDialog.setOnKeyListener(new Dialog.OnKeyListener() {
@@ -134,7 +137,7 @@ public class XWalkLaunchScreenManager
                 mLaunchScreenDialog.show();
 
                 // Change the layout depends on the orientation change.
-                mOrientationListener = new OrientationEventListener(mActivity,
+                mOrientationListener = new OrientationEventListener(mContext,
                         SensorManager.SENSOR_DELAY_NORMAL) {
                     public void onOrientationChanged(int ori) {
                         if (mLaunchScreenDialog == null || !mLaunchScreenDialog.isShowing()) {
@@ -279,7 +282,7 @@ public class XWalkLaunchScreenManager
         if (!imgRect.contains(subRect)) return null;
 
         Bitmap subImage = Bitmap.createBitmap(img, x, y, width, height);
-        ImageView subImageView = new ImageView(mActivity);
+        ImageView subImageView = new ImageView(mContext);
         BitmapDrawable drawable;
         if (mode == BorderModeType.ROUND) {
             int originW = subImage.getWidth();
@@ -296,7 +299,7 @@ public class XWalkLaunchScreenManager
             mode = BorderModeType.REPEAT;
         }
         if (mode == BorderModeType.REPEAT) {
-            drawable = new BitmapDrawable(mActivity.getResources(), subImage);
+            drawable = new BitmapDrawable(mContext.getResources(), subImage);
             drawable.setTileModeXY(TileMode.REPEAT, TileMode.REPEAT);
             subImageView.setImageDrawable(drawable);
             subImageView.setScaleType(ScaleType.FIT_XY);
@@ -311,10 +314,10 @@ public class XWalkLaunchScreenManager
     }
 
     private int getStatusBarHeight() {
-        int resourceId = mActivity.getResources().getIdentifier(
+        int resourceId = mContext.getResources().getIdentifier(
                 "status_bar_height", "dimen", "android");
         if (resourceId > 0) {
-            return mActivity.getResources().getDimensionPixelSize(resourceId);
+            return mContext.getResources().getDimensionPixelSize(resourceId);
         }
         // If not found, return default one.
         return 25;
@@ -369,7 +372,7 @@ public class XWalkLaunchScreenManager
         }
 
         // The border values are dpi from manifest.json, need to translate to px.
-        DisplayMetrics matrix = mActivity.getResources().getDisplayMetrics();
+        DisplayMetrics matrix = mContext.getResources().getDisplayMetrics();
         topBorder = (int)TypedValue.applyDimension(
                 TypedValue.COMPLEX_UNIT_DIP, topBorder, matrix);
         rightBorder = (int)TypedValue.applyDimension(
@@ -388,13 +391,13 @@ public class XWalkLaunchScreenManager
         }
 
         // Get foreground image
-        int imgResId = mActivity.getResources().getIdentifier(
-                       "launchscreen_img", "drawable", mActivity.getPackageName());
+        int imgResId = mContext.getResources().getIdentifier(
+                       "launchscreen_img", "drawable", mContext.getPackageName());
         if (imgResId == 0) return null;
-        Bitmap img = BitmapFactory.decodeResource(mActivity.getResources(), imgResId);
+        Bitmap img = BitmapFactory.decodeResource(mContext.getResources(), imgResId);
         if (img == null) return null;
 
-        RelativeLayout root = new RelativeLayout(mActivity);
+        RelativeLayout root = new RelativeLayout(mContext);
         root.setLayoutParams(new RelativeLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT));
@@ -403,7 +406,7 @@ public class XWalkLaunchScreenManager
 
         // If no border specified, display the foreground image centered horizontally and vertically.
         if (borders.size() == 0) {
-            subImageView = new ImageView(mActivity);
+            subImageView = new ImageView(mContext);
             subImageView.setImageBitmap(img);
             params = new RelativeLayout.LayoutParams(
                     RelativeLayout.LayoutParams.WRAP_CONTENT,
@@ -558,7 +561,7 @@ public class XWalkLaunchScreenManager
                 hideLaunchScreenWhenReady();
             }
         };
-        mActivity.registerReceiver(mLaunchScreenReadyWhenReceiver, intentFilter);
+        mContext.registerReceiver(mLaunchScreenReadyWhenReceiver, intentFilter);
     }
 
     private void hideLaunchScreenWhenReady() {
@@ -582,7 +585,7 @@ public class XWalkLaunchScreenManager
             mLaunchScreenDialog = null;
         }
         if (mReadyWhen == ReadyWhenType.CUSTOM) {
-            mActivity.unregisterReceiver(mLaunchScreenReadyWhenReceiver);
+            mContext.unregisterReceiver(mLaunchScreenReadyWhenReceiver);
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNotificationServiceImpl.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkNotificationServiceImpl.java
@@ -93,11 +93,11 @@ public class XWalkNotificationServiceImpl implements XWalkNotificationService {
         int notificationId = intent.getIntExtra(XWALK_INTENT_EXTRA_KEY_NOTIFICATION_ID, -1);
         if (notificationId <= 0) return false;
         if (intent.getAction().equals(
-                mView.getActivity().getPackageName() + XWALK_ACTION_CLOSE_NOTIFICATION_SUFFIX)) {
+                mView.getContext().getPackageName() + XWALK_ACTION_CLOSE_NOTIFICATION_SUFFIX)) {
             onNotificationClose(notificationId, true);
             return true;
         } else if (intent.getAction().equals(
-                mView.getActivity().getPackageName() + XWALK_ACTION_CLICK_NOTIFICATION_SUFFIX)) {
+                mView.getContext().getPackageName() + XWALK_ACTION_CLICK_NOTIFICATION_SUFFIX)) {
             onNotificationClick(notificationId);
             return true;
         }
@@ -165,23 +165,23 @@ public class XWalkNotificationServiceImpl implements XWalkNotificationService {
         Bitmap bigIcon = getNotificationIcon(icon);
         if (bigIcon != null) builder.setLargeIcon(bigIcon);
 
-        Context activity = mView.getActivity();
+        Context context = mView.getContext();
         String category = getCategoryFromNotificationId(notificationId);
 
-        Intent clickIntent = new Intent(activity, activity.getClass())
-                .setAction(activity.getPackageName() + XWALK_ACTION_CLICK_NOTIFICATION_SUFFIX)
+        Intent clickIntent = new Intent(context, context.getClass())
+                .setAction(context.getPackageName() + XWALK_ACTION_CLICK_NOTIFICATION_SUFFIX)
                 .putExtra(XWALK_INTENT_EXTRA_KEY_NOTIFICATION_ID, notificationId)
                 .setFlags(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY | Intent.FLAG_ACTIVITY_SINGLE_TOP)
                 .addCategory(category);
 
-        Intent closeIntent = new Intent(activity.getPackageName() + XWALK_ACTION_CLOSE_NOTIFICATION_SUFFIX)
+        Intent closeIntent = new Intent(context.getPackageName() + XWALK_ACTION_CLOSE_NOTIFICATION_SUFFIX)
                 .putExtra(XWALK_INTENT_EXTRA_KEY_NOTIFICATION_ID, notificationId)
                 .addCategory(category);
 
         builder.setContentIntent(PendingIntent.getActivity(
-                activity, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
+                context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
         builder.setDeleteIntent(PendingIntent.getBroadcast(
-                activity, 0, closeIntent, PendingIntent.FLAG_UPDATE_CURRENT));
+                context, 0, closeIntent, PendingIntent.FLAG_UPDATE_CURRENT));
 
         doShowNotification(notificationId,
                 VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN ? builder.build() : builder.getNotification());
@@ -253,14 +253,14 @@ public class XWalkNotificationServiceImpl implements XWalkNotificationService {
 
     private void registerReceiver() {
         IntentFilter filter = new IntentFilter(
-                mView.getActivity().getPackageName() + XWALK_ACTION_CLOSE_NOTIFICATION_SUFFIX);
+                mView.getContext().getPackageName() + XWALK_ACTION_CLOSE_NOTIFICATION_SUFFIX);
 
         for(Integer id : mExistNotificationIds.keySet()) {
             filter.addCategory(getCategoryFromNotificationId(id));
         }
 
         try {
-            mView.getActivity().registerReceiver(mNotificationCloseReceiver, filter);
+            mView.getContext().registerReceiver(mNotificationCloseReceiver, filter);
         } catch (AndroidRuntimeException e) {
             //FIXME(wang16): The exception will happen when there are multiple xwalkviews in one activity.
             //               Remove it after notification service supports multi-views.
@@ -269,6 +269,6 @@ public class XWalkNotificationServiceImpl implements XWalkNotificationService {
     }
 
     private void unregisterReceiver() {
-        mView.getActivity().unregisterReceiver(mNotificationCloseReceiver);
+        mView.getContext().unregisterReceiver(mNotificationCloseReceiver);
     }
 }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -4,7 +4,6 @@
 
 package org.xwalk.core.internal;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -237,7 +236,7 @@ public class XWalkResourceClientInternal {
     @XWalkAPI
     public void onReceivedLoadError(XWalkViewInternal view, int errorCode, String description,
             String failingUrl) {
-        Toast.makeText(view.getActivity(), description, Toast.LENGTH_SHORT).show();
+        Toast.makeText(view.getContext(), description, Toast.LENGTH_SHORT).show();
     }
 
     /**
@@ -300,9 +299,9 @@ public class XWalkResourceClientInternal {
     }
 
     /**
-     * Notify the host application to handle a SSL client certificate request. The host application 
-     * is responsible for showing the UI if desired and providing the keys. There are three ways to 
-     * respond: proceed(), cancel() or ignore(). XWalkView remembers the response if proceed() or cancel() 
+     * Notify the host application to handle a SSL client certificate request. The host application
+     * is responsible for showing the UI if desired and providing the keys. There are three ways to
+     * respond: proceed(), cancel() or ignore(). XWalkView remembers the response if proceed() or cancel()
      * is called and does not call onReceivedClientCertRequest() again for the same host and port pair.
      * XWalkView does not remember the response if ignore() is called.
      *
@@ -312,7 +311,7 @@ public class XWalkResourceClientInternal {
      *
      * @param view The XWalkView that is initiating the callback
      * @param handler An instance of a ClientCertRequestHandlerInternal
-     * 
+     *
      * @since 6.0
      */
     @XWalkAPI
@@ -386,8 +385,7 @@ public class XWalkResourceClientInternal {
         layout.addView(userNameEditText);
         layout.addView(passwordEditText);
 
-        final Activity curActivity = view.getActivity();
-        AlertDialog.Builder httpAuthDialog = new AlertDialog.Builder(curActivity);
+        AlertDialog.Builder httpAuthDialog = new AlertDialog.Builder(view.getContext());
         httpAuthDialog.setTitle(R.string.http_auth_title)
                 .setView(layout)
                 .setCancelable(false)

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -32,7 +32,6 @@ public class XWalkUIClientInternal {
     private AlertDialog mDialog;
     private EditText mPromptText;
     private int mSystemUiFlag;
-    private View mDecorView;
     private XWalkViewInternal mXWalkView;
     private boolean mOriginalFullscreen;
     private boolean mOriginalForceNotFullscreen;
@@ -56,7 +55,6 @@ public class XWalkUIClientInternal {
     @XWalkAPI
     public XWalkUIClientInternal(XWalkViewInternal view) {
         mContext = view.getContext();
-        mDecorView = view.getActivity().getWindow().getDecorView();
         if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
             mSystemUiFlag = View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
                     View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
@@ -84,9 +82,14 @@ public class XWalkUIClientInternal {
      * @param color the new color in RGB format.
      */
     public void onDidChangeThemeColor(XWalkViewInternal view, int color) {
-        if (view == null || view.getActivity() == null) return;
-        ApiCompatibilityUtils.setStatusBarColor(view.getActivity().getWindow(),color);
-        ApiCompatibilityUtils.setTaskDescription(view.getActivity(), null, null, color);
+        Activity activity = null;
+        try {
+            activity = (Activity) mContext;
+        } catch (ClassCastException e) {
+        }
+        if (view == null || activity == null) return;
+        ApiCompatibilityUtils.setStatusBarColor(activity.getWindow(),color);
+        ApiCompatibilityUtils.setTaskDescription(activity, null, null, color);
     }
 
     /**
@@ -127,8 +130,13 @@ public class XWalkUIClientInternal {
      */
     @XWalkAPI
     public void onJavascriptCloseWindow(XWalkViewInternal view) {
-        if (view != null && view.getActivity() != null) {
-            view.getActivity().finish();
+        Activity activity = null;
+        try {
+            activity = (Activity) mContext;
+        } catch (ClassCastException e) {
+        }
+        if (view != null && activity != null) {
+            activity.finish();
         }
     }
 
@@ -186,7 +194,13 @@ public class XWalkUIClientInternal {
      */
     @XWalkAPI
     public void onFullscreenToggled(XWalkViewInternal view, boolean enterFullscreen) {
-        Activity activity = view.getActivity();
+        Activity activity = null;
+        try {
+            activity = (Activity) mContext;
+        } catch (ClassCastException e) {
+        }
+        if (activity == null) return;
+
         if (enterFullscreen) {
             if ((activity.getWindow().getAttributes().flags &
                     WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN) != 0) {
@@ -198,8 +212,9 @@ public class XWalkUIClientInternal {
             }
             if (!mIsFullscreen) {
                 if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-                    mSystemUiFlag = mDecorView.getSystemUiVisibility();
-                    mDecorView.setSystemUiVisibility(
+                    View decorView = activity.getWindow().getDecorView();
+                    mSystemUiFlag = decorView.getSystemUiVisibility();
+                    decorView.setSystemUiVisibility(
                             View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
                             View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
                             View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
@@ -223,7 +238,7 @@ public class XWalkUIClientInternal {
                         WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
             }
             if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-                mDecorView.setSystemUiVisibility(mSystemUiFlag);
+                activity.getWindow().getDecorView().setSystemUiVisibility(mSystemUiFlag);
             } else {
                 // Clear the activity fullscreen flag.
                 if (!mOriginalFullscreen) {
@@ -382,11 +397,11 @@ public class XWalkUIClientInternal {
     @XWalkAPI
     public void onPageLoadStopped(XWalkViewInternal view, String url, LoadStatusInternal status) {
     }
-    
+
     /**
      * Tell the client to display an alert dialog to the user.
-     * WARN: Please DO NOT override this API and onJavascriptModalDialog API in the 
-     *       same subclass to avoid unexpected behavior. 
+     * WARN: Please DO NOT override this API and onJavascriptModalDialog API in the
+     *       same subclass to avoid unexpected behavior.
      * @param view the owner XWalkViewInternal instance.
      * @param url the url of the web page which wants to show this dialog.
      * @param message the message to be shown.
@@ -423,7 +438,7 @@ public class XWalkUIClientInternal {
 
     /**
      * Tell the client to display a confirm dialog to the user.
-     * WARN: Please DO NOT override this API and onJavascriptModalDialog API in the 
+     * WARN: Please DO NOT override this API and onJavascriptModalDialog API in the
      *       same subclass to avoid unexpected behavior.
      * @param view the owner XWalkViewInternal instance.
      * @param url the url of the web page which wants to show this dialog.
@@ -468,10 +483,10 @@ public class XWalkUIClientInternal {
         mDialog.show();
         return false;
     }
-    
+
     /**
      * Tell the client to display a prompt dialog to the user.
-     * WARN: Please DO NOT override this API and onJavascriptModalDialog API in the 
+     * WARN: Please DO NOT override this API and onJavascriptModalDialog API in the
      *       same subclass to avoid unexpected behavior.
      * @param view the owner XWalkViewInternal instance.
      * @param url the url of the web page which wants to show this dialog.

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -38,6 +38,8 @@ import org.chromium.base.library_loader.ProcessInitException;
 import org.chromium.content.browser.BrowserStartupController;
 import org.chromium.content.browser.DeviceUtils;
 
+import org.xwalk.core.internal.extension.BuiltinXWalkExtensions;
+
 @JNINamespace("xwalk")
 class XWalkViewDelegate {
     private static boolean sInitialized = false;
@@ -181,6 +183,7 @@ class XWalkViewDelegate {
         ResourceExtractor.get(context);
 
         startBrowserProcess(context);
+
         sInitialized = true;
     }
 
@@ -209,6 +212,15 @@ class XWalkViewDelegate {
                 } catch (ProcessInitException e) {
                     throw new RuntimeException("Cannot initialize Crosswalk Core", e);
                 }
+
+                if (!CommandLine.getInstance().hasSwitch("disable-xwalk-extensions")) {
+                    BuiltinXWalkExtensions.load(context);
+                } else {
+                    XWalkPreferencesInternal.setValue(
+                            XWalkPreferencesInternal.ENABLE_EXTENSIONS, false);
+                }
+
+                XWalkPresentationHost.createInstanceOnce(context);
             }
         });
     }

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkWebChromeClient.java
@@ -76,7 +76,11 @@ public class XWalkWebChromeClient {
     }
 
     private Activity addContentView(View view, CustomViewCallback callback) {
-        Activity activity = mXWalkView.getActivity();
+        Activity activity = null;
+        try {
+            activity = (Activity) mXWalkView.getContext();
+        } catch (ClassCastException e) {
+        }
 
         if (mCustomXWalkView != null || activity == null) {
             if (callback != null) callback.onCustomViewHidden();
@@ -140,7 +144,11 @@ public class XWalkWebChromeClient {
      * like to hide its custom view.
      */
     public void onHideCustomView() {
-        Activity activity = mXWalkView.getActivity();
+        Activity activity = null;
+        try {
+            activity = (Activity) mXWalkView.getContext();
+        } catch (ClassCastException e) {
+        }
         if (mCustomXWalkView == null || activity == null) return;
 
         if (mContentsClient != null) {

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/BuiltinXWalkExtensions.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/BuiltinXWalkExtensions.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 
 import org.xwalk.core.internal.XWalkExtensionInternal;
 import org.xwalk.core.internal.extension.api.launchscreen.LaunchScreenExtension;
-import org.xwalk.core.internal.extension.api.wifidirect.WifiDirect;
 
 import android.app.Activity;
 import android.content.Context;
@@ -25,7 +24,7 @@ public class BuiltinXWalkExtensions {
     private static HashMap<String, XWalkExtensionInternal> sBuiltinExtensions =
             new HashMap<String, XWalkExtensionInternal>();
 
-    public static void load(Context context, Activity activity) {
+    public static void load(Context context) {
         // Create all built-in extension instances here.
 
         {
@@ -34,21 +33,9 @@ public class BuiltinXWalkExtensions {
                 jsApiContent = getExtensionJSFileContent(
                         context, LaunchScreenExtension.JS_API_PATH, true);
                 sBuiltinExtensions.put(LaunchScreenExtension.JS_API_PATH,
-                        new LaunchScreenExtension(jsApiContent, activity));
+                        new LaunchScreenExtension(jsApiContent, context));
             } catch (IOException e) {
                 Log.w(TAG, "Failed to read JS API file: " + LaunchScreenExtension.JS_API_PATH);
-            }
-        }
-
-        {
-            String jsApiContent = "";
-            try {
-                jsApiContent = getExtensionJSFileContent(
-                        context, WifiDirect.JS_API_PATH, true);
-                sBuiltinExtensions.put(WifiDirect.JS_API_PATH,
-                        new WifiDirect(jsApiContent, activity));
-            } catch(IOException e) {
-                Log.w(TAG, "Failed to read JS API file: " + WifiDirect.JS_API_PATH);
             }
         }
     }

--- a/runtime/android/core_internal_shell/src/org/xwalk/core/internal/xwview/shell/XWalkViewInternalShellActivity.java
+++ b/runtime/android/core_internal_shell/src/org/xwalk/core/internal/xwview/shell/XWalkViewInternalShellActivity.java
@@ -123,11 +123,6 @@ public class XWalkViewInternalShellActivity extends Activity {
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (mView != null) mView.onActivityResult(requestCode, resultCode, data);
-    }
-
-    @Override
     public void onNewIntent(Intent intent) {
         if (mView != null) {
             if (!mView.onNewIntent(intent)) super.onNewIntent(intent);

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/SectionsPagerAdapter.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/SectionsPagerAdapter.java
@@ -93,14 +93,4 @@ public class SectionsPagerAdapter extends FragmentPagerAdapter {
             if (xwalkView != null) xwalkView.onDestroy();
         }
     }
-
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        for (int i=0; i<mFragmentList.size(); i++) {
-            XWalkViewSectionFragment fragment = (XWalkViewSectionFragment)mFragmentList.get(i);
-            XWalkView xwalkView = fragment.getXWalkView();
-            if (xwalkView != null) {
-                xwalkView.onActivityResult(requestCode, resultCode, data);
-            }
-        }
-    }
 }

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -178,11 +178,6 @@ public class XWalkViewShellActivity extends XWalkActivity
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (mActiveView != null) mActiveView.onActivityResult(requestCode, resultCode, data);
-    }
-
-    @Override
     public void onNewIntent(Intent intent) {
         if (mActiveView != null) {
             if (!mActiveView.onNewIntent(intent)) super.onNewIntent(intent);

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/HandleActionUriTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/HandleActionUriTest.java
@@ -50,7 +50,7 @@ public class HandleActionUriTest extends XWalkViewInternalTestBase {
             @Override
             public void run() {
                 mNavigationHandler = new TestXWalkNavigationHandler(
-                        getXWalkView().getActivity());
+                        getXWalkView().getContext());
                 getXWalkView().setNavigationHandler(mNavigationHandler);
             }
         });

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/WebNotificationTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/WebNotificationTest.java
@@ -70,7 +70,7 @@ public class WebNotificationTest extends XWalkViewInternalTestBase {
             @Override
             public void run() {
                 mNotificationService = new TestXWalkNotificationService(
-                        getXWalkView().getActivity(), getXWalkView());
+                        getXWalkView().getContext(), getXWalkView());
                 getXWalkView().setNotificationService(mNotificationService);
                 XWalkPreferencesInternal.setValue(XWalkPreferencesInternal.REMOTE_DEBUGGING, true);
             }

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -20,6 +20,7 @@
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkActivity.java',
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java',
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkInitializer.java',
+          '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java',
           '<(DEPTH)/xwalk/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/ClientCertRequest.java',
           '>(reflection_gen_dir)/wrapper/org/xwalk/core/XWalkCookieManager.java',


### PR DESCRIPTION
Originally, XWalkView is designed to be tightly bound to the activity
that creates and holds it, and to listen the state change and activity
result, which will cause following problems:

- With the change of the container activity's life cycle, XWalkView will
  pause all timers and other components like videos when activity
  paused, which is not suited to the usage in background.
- Single XWalkView can't be shared across multiple activities.
- XWalkView must be created in an activity, it can't be used for a
  service.
- A XWalkView object will be destroyed after its container activity
  died and can't be used anymore.

To solve the problems above, we decided to decouple XWalkView from the
activity and give the developer more freedom to handle it. This patch
does following things:

- XWalkView can be created and held in any context, including a service.
- XWalkInitializer and XWalkUpdate don't have to be created in an
  activity, they support to initialize Crosswalk environment in any context.
- XWalkExternalExtensionManager doesn't handle the activity result anymore.
- The implementation of the file chooser in XWalkView is separated to
  a individual class called XWalkFileChooser. Because it needs to receive
  an activity, it can't be integrated into internal library as default
  file chooser. So move it from org.xwalk.core.internal to org.xwalk.core
  as a new API, the developer has to invoke it manually in
  XWalkUIClient.openFileChooser.
- Remove built-in extension "WifiDirect". WifiDirect extension needs an
  activity parameter, meanwhile BuiltinXWalkExtensions handles all of the
  loaded Crosswalk extensions in a static member. So the activity passed
  to WifiDirect extension will be held permanently, which may cause memory
  leak.
- Use the application context instead of the activity in
  XWalkPresentationHot to avoid memory leak.

BUG=XWALK-7002