### PR TITLE
[Windows][Linux] Fix crash when clicking the Resources tab in the

### DIFF
--- a/runtime/common/xwalk_content_client.cc
+++ b/runtime/common/xwalk_content_client.cc
@@ -214,6 +214,12 @@ void XWalkContentClient::AddAdditionalSchemes(
   savable_schemes->push_back(application::kApplicationScheme);
 }
 
+void XWalkContentClient::AddSecureSchemesAndOrigins(
+    std::set<std::string>* schemes,
+    std::set<GURL>* origins) {
+    schemes->insert(application::kApplicationScheme);
+}
+
 std::string XWalkContentClient::GetProcessTypeNameInEnglish(int type) {
   switch (type) {
     case PROCESS_TYPE_NACL_LOADER:

--- a/runtime/common/xwalk_content_client.h
+++ b/runtime/common/xwalk_content_client.h
@@ -37,6 +37,8 @@ class XWalkContentClient : public content::ContentClient {
       std::vector<url::SchemeWithType>* standard_schemes,
       std::vector<url::SchemeWithType>* referrer_schemes,
       std::vector<std::string>* saveable_shemes) override;
+  void AddSecureSchemesAndOrigins(std::set<std::string>* schemes,
+      std::set<GURL>* origins) override;
   std::string GetProcessTypeNameInEnglish(int type) override;
 
  private:

--- a/runtime/common/xwalk_content_client_unittest.cc
+++ b/runtime/common/xwalk_content_client_unittest.cc
@@ -7,7 +7,9 @@
 #include "base/command_line.h"
 #include "base/strings/string_split.h"
 #include "content/public/common/content_switches.h"
+#include "content/public/common/origin_util.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 
 namespace {
 
@@ -60,4 +62,12 @@ void CheckUserAgentStringOrdering(bool mobile_device) {
 
 TEST(XWalkContentClientTest, Basic) {
   CheckUserAgentStringOrdering(false);
+}
+
+TEST(XWalkContentClientTest, TestSecuredOrigins) {
+  // XWalkContentClient is responsible of adding the app:// scheme as secure.
+  xwalk::XWalkContentClient content_client;
+  SetContentClient(&content_client);
+  GURL url("app://abcdefgh");
+  EXPECT_TRUE(content::IsOriginSecure(url));
 }


### PR DESCRIPTION
Inspector.

It turns out that the Renderer was crashing so the inspector would stop
working. The Resources tab lists for example the application cache, as
well as the IndexedDb or the ServiceWorker. Chromium now requires these
values to be coming from a secured origin (such as HTTPS) but in the case
of Crosswalk it was failing (and thus sending a bad IPC message which
would trigger the shutdown of the renderer) because we use the app://
protocol. This scheme is trusted so we can safely add it as such.

BUG=XWALK-7194