### PR TITLE
Revert "[Android] Refactor XWalkView to receive events directly."

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContent.java
@@ -5,11 +5,9 @@
 
 package org.xwalk.core.internal;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
@@ -17,22 +15,18 @@ import android.net.http.SslCertificate;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Message;
 import android.view.View;
 import android.view.WindowManager;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Base64;
 import android.util.Log;
-import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
-import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.ViewGroup;
-import android.view.ViewStructure;
+import android.view.View.OnTouchListener;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 import android.widget.FrameLayout;
@@ -48,7 +42,7 @@ import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.ThreadUtils;
 import org.chromium.components.navigation_interception.InterceptNavigationDelegate;
-import org.chromium.content.browser.ContentViewClient;
+import org.chromium.content.browser.ContentView;
 import org.chromium.content.browser.ContentViewCore;
 import org.chromium.content.browser.ContentViewRenderView;
 import org.chromium.content.browser.ContentViewRenderView.CompositingSurfaceType;
@@ -77,6 +71,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
 
     private ContentViewCore mContentViewCore;
     private Context mViewContext;
+    private XWalkContentView mContentView;
     private ContentViewRenderView mContentViewRenderView;
     private ActivityWindowAndroid mWindow;
     private XWalkDevToolsServer mDevToolsServer;
@@ -188,6 +183,9 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         mContentViewRenderView.onNativeLibraryLoaded(mWindow);
         mLaunchScreenManager = new XWalkLaunchScreenManager(mViewContext, mXWalkView);
         mContentViewRenderView.registerFirstRenderedFrameListener(mLaunchScreenManager);
+        mXWalkView.addView(mContentViewRenderView, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT));
 
         mNativeContent = newNativeContent;
 
@@ -197,11 +195,15 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
 
         mWebContents = nativeGetWebContents(mNativeContent);
 
-        // Initialize ContentViewCore.
+        // Initialize ContentView.
         mContentViewCore = new ContentViewCore(mViewContext);
-        mContentViewCore.initialize(mXWalkView, mXWalkView, mWebContents, mWindow);
+        mContentView = XWalkContentView.createContentView(
+                mViewContext, mContentViewCore, mXWalkView);
+        mContentViewCore.initialize(mContentView, mContentView, mWebContents, mWindow);
         mNavigationController = mWebContents.getNavigationController();
-
+        mXWalkView.addView(mContentView, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT));
         mContentViewCore.setContentViewClient(mContentsClientBridge);
         mContentViewRenderView.setCurrentContentViewCore(mContentViewCore);
         // For addJavascriptInterface
@@ -293,7 +295,7 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
             mNavigationController.loadUrl(params);
         }
 
-        mXWalkView.requestFocus();
+        mContentView.requestFocus();
     }
 
     public void loadUrl(String url, String data, Map<String, String> headers) {
@@ -704,6 +706,9 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
         XWalkPreferencesInternal.unload(this);
         // Reset existing notification service in order to destruct it.
         setNotificationService(null);
+        // Remove its children used for page rendering from view hierarchy.
+        mXWalkView.removeView(mContentView);
+        mXWalkView.removeView(mContentViewRenderView);
         mContentViewRenderView.setCurrentContentViewCore(null);
 
         // Destroy the native resources.
@@ -720,39 +725,43 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
     }
 
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        return mContentViewCore.onCreateInputConnection(outAttrs);
+        return mContentView.onCreateInputConnectionSuper(outAttrs);
     }
 
     public boolean onTouchEvent(MotionEvent event) {
         return mContentViewCore.onTouchEvent(event);
     }
 
+    public void setOnTouchListener(OnTouchListener l) {
+        mContentView.setOnTouchListener(l);
+    }
+
     public void scrollTo(int x, int y) {
-        mContentViewCore.scrollTo(x, y);
+        mContentView.scrollTo(x, y);
     }
 
     public void scrollBy(int x, int y) {
-        mContentViewCore.scrollBy(x, y, false);
+        mContentView.scrollBy(x, y);
     }
 
     public int computeHorizontalScrollRange() {
-        return mContentViewCore.computeHorizontalScrollRange();
+        return mContentView.computeHorizontalScrollRangeDelegate();
     }
 
     public int computeHorizontalScrollOffset() {
-        return mContentViewCore.computeHorizontalScrollOffset();
+        return mContentView.computeHorizontalScrollOffsetDelegate();
     }
 
     public int computeVerticalScrollRange() {
-        return mContentViewCore.computeVerticalScrollRange();
+        return mContentView.computeVerticalScrollRangeDelegate();
     }
 
     public int computeVerticalScrollOffset() {
-        return mContentViewCore.computeVerticalScrollOffset();
+        return mContentView.computeVerticalScrollOffsetDelegate();
     }
 
     public int computeVerticalScrollExtent() {
-        return mContentViewCore.computeVerticalScrollExtent();
+        return mContentView.computeVerticalScrollExtentDelegate();
     }
 
     //--------------------------------------------------------------------------------------------
