### PR TITLE
Eliminate comparisons between size_t and int, different signs in unittest code

### DIFF
--- a/application/common/manifest_handlers/csp_handler_unittest.cc
+++ b/application/common/manifest_handlers/csp_handler_unittest.cc
@@ -38,7 +38,7 @@ TEST_F(CSPHandlerTest, DISABLED_NoCSP) {
   scoped_refptr<ApplicationData> application =
       CreateApplication(Manifest::TYPE_MANIFEST, *manifest);
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 2);
+  EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 2u);
 }
 
 TEST_F(CSPHandlerTest, EmptyCSP) {
@@ -47,7 +47,7 @@ TEST_F(CSPHandlerTest, EmptyCSP) {
   scoped_refptr<ApplicationData> application =
       CreateApplication(Manifest::TYPE_MANIFEST, *manifest);
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 0);
+  EXPECT_EQ(GetCSPInfo(application)->GetDirectives().size(), 0u);
 }
 
 TEST_F(CSPHandlerTest, CSP) {
@@ -58,11 +58,11 @@ TEST_F(CSPHandlerTest, CSP) {
   EXPECT_TRUE(application.get());
   const std::map<std::string, std::vector<std::string> >& policies =
       GetCSPInfo(application)->GetDirectives();
-  EXPECT_EQ(policies.size(), 1);
+  EXPECT_EQ(policies.size(), 1u);
   std::map<std::string, std::vector<std::string> >::const_iterator it =
       policies.find("default-src");
   ASSERT_NE(it, policies.end());
-  EXPECT_EQ(it->second.size(), 1);
+  EXPECT_EQ(it->second.size(), 1u);
   EXPECT_STREQ((it->second)[0].c_str(), "'self'");
 }
 

--- a/application/common/manifest_handlers/permissions_handler_unittest.cc
+++ b/application/common/manifest_handlers/permissions_handler_unittest.cc
@@ -36,7 +36,7 @@ TEST_F(PermissionsHandlerTest, NonePermission) {
   scoped_refptr<ApplicationData> application =
       CreateApplication(Manifest::TYPE_MANIFEST, manifest);
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0);
+  EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0u);
 }
 
 TEST_F(PermissionsHandlerTest, EmptyPermission) {
@@ -48,7 +48,7 @@ TEST_F(PermissionsHandlerTest, EmptyPermission) {
   scoped_refptr<ApplicationData> application =
       CreateApplication(Manifest::TYPE_MANIFEST, manifest);
   EXPECT_TRUE(application.get());
-  EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0);
+  EXPECT_EQ(GetAPIPermissionsInfo(application).size(), 0u);
 }
 
 TEST_F(PermissionsHandlerTest, DeviceAPIPermission) {
@@ -63,7 +63,7 @@ TEST_F(PermissionsHandlerTest, DeviceAPIPermission) {
   EXPECT_TRUE(application.get());
   const PermissionSet& permission_list =
       GetAPIPermissionsInfo(application);
-  EXPECT_EQ(permission_list.size(), 1);
+  EXPECT_EQ(permission_list.size(), 1u);
   EXPECT_STREQ((*(permission_list.begin())).c_str(), "geolocation");
 }
 

--- a/application/common/manifest_handlers/widget_handler_unittest.cc
+++ b/application/common/manifest_handlers/widget_handler_unittest.cc
@@ -140,7 +140,7 @@ TEST_F(WidgetHandlerTest, ParseManifestWithOnlyNameAndVersion) {
 
   // Only name and version ,others are empty string "",but exist.
   // And widget have 10 items.
-  EXPECT_EQ(info->GetWidgetInfo()->size(), 10);
+  EXPECT_EQ(info->GetWidgetInfo()->size(), 10u);
 
   base::DictionaryValue* widget = info->GetWidgetInfo();
   base::DictionaryValue::Iterator it(*widget);

--- a/application/test/application_test.cc
+++ b/application/test/application_test.cc
@@ -34,7 +34,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationTest, TestMultiApp) {
   test_runner_->WaitForTestNotification();
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
   // The App1 has 2 pages: main doc page and "main.html" page.
-  EXPECT_EQ(app1->runtimes().size(), 1);
+  EXPECT_EQ(app1->runtimes().size(), 1u);
 
   EXPECT_EQ(service->active_applications().size(), currently_running_count + 1);
   EXPECT_EQ(service->GetApplicationByID(app1->id()), app1);
@@ -58,7 +58,7 @@ IN_PROC_BROWSER_TEST_F(ApplicationTest, TestMultiApp) {
   EXPECT_EQ(test_runner_->GetTestsResult(), ApiTestRunner::PASS);
 
   // The App2 also has 2 pages: main doc page and "main.html" page.
-  EXPECT_EQ(app2->runtimes().size(), 1);
+  EXPECT_EQ(app2->runtimes().size(), 1u);
 
   // Check that the apps have different IDs and RPH IDs.
   EXPECT_NE(app1->id(), app2->id());

--- a/extensions/browser/xwalk_extension_function_handler_unittest.cc
+++ b/extensions/browser/xwalk_extension_function_handler_unittest.cc
@@ -64,7 +64,7 @@ TEST(XWalkExtensionFunctionHandlerTest, RegisterAndHandleFunction) {
   handler.Register("echoData", base::Bind(&EchoData, &counter));
   handler.Register("reset", base::Bind(&ResetCounter, &counter));
 
-  for (unsigned i = 0; i < 1000; ++i) {
+  for (int i = 0; i < 1000; ++i) {
     std::string str1;
     std::unique_ptr<base::ListValue> data1(new base::ListValue());
     data1->AppendString(kTestString);

--- a/sysapps/common/binding_object_store_unittest.cc
+++ b/sysapps/common/binding_object_store_unittest.cc
@@ -154,7 +154,7 @@ TEST(XWalkSysAppsBindingObjectStoreTest, OnPostMessageToObject) {
   store->AddBindingObject("foobar2", std::move(binding_object_ptr2));
   EXPECT_EQ(BindingObjectTest::instance_count(), 2);
 
-  for (unsigned i = 0; i < 1000; ++i) {
+  for (int i = 0; i < 1000; ++i) {
     std::unique_ptr<base::ListValue> arguments(new base::ListValue);
 
     // Object ID.

--- a/sysapps/common/event_target_unittest.cc
+++ b/sysapps/common/event_target_unittest.cc
@@ -158,7 +158,7 @@ TEST(XWalkSysAppsEventTargetTest, DispatchEvent) {
 
   EXPECT_TRUE(target->HandleFunction(std::move(eventInfo)));
 
-  for (unsigned i = 0; i < 1000; ++i) {
+  for (int i = 0; i < 1000; ++i) {
     target->InjectEvent("event1");
     EXPECT_EQ(message_count, i + 1);
   }


### PR DESCRIPTION
With "-Wsign-compare" build option, errors are found:
error: comparison of integers of different signs: 'const unsigned long'
and 'const int' [-Werror,-Wsign-compare]
error: comparison of integers of different signs: 'const int' and
'const unsigned int' [-Werror,-Wsign-compare]