### PR TITLE
[Windows] Presentation API : Fix bug where no screens would be listed…

### DIFF
--- a/runtime/browser/xwalk_presentation_service_helper.cc
+++ b/runtime/browser/xwalk_presentation_service_helper.cc
@@ -11,7 +11,8 @@
 
 namespace xwalk {
 
-DisplayInfo::DisplayInfo() {}
+DisplayInfo::DisplayInfo()
+    : is_primary(false), in_use(false) { }
 
 std::unique_ptr<DisplayInfoManagerService> DisplayInfoManagerService::Create() {
 #if defined(OS_WIN)


### PR DESCRIPTION
… as available.

When creating the monitors list we need to make sure that they are
initialized first as not in use. Before the field was not initialized by default
and was being affected a random value (which then resolve as true) and
all monitors becomes in use and the API never let you choose one.

BUG=XWALK-7098

(cherry picked from commit 630ba8e1d3fc6a40aba73156074ef839d89ac874)
(cherry picked from commit e391cd853693ad4d7a945f2109dbe0538cf91ef8)