@@ -1044,129 +1053,6 @@ class XWalkContent implements XWalkPreferencesInternal.KeyValueChangeListener {
             boolean isDoneCounting) {
         mContentsClientBridge.onFindResultReceived(activeMatchOrdinal, numberOfMatches,
                 isDoneCounting);
-    }
-
-    protected void onAttachedToWindow() {
-        mContentViewCore.onAttachedToWindow();
-    }
-
-    protected void onDetachedFromWindow() {
-        mContentViewCore.onDetachedFromWindow();
-    }
-
-    protected void onVisibilityChanged(View changedView, int visibility) {
-        mContentViewCore.onVisibilityChanged(changedView, visibility);
-    }
-
-    protected ContentViewClient getContentViewClient() {
-        return mContentViewCore.getContentViewClient();
-    }
-
-    protected void onSizeChanged(int w, int h, int ow, int oh) {
-        mContentViewCore.onSizeChanged(w, h, ow, oh);
-    }
-
-    protected void onFocusChanged(boolean gainFocus) {
-        mContentViewCore.onFocusChanged(gainFocus);
-    }
-
-    protected void onWindowFocusChanged(boolean hasWindowFocus) {
-        mContentViewCore.onWindowFocusChanged(hasWindowFocus);
-    }
-
-    protected boolean supportsAccessibilityAction(int action) {
-        return mContentViewCore.supportsAccessibilityAction(action);
-    }
-
-    protected boolean performAccessibilityAction(int action, Bundle arguments) {
-        return mContentViewCore.performAccessibilityAction(action, arguments);
-    }
-
-    protected AccessibilityNodeProvider getAccessibilityNodeProvider() {
-        return mContentViewCore.getAccessibilityNodeProvider();
-    }
-
-    @TargetApi(VERSION_CODES.M)
-    protected void onProvideVirtualStructure(final ViewStructure structure) {
-        if (VERSION.SDK_INT < VERSION_CODES.M) {
-            return;
-        }
-        mContentViewCore.onProvideVirtualStructure(structure, false);
-    }
-
-    protected boolean onCheckIsTextEditor() {
-        return mContentViewCore.onCheckIsTextEditor();
-    }
-
-    protected boolean onKeyUp(int keyCode, KeyEvent event) {
-        return mContentViewCore.onKeyUp(keyCode, event);
-    }
-
-    protected boolean dispatchKeyEventPreIme(KeyEvent event) {
-        return mContentViewCore.dispatchKeyEventPreIme(event);
-    }
-
-    protected boolean dispatchKeyEvent(KeyEvent event) {
-        return mContentViewCore.dispatchKeyEvent(event);
-    }
-
-    protected boolean onHoverEvent(MotionEvent event) {
-        return mContentViewCore.onHoverEvent(event);
-    }
-
-    protected boolean isTouchExplorationEnabled() {
-        return mContentViewCore.isTouchExplorationEnabled();
-    }
-
-    protected boolean onGenericMotionEvent(MotionEvent event) {
-        return mContentViewCore.onGenericMotionEvent(event);
-    }
-
-    protected void onConfigurationChanged(Configuration newConfig) {
-        mContentViewCore.onConfigurationChanged(newConfig);
-    }
-
-    protected int computeHorizontalScrollExtent() {
-        // TODO(dtrainor): Need to expose scroll events properly to public. Either make getScroll*
-        // work or expose computeHorizontalScrollOffset()/computeVerticalScrollOffset as public.
-        return mContentViewCore.computeHorizontalScrollExtent();
-    }
-
-    protected boolean awakenScrollBars(int startDelay, boolean invalidate) {
-        return mContentViewCore.awakenScrollBars(startDelay, invalidate);
-    }
-
-    protected void extractSmartClipData(int x, int y, int width, int height) {
-        mContentViewCore.extractSmartClipData(x, y, width, height);
-    }
-
-    protected void setSmartClipResultHandler(final Handler resultHandler) {
-        if (resultHandler == null) {
-            mContentViewCore.setSmartClipDataListener(null);
-            return;
-        }
-        mContentViewCore.setSmartClipDataListener(new ContentViewCore.SmartClipDataListener() {
-            @Override
-            public void onSmartClipDataExtracted(String text, String html, Rect clipRect) {
-                Bundle bundle = new Bundle();
-                bundle.putString("url", mContentViewCore.getWebContents().getVisibleUrl());
-                bundle.putString("title", mContentViewCore.getWebContents().getTitle());
-                bundle.putParcelable("rect", clipRect);
-                bundle.putString("text", text);
-                bundle.putString("html", html);
-                try {
-                    Message msg = Message.obtain(resultHandler, 0);
-                    msg.setData(bundle);
-                    msg.sendToTarget();
-                } catch (Exception e) {
-                    Log.e(TAG, "Error calling handler for smart clip data: ", e);
-                }
-            }
-        });
-    }
-
-    protected ContentViewRenderView getContentViewRenderView() {
-        return mContentViewRenderView;
     }
 
     private native long nativeInit();

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentView.java
@@ -1,0 +1,144 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.core.internal;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.accessibility.AccessibilityNodeProvider;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewStructure;
+
+import org.chromium.content.browser.ContentView;
+import org.chromium.content.browser.ContentViewCore;
+
+public class XWalkContentView extends ContentView {
+    private static final String TAG = "XWalkContentView";
+    private XWalkViewInternal mXWalkView;
+
+    public static XWalkContentView createContentView(Context context, ContentViewCore cvc,
+            XWalkViewInternal xwView) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return new XWalkContentViewApi23(context, cvc, xwView);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            return new XWalkContentViewApi16(context, cvc, xwView);
+        }
+        return new XWalkContentView(context, cvc, xwView);
+    }
+
+    private XWalkContentView(Context context, ContentViewCore cvc, XWalkViewInternal xwView) {
+        super(context, cvc);
+        mXWalkView = xwView;
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        return mXWalkView.onCreateInputConnection(outAttrs);
+    }
+
+    public InputConnection onCreateInputConnectionSuper(EditorInfo outAttrs) {
+        return super.onCreateInputConnection(outAttrs);
+    }
+
+    @Override
+    public boolean performLongClick(){
+        return mXWalkView.performLongClickDelegate();
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        // Give XWalkView a chance to handle touch event
+        if(mXWalkView.onTouchEventDelegate(event)) {
+            return true;
+        }
+        return mContentViewCore.onTouchEvent(event);
+    }
+
+    @Override
+    public void onScrollChanged(int l, int t, int oldl, int oldt) {
+        mXWalkView.onScrollChangedDelegate(l, t, oldl, oldt);
+
+        // To keep the same behaviour with WebView onOverScrolled API,
+        // call onOverScrolledDelegate here.
+        mXWalkView.onOverScrolledDelegate(l, t, false, false);
+    }
+
+    /**
+     * Since compute* APIs in ContentView are all protected, use delegate methods
+     * to get the result.
+     */
+    public int computeHorizontalScrollRangeDelegate() {
+        return computeHorizontalScrollRange();
+    }
+
+    public int computeHorizontalScrollOffsetDelegate() {
+        return computeHorizontalScrollOffset();
+    }
+
+    public int computeVerticalScrollRangeDelegate() {
+        return computeVerticalScrollRange();
+    }
+
+    public int computeVerticalScrollOffsetDelegate() {
+        return computeVerticalScrollOffset();
+    }
+
+    public int computeVerticalScrollExtentDelegate() {
+        return computeVerticalScrollExtent();
+    }
+
+    @Override
+    protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
+        mXWalkView.onFocusChangedDelegate(gainFocus, direction, previouslyFocusedRect);
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+    }
+
+    // Imitate JellyBeanContentView
+    private static class XWalkContentViewApi16 extends XWalkContentView {
+        public XWalkContentViewApi16(Context context, ContentViewCore cvc,
+                XWalkViewInternal xwView) {
+            super(context, cvc, xwView);
+        }
+
+        @Override
+        public boolean performAccessibilityAction(int action, Bundle arguments) {
+            if (mContentViewCore.supportsAccessibilityAction(action)) {
+                return mContentViewCore.performAccessibilityAction(action, arguments);
+            }
+
+            return super.performAccessibilityAction(action, arguments);
+        }
+
+        // Copy the implementation of JellyBeanContentView
+        @Override
+        public AccessibilityNodeProvider getAccessibilityNodeProvider() {
+            AccessibilityNodeProvider provider = mContentViewCore.getAccessibilityNodeProvider();
+            if (provider != null) {
+                return provider;
+            } else {
+                return super.getAccessibilityNodeProvider();
+            }
+        }
+    }
+
+    // Imitate ContentView.ContentViewApi23
+    private static class XWalkContentViewApi23 extends XWalkContentViewApi16 {
+        public XWalkContentViewApi23(Context context, ContentViewCore cvc,
+                XWalkViewInternal xwView) {
+            super(context, cvc, xwView);
+        }
+
+        @Override
+        public void onProvideVirtualStructure(final ViewStructure structure) {
+            mContentViewCore.onProvideVirtualStructure(structure, false);
+        }
+    }
+}

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClient.java
@@ -30,7 +30,7 @@ import org.chromium.content_public.browser.WebContentsObserver;
 import org.chromium.net.NetError;
 
 /**
- * Base-class that a XWalkContent embedder derives from to receive callbacks.
+ * Base-class that a XWalkViewContents embedder derives from to receive callbacks.
  * This extends ContentViewClient, as in many cases we want to pass-thru ContentViewCore
  * callbacks right to our embedder, and this setup facilities that.
  * For any other callbacks we need to make transformations of (e.g. adapt parameters
@@ -174,7 +174,7 @@ abstract class XWalkContentsClient extends ContentViewClient {
 
     public abstract void onReceivedSslError(ValueCallback<Boolean> callback, SslError error);
 
-    public abstract void onReceivedClientCertRequest(ClientCertRequestInternal handler);
+    public abstract void onReceivedClientCertRequest(ClientCertRequestInternal handler);    
 
     public abstract void onReceivedResponseHeaders(WebResourceRequestInner request,
             XWalkWebResourceResponseInternal response);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -48,7 +48,7 @@ import org.chromium.content.browser.DownloadInfo;
 
 import org.xwalk.core.internal.XWalkUIClientInternal.LoadStatusInternal;
 
-// Help bridge callback in XWalkContentsClient to XWalkResourceClient, XWalkUIClient and
+// Help bridge callback in XWalkContentsClient to XWalkViewClient and
 // XWalkWebChromeClient; Also handle the JNI conmmunication logic.
 @JNINamespace("xwalk")
 class XWalkContentsClientBridge extends XWalkContentsClient

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -19,33 +19,27 @@
 
 package org.xwalk.core.internal;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ApplicationErrorReport;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.Manifest;
 import android.net.http.SslCertificate;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
-import android.os.Handler;
 import android.os.Looper;
 import android.provider.MediaStore;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.KeyEvent;
 import android.view.SurfaceView;
 import android.view.ViewGroup;
-import android.view.ViewStructure;
 import android.view.View.OnTouchListener;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
@@ -69,10 +63,7 @@ import org.chromium.base.ApplicationStatus;
 import org.chromium.base.ApplicationStatus.ActivityStateListener;
 import org.chromium.base.ApplicationStatusManager;
 import org.chromium.base.CommandLine;
-import org.chromium.content.browser.ContentViewClient;
 import org.chromium.content.browser.ContentViewCore;
-import org.chromium.content.browser.ContentViewRenderView;
-import org.chromium.content.browser.SmartClipProvider;
 
 import org.xwalk.core.internal.extension.BuiltinXWalkExtensions;
 
@@ -244,8 +235,7 @@ import org.xwalk.core.internal.extension.BuiltinXWalkExtensions;
  * </pre>
  */
 @XWalkAPI(extendClass = FrameLayout.class, createExternally = true)
