### PR TITLE
Change locale-path from "locales" to "locales/xwalk"

### DIFF
--- a/runtime/app/xwalk_main_delegate.cc
+++ b/runtime/app/xwalk_main_delegate.cc
@@ -19,6 +19,7 @@
 #include "xwalk/runtime/common/logging_xwalk.h"
 #include "xwalk/runtime/common/paths_mac.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
+#include "xwalk/runtime/common/xwalk_resource_delegate.h"
 #include "xwalk/runtime/renderer/xwalk_content_renderer_client.h"
 
 #if !defined(DISABLE_NACL) && defined(OS_LINUX)
@@ -116,7 +117,6 @@ void XWalkMainDelegate::ZygoteStarting(
 
 #endif  // defined(OS_POSIX) && !defined(OS_ANDROID)
 
-// static
 void XWalkMainDelegate::InitializeResourceBundle() {
   base::FilePath pak_file;
   base::FilePath pak_dir;
@@ -129,8 +129,10 @@ void XWalkMainDelegate::InitializeResourceBundle() {
 #endif
 
 #if !defined(OS_ANDROID)
+  resource_delegate_.reset(new XWalkResourceDelegate());
   ui::ResourceBundle::InitSharedInstanceWithLocale(
-      "en-US", nullptr, ui::ResourceBundle::DO_NOT_LOAD_COMMON_RESOURCES);
+      "en-US", resource_delegate_.get(),
+      ui::ResourceBundle::DO_NOT_LOAD_COMMON_RESOURCES);
   pak_file = pak_dir.Append(FILE_PATH_LITERAL("xwalk.pak"));
   ResourceBundle::GetSharedInstance().AddDataPackFromPath(
       pak_file, ui::SCALE_FACTOR_NONE);

--- a/runtime/app/xwalk_main_delegate.h
+++ b/runtime/app/xwalk_main_delegate.h
@@ -15,6 +15,7 @@
 namespace xwalk {
 
 class XWalkRunner;
+class XWalkResourceDelegate;
 
 class XWalkMainDelegate : public content::ContentMainDelegate {
  public:
@@ -35,12 +36,13 @@ class XWalkMainDelegate : public content::ContentMainDelegate {
   content::ContentBrowserClient* CreateContentBrowserClient() override;
   content::ContentRendererClient* CreateContentRendererClient() override;
 
-  static void InitializeResourceBundle();
-
  private:
+  void InitializeResourceBundle();
+
   std::unique_ptr<XWalkRunner> xwalk_runner_;
   std::unique_ptr<content::ContentRendererClient> renderer_client_;
   std::unique_ptr<content::ContentClient> content_client_;
+  std::unique_ptr<XWalkResourceDelegate> resource_delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkMainDelegate);
 };

--- a/runtime/common/xwalk_resource_delegate.cc
+++ b/runtime/common/xwalk_resource_delegate.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/common/xwalk_resource_delegate.h"
+
+#include "base/files/file_path.h"
+#include "base/path_service.h"
+#include "ui/gfx/image/image.h"
+
+namespace xwalk {
+
+XWalkResourceDelegate::XWalkResourceDelegate() {}
+
+XWalkResourceDelegate::~XWalkResourceDelegate() {}
+
+base::FilePath XWalkResourceDelegate::GetPathForResourcePack(
+    const base::FilePath& pack_path,
+    ui::ScaleFactor scale_factor) {
+  return pack_path;
+}
+
+base::FilePath XWalkResourceDelegate::GetPathForLocalePack(
+    const base::FilePath& pack_path,
+    const std::string& locale) {
+  base::FilePath product_dir;
+  if (!PathService::Get(base::DIR_MODULE, &product_dir)) {
+    NOTREACHED();
+  }
+  return product_dir.
+      Append(FILE_PATH_LITERAL("locales")).
+      Append(FILE_PATH_LITERAL("xwalk")).
+      AppendASCII(locale + ".pak");
+}
+
+gfx::Image XWalkResourceDelegate::GetImageNamed(int resource_id) {
+  return gfx::Image();
+}
+
+gfx::Image XWalkResourceDelegate::GetNativeImageNamed(int resource_id) {
+  return gfx::Image();
+}
+
+base::RefCountedStaticMemory* XWalkResourceDelegate::LoadDataResourceBytes(
+    int resource_id,
+    ui::ScaleFactor scale_factor) {
+  return nullptr;
+}
+
+bool XWalkResourceDelegate::GetRawDataResource(int resource_id,
+                                               ui::ScaleFactor scale_factor,
+                                               base::StringPiece* value) {
+  return false;
+}
+
+bool XWalkResourceDelegate::GetLocalizedString(int message_id,
+                                               base::string16* value) {
+  return false;
+}
+
+}  // namespace xwalk

--- a/runtime/common/xwalk_resource_delegate.h
+++ b/runtime/common/xwalk_resource_delegate.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_COMMON_XWALK_RESOURCE_DELEGATE_H_
+#define XWALK_RUNTIME_COMMON_XWALK_RESOURCE_DELEGATE_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "base/macros.h"
+#include "base/memory/ref_counted_memory.h"
+#include "ui/base/resource/resource_bundle.h"
+
+namespace base {
+class FilePath;
+}
+
+namespace gfx {
+class Image;
+}
+
+namespace xwalk {
+
+// In Chrome, the locales path is set as "locales/" which potentially conflicts
+// with it is in Crosswalk. So the purpose of XWalkResourceDelegate is to set
+// the locale pack path of Crosswalk as "locales/xwalk/".
+class XWalkResourceDelegate : public ui::ResourceBundle::Delegate {
+ public:
+  XWalkResourceDelegate();
+  ~XWalkResourceDelegate() override;
+
+  // ui:ResourceBundle::Delegate implementation:
+  base::FilePath GetPathForResourcePack(
+      const base::FilePath& pack_path,
+      ui::ScaleFactor scale_factor) override;
+  base::FilePath GetPathForLocalePack(
+      const base::FilePath& pack_path,
+      const std::string& locale) override;
+  gfx::Image GetImageNamed(int resource_id) override;
+  gfx::Image GetNativeImageNamed(int resource_id) override;
+  base::RefCountedStaticMemory* LoadDataResourceBytes(
+      int resource_id,
+      ui::ScaleFactor scale_factor) override;
+  bool GetRawDataResource(int resource_id,
+                          ui::ScaleFactor scale_factor,
+                          base::StringPiece* value) override;
+  bool GetLocalizedString(int message_id, base::string16* value) override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(XWalkResourceDelegate);
+};
+
+}  // namespace xwalk
+
+#endif  // XWALK_RUNTIME_COMMON_XWALK_RESOURCE_DELEGATE_H_

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -336,6 +336,8 @@
         'runtime/common/xwalk_localized_error.h',
         'runtime/common/xwalk_paths.cc',
         'runtime/common/xwalk_paths.h',
+        'runtime/common/xwalk_resource_delegate.cc',
+        'runtime/common/xwalk_resource_delegate.h',
         'runtime/common/xwalk_runtime_features.cc',
         'runtime/common/xwalk_runtime_features.h',
         'runtime/common/xwalk_switches.cc',
@@ -617,7 +619,12 @@
       'target_name': 'xwalk_strings',
       'type': 'none',
       'variables': {
-        'grit_out_dir': '<(SHARED_INTERMEDIATE_DIR)/xwalk/locales',
+        'grit_out_dir': '<(SHARED_INTERMEDIATE_DIR)/xwalk/locales/xwalk',
+      },
+      'direct_dependent_settings': {
+        'include_dirs': [
+          '<(SHARED_INTERMEDIATE_DIR)/xwalk/locales',
+        ],
       },
       'actions': [
         {
@@ -632,7 +639,7 @@
       ],
       'copies': [
         {
-          'destination': '<(PRODUCT_DIR)/',
+          'destination': '<(PRODUCT_DIR)/locales/',
           'files': [ '<(grit_out_dir)/' ],
         },
       ],

--- a/xwalk_win_zip.gypi
+++ b/xwalk_win_zip.gypi
@@ -3,7 +3,7 @@
     # The files and directories will be added with the same names to the
     # generated zip file, with <(PRODUCT_DIR)/ stripped from the beginning.
     'directories_to_package': [
-      '<(PRODUCT_DIR)/locales',
+      '<(PRODUCT_DIR)/locales/xwalk',
     ],
     'files_to_package': [
       '<(PRODUCT_DIR)/VERSION',


### PR DESCRIPTION
Both Crosswalk and Chrome they place the en-US.pak into folder
"locales" in build of Linux and windows. Potientially there is
conflicts, so it's better to set Crosswalk's locale-path as
"locales/xwalk".

Add a "xwalk_resource_delegate" class which indicates the right
locale pack file to load for Crosswalk.