### PR TITLE
[Linux] Fix build after 630ba8e

### DIFF
--- a/runtime/browser/xwalk_presentation_service_helper.cc
+++ b/runtime/browser/xwalk_presentation_service_helper.cc
@@ -11,6 +11,9 @@
 
 namespace xwalk {
 
+DisplayInfo::DisplayInfo()
+    : is_primary(false), in_use(false) { }
+
 std::unique_ptr<DisplayInfoManagerService> DisplayInfoManagerService::Create() {
 #if defined(OS_WIN)
   return std::unique_ptr<DisplayInfoManagerService>(

--- a/runtime/browser/xwalk_presentation_service_helper.h
+++ b/runtime/browser/xwalk_presentation_service_helper.h
@@ -69,6 +69,8 @@ inline Application* GetApplication(content::WebContents* contents) {
 }
 
 struct DisplayInfo {
+  DisplayInfo();
+
   gfx::Rect bounds;
   bool is_primary;
   bool in_use;


### PR DESCRIPTION
Chromium style requires us to define an explicit out-of-line constructor
so we can't use the C++11 trick. Let's just use old school initialization.