### PR TITLE
Add copy-constructors to some classes to fix the sysroot build.

### DIFF
--- a/runtime/browser/xwalk_ssl_host_state_delegate.cc
+++ b/runtime/browser/xwalk_ssl_host_state_delegate.cc
@@ -26,6 +26,8 @@ CertPolicy::CertPolicy() {
 CertPolicy::~CertPolicy() {
 }
 
+CertPolicy::CertPolicy(const CertPolicy&) = default;
+
 // For an allowance, we consider a given |cert| to be a match to a saved
 // allowed cert if the |error| is an exact match to or subset of the errors
 // in the saved CertStatus.

--- a/runtime/browser/xwalk_ssl_host_state_delegate.h
+++ b/runtime/browser/xwalk_ssl_host_state_delegate.h
@@ -23,6 +23,8 @@ class CertPolicy {
  public:
   CertPolicy();
   ~CertPolicy();
+  CertPolicy(const CertPolicy&);
+
   // Returns true if the user has decided to proceed through the ssl error
   // before. For a certificate to be allowed, it must not have any
   // *additional* errors from when it was allowed.

--- a/runtime/common/xwalk_runtime_features.cc
+++ b/runtime/common/xwalk_runtime_features.cc
@@ -31,6 +31,9 @@ XWalkRuntimeFeatures::Feature::Feature(
       enabled(enabled) {
 }
 
+XWalkRuntimeFeatures::Feature::Feature(const XWalkRuntimeFeatures::Feature&) =
+    default;
+
 // static
 XWalkRuntimeFeatures* XWalkRuntimeFeatures::GetInstance() {
   return base::Singleton<XWalkRuntimeFeatures>::get();

--- a/runtime/common/xwalk_runtime_features.h
+++ b/runtime/common/xwalk_runtime_features.h
@@ -43,6 +43,7 @@ class XWalkRuntimeFeatures {
             const std::string& description,
             Status status = Experimental,
             bool enabled = false);
+    Feature(const Feature&);
 
     std::string name;
     std::string cmd_line;


### PR DESCRIPTION
The two commits in this pull request are required to fix the Linux build
when `use_sysroot` is enabled (which we use for our release builds)
after moving to M52.

Something in the old libstdc++ classes in the Debian Wheezy sysroot end
up causing Chromium's chromium-style clang plugin to complain; when
`use_sysroot` is disabled (as is the case by default and what our
Buildbot slaves build), the libstdc++ version used is much more recent
and does not trigger Chromium's plugin.

BUG=XWALK-7022