-public class XWalkViewInternal extends android.widget.FrameLayout
-        implements ContentViewCore.InternalAccessDelegate, SmartClipProvider {
+public class XWalkViewInternal extends android.widget.FrameLayout {
 
     private class XWalkActivityStateListener implements ActivityStateListener {
         WeakReference<XWalkViewInternal> mXWalkViewRef;
@@ -323,11 +313,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
                   "        surfaceView.setLayoutParams(new ViewGroup.LayoutParams(0, 0));",
                   "        addView(surfaceView);"},
               postWrapperLines = {
-                  "        ReflectMethod getContentViewRenderViewMethod = new ReflectMethod(null, \"getContentViewRenderView\");",
-                  "        getContentViewRenderViewMethod.init(bridge, null, \"getContentViewRenderView\");",
-                  "        addView((FrameLayout)getContentViewRenderViewMethod.invoke(), new FrameLayout.LayoutParams(",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT,",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT));",
                   "        addView((FrameLayout)bridge, new FrameLayout.LayoutParams(",
                   "                FrameLayout.LayoutParams.MATCH_PARENT,",
                   "                FrameLayout.LayoutParams.MATCH_PARENT));",
@@ -339,14 +324,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
         checkThreadSafety();
         mActivity = (Activity) context;
         mContext = getContext();
-
-        if (getScrollBarStyle() == View.SCROLLBARS_INSIDE_OVERLAY) {
-            setHorizontalScrollBarEnabled(false);
-            setVerticalScrollBarEnabled(false);
-        }
-
-        setFocusable(true);
-        setFocusableInTouchMode(true);
 
         init(getContext(), getActivity());
         initXWalkContent(mContext, null);
@@ -370,11 +347,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
                   "        surfaceView.setLayoutParams(new ViewGroup.LayoutParams(0, 0));",
                   "        addView(surfaceView);"},
               postWrapperLines = {
-                  "        ReflectMethod getContentViewRenderViewMethod = new ReflectMethod(null, \"getContentViewRenderView\");",
-                  "        getContentViewRenderViewMethod.init(bridge, null, \"getContentViewRenderView\");",
-                  "        addView((FrameLayout)getContentViewRenderViewMethod.invoke(), new FrameLayout.LayoutParams(",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT,",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT));",
                   "        addView((FrameLayout)bridge, new FrameLayout.LayoutParams(",
                   "                FrameLayout.LayoutParams.MATCH_PARENT,",
                   "                FrameLayout.LayoutParams.MATCH_PARENT));",
@@ -394,14 +366,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
         mActivity = (Activity) context;
         mContext = getContext();
 
-        if (getScrollBarStyle() == View.SCROLLBARS_INSIDE_OVERLAY) {
-            setHorizontalScrollBarEnabled(false);
-            setVerticalScrollBarEnabled(false);
-        }
-
-        setFocusable(true);
-        setFocusableInTouchMode(true);
-
         init(getContext(), getActivity());
     }
 
@@ -418,11 +382,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
                   "        surfaceView.setLayoutParams(new ViewGroup.LayoutParams(0, 0));",
                   "        addView(surfaceView);"},
               postWrapperLines = {
-                  "        ReflectMethod getContentViewRenderViewMethod = new ReflectMethod(null, \"getContentViewRenderView\");",
-                  "        getContentViewRenderViewMethod.init(bridge, null, \"getContentViewRenderView\");",
-                  "        addView((FrameLayout)getContentViewRenderViewMethod.invoke(), new FrameLayout.LayoutParams(",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT,",
-                  "                FrameLayout.LayoutParams.MATCH_PARENT));",
                   "        addView((FrameLayout)bridge, new FrameLayout.LayoutParams(",
                   "                FrameLayout.LayoutParams.MATCH_PARENT,",
                   "                FrameLayout.LayoutParams.MATCH_PARENT));",
@@ -435,14 +394,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
         // Make sure mActivity is initialized before calling 'init' method.
         mActivity = activity;
         mContext = getContext();
-
-        if (getScrollBarStyle() == View.SCROLLBARS_INSIDE_OVERLAY) {
-            setHorizontalScrollBarEnabled(false);
-            setVerticalScrollBarEnabled(false);
-        }
-
-        setFocusable(true);
-        setFocusableInTouchMode(true);
 
         init(getContext(), getActivity());
         initXWalkContent(mContext, null);
@@ -1447,9 +1398,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
                 return true;
             }
         }
