### PR TITLE
Clean up our OWNERS files.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,3 @@
 alexis.menard@intel.com
-caio.oliveira@intel.com
 kenneth.r.christiansen@intel.com
 raphael.kubo.da.costa@intel.com

--- a/app/OWNERS
+++ b/app/OWNERS
@@ -1,4 +1,2 @@
 halton.huo@intel.com
 lin.sun@intel.com
-shiliu.wang@intel.com
-yongsheng.zhu@intel.com

--- a/build/android/OWNERS
+++ b/build/android/OWNERS
@@ -1,7 +1,2 @@
-girish.ramakrishnan@intel.com
 halton.huo@intel.com
 lin.sun@intel.com
-shiliu.wang@intel.com
-shouqun.liu@intel.com
-xingnan.wang@intel.com
-yongsheng.zhu@intel.com

--- a/experimental/presentation/OWNERS
+++ b/experimental/presentation/OWNERS
@@ -1,1 +1,0 @@
-hongbo.min@intel.com

--- a/extensions/OWNERS
+++ b/extensions/OWNERS
@@ -1,3 +1,0 @@
-caio.oliveira@intel.com
-jesus.sanchez-palencia@intel.com
-thiago.santos@intel.com

--- a/runtime/android/OWNERS
+++ b/runtime/android/OWNERS
@@ -1,7 +1,2 @@
-girish.ramakrishnan@intel.com
 halton.huo@intel.com
 lin.sun@intel.com
-shiliu.wang@intel.com
-shouqun.liu@intel.com
-xingnan.wang@intel.com
-yongsheng.zhu@intel.com

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/OWNERS
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/OWNERS
@@ -1,1 +1,0 @@
-hongbo.min@intel.com

--- a/runtime/app/android/OWNERS
+++ b/runtime/app/android/OWNERS
@@ -1,7 +1,2 @@
-girish.ramakrishnan@intel.com
 halton.huo@intel.com
 lin.sun@intel.com
-shiliu.wang@intel.com
-shouqun.liu@intel.com
-xingnan.wang@intel.com
-yongsheng.zhu@intel.com

--- a/runtime/common/android/OWNERS
+++ b/runtime/common/android/OWNERS
@@ -1,7 +1,2 @@
-girish.ramakrishnan@intel.com
 halton.huo@intel.com
 lin.sun@intel.com
-shiliu.wang@intel.com
-shouqun.liu@intel.com
-xingnan.wang@intel.com
-yongsheng.zhu@intel.com

--- a/runtime/renderer/android/OWNERS
+++ b/runtime/renderer/android/OWNERS
@@ -1,7 +1,2 @@
-girish.ramakrishnan@intel.com
 halton.huo@intel.com
 lin.sun@intel.com
-shiliu.wang@intel.com
-shouqun.liu@intel.com
-xingnan.wang@intel.com
-yongsheng.zhu@intel.com

--- a/sysapps/OWNERS
+++ b/sysapps/OWNERS
@@ -1,1 +1,0 @@
-thiago.santos@intel.com

--- a/test/android/OWNERS
+++ b/test/android/OWNERS
@@ -1,4 +1,2 @@
 halton.huo@intel.com
 lin.sun@intel.com
-shiliu.wang@intel.com
-yongsheng.zhu@intel.com


### PR DESCRIPTION
Drop people who have not contributed to the Crosswalk Project in a long
time. When they were the sole OWNERS in a given directory, the file
itself was removed.