### PR TITLE
[Windows] Presentation API : Fix bug where no screens would be listed as available.

### DIFF
--- a/runtime/browser/xwalk_presentation_service_helper.cc
+++ b/runtime/browser/xwalk_presentation_service_helper.cc
@@ -11,8 +11,6 @@
 
 namespace xwalk {
 
-DisplayInfo::DisplayInfo() {}
-
 std::unique_ptr<DisplayInfoManagerService> DisplayInfoManagerService::Create() {
 #if defined(OS_WIN)
   return std::unique_ptr<DisplayInfoManagerService>(

--- a/runtime/browser/xwalk_presentation_service_helper.h
+++ b/runtime/browser/xwalk_presentation_service_helper.h
@@ -69,8 +69,6 @@ inline Application* GetApplication(content::WebContents* contents) {
 }
 
 struct DisplayInfo {
-  DisplayInfo();
-
   gfx::Rect bounds;
   bool is_primary;
   bool in_use;


### PR DESCRIPTION
When creating the monitors list we need to make sure that they are
initialized first as not in use. In order to do that we're removing the
user defined DisplayInfo constructor and thanks to C++11 the field in_use
will be set to false. Before the field was not initialized by default
and was being affected a random value (which then resolve as true) and
all monitors becomes in use and the API never let you choose one.

BUG=XWALK-7098