### PR TITLE
[Android] Stop passing -Wl,--no-fatal-warnings when linking libxwalkcore

### DIFF
--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -26,9 +26,6 @@
       'include_dirs': [
         '..',
       ],
-      'ldflags': [
-        '-Wl,--no-fatal-warnings',
-      ],
       'sources': [
         'runtime/app/android/xwalk_entry_point.cc',
         'runtime/app/android/xwalk_jni_registrar.cc',


### PR DESCRIPTION
This was added back in 2013 with commit dd2dbba7 ("[Android] Merge
initial files for native library (libxwalkcore) build") and is no longer
necessary.