### PR TITLE
[Android] Refine the default values of mUseWideViewport and mLoadWith…

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -94,8 +94,8 @@ public class XWalkSettingsInternal {
     private boolean mAppCacheEnabled = true;
     private boolean mDomStorageEnabled = true;
     private boolean mDatabaseEnabled = true;
-    private boolean mUseWideViewport = false;
-    private boolean mLoadWithOverviewMode = false;
+    private boolean mUseWideViewport = true;
+    private boolean mLoadWithOverviewMode = true;
     private boolean mMediaPlaybackRequiresUserGesture = false;
     private String mDefaultVideoPosterURL;
     private final boolean mPasswordEchoEnabled;


### PR DESCRIPTION
…OverviewMode

XWalk enable the wide viewport quirk in 2e9640b and implemented corresponding APIs
in ebfc438, and the default values of mUseWideViewport and mLoadWithOverviewMode were
set to false to keep the same with Android WebView.

However, XWalk has the different usage in H5 game development, it no need to require
developer set those valuse via APIs, and it's better to keep the same with Chromium
instead of WebView, so set the default values to true will have benefit and convenience.

BUG=XWALK-6995
BUG=XWALK-6963
BUG=XWALK-7051