-        if (isFocused() && mContent != null) {
-            return mContent.dispatchKeyEvent(event);
-        }
         return super.dispatchKeyEvent(event);
     }
 
@@ -1609,7 +1557,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
 
     // For instrumentation test.
     public ContentViewCore getXWalkContentForTest() {
-        if (mContent == null) return null;
         return mContent.getContentViewCoreForTest();
     }
 
@@ -1618,16 +1565,21 @@ public class XWalkViewInternal extends android.widget.FrameLayout
     // action bar.
     @XWalkAPI(delegate = true,
               preWrapperLines = {"return performLongClick();"})
-    public boolean performLongClickDelegate() {
+    public boolean performLongClickDelegate(){
         return false;
     }
 
+    @XWalkAPI(delegate = true,
+              preWrapperLines = {"return onTouchEvent(event);"})
+    public boolean onTouchEventDelegate(MotionEvent event){
+        return false;
+    }
+
+    // Usually super.onTouchEvent is called within XWalkView.onTouchEvent override
+    // This is used as our default touch event handler.
     @Override
     @XWalkAPI
     public boolean onTouchEvent(MotionEvent event) {
-        if (mContent == null) return false;
-        checkThreadSafety();
-
         return mContent.onTouchEvent(event);
     }
 
@@ -1647,27 +1599,23 @@ public class XWalkViewInternal extends android.widget.FrameLayout
     public void onOverScrolledDelegate(int scrollX, int scrollY, boolean clampedX, boolean clampedY) {
     }
 
+    // Override XWalkView.setOnTouchListener to install the listener to ContentView
+    // therefore touch event intercept through onTouchListener is available on XWalkView.
     @Override
     @XWalkAPI
     public void setOnTouchListener(OnTouchListener l) {
-        if (mContent == null) return;
-        checkThreadSafety();
-        super.setOnTouchListener(l);
+        mContent.setOnTouchListener(l);
     }
 
     @Override
     @XWalkAPI
     public void scrollTo(int x, int y) {
-        if (mContent == null) return;
-        checkThreadSafety();
         mContent.scrollTo(x, y);
     }
 
     @Override
     @XWalkAPI
     public void scrollBy(int x, int y) {
-        if (mContent == null) return;
-        checkThreadSafety();
         mContent.scrollBy(x, y);
     }
 
@@ -1748,8 +1696,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
      */
     @XWalkAPI
     public int computeHorizontalScrollRange() {
-        if (mContent == null) return 0;
-        checkThreadSafety();
         return mContent.computeHorizontalScrollRange();
     }
 
@@ -1761,8 +1707,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
      */
     @XWalkAPI
     public int computeHorizontalScrollOffset() {
-        if (mContent == null) return 0;
-        checkThreadSafety();
         return mContent.computeHorizontalScrollOffset();
     }
 
@@ -1773,8 +1717,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
      */
     @XWalkAPI
     public int computeVerticalScrollRange() {
-        if (mContent == null) return 0;
-        checkThreadSafety();
         return mContent.computeVerticalScrollRange();
     }
 
@@ -1786,8 +1728,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
      */
     @XWalkAPI
     public int computeVerticalScrollOffset() {
-        if (mContent == null) return 0;
-        checkThreadSafety();
         return mContent.computeVerticalScrollOffset();
     }
 
@@ -1799,8 +1739,6 @@ public class XWalkViewInternal extends android.widget.FrameLayout
      */
     @XWalkAPI
     public int computeVerticalScrollExtent() {
-        if (mContent == null) return 0;
-        checkThreadSafety();
         return mContent.computeVerticalScrollExtent();
     }
 
@@ -1930,302 +1868,5 @@ public class XWalkViewInternal extends android.widget.FrameLayout
         checkThreadSafety();
         if (mContent == null) return null;
         return mContent.getCompositingSurfaceType();
-    }
-
-    @Override
-    protected void onAttachedToWindow() {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        super.onAttachedToWindow();
-        mContent.onAttachedToWindow();
-    }
-
-    @Override
-    protected void onDetachedFromWindow() {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        super.onDetachedFromWindow();
-        mContent.onDetachedFromWindow();
-    }
-
-    @Override
-    protected void onVisibilityChanged(View changedView, int visibility) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        super.onVisibilityChanged(changedView, visibility);
-        mContent.onVisibilityChanged(changedView, visibility);
-    }
-
-    @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        ContentViewClient client = mContent.getContentViewClient();
-
-        // Allow the ContentViewClient to override the ContentView's width.
-        int desiredWidthMeasureSpec = client.getDesiredWidthMeasureSpec();
-        if (MeasureSpec.getMode(desiredWidthMeasureSpec) != MeasureSpec.UNSPECIFIED) {
-            widthMeasureSpec = desiredWidthMeasureSpec;
-        }
-
-        // Allow the ContentViewClient to override the ContentView's height.
-        int desiredHeightMeasureSpec = client.getDesiredHeightMeasureSpec();
-        if (MeasureSpec.getMode(desiredHeightMeasureSpec) != MeasureSpec.UNSPECIFIED) {
-            heightMeasureSpec = desiredHeightMeasureSpec;
-        }
-
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-    }
-
-    @Override
-    protected void onSizeChanged(int w, int h, int ow, int oh) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        super.onSizeChanged(w, h, ow, oh);
-        mContent.onSizeChanged(w, h, ow, oh);
-    }
-
-    @Override
-    public void onScrollChanged(int l, int t, int oldl, int oldt) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        super.onScrollChanged(l, t, oldl, oldt);
-        onScrollChangedDelegate(l, t, oldl, oldt);
-
-        // To keep the same behaviour with WebView onOverScrolled API,
-        // call onOverScrolledDelegate here.
-        onOverScrolledDelegate(l, t, false, false);
-    }
-
-    @Override
-    protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
-        onFocusChangedDelegate(gainFocus, direction, previouslyFocusedRect);
-        mContent.onFocusChanged(gainFocus);
-    }
-
-    @Override
-    public void onWindowFocusChanged(boolean hasWindowFocus) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        super.onWindowFocusChanged(hasWindowFocus);
-        mContent.onWindowFocusChanged(hasWindowFocus);
-    }
-
-    @Override
-    public boolean performLongClick() {
-        checkThreadSafety();
-
-        return performLongClickDelegate();
-    }
-
-    @Override
-    public boolean onCheckIsTextEditor() {
-        if (mContent == null) return false;
-        checkThreadSafety();
-
-        return mContent.onCheckIsTextEditor();
-    }
-
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        if (mContent == null) return false;
-        checkThreadSafety();
-
-        return mContent.onKeyUp(keyCode, event);
-    }
-
-    @Override
-    public boolean dispatchKeyEventPreIme(KeyEvent event) {
-        if (mContent == null) return false;
-        checkThreadSafety();
-
-        return mContent.dispatchKeyEventPreIme(event);
-    }
-
-    /**
-     * Mouse move events are sent on hover enter, hover move and hover exit.
-     * They are sent on hover exit because sometimes it acts as both a hover
-     * move and hover exit.
-     */
-    @Override
-    public boolean onHoverEvent(MotionEvent event) {
-        if (mContent == null) return false;
-        checkThreadSafety();
-
-        boolean consumed = mContent.onHoverEvent(event);
-        if (!mContent.isTouchExplorationEnabled()) super.onHoverEvent(event);
-        return consumed;
-    }
-
-    @Override
-    public boolean onGenericMotionEvent(MotionEvent event) {
-        if (mContent == null) return false;
-        checkThreadSafety();
-
-        return mContent.onGenericMotionEvent(event);
-    }
-
-    @Override
-    protected void onConfigurationChanged(Configuration newConfig) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        mContent.onConfigurationChanged(newConfig);
-    }
-
-    /**
-     * Compute the horizontal extent of the horizontal scrollbar's thumb within the horizontal
-     * range. This value is used to compute the length of the thumb within the scrollbar's track.
-     * @return the horizontal extent of the scrollbar's thumb.
-     * @since 7.0
-     */
-    @Override
-    @XWalkAPI
-    public int computeHorizontalScrollExtent() {
-        if (mContent == null) return 0;
-        checkThreadSafety();
-
-        return mContent.computeHorizontalScrollExtent();
-    }
-
-    @Override
-    public boolean awakenScrollBars(int startDelay, boolean invalidate) {
-        if (mContent == null) return false;
-        checkThreadSafety();
-
-        return mContent.awakenScrollBars(startDelay, invalidate);
-    }
-
-    @Override
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
-    public boolean performAccessibilityAction(int action, Bundle arguments) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-            return false;
-        }
-        if (mContent == null) return false;
-        checkThreadSafety();
-
-        if (mContent.supportsAccessibilityAction(action)) {
-            return mContent.performAccessibilityAction(action, arguments);
-        }
-
-        return super.performAccessibilityAction(action, arguments);
-    }
-
-    @Override
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
-    public AccessibilityNodeProvider getAccessibilityNodeProvider() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-            return null;
-        }
-        if (mContent == null) return null;
-        checkThreadSafety();
-
-        AccessibilityNodeProvider provider = mContent.getAccessibilityNodeProvider();
-        if (provider != null) {
-            return provider;
-        } else {
-            return super.getAccessibilityNodeProvider();
-        }
-    }
-
-    @Override
-    @TargetApi(Build.VERSION_CODES.M)
-    public void onProvideVirtualStructure(final ViewStructure structure) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return;
-        }
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        mContent.onProvideVirtualStructure(structure);
-    }
-
-    // Start: Needed by ContentViewCore.InternalAccessDelegate.
-    @Override
-    public boolean super_onKeyUp(int keyCode, KeyEvent event) {
-        checkThreadSafety();
-
-        return super.onKeyUp(keyCode, event);
-    }
-
-    @Override
-    public boolean super_dispatchKeyEventPreIme(KeyEvent event) {
-        checkThreadSafety();
-
-        return super.dispatchKeyEventPreIme(event);
-    }
-
-    @Override
-    public boolean super_dispatchKeyEvent(KeyEvent event) {
-        checkThreadSafety();
-
-
-        return super.dispatchKeyEvent(event);
-    }
-
-    @Override
-    public boolean super_onGenericMotionEvent(MotionEvent event) {
-        checkThreadSafety();
-
-        return super.onGenericMotionEvent(event);
-    }
-
-    @Override
-    public void super_onConfigurationChanged(Configuration newConfig) {
-        checkThreadSafety();
-
-        super.onConfigurationChanged(newConfig);
-    }
-
-    @Override
-    public boolean awakenScrollBars() {
-        checkThreadSafety();
-
-        return super.awakenScrollBars();
-    }
-
-    @Override
-    public boolean super_awakenScrollBars(int startDelay, boolean invalidate) {
-        checkThreadSafety();
-
-        return super.awakenScrollBars(startDelay, invalidate);
-    }
-    // End: Needed by ContentViewCore.InternalAccessDelegate.
-
-    // Start: Needed by SmartClipProvider.
-    @Override
-    public void extractSmartClipData(int x, int y, int width, int height) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        mContent.extractSmartClipData(x, y, width, height);
-    }
-
-    @Override
-    public void setSmartClipResultHandler(final Handler resultHandler) {
-        if (mContent == null) return;
-        checkThreadSafety();
-
-        mContent.setSmartClipResultHandler(resultHandler);
-    }
-    // End: Needed by SmartClipProvider.
-
-    public ContentViewRenderView getContentViewRenderView() {
-        if (mContent == null) return null;
-        checkThreadSafety();
-
-        return mContent.getContentViewRenderView();
     }
 }

