### PR TITLE
DEPS.xwalk: Roll chromium-crosswalk (7e0c695..31733c8) and v8-crosswalk (edf5696..a91989e)

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -18,7 +18,7 @@
 # -----------------------------------
 
 chromium_crosswalk_rev = '31733c8a0c1274417f52d37b401cb60258e7d449'
-v8_crosswalk_rev = 'edf5696a198dc08fd3647910baf62ec71b6133a5'
+v8_crosswalk_rev = 'a91989e7fd7d36a35a2272a80b0138f8c59ec493'
 
 # We need our own copy of src/buildtools in order to have the gn and
 # clang-format binaries in a location that can be found automatically both by

--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,7 +17,7 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = '7e0c6957238b21de4b1a1a47b2ede4960f08a639'
+chromium_crosswalk_rev = '31733c8a0c1274417f52d37b401cb60258e7d449'
 v8_crosswalk_rev = 'edf5696a198dc08fd3647910baf62ec71b6133a5'
 
 # We need our own copy of src/buildtools in order to have the gn and


### PR DESCRIPTION
Roll our dependencies in order to be able to build Crosswalk with GN in M52. Most of the commits are backports from newer Chromium/V8 releases.

chromium-crosswalk:
* 31733c8 Merge pull request #378 from rakuco/v8-external-data-backport
* f3fb6c0 Merge pull request #375 from heke123/gn-linux-1
* bde5610 Preparation for adding GN build support in Crosswalk.
* 0908bc7 [Backport] gn: Remove unnecessary v8 defaults
* b5d9bfd Merge pull request #377 from rakuco/local-android-commits-gn
* 2462584 [Backport] GN: Set |enable_webvr| in the declare_args() block.
* 70c7fe9 [Android] Add ApplicationStatusManager.java to the GN build.
* b3d3e4d [Temp] Make |enable_webvr==false| work in GN.

v8-crosswalk:
* a91989e Merge pull request #164 from rakuco/backport-gn-fix
* d09d8a9 [Backport][gn] Turn on external_startup_data by default except on ios

RELATED BUG=XWALK-3674
RELATED BUG=XWALK-7180
