### PR TITLE
Stop changing |enable_widevine| in gyp.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -73,10 +73,6 @@
       # Whether to disable NaCl support.
       'disable_nacl%': 0,
 
-      # From src/third_party/widevine/cdm/widevine_cdm.gyp.
-      # Whether to build Crosswalk with support for the Widevine CDM.
-      'enable_widevine%': 0,
-
       # From src/third_party/ffmpeg/ffmpeg.gyp.
       # Whether to build the Chromium or Google Chrome version of FFmpeg (the
       # latter contains additional codecs).
@@ -166,7 +162,6 @@
     # Copy conditionally-set variables out one scope.
     'component%': '<(component)',
     'disable_nacl%': '<(disable_nacl)',
-    'enable_widevine%': '<(enable_widevine)',
     'ffmpeg_branding%': '<(ffmpeg_branding)',
     'ffmpeg_component%': '<(ffmpeg_component)',
     'mediacodecs_EULA%': '<(mediacodecs_EULA)',


### PR DESCRIPTION
Changing it used to make sense because we used to enable it on Windows
by default before reverting that change. We're now always setting it to
the same value it has by default upstream.

Related BUG=XWALK-6207