--- a/runtime/android/core_internal_shell/res/layout/testshell_activity.xml
+++ b/runtime/android/core_internal_shell/res/layout/testshell_activity.xml
@@ -50,8 +50,8 @@
             android:src="@android:drawable/ic_menu_rotate"
             android:scaleType="center" />
     </LinearLayout>
-    <FrameLayout android:id="@+id/view_container"
+    <org.xwalk.core.internal.XWalkViewInternal android:id="@+id/xwalkview"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-    </FrameLayout>
+    </org.xwalk.core.internal.XWalkViewInternal>
 </LinearLayout>

--- a/runtime/android/core_internal_shell/src/org/xwalk/core/internal/xwview/shell/XWalkViewInternalShellActivity.java
+++ b/runtime/android/core_internal_shell/src/org/xwalk/core/internal/xwview/shell/XWalkViewInternalShellActivity.java
@@ -21,13 +21,11 @@ import android.view.View.OnFocusChangeListener;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
-import android.widget.FrameLayout;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 
 import org.chromium.base.BaseSwitches;
 import org.chromium.base.CommandLine;
-import org.chromium.content.browser.ContentViewRenderView;
 import org.xwalk.core.internal.XWalkNavigationHistoryInternal;
 import org.xwalk.core.internal.XWalkPreferencesInternal;
 import org.xwalk.core.internal.XWalkResourceClientInternal;
