### PR TITLE
[Android] Crash when parent construct using child reflected method

### DIFF
--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -563,7 +563,7 @@ ${POST_BRIDGE_LINES}
     if return_is_internal:
       template = Template("""\
     public ${RETURN_TYPE} ${NAME}(${PARAMS}) {
-        if (${METHOD_DECLARE_NAME}.isNull()) {
+        if (${METHOD_DECLARE_NAME} == null || ${METHOD_DECLARE_NAME}.isNull()) {
             ${RETURN_SUPER}${NAME}Super(${PARAMS_PASSING_SUPER});
         } else {
             ${GENERIC_TYPE_DECLARE}${RETURN}coreBridge.getBridgeObject(\
@@ -581,7 +581,7 @@ ${PARAMS_PASSING});
     else :
       template = Template("""\
     public ${RETURN_TYPE} ${NAME}(${PARAMS}) {
-        if (${METHOD_DECLARE_NAME}.isNull()) {
+        if (${METHOD_DECLARE_NAME} == null || ${METHOD_DECLARE_NAME}.isNull()) {
             ${RETURN_SUPER}${NAME}Super(${PARAMS_PASSING_SUPER});
         } else {
             ${GENERIC_TYPE_DECLARE}${RETURN}${METHOD_DECLARE_NAME}.invoke(\


### PR DESCRIPTION
The order of constructing object is parent member variables => parent constructor => child member variables => child constructor, so it will be crash when parent constructor using child override reflected method.