### PR TITLE
AndroidStreamReaderURLRequestJob: Remove leftover DCHECK.

### DIFF
--- a/runtime/browser/android/net/android_stream_reader_url_request_job.cc
+++ b/runtime/browser/android/net/android_stream_reader_url_request_job.cc
@@ -287,10 +287,6 @@ bool AndroidStreamReaderURLRequestJob::GetMimeType(
   if (!input_stream_reader_wrapper_.get())
     return false;
 
-  // Since it's possible for this call to alter the InputStream a
-  // Seek or ReadRawData operation running in the background is not permitted.
-  DCHECK(!request_->status().is_io_pending());
-
   return delegate_->GetMimeType(
       env, request(), input_stream_reader_wrapper_->input_stream(), mime_type);
 }


### PR DESCRIPTION
This DCHECK should have been removed in commit e1f52c3 ("Roll Chromium
50.0.2661.102") to adapt to https://codereview.chromium.org/1563633002:
the upstream code was refactored and we need to follow the changes that
were done to android_webview's version of this file, otherwise a debug
build crashes at least whenever a media file is being played.