@@ -72,22 +70,7 @@ public class XWalkViewInternalShellActivity extends Activity {
         waitForDebuggerIfNeeded();
 
         setContentView(R.layout.testshell_activity);
-        FrameLayout viewContainer = (FrameLayout) findViewById(R.id.view_container);
-        // For XWalkViewInternal shell, currently we can not put XWalkViewInternal in
-        // testshell_activity.xml directly, since the constructor
-        // 'XWalkViewInternal(Context context, AttributeSet attrs)' will be invoked,
-        // 'initXWalkContent(getContext(), animatable);' was moved out of this constructor,
-        // this will lead to XWalkContent could not be initialized.
-        mView = new XWalkViewInternal(this, this);
-        ContentViewRenderView renderView = mView.getContentViewRenderView();
-        if (renderView != null) {
-            viewContainer.addView((FrameLayout)renderView, new FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT));
-        }
-        viewContainer.addView((FrameLayout)mView, new FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT));
+        mView = (XWalkViewInternal) findViewById(R.id.xwalkview);
 
         XWalkPreferencesInternal.setValue(XWalkPreferencesInternal.REMOTE_DEBUGGING, true);
 

--- a/runtime/browser/android/xwalk_contents_client_bridge.cc
+++ b/runtime/browser/android/xwalk_contents_client_bridge.cc
@@ -97,7 +97,7 @@ XWalkContentsClientBridge::~XWalkContentsClientBridge() {
   if (obj.is_null())
     return;
   // Clear the weak reference from the java peer to the native object since
-  // it is possible that java object lifetime can exceed the XWalkContent.
+  // it is possible that java object lifetime can exceed the XWalkViewContents.
   Java_XWalkContentsClientBridge_setNativeContentsClientBridge(
       env, obj.obj(), 0);
 }

