### PR TITLE
DEPS.xwalk: Roll v8-crosswalk (ef916fc->d4a8f69)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -18,7 +18,7 @@
 # -----------------------------------
 
 chromium_crosswalk_rev = 'a198c470a760f45a855cbd698071b0fc6c08a851'
-v8_crosswalk_rev = 'ef916fcaccd4df07b38abecbbcc023817b4a50e5'
+v8_crosswalk_rev = 'd4a8f6963831d1303d0432ef65cf9df4a247d4d5'
 
 # We need our own copy of src/buildtools in order to have the gn and
 # clang-format binaries in a location that can be found automatically both by


### PR DESCRIPTION
d4a8f69 Merge pull request #160 from chuan9/xwalk-6040-release
99f0e62 Add SIMD.Bool32x4.allTrue in crankshaft, use SIMD.Int32x4 to represent result of SIMD.Float32x4.lessThanOrEqual to accelerate mandlebrot, wirte testcase for SIMID.Bool32x4.anyTrue and SIMD.Bool32x4.allTrue. It's a workaround and needed to be refined
e7ca202 [SIMD.Bool32x4] Modify parameter of SIMD.Int32x4.select in crankshaft, and change the method of constructor of SIMD.Bool32x4 for ia32 and x64 Correct type to SIMD128_VALUE_TYPE in HanleTaggedToSIMD128
ef916fc Adjust coding style in files touched by e236921

BUG=XWALK-6040