--- a/runtime/browser/android/xwalk_contents_client_bridge.h
+++ b/runtime/browser/android/xwalk_contents_client_bridge.h
@@ -37,7 +37,7 @@ namespace xwalk {
 
 // A class that handles the Java<->Native communication for the
 // XWalkContentsClient. XWalkContentsClientBridge is created and owned by
-// native XWalkContent class and it only has a weak reference to the
+// native XWalkViewContents class and it only has a weak reference to the
 // its Java peer. Since the Java XWalkContentsClientBridge can have
 // indirect refs from the Application (via callbacks) and so can outlive
 // XWalkView, this class notifies it before being destroyed and to nullify

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/RendererResponsivenessTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/RendererResponsivenessTest.java
@@ -5,7 +5,9 @@
 
 package org.xwalk.core.internal.xwview.test;
 
+import android.graphics.Bitmap;
 import android.test.suitebuilder.annotation.MediumTest;
+import android.util.Log;
 import android.test.TouchUtils;
 import android.test.InstrumentationTestCase;
 
@@ -14,6 +16,8 @@ import java.util.concurrent.TimeUnit;
 import org.chromium.content.browser.test.util.CallbackHelper;
 import org.chromium.base.test.util.DisabledTest;
 import org.chromium.base.test.util.Feature;
+import org.chromium.content.browser.ContentView;
+import org.chromium.content.browser.ContentViewCore;
 
 import org.xwalk.core.internal.XWalkClient;
 import org.xwalk.core.internal.XWalkViewInternal;

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
@@ -241,30 +241,7 @@ public class XWalkViewInternalTestBase
             @Override
             public void run() {
                 mXWalkViewInternal = new XWalkViewInternal(activity, activity);
-                // Create new FrameLayout as a container to add XWalkViewInternal and
-                // ContentViewRenderView, it is just for test case
-                // "OnShowOnHideCustomViewTest.testOnShowCustomViewAndPlayWithHtmlControl".
-                // The play button should be rendered above the video right in
-                // the middle of the custom view, if not, test case will be failed.
-                // But it still has the failure rate, maybe we need to disbale this test case.
-                FrameLayout layout = new FrameLayout(getActivity());
-                FrameLayout.LayoutParams layoutparams = new FrameLayout.LayoutParams(
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                        Gravity.CENTER_HORIZONTAL|Gravity.CENTER_VERTICAL);
-                layout.setLayoutParams(layoutparams);
-                layout.addView((FrameLayout)mXWalkViewInternal.getContentViewRenderView(),
-                        new FrameLayout.LayoutParams(
-                                FrameLayout.LayoutParams.MATCH_PARENT,
-                                FrameLayout.LayoutParams.MATCH_PARENT,
-                                Gravity.CENTER_HORIZONTAL|Gravity.CENTER_VERTICAL));
-                layout.addView((FrameLayout)mXWalkViewInternal, new FrameLayout.LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        Gravity.CENTER_HORIZONTAL|Gravity.CENTER_VERTICAL));
-                getActivity().addView(layout);
-                // getActivity().addView(mXWalkViewInternal.getContentViewRenderView());
-                // getActivity().addView(mXWalkViewInternal);
+                getActivity().addView(mXWalkViewInternal);
                 mXWalkViewInternal.setUIClient(new TestXWalkUIClientInternal());
                 mXWalkViewInternal.setResourceClient(new TestXWalkResourceClient());
             }
@@ -409,7 +386,6 @@ public class XWalkViewInternalTestBase
             @Override
             public void run() {
                 xWalkViewContainer.set(new XWalkViewInternal(context, getActivity()));
-                getActivity().addView(xWalkViewContainer.get().getContentViewRenderView());
                 getActivity().addView(xWalkViewContainer.get());
                 xWalkViewContainer.get().setUIClient(uiClient);
                 xWalkViewContainer.get().setResourceClient(resourceClient);


### PR DESCRIPTION
This reverts commit 9808ed4cf8bf9b35f312fb5b04fc16cdde692932, it caused
the compatibility in shared mode.
After refactor XWalkView, XWalkViewInternal and ContentViewRenderView
need to be added to XWalkView concurrently. If the older XWalkView was
used, ContentViewRenderView was not added, so leads to the black screen
issue.

Related=XWALK-7217
BUG=XWALK-7100