### PR TITLE
Enable GN build for crosswalk-android.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -20,6 +20,24 @@ group("xwalk_builder") {
       ":xwalk_all_tests",
     ]
   }
+  if (is_android) {
+    deps += [
+      # For internal testing.
+      "app/android/runtime_client_embedded_shell:xwalk_runtime_client_embedded_shell_apk",
+      "app/android/runtime_client_shell:xwalk_runtime_client_shell_apk",
+      "runtime/android/core_internal_shell:xwalk_core_internal_shell_apk",
+      "runtime/android/core_shell:xwalk_core_shell_apk",
+      "test/android/core/javatests:xwalk_core_test_apk",
+      "test/android/core_internal/javatests:xwalk_core_internal_test_apk",
+      "test/android/runtime_client/javatests:xwalk_runtime_client_test_apk",
+      "test/android/runtime_client_embedded/javatests:xwalk_runtime_client_embedded_test_apk",
+
+      # For external testing.
+      "app/android/app_hello_world:xwalk_app_hello_world_apk",
+      "runtime/android/runtime_lib:xwalk_runtime_lib_apk",
+      "runtime/android/sample:xwalk_core_sample_apk",
+    ]
+  }
 }
 
 if (is_linux) {
@@ -363,14 +381,25 @@ source_set("xwalk_runtime") {
     "//xwalk/resources:xwalk_resources_100_percent_pak",
     "//xwalk/resources:xwalk_resources_200_percent_pak",
     "//xwalk/resources:xwalk_resources_300_percent_pak",
-    "//xwalk/resources:xwalk_strings",
     "//xwalk/sysapps",
     "//xwalk/sysapps:xwalk_sysapps_resources",
   ]
 
+  if (is_android) {
+    deps += [
+      "//components/cdm/browser",
+      "//xwalk/runtime/android/core_internal:xwalk_core_jar_jni",
+      "//xwalk/runtime/android/core_internal:xwalk_core_native_jni",
+    ]
+  } else {
+    deps += [
+      "//xwalk/resources:xwalk_locales",
+      "//xwalk/resources:xwalk_strings",
+    ]
+  }
+
   if (is_linux) {
     configs += [ "//xwalk/build/libnotify" ]
-    deps += [ "//xwalk/resources:xwalk_locales" ]
   }
 
   if (disable_bundled_extensions) {

--- a/app/android/app_hello_world/BUILD.gn
+++ b/app/android/app_hello_world/BUILD.gn
@@ -1,0 +1,35 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+android_apk("xwalk_app_hello_world_apk") {
+  apk_name = "XWalkAppHelloWorld"
+  android_manifest = "AndroidManifest.xml"
+  java_files = [ "src/org/xwalk/app/hello/world/HelloWorldActivity.java" ]
+  deps = [
+    ":xwalk_app_hello_world_apk_assets",
+    ":xwalk_app_hello_world_apk_resources",
+    "//xwalk/app/android/runtime_client:xwalk_app_runtime_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+  ]
+}
+
+android_resources("xwalk_app_hello_world_apk_resources") {
+  visibility = [ ":*" ]
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.app.hello.world"
+}
+
+android_assets("xwalk_app_hello_world_apk_assets") {
+  visibility = [ ":*" ]
+  renaming_sources = [
+    "//xwalk/test/android/data/index.html",
+    "//xwalk/test/android/data/sampapp-icon-helloworld.png",
+  ]
+  renaming_destinations = [
+    "www/index.html",
+    "www/sampapp-icon-helloworld.png",
+  ]
+}

--- a/app/android/app_template/BUILD.gn
+++ b/app/android/app_template/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+android_apk("xwalk_app_template_apk") {
+  apk_name = "XWalkAppTemplate"
+  android_manifest = "AndroidManifest.xml"
+  java_files = [ "src/org/xwalk/app/template/AppTemplateActivity.java" ]
+  deps = [
+    ":xwalk_app_template_apk_assets",
+    ":xwalk_app_template_apk_resources",
+    "//xwalk/app/android/runtime_client:xwalk_app_runtime_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+  ]
+}
+
+android_assets("xwalk_app_template_apk_assets") {
+  renaming_sources = [
+    "//xwalk/test/android/data/index.html",
+    "//xwalk/test/android/data/sampapp-icon-helloworld.png",
+  ]
+  renaming_destinations = [
+    "www/index.html",
+    "www/sampapp-icon-helloworld.png",
+  ]
+}
+
+android_resources("xwalk_app_template_apk_resources") {
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.app.template"
+}

--- a/app/android/runtime_client/BUILD.gn
+++ b/app/android/runtime_client/BUILD.gn
@@ -1,0 +1,20 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+android_library("xwalk_app_runtime_java") {
+  java_files = [
+    "//xwalk/app/android/runtime_activity/src/org/xwalk/app/XWalkRuntimeActivityBase.java",
+    "src/org/xwalk/app/runtime/extension/XWalkRuntimeExtensionLoader.java",
+    "src/org/xwalk/app/runtime/XWalkCoreProviderImpl.java",
+    "src/org/xwalk/app/runtime/XWalkRuntimeTestHelper.java",
+    "src/org/xwalk/app/runtime/XWalkRuntimeView.java",
+    "src/org/xwalk/app/runtime/XWalkRuntimeViewProvider.java",
+    "src/org/xwalk/app/runtime/XWalkRuntimeViewProviderFactory.java",
+  ]
+  deps = [
+    "//xwalk/runtime/android/core:xwalk_core_java",
+  ]
+}

--- a/app/android/runtime_client_embedded_shell/BUILD.gn
+++ b/app/android/runtime_client_embedded_shell/BUILD.gn
@@ -1,0 +1,107 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+import("//third_party/icu/config.gni")
+
+android_apk("xwalk_runtime_client_embedded_shell_apk") {
+  apk_name = "XWalkRuntimeClientEmbeddedShell"
+  android_manifest = "AndroidManifest.xml"
+  native_libs = [
+    "$root_out_dir/libxwalkdummy.so",
+    "$root_out_dir/libxwalkcore.so",
+    "$root_out_dir/libecho_extension.so",
+  ]
+  deps = [
+    ":xwalk_runtime_client_embedded_shell_apk_assets",
+    ":xwalk_runtime_client_embedded_shell_apk_java",
+    ":xwalk_runtime_client_embedded_shell_apk_pak",
+    ":xwalk_runtime_client_embedded_shell_apk_resources",
+    "//base:base_java",
+    "//xwalk/extensions/test:echo_extension",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
+    "//xwalk/runtime/android/dummy_lib:libxwalkdummy",
+    "//xwalk/runtime/app/android:libxwalkcore",
+  ]
+}
+
+android_library("xwalk_runtime_client_embedded_shell_apk_java") {
+  java_files = [ "src/org/xwalk/runtime/client/embedded/shell/XWalkRuntimeClientEmbeddedShellActivity.java" ]
+  deps = [
+    ":xwalk_runtime_client_embedded_shell_apk_resources",
+    "//base:base_java",
+    "//content/public/android:content_java",
+    "//xwalk/app/android/runtime_client:xwalk_app_runtime_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+  ]
+}
+
+android_assets("xwalk_runtime_client_embedded_shell_apk_pak") {
+  sources = [
+    "$root_out_dir/xwalk.pak",
+    "$root_out_dir/xwalk_100_percent.pak",
+  ]
+  deps = [
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+  ]
+  if (icu_use_data_file) {
+    sources += [ "$root_out_dir/icudtl.dat" ]
+    deps += [ "//third_party/icu:icudata" ]
+  }
+  if (v8_use_external_startup_data) {
+    sources += [
+      "$root_out_dir/natives_blob.bin",
+      "$root_out_dir/snapshot_blob.bin",
+    ]
+  }
+  disable_compression = true
+}
+
+android_assets("xwalk_runtime_client_embedded_shell_apk_assets") {
+  sources = []
+  deps = [
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+  ]
+  if (icu_use_data_file) {
+    sources += [ "$root_out_dir/icudtl.dat" ]
+    deps += [ "//third_party/icu:icudata" ]
+  }
+  renaming_sources = [
+    "//xwalk/test/android/data/manifest.json",
+    "//xwalk/test/android/data/index.html",
+    "//xwalk/test/android/data/sampapp-icon-helloworld.png",
+    "//xwalk/test/android/data/myextension/myextension.js",
+    "//xwalk/test/android/data/myextension/myextension.json",
+    "//xwalk/experimental/launch_screen/launch_screen_api.js",
+    "//xwalk/experimental/wifidirect/wifidirect_api.js",
+    "//xwalk/test/android/data/www/manifest_self.json",
+    "//xwalk/test/android/data/www/manifest_inline_script.json",
+    "//xwalk/test/android/data/www/cross_origin.html",
+    "//xwalk/test/android/data/www/csp.html",
+    "//xwalk/test/android/data/www/manifest_without_xwalk_hosts.json",
+    "//xwalk/test/android/data/www/manifest_xwalk_hosts.json",
+  ]
+  renaming_destinations = [
+    "manifest.json",
+    "index.html",
+    "sampapp-icon-helloworld.png",
+    "xwalk-extensions/myextension/myextension.js",
+    "xwalk-extensions/myextension/myextension.json",
+    "jsapi/launch_screen_api.js",
+    "jsapi/wifidirect_api.js",
+    "www/manifest_self.json",
+    "www/manifest_inline_script.json",
+    "www/cross_origin.html",
+    "www/csp.html",
+    "www/manifest_without_xwalk_hosts.json",
+    "www/manifest_xwalk_hosts.json",
+  ]
+}
+
+android_resources("xwalk_runtime_client_embedded_shell_apk_resources") {
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.runtime.client.embedded.shell"
+}

--- a/app/android/runtime_client_shell/BUILD.gn
+++ b/app/android/runtime_client_shell/BUILD.gn
@@ -1,0 +1,65 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+android_apk("xwalk_runtime_client_shell_apk") {
+  apk_name = "XWalkRuntimeClientShell"
+  android_manifest = "AndroidManifest.xml"
+  native_libs = [
+    "$root_out_dir/libecho_extension.so",
+    "$root_out_dir/libxwalkdummy.so",
+  ]
+  deps = [
+    ":xwalk_runtime_client_shell_apk_assets",
+    ":xwalk_runtime_client_shell_apk_java",
+    ":xwalk_runtime_client_shell_apk_resources",
+    "//base:base_java",
+    "//xwalk/extensions/test:echo_extension",
+    "//xwalk/runtime/android/dummy_lib:libxwalkdummy",
+  ]
+}
+
+android_library("xwalk_runtime_client_shell_apk_java") {
+  java_files = [ "src/org/xwalk/runtime/client/shell/XWalkRuntimeClientShellActivity.java" ]
+  deps = [
+    ":xwalk_runtime_client_shell_apk_resources",
+    "//xwalk/app/android/runtime_client:xwalk_app_runtime_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+  ]
+}
+
+android_assets("xwalk_runtime_client_shell_apk_assets") {
+  renaming_sources = [
+    "//xwalk/test/android/data/www/manifest_self.json",
+    "//xwalk/test/android/data/www/manifest_inline_script.json",
+    "//xwalk/test/android/data/www/cross_origin.html",
+    "//xwalk/test/android/data/www/csp.html",
+    "//xwalk/test/android/data/www/manifest_without_xwalk_hosts.json",
+    "//xwalk/test/android/data/www/manifest_xwalk_hosts.json",
+    "//xwalk/test/android/data/manifest.json",
+    "//xwalk/test/android/data/index.html",
+    "//xwalk/test/android/data/sampapp-icon-helloworld.png",
+    "//xwalk/test/android/data/myextension/myextension.js",
+    "//xwalk/test/android/data/myextension/myextension.json",
+  ]
+  renaming_destinations = [
+    "www/manifest_self.json",
+    "www/manifest_inline_script.json",
+    "www/cross_origin.html",
+    "www/csp.html",
+    "www/manifest_without_xwalk_hosts.json",
+    "www/manifest_xwalk_hosts.json",
+    "manifest.json",
+    "index.html",
+    "sampapp-icon-helloworld.png",
+    "xwalk-extensions/myextension/myextension.js",
+    "xwalk-extensions/myextension/myextension.json",
+  ]
+}
+
+android_resources("xwalk_runtime_client_shell_apk_resources") {
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.runtime.client.shell"
+}

--- a/build/android.gni
+++ b/build/android.gni
@@ -1,0 +1,25 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file contains feature flags for Crosswalk Android build. Users should
+# import it into their build folder by run:
+#   echo 'import("//xwalk/build/android.gni")' > out/your_dir/args.gn'
+# Add your build args in file args.gn like: target_os = "android"
+# See more in "https://chromium.googlesource.com/chromium/src/+/master/docs/
+# android_build_instructions.md"
+# Then run:
+#   gn gen out/your_dir
+#   ninja -C out/your_dir xwalk_builder
+# to generate Android Apks of Crosswalk.
+
+import("//xwalk/build/common.gni")
+
+# Make release builds smaller by omitting stack unwind support for backtrace()
+# TODO(rakuco): determine if we only want this in official builds.
+# From //build/config/compiler/BUILD.gn
+exclude_unwind_tables = true
+
+# Temporarily disable use of external snapshot files (XWALK-3516).
+# From //build_overrides/v8.gni
+v8_use_external_startup_data = false

--- a/build/version.gni
+++ b/build/version.gni
@@ -46,3 +46,32 @@ _result = exec_script("//build/util/version.py",
                       "scope",
                       [ xwalk_version_file ])
 xwalk_version = _result.full
+
+if (is_android) {
+  import("//build/config/android/config.gni")
+
+  # Get xwalk API version
+  _xwalk_api_version_template = "api = \"@API@\" min_api = \"@MIN_API@\""
+  xwalk_api_version_file = "//xwalk/API_VERSION"
+  _result = exec_script("//build/util/version.py",
+                        [
+                          "-f",
+                          rebase_path(xwalk_api_version_file, root_build_dir),
+                          "-t",
+                          _xwalk_api_version_template,
+                        ],
+                        "scope",
+                        [ xwalk_api_version_file ])
+  api_version = _result.api
+  min_api_version = _result.min_api
+
+  # Get xwalk_version_code
+  _result = exec_script("//xwalk/build/android/generate_version_code.py",
+                        [
+                          "--abi-name=$android_app_abi",
+                          "--version=$xwalk_version",
+                        ],
+                        "trim string",
+                        [ xwalk_version_file ])
+  xwalk_version_code = _result
+}

--- a/build/xwalk.gni
+++ b/build/xwalk.gni
@@ -7,4 +7,13 @@ declare_args() {
   # Whether to build and use Crosswalk's internal extensions (device
   # capabilities, sysapps etc).
   disable_bundled_extensions = false
+
+  # Android: whether the integrity of the Crosswalk runtime library should
+  # be verified when Crosswalk is run in shared mode.
+  verify_xwalk_apk = false
+
+  # Name of Crosswalk Maven artifacts used to generate their respective POM
+  # files.
+  xwalk_core_library_artifact_id = "xwalk_core_library_canary"
+  xwalk_shared_library_artifact_id = "xwalk_shared_library_canary"
 }

--- a/extensions/BUILD.gn
+++ b/extensions/BUILD.gn
@@ -14,10 +14,6 @@ source_set("extensions") {
     "browser/xwalk_extension_process_host.h",
     "browser/xwalk_extension_service.cc",
     "browser/xwalk_extension_service.h",
-    "common/android/xwalk_extension_android.cc",
-    "common/android/xwalk_extension_android.h",
-    "common/android/xwalk_native_extension_loader_android.cc",
-    "common/android/xwalk_native_extension_loader_android.h",
     "common/xwalk_extension.cc",
     "common/xwalk_extension.h",
     "common/xwalk_extension_messages.cc",
@@ -67,6 +63,15 @@ source_set("extensions") {
     "//url",
     "//v8",
   ]
+  if (is_android) {
+    sources += [
+      "common/android/xwalk_extension_android.cc",
+      "common/android/xwalk_extension_android.h",
+      "common/android/xwalk_native_extension_loader_android.cc",
+      "common/android/xwalk_native_extension_loader_android.h",
+    ]
+    deps += [ "//xwalk/extensions/android:xwalk_core_extensions_native_jni" ]
+  }
 }
 
 # TODO(heke123): Remove this config by putting the files in the right place

--- a/extensions/android/BUILD.gn
+++ b/extensions/android/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+android_library("xwalk_core_extensions_java") {
+  deps = [
+    "//base:base_java",
+    "//content/public/android:content_java",
+  ]
+  java_files = [
+    "java/src/org/xwalk/core/internal/extensions/XWalkExtensionAndroid.java",
+    "java/src/org/xwalk/core/internal/extensions/XWalkNativeExtensionLoaderAndroid.java",
+  ]
+}
+
+generate_jni("xwalk_core_extensions_native_jni") {
+  jni_package = "xwalk"
+  sources = [
+    "java/src/org/xwalk/core/internal/extensions/XWalkExtensionAndroid.java",
+    "java/src/org/xwalk/core/internal/extensions/XWalkNativeExtensionLoaderAndroid.java",
+  ]
+}

--- a/extensions/test/BUILD.gn
+++ b/extensions/test/BUILD.gn
@@ -101,11 +101,23 @@ action("generate_jsapi_extensions_test") {
 }
 
 loadable_module("echo_extension") {
-  visibility = [ ":*" ]
+  visibility = [
+    ":*",
+
+    # These test Android targets also package this library.
+    "//xwalk/app/android/runtime_client_shell:*",
+    "//xwalk/app/android/runtime_client_embedded_shell:*",
+  ]
   sources = [
     "echo_extension.c",
   ]
-  output_dir = "$root_out_dir/tests/extension/echo_extension"
+
+  # This library is used as in |native_libs| in the Android targets mentioned
+  # above, and as of M52 these libraries are required to be in $root_out_dir.
+  # TODO(heke123): Check if we can get rid of this once we move to M53.
+  if (!is_android) {
+    output_dir = "$root_out_dir/tests/extension/echo_extension"
+  }
 }
 
 loadable_module("echo_extension_messaging_2") {

--- a/resources/BUILD.gn
+++ b/resources/BUILD.gn
@@ -37,7 +37,7 @@ repack("xwalk_pak") {
     "//xwalk/extensions:xwalk_extensions_resources",
     "//xwalk/sysapps:xwalk_sysapps_resources",
   ]
-  if (is_linux) {
+  if (!is_android) {
     sources += [
       "$root_gen_dir/blink/devtools_resources.pak",
       "$root_gen_dir/components/strings/components_strings_en-US.pak",

--- a/runtime/android/core/BUILD.gn
+++ b/runtime/android/core/BUILD.gn
@@ -1,0 +1,64 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+android_library("xwalk_core_java") {
+  deps = [
+    ":xwalk_core_java_resources",
+    "//xwalk/runtime/android/core_internal:xwalk_core_reflection_layer_java_gen",
+    "//xwalk/third_party/lzma_sdk:lzma_sdk_java",
+  ]
+  srcjars =
+      [ "$root_gen_dir/xwalk_core_reflection_layer/wrapper/wrapper.srcjar" ]
+  java_files = [
+    "src/org/xwalk/core/extension/BindingObject.java",
+    "src/org/xwalk/core/extension/BindingObjectAutoJS.java",
+    "src/org/xwalk/core/extension/BindingObjectStore.java",
+    "src/org/xwalk/core/extension/EventTarget.java",
+    "src/org/xwalk/core/extension/ExtensionInstanceHelper.java",
+    "src/org/xwalk/core/extension/JsApi.java",
+    "src/org/xwalk/core/extension/JsConstructor.java",
+    "src/org/xwalk/core/extension/JsContextInfo.java",
+    "src/org/xwalk/core/extension/JsStubGenerator.java",
+    "src/org/xwalk/core/extension/MessageHandler.java",
+    "src/org/xwalk/core/extension/MessageInfo.java",
+    "src/org/xwalk/core/extension/ReflectionHelper.java",
+    "src/org/xwalk/core/extension/XWalkCoreExtensionBridge.java",
+    "src/org/xwalk/core/extension/XWalkExtensionContextClient.java",
+    "src/org/xwalk/core/extension/XWalkExternalExtension.java",
+    "src/org/xwalk/core/extension/XWalkExternalExtensionBridge.java",
+    "src/org/xwalk/core/extension/XWalkExternalExtensionBridgeFactory.java",
+    "src/org/xwalk/core/extension/XWalkExternalExtensionManagerImpl.java",
+    "src/org/xwalk/core/JavascriptInterface.java",
+    "src/org/xwalk/core/XWalkActivity.java",
+    "src/org/xwalk/core/XWalkActivityDelegate.java",
+    "src/org/xwalk/core/XWalkApplication.java",
+    "src/org/xwalk/core/XWalkEnvironment.java",
+    "src/org/xwalk/core/XWalkFileChooser.java",
+    "src/org/xwalk/core/XWalkCoreWrapper.java",
+    "src/org/xwalk/core/XWalkDialogManager.java",
+    "src/org/xwalk/core/XWalkInitializer.java",
+    "src/org/xwalk/core/XWalkDecompressor.java",
+    "src/org/xwalk/core/XWalkLibraryInterface.java",
+    "src/org/xwalk/core/XWalkLibraryLoader.java",
+    "src/org/xwalk/core/XWalkMixedResources.java",
+    "src/org/xwalk/core/XWalkUpdater.java",
+  ]
+}
+
+android_resources("xwalk_core_java_resources") {
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.core"
+  deps = [
+    ":xwalk_app_strings",
+  ]
+}
+
+java_strings_grd("xwalk_app_strings") {
+  grd_file = "strings/xwalk_app_strings.grd"
+  outputs = [
+    "values/xwalk_app_strings.xml",
+  ]
+}

--- a/runtime/android/core_internal/BUILD.gn
+++ b/runtime/android/core_internal/BUILD.gn
@@ -1,0 +1,175 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+import("//xwalk/build/version.gni")
+import("//xwalk/build/xwalk.gni")
+
+reflection_gen_dir = "$root_gen_dir/xwalk_core_reflection_layer/"
+android_library("xwalk_core_internal_java") {
+  deps = [
+    ":xwalk_core_internal_java_resources",
+    ":xwalk_core_reflection_layer_java_gen",
+    "//base:base_java",
+    "//components/navigation_interception/android:navigation_interception_java",
+    "//components/web_contents_delegate_android:web_contents_delegate_android_java",
+    "//content/public/android:content_java",
+    "//media/base/android:media_java",
+    "//net/android:net_java",
+    "//ui/android:ui_java",
+    "//xwalk/extensions/android:xwalk_core_extensions_java",
+  ]
+  srcjars = [ "$reflection_gen_dir/bridge/bridge.srcjar" ]
+  java_files = [
+    "src/org/xwalk/core/internal/AndroidProtocolHandler.java",
+    "src/org/xwalk/core/internal/ClientCertLookupTable.java",
+    "src/org/xwalk/core/internal/ClientCertRequestHandlerInternal.java",
+    "src/org/xwalk/core/internal/ClientCertRequestInternal.java",
+    "src/org/xwalk/core/internal/CustomViewCallbackHandlerInternal.java",
+    "src/org/xwalk/core/internal/CustomViewCallbackInternal.java",
+    "src/org/xwalk/core/internal/ErrorCodeConversionHelper.java",
+    "src/org/xwalk/core/internal/InMemorySharedPreferences.java",
+    "src/org/xwalk/core/internal/MixedContext.java",
+    "src/org/xwalk/core/internal/PageLoadListener.java",
+    "src/org/xwalk/core/internal/ReflectConstructor.java",
+    "src/org/xwalk/core/internal/ReflectField.java",
+    "src/org/xwalk/core/internal/ReflectMethod.java",
+    "src/org/xwalk/core/internal/SslUtil.java",
+    "src/org/xwalk/core/internal/UrlUtilities.java",
+    "src/org/xwalk/core/internal/XWalkAPI.java",
+    "src/org/xwalk/core/internal/XWalkAutofillClientAndroid.java",
+    "src/org/xwalk/core/internal/XWalkClient.java",
+    "src/org/xwalk/core/internal/XWalkContent.java",
+    "src/org/xwalk/core/internal/XWalkContentLifecycleNotifier.java",
+    "src/org/xwalk/core/internal/XWalkContentVideoViewClient.java",
+    "src/org/xwalk/core/internal/XWalkContentView.java",
+    "src/org/xwalk/core/internal/XWalkContentsClient.java",
+    "src/org/xwalk/core/internal/XWalkContentsClientBridge.java",
+    "src/org/xwalk/core/internal/XWalkContentsClientCallbackHelper.java",
+    "src/org/xwalk/core/internal/XWalkContentsIoThreadClient.java",
+    "src/org/xwalk/core/internal/XWalkCookieManagerInternal.java",
+    "src/org/xwalk/core/internal/XWalkCoreBridge.java",
+    "src/org/xwalk/core/internal/XWalkDevToolsServer.java",
+    "src/org/xwalk/core/internal/XWalkDownloadListenerImpl.java",
+    "src/org/xwalk/core/internal/XWalkDownloadListenerInternal.java",
+    "src/org/xwalk/core/internal/XWalkExtensionInternal.java",
+    "src/org/xwalk/core/internal/XWalkExternalExtensionManagerInternal.java",
+    "src/org/xwalk/core/internal/XWalkFindListenerInternal.java",
+    "src/org/xwalk/core/internal/XWalkGeolocationPermissions.java",
+    "src/org/xwalk/core/internal/XWalkGetBitmapCallbackInternal.java",
+    "src/org/xwalk/core/internal/XWalkHitTestResultInternal.java",
+    "src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java",
+    "src/org/xwalk/core/internal/XWalkHttpAuthInternal.java",
+    "src/org/xwalk/core/internal/XWalkInternalResources.java",
+    "src/org/xwalk/core/internal/XWalkJavascriptResultHandlerInternal.java",
+    "src/org/xwalk/core/internal/XWalkJavascriptResultInternal.java",
+    "src/org/xwalk/core/internal/XWalkLaunchScreenManager.java",
+    "src/org/xwalk/core/internal/XWalkMediaPlayerResourceLoadingFilter.java",
+    "src/org/xwalk/core/internal/XWalkNativeExtensionLoaderInternal.java",
+    "src/org/xwalk/core/internal/XWalkNavigationHandler.java",
+    "src/org/xwalk/core/internal/XWalkNavigationHandlerImpl.java",
+    "src/org/xwalk/core/internal/XWalkNavigationHistoryInternal.java",
+    "src/org/xwalk/core/internal/XWalkNavigationItemInternal.java",
+    "src/org/xwalk/core/internal/XWalkNotificationService.java",
+    "src/org/xwalk/core/internal/XWalkNotificationServiceImpl.java",
+    "src/org/xwalk/core/internal/XWalkPathHelper.java",
+    "src/org/xwalk/core/internal/XWalkPreferencesInternal.java",
+    "src/org/xwalk/core/internal/XWalkPresentationHost.java",
+    "src/org/xwalk/core/internal/XWalkResourceClientInternal.java",
+    "src/org/xwalk/core/internal/XWalkSettingsInternal.java",
+    "src/org/xwalk/core/internal/XWalkSwitches.java",
+    "src/org/xwalk/core/internal/XWalkUIClientInternal.java",
+    "src/org/xwalk/core/internal/XWalkViewDelegate.java",
+    "src/org/xwalk/core/internal/XWalkViewInternal.java",
+    "src/org/xwalk/core/internal/XWalkWebChromeClient.java",
+    "src/org/xwalk/core/internal/XWalkWebContentsDelegate.java",
+    "src/org/xwalk/core/internal/XWalkWebContentsDelegateAdapter.java",
+    "src/org/xwalk/core/internal/XWalkWebResourceRequestHandlerInternal.java",
+    "src/org/xwalk/core/internal/XWalkWebResourceRequestInternal.java",
+    "src/org/xwalk/core/internal/XWalkWebResourceResponseInternal.java",
+    "src/org/xwalk/core/internal/extension/BuiltinXWalkExtensions.java",
+    "src/org/xwalk/core/internal/extension/XWalkExtensionWithActivityStateListener.java",
+    "src/org/xwalk/core/internal/extension/api/launchscreen/LaunchScreenExtension.java",
+    "src/org/xwalk/core/internal/extension/api/presentation/PresentationExtension.java",
+    "src/org/xwalk/core/internal/extension/api/presentation/PresentationView.java",
+    "src/org/xwalk/core/internal/extension/api/presentation/PresentationViewJBMR1.java",
+    "src/org/xwalk/core/internal/extension/api/presentation/PresentationViewNull.java",
+    "src/org/xwalk/core/internal/extension/api/presentation/XWalkPresentationContent.java",
+    "src/org/xwalk/core/internal/extension/api/wifidirect/WifiDirect.java",
+    "src/org/xwalk/core/internal/extension/api/DisplayManagerJBMR1.java",
+    "src/org/xwalk/core/internal/extension/api/DisplayManagerNull.java",
+    "src/org/xwalk/core/internal/extension/api/XWalkDisplayManager.java",
+  ]
+}
+
+java_strings_grd("xwalk_core_strings") {
+  grd_file = "strings/android_xwalk_strings.grd"
+  outputs = [
+    "values/android_xwalk_strings.xml",
+  ]
+}
+
+android_resources("xwalk_core_internal_java_resources") {
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.core.internal"
+  deps = [
+    ":xwalk_core_strings",
+  ]
+}
+
+action("xwalk_core_reflection_layer_java_gen") {
+  script = "//xwalk/tools/reflection_generator/reflection_generator.py"
+  args = [
+    "--input-dir",
+    rebase_path("src/org/xwalk/core/internal/"),
+    "--template-dir",
+    rebase_path("//xwalk/runtime/android/templates/"),
+    "--bridge-output",
+    rebase_path("$reflection_gen_dir/bridge/"),
+    "--wrapper-output",
+    rebase_path("$reflection_gen_dir/wrapper/"),
+    "--use-srcjars",
+    "--stamp",
+    rebase_path("$reflection_gen_dir/gen.timestamp"),
+    "--api-version",
+    api_version,
+    "--min-api-version",
+    min_api_version,
+    "--xwalk-build-version",
+    xwalk_version,
+  ]
+  if (verify_xwalk_apk) {
+    args += [ "--verify-xwalk-apk" ]
+  }
+  outputs = [
+    "$reflection_gen_dir/bridge/bridge.srcjar",
+    "$reflection_gen_dir/wrapper/wrapper.srcjar",
+  ]
+}
+
+generate_jni("xwalk_core_native_jni") {
+  jni_package = "xwalk"
+  sources = [
+    "src/org/xwalk/core/internal/AndroidProtocolHandler.java",
+    "src/org/xwalk/core/internal/XWalkAutofillClientAndroid.java",
+    "src/org/xwalk/core/internal/XWalkContent.java",
+    "src/org/xwalk/core/internal/XWalkContentLifecycleNotifier.java",
+    "src/org/xwalk/core/internal/XWalkContentsClientBridge.java",
+    "src/org/xwalk/core/internal/XWalkContentsIoThreadClient.java",
+    "src/org/xwalk/core/internal/XWalkCookieManagerInternal.java",
+    "src/org/xwalk/core/internal/XWalkDevToolsServer.java",
+    "src/org/xwalk/core/internal/XWalkHttpAuthHandlerInternal.java",
+    "src/org/xwalk/core/internal/XWalkPathHelper.java",
+    "src/org/xwalk/core/internal/XWalkPresentationHost.java",
+    "src/org/xwalk/core/internal/XWalkSettingsInternal.java",
+    "src/org/xwalk/core/internal/XWalkViewDelegate.java",
+    "src/org/xwalk/core/internal/XWalkWebContentsDelegate.java",
+    "src/org/xwalk/core/internal/XWalkWebResourceResponseInternal.java",
+  ]
+}
+
+generate_jar_jni("xwalk_core_jar_jni") {
+  jni_package = "xwalk"
+  classes = [ "java/io/InputStream.class" ]
+}

--- a/runtime/android/core_internal_shell/BUILD.gn
+++ b/runtime/android/core_internal_shell/BUILD.gn
@@ -1,0 +1,73 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+import("//third_party/icu/config.gni")
+
+android_apk("xwalk_core_internal_shell_apk") {
+  apk_name = "XWalkCoreInternalShell"
+  android_manifest = "AndroidManifest.xml"
+  native_libs = [ "$root_out_dir/libxwalkcore.so" ]
+  deps = [
+    ":xwalk_core_internal_shell_apk_assets",
+    ":xwalk_core_internal_shell_apk_java",
+    ":xwalk_core_internal_shell_apk_pak",
+    ":xwalk_core_internal_shell_apk_resources",
+    "//base:base_java",
+    "//xwalk/runtime/app/android:libxwalkcore",
+  ]
+}
+
+android_library("xwalk_core_internal_shell_apk_java") {
+  java_files = [
+    "src/org/xwalk/core/internal/xwview/shell/XWalkViewInternalShellActivity.java",
+    "src/org/xwalk/core/internal/xwview/test/TestContentProvider.java",
+    "src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestRunnerActivity.java",
+  ]
+  deps = [
+    ":xwalk_core_internal_shell_apk_resources",
+    "//base:base_java",
+    "//xwalk/extensions/android:xwalk_core_extensions_java",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
+  ]
+}
+
+android_assets("xwalk_core_internal_shell_apk_assets") {
+  visibility = [ ":*" ]
+  renaming_sources = [ "//xwalk/test/android/data/index.html" ]
+  renaming_destinations = [ "www/index.html" ]
+  deps = [
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+  ]
+}
+
+android_assets("xwalk_core_internal_shell_apk_pak") {
+  visibility = [ ":*" ]
+  sources = [
+    "$root_out_dir/xwalk.pak",
+    "$root_out_dir/xwalk_100_percent.pak",
+  ]
+  deps = [
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+  ]
+  if (icu_use_data_file) {
+    sources += [ "$root_out_dir/icudtl.dat" ]
+    deps += [ "//third_party/icu:icudata" ]
+  }
+  if (v8_use_external_startup_data) {
+    sources += [
+      "$root_out_dir/natives_blob.bin",
+      "$root_out_dir/snapshot_blob.bin",
+    ]
+  }
+  disable_compression = true
+}
+
+android_resources("xwalk_core_internal_shell_apk_resources") {
+  visibility = [ ":*" ]
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.core.internal.xwview.shell"
+}

--- a/runtime/android/core_shell/BUILD.gn
+++ b/runtime/android/core_shell/BUILD.gn
@@ -1,0 +1,100 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+import("//third_party/icu/config.gni")
+
+android_apk("xwalk_core_shell_apk") {
+  apk_name = "XWalkCoreShell"
+  android_manifest = "AndroidManifest.xml"
+  native_libs = [
+    "$root_out_dir/libxwalkcore.so",
+    "$root_out_dir/libxwalkdummy.so",
+  ]
+  deps = [
+    ":xwalk_core_shell_apk_assets",
+    ":xwalk_core_shell_apk_java",
+    ":xwalk_core_shell_apk_pak",
+    ":xwalk_core_shell_apk_resources",
+    "//base:base_java",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
+    "//xwalk/runtime/android/dummy_lib:libxwalkdummy",
+    "//xwalk/runtime/app/android:libxwalkcore",
+  ]
+}
+
+android_library("xwalk_core_shell_apk_java") {
+  java_files = [
+    "src/org/xwalk/core/xwview/shell/SectionsPagerAdapter.java",
+    "src/org/xwalk/core/xwview/shell/XWalkViewSectionFragment.java",
+    "src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java",
+    "src/org/xwalk/core/xwview/test/TestContentProvider.java",
+    "src/org/xwalk/core/xwview/test/XWalkViewTestRunnerActivity.java",
+  ]
+  deps = [
+    ":xwalk_core_shell_apk_resources",
+    "//base:base_java",
+    "//content/public/android:content_java",
+    "//third_party/android_tools:android_support_v13_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+  ]
+}
+
+android_assets("xwalk_core_shell_apk_assets") {
+  visibility = [ ":*" ]
+  renaming_sources = [
+    "//xwalk/test/android/data/asset_file.html",
+    "//xwalk/test/android/data/index.html",
+    "//xwalk/test/android/data/www/cross_origin.html",
+    "//xwalk/test/android/data/request_focus_left_frame.html",
+    "//xwalk/test/android/data/request_focus_main.html",
+    "//xwalk/test/android/data/request_focus_right_frame.html",
+    "//xwalk/test/android/data/request_focus_right_frame1.html",
+    "//xwalk/experimental/launch_screen/launch_screen_api.js",
+    "//xwalk/experimental/wifidirect/wifidirect_api.js",
+  ]
+  renaming_destinations = [
+    "www/asset_file.html",
+    "www/index.html",
+    "www/cross_origin.html",
+    "www/request_focus_left_frame.html",
+    "www/request_focus_main.html",
+    "www/request_focus_right_frame.html",
+    "www/request_focus_right_frame1.html",
+    "jsapi/launch_screen_api.js",
+    "jsapi/wifidirect_api.js",
+  ]
+  deps = [
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+  ]
+}
+
+android_assets("xwalk_core_shell_apk_pak") {
+  sources = [
+    "$root_out_dir/xwalk.pak",
+    "$root_out_dir/xwalk_100_percent.pak",
+  ]
+  deps = [
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+  ]
+  if (icu_use_data_file) {
+    deps += [ "//third_party/icu:icudata" ]
+    sources += [ "$root_out_dir/icudtl.dat" ]
+  }
+  if (v8_use_external_startup_data) {
+    sources += [
+      "$root_out_dir/natives_blob.bin",
+      "$root_out_dir/snapshot_blob.bin",
+    ]
+  }
+  disable_compression = true
+}
+
+android_resources("xwalk_core_shell_apk_resources") {
+  visibility = [ ":*" ]
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.core.xwview.shell"
+}

--- a/runtime/android/dummy_lib/BUILD.gn
+++ b/runtime/android/dummy_lib/BUILD.gn
@@ -1,0 +1,9 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+shared_library("libxwalkdummy") {
+  sources = [
+    "dummy_lib.cc",
+  ]
+}

--- a/runtime/android/runtime_lib/BUILD.gn
+++ b/runtime/android/runtime_lib/BUILD.gn
@@ -1,0 +1,62 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+import("//xwalk/build/version.gni")
+import("//third_party/icu/config.gni")
+
+android_apk("xwalk_runtime_lib_apk") {
+  apk_name = "XWalkRuntimeLib"
+  android_manifest = "AndroidManifest.xml"
+  java_files = []
+  native_libs = [ "$root_out_dir/libxwalkcore.so" ]
+  version_name = xwalk_version
+  version_code = xwalk_version_code
+  deps = [
+    ":xwalk_runtime_lib_apk_assets",
+    ":xwalk_runtime_lib_apk_resources",
+    "//base:base_java",
+    "//components/web_contents_delegate_android:web_contents_delegate_android_java_resources",
+    "//ui/android:ui_java_resources",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java_resources",
+    "//xwalk/runtime/app/android:libxwalkcore",
+  ]
+}
+
+android_resources("xwalk_runtime_lib_apk_resources") {
+  visibility = [ ":*" ]
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.core"
+}
+
+android_assets("xwalk_runtime_lib_apk_assets") {
+  visibility = [ ":*" ]
+  sources = [
+    "$root_out_dir/xwalk.pak",
+    "$root_out_dir/xwalk_100_percent.pak",
+  ]
+  renaming_sources = [
+    "//xwalk/experimental/launch_screen/launch_screen_api.js",
+    "//xwalk/experimental/wifidirect/wifidirect_api.js",
+  ]
+  renaming_destinations = [
+    "jsapi/launch_screen_api.js",
+    "jsapi/wifidirect_api.js",
+  ]
+  deps = [
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+  ]
+  if (icu_use_data_file) {
+    deps += [ "//third_party/icu:icudata" ]
+    sources += [ "$root_out_dir/icudtl.dat" ]
+  }
+  if (v8_use_external_startup_data) {
+    sources += [
+      "$root_out_dir/natives_blob.bin",
+      "$root_out_dir/snapshot_blob.bin",
+    ]
+  }
+}

--- a/runtime/android/sample/BUILD.gn
+++ b/runtime/android/sample/BUILD.gn
@@ -1,0 +1,90 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+import("//third_party/icu/config.gni")
+
+android_apk("xwalk_core_sample_apk") {
+  apk_name = "CrosswalkSample"
+  android_manifest = "AndroidManifest.xml"
+  java_files = [
+    "src/org/xwalk/core/sample/AnimatableXWalkViewActivity.java",
+    "src/org/xwalk/core/sample/ExtensionActivity.java",
+    "src/org/xwalk/core/sample/ExtensionEcho.java",
+    "src/org/xwalk/core/sample/LoadAppFromManifestActivity.java",
+    "src/org/xwalk/core/sample/MultiXWalkViewActivity.java",
+    "src/org/xwalk/core/sample/MultiXWalkViewOverlayActivity.java",
+    "src/org/xwalk/core/sample/OnCreateWindowRequestedActivity.java",
+    "src/org/xwalk/core/sample/OnHideOnShowActivity.java",
+    "src/org/xwalk/core/sample/OnReceivedIconActivity.java",
+    "src/org/xwalk/core/sample/PauseTimersActivity.java",
+    "src/org/xwalk/core/sample/ResourceAndUIClientsActivity.java",
+    "src/org/xwalk/core/sample/SupportZoomActivity.java",
+    "src/org/xwalk/core/sample/XWalkBaseActivity.java",
+    "src/org/xwalk/core/sample/XWalkEmbeddingAPISample.java",
+    "src/org/xwalk/core/sample/XWalkNavigationActivity.java",
+    "src/org/xwalk/core/sample/XWalkPreferencesActivity.java",
+    "src/org/xwalk/core/sample/XWalkVersionAndAPIVersion.java",
+    "src/org/xwalk/core/sample/XWalkViewWithLayoutActivity.java",
+  ]
+  native_libs = [ "$root_out_dir/libxwalkcore.so" ]
+  deps = [
+    ":xwalk_core_sample_apk_assets",
+    ":xwalk_core_sample_apk_resources",
+    "//base:base_java",
+    "//xwalk/extensions/android:xwalk_core_extensions_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
+    "//xwalk/runtime/android/core_shell:xwalk_core_shell_apk_pak",
+    "//xwalk/runtime/app/android:libxwalkcore",
+  ]
+}
+
+android_resources("xwalk_core_sample_apk_resources") {
+  visibility = [ ":*" ]
+  resource_dirs = [ "res" ]
+  custom_package = "org.xwalk.core.sample"
+}
+
+android_assets("xwalk_core_sample_apk_assets") {
+  visibility = [ ":*" ]
+  renaming_sources = [
+    "assets/builtinzoom.html",
+    "assets/create_window_1.html",
+    "assets/create_window_2.html",
+    "assets/doubletapzoom.html",
+    "assets/favicon.html",
+    "assets/icon.png",
+    "assets/index.html",
+    "assets/manifest.json",
+    "assets/new_window.html",
+    "assets/pause_timers.html",
+    "//xwalk/test/android/data/echo_java.html",
+  ]
+  renaming_destinations = [
+    "builtinzoom.html",
+    "create_window_1.html",
+    "create_window_2.html",
+    "doubletapzoom.html",
+    "favicon.html",
+    "icon.png",
+    "index.html",
+    "manifest.json",
+    "new_window.html",
+    "pause_timers.html",
+    "echo_java.html",
+  ]
+  sources = []
+  deps = []
+  if (icu_use_data_file) {
+    sources += [ "$root_out_dir/icudtl.dat" ]
+    deps += [ "//third_party/icu:icudata" ]
+  }
+  if (v8_use_external_startup_data) {
+    sources += [
+      "$root_out_dir/natives_blob.bin",
+      "$root_out_dir/snapshot_blob.bin",
+    ]
+  }
+}

--- a/runtime/app/android/BUILD.gn
+++ b/runtime/app/android/BUILD.gn
@@ -1,0 +1,26 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+shared_library("libxwalkcore") {
+  sources = [
+    "xwalk_entry_point.cc",
+    "xwalk_jni_registrar.cc",
+    "xwalk_jni_registrar.h",
+  ]
+  deps = [
+    "//components/auto_login_parser",
+    "//components/cdm/browser",
+    "//components/cdm/renderer",
+    "//components/navigation_interception",
+    "//components/visitedlink/browser",
+    "//components/visitedlink/renderer",
+    "//components/web_contents_delegate_android",
+    "//mojo/public/cpp/bindings",
+    "//skia",
+    "//xwalk:xwalk_runtime",
+    "//xwalk/extensions/android:xwalk_core_extensions_native_jni",
+    "//xwalk/runtime/android/core_internal:xwalk_core_jar_jni",
+    "//xwalk/runtime/android/core_internal:xwalk_core_native_jni",
+  ]
+}

--- a/test/android/core/javatests/BUILD.gn
+++ b/test/android/core/javatests/BUILD.gn
@@ -1,0 +1,168 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+instrumentation_test_apk("xwalk_core_test_apk") {
+  apk_name = "XWalkCoreTest"
+  android_manifest = "AndroidManifest.xml"
+  apk_under_test = "//xwalk/runtime/android/core_shell:xwalk_core_shell_apk"
+  deps = [
+    ":xwalk_core_test_apk_assets",
+    ":xwalk_core_test_java",
+    "//tools/android/forwarder2:forwarder2",
+    "//tools/android/md5sum:md5sum",
+    "//xwalk/runtime/android/core_shell:xwalk_core_shell_apk_java",
+  ]
+  data_deps = [
+    "//xwalk/runtime/android/core_shell:xwalk_core_shell_apk",
+  ]
+}
+
+android_library("xwalk_core_test_java") {
+  testonly = true
+  visibility = [ ":*" ]
+  java_files = [
+    "src/org/xwalk/core/xwview/test/util/CommonResources.java",
+    "src/org/xwalk/core/xwview/test/util/ImagePageGenerator.java",
+    "src/org/xwalk/core/xwview/test/AddAndRemoveJavascriptInterfaceTest.java",
+    "src/org/xwalk/core/xwview/test/CanGoBackTest.java",
+    "src/org/xwalk/core/xwview/test/CanGoForwardTest.java",
+    "src/org/xwalk/core/xwview/test/ClearCacheForSingleFileTest.java",
+    "src/org/xwalk/core/xwview/test/ClearCacheTest.java",
+    "src/org/xwalk/core/xwview/test/ClearClientCertPreferenceTest.java",
+    "src/org/xwalk/core/xwview/test/ClearHistoryTest.java",
+    "src/org/xwalk/core/xwview/test/ClearSslPreferenceTest.java",
+    "src/org/xwalk/core/xwview/test/CookieManagerTest.java",
+    "src/org/xwalk/core/xwview/test/DefaultFixedFontSizeTest.java",
+    "src/org/xwalk/core/xwview/test/DefaultFontSizeTest.java",
+    "src/org/xwalk/core/xwview/test/DownloadListenerTest.java",
+    "src/org/xwalk/core/xwview/test/EnterAndLeaveFullscreenTest.java",
+    "src/org/xwalk/core/xwview/test/EvaluateJavascriptTest.java",
+    "src/org/xwalk/core/xwview/test/ExtensionEcho.java",
+    "src/org/xwalk/core/xwview/test/ExtensionEchoTest.java",
+    "src/org/xwalk/core/xwview/test/FindAsyncTest.java",
+    "src/org/xwalk/core/xwview/test/GetAPIVersionTest.java",
+    "src/org/xwalk/core/xwview/test/GetCompositingSurfaceTypeTest.java",
+    "src/org/xwalk/core/xwview/test/GetContentHeightTest.java",
+    "src/org/xwalk/core/xwview/test/GetCurrentItemTest.java",
+    "src/org/xwalk/core/xwview/test/GetFaviconTest.java",
+    "src/org/xwalk/core/xwview/test/GetItemAtTest.java",
+    "src/org/xwalk/core/xwview/test/GetTitleTest.java",
+    "src/org/xwalk/core/xwview/test/GetUrlTest.java",
+    "src/org/xwalk/core/xwview/test/GetXWalkVersionTest.java",
+    "src/org/xwalk/core/xwview/test/HasItemAtTest.java",
+    "src/org/xwalk/core/xwview/test/HistorySizeTest.java",
+    "src/org/xwalk/core/xwview/test/LayoutAlgorithmTest.java",
+    "src/org/xwalk/core/xwview/test/LoadTest.java",
+    "src/org/xwalk/core/xwview/test/LoadWithOverviewModeTest.java",
+    "src/org/xwalk/core/xwview/test/NavigateTest.java",
+    "src/org/xwalk/core/xwview/test/OnConsoleMessageTest.java",
+    "src/org/xwalk/core/xwview/test/OnCreateWindowRequestedTest.java",
+    "src/org/xwalk/core/xwview/test/OnDocumentLoadedInFrameTest.java",
+    "src/org/xwalk/core/xwview/test/OnFullscreenToggledTest.java",
+    "src/org/xwalk/core/xwview/test/OnJavascriptCloseWindowTest.java",
+    "src/org/xwalk/core/xwview/test/OnJavascriptModalDialogTest.java",
+    "src/org/xwalk/core/xwview/test/OnLoadFinishedTest.java",
+    "src/org/xwalk/core/xwview/test/OnPageFinishedTest.java",
+    "src/org/xwalk/core/xwview/test/OnPageLoadStartedTest.java",
+    "src/org/xwalk/core/xwview/test/OnPageLoadStoppedTest.java",
+    "src/org/xwalk/core/xwview/test/OnProgressChangedTest.java",
+    "src/org/xwalk/core/xwview/test/OnReceivedClientCertRequestTest.java",
+    "src/org/xwalk/core/xwview/test/OnReceivedErrorTest.java",
+    "src/org/xwalk/core/xwview/test/OnReceivedHttpAuthRequestTest.java",
+    "src/org/xwalk/core/xwview/test/OnReceivedIconTest.java",
+    "src/org/xwalk/core/xwview/test/OnReceivedResponseHeadersTest.java",
+    "src/org/xwalk/core/xwview/test/OnReceivedTitleTest.java",
+    "src/org/xwalk/core/xwview/test/OnRequestFocusTest.java",
+    "src/org/xwalk/core/xwview/test/OnScaleChangedTest.java",
+    "src/org/xwalk/core/xwview/test/OnTitleUpdatedHelper.java",
+    "src/org/xwalk/core/xwview/test/OnUnhandledKeyEventTest.java",
+    "src/org/xwalk/core/xwview/test/OnUpdateTitleTest.java",
+    "src/org/xwalk/core/xwview/test/OpenFileChooserTest.java",
+    "src/org/xwalk/core/xwview/test/ProfileTest.java",
+    "src/org/xwalk/core/xwview/test/ReloadTest.java",
+    "src/org/xwalk/core/xwview/test/SaveRestoreStateTest.java",
+    "src/org/xwalk/core/xwview/test/SetAcceptLanuagesTest.java",
+    "src/org/xwalk/core/xwview/test/SetInitialScaleTest.java",
+    "src/org/xwalk/core/xwview/test/SetOriginAccessWhitelistTest.java",
+    "src/org/xwalk/core/xwview/test/SetUserAgentStringTest.java",
+    "src/org/xwalk/core/xwview/test/SettingsTest.java",
+    "src/org/xwalk/core/xwview/test/ShouldInterceptLoadRequestTest.java",
+    "src/org/xwalk/core/xwview/test/ShouldOverrideKeyEventTest.java",
+    "src/org/xwalk/core/xwview/test/ShouldOverrideUrlLoadingTest.java",
+    "src/org/xwalk/core/xwview/test/SpatialNavigationTest.java",
+    "src/org/xwalk/core/xwview/test/TestHelperBridge.java",
+    "src/org/xwalk/core/xwview/test/TextZoomTest.java",
+    "src/org/xwalk/core/xwview/test/UseWideViewportTest.java",
+    "src/org/xwalk/core/xwview/test/UserAgentTest.java",
+    "src/org/xwalk/core/xwview/test/VideoWithBlobUrlTest.java",
+    "src/org/xwalk/core/xwview/test/XWalkViewTestBase.java",
+    "src/org/xwalk/core/xwview/test/ZoomTest.java",
+  ]
+  deps = [
+    "//base:base_java",
+    "//base:base_java_test_support",
+    "//content/public/android:content_java",
+    "//content/public/test/android:content_java_test_support",
+    "//net/android:net_java_test_support",
+    "//third_party/android_tools:legacy_http_javalib",
+    "//ui/android:ui_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
+    "//xwalk/runtime/android/core_shell:xwalk_core_shell_apk_java",
+  ]
+}
+
+android_assets("xwalk_core_test_apk_assets") {
+  visibility = [ ":*" ]
+  renaming_sources = [
+    "//xwalk/test/android/data/add_js_interface.html",
+    "//xwalk/test/android/data/create_window_1.html",
+    "//xwalk/test/android/data/create_window_2.html",
+    "//xwalk/test/android/data/console_message.html",
+    "//xwalk/test/android/data/echo_binary_java.html",
+    "//xwalk/test/android/data/echo_java.html",
+    "//xwalk/test/android/data/echo_sync_java.html",
+    "//xwalk/test/android/data/favicon.html",
+    "//xwalk/test/android/data/file_chooser.html",
+    "//xwalk/test/android/data/find.html",
+    "//xwalk/test/android/data/framesEcho.html",
+    "//xwalk/test/android/data/fullscreen_enter_exit.html",
+    "//xwalk/test/android/data/fullscreen_togged.html",
+    "//xwalk/test/android/data/icon.png",
+    "//xwalk/test/android/data/index.html",
+    "//xwalk/test/android/data/js_modal_dialog.html",
+    "//xwalk/test/android/data/new_window.html",
+    "//xwalk/test/android/data/profile.html",
+    "//xwalk/test/android/data/read_video_data.html",
+    "//xwalk/test/android/data/save_video_data.html",
+    "//xwalk/test/android/data/scale_changed.html",
+    "//xwalk/test/android/data/window.close.html",
+  ]
+  renaming_destinations = [
+    "add_js_interface.html",
+    "create_window_1.html",
+    "create_window_2.html",
+    "console_message.html",
+    "echo_binary_java.html",
+    "echo_java.html",
+    "echo_sync_java.html",
+    "favicon.html",
+    "file_chooser.html",
+    "find.html",
+    "framesEcho.html",
+    "fullscreen_enter_exit.html",
+    "fullscreen_togged.html",
+    "icon.png",
+    "index.html",
+    "js_modal_dialog.html",
+    "new_window.html",
+    "profile.html",
+    "read_video_data.html",
+    "save_video_data.html",
+    "scale_changed.html",
+    "window.close.html",
+  ]
+}

--- a/test/android/core_internal/javatests/BUILD.gn
+++ b/test/android/core_internal/javatests/BUILD.gn
@@ -1,0 +1,94 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+instrumentation_test_apk("xwalk_core_internal_test_apk") {
+  apk_name = "XWalkCoreInternalTest"
+  android_manifest = "AndroidManifest.xml"
+  apk_under_test = "//xwalk/runtime/android/core_internal_shell:xwalk_core_internal_shell_apk"
+  deps = [
+    ":xwalk_core_internal_test_apk_assets",
+    ":xwalk_core_internal_test_java",
+    "//tools/android/forwarder2:forwarder2",
+    "//tools/android/md5sum:md5sum",
+    "//xwalk/runtime/android/core_internal_shell:xwalk_core_internal_shell_apk_java",
+  ]
+  data_deps = [
+    "//xwalk/runtime/android/core_internal_shell:xwalk_core_internal_shell_apk",
+  ]
+}
+
+android_library("xwalk_core_internal_test_java") {
+  testonly = true
+  visibility = [ ":*" ]
+  java_files = [
+    "src/org/xwalk/core/internal/xwview/test/util/CommonResources.java",
+    "src/org/xwalk/core/internal/xwview/test/util/VideoTestWebServer.java",
+    "src/org/xwalk/core/internal/xwview/test/ExtensionBroadcastInternal.java",
+    "src/org/xwalk/core/internal/xwview/test/ExtensionBroadcastInternalTest.java",
+    "src/org/xwalk/core/internal/xwview/test/ExtensionEchoInternal.java",
+    "src/org/xwalk/core/internal/xwview/test/ExtensionEchoInternalTest.java",
+    "src/org/xwalk/core/internal/xwview/test/GeolocationPermissionTest.java",
+    "src/org/xwalk/core/internal/xwview/test/HandleActionUriTest.java",
+    "src/org/xwalk/core/internal/xwview/test/LoadTest.java",
+    "src/org/xwalk/core/internal/xwview/test/OnReceivedErrorTest.java",
+    "src/org/xwalk/core/internal/xwview/test/OnShowOnHideCustomViewTest.java",
+    "src/org/xwalk/core/internal/xwview/test/OnTitleUpdatedHelper.java",
+    "src/org/xwalk/core/internal/xwview/test/RendererResponsivenessTest.java",
+    "src/org/xwalk/core/internal/xwview/test/SetAppCacheEnabledTest.java",
+    "src/org/xwalk/core/internal/xwview/test/SetDatabaseEnabledTest.java",
+    "src/org/xwalk/core/internal/xwview/test/SetDomStorageEnabledTest.java",
+    "src/org/xwalk/core/internal/xwview/test/SetNetworkAvailableTest.java",
+    "src/org/xwalk/core/internal/xwview/test/TestHelperBridge.java",
+    "src/org/xwalk/core/internal/xwview/test/UserAgentTest.java",
+    "src/org/xwalk/core/internal/xwview/test/WebNotificationTest.java",
+    "src/org/xwalk/core/internal/xwview/test/XWalkJavascriptResultTest.java",
+    "src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java",
+    "src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestTouchUtils.java",
+    "src/org/xwalk/core/internal/xwview/test/ZoomTest.java",
+  ]
+  deps = [
+    "//base:base_java",
+    "//base:base_java_test_support",
+    "//content/public/android:content_java",
+    "//content/public/test/android:content_java_test_support",
+    "//net/android:net_java_test_support",
+    "//third_party/android_tools:legacy_http_javalib",
+    "//ui/android:ui_java",
+    "//xwalk/extensions/android:xwalk_core_extensions_java",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
+    "//xwalk/runtime/android/core_internal_shell:xwalk_core_internal_shell_apk_java",
+  ]
+}
+
+android_assets("xwalk_core_internal_test_apk_assets") {
+  visibility = [ ":*" ]
+  renaming_sources = [
+    "//xwalk/test/android/data/broadcast.html",
+    "//xwalk/test/android/data/echo_binary_java.html",
+    "//xwalk/test/android/data/echo_java.html",
+    "//xwalk/test/android/data/echo_sync_java.html",
+    "//xwalk/test/android/data/framesEcho.html",
+    "//xwalk/test/android/data/full_screen_video_test.html",
+    "//xwalk/test/android/data/geolocation.html",
+    "//xwalk/test/android/data/index.html",
+    "//xwalk/test/android/data/navigator.online.html",
+    "//xwalk/test/android/data/notification.html",
+    "//xwalk/test/android/data/renderHung.html",
+  ]
+  renaming_destinations = [
+    "broadcast.html",
+    "echo_binary_java.html",
+    "echo_java.html",
+    "echo_sync_java.html",
+    "framesEcho.html",
+    "full_screen_video_test.html",
+    "geolocation.html",
+    "index.html",
+    "navigator.online.html",
+    "notification.html",
+    "renderHung.html",
+  ]
+}

--- a/test/android/runtime_client/javatests/BUILD.gn
+++ b/test/android/runtime_client/javatests/BUILD.gn
@@ -1,0 +1,75 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+instrumentation_test_apk("xwalk_runtime_client_test_apk") {
+  apk_name = "XWalkRuntimeClientTest"
+  android_manifest = "AndroidManifest.xml"
+  apk_under_test =
+      "//xwalk/app/android/runtime_client_shell:xwalk_runtime_client_shell_apk"
+  deps = [
+    ":xwalk_runtime_client_test_apk_assets",
+    ":xwalk_runtime_client_test_java",
+    "//tools/android/forwarder2:forwarder2",
+    "//tools/android/md5sum:md5sum",
+  ]
+  data_deps = [
+    "//xwalk/app/android/runtime_client_shell:xwalk_runtime_client_shell_apk",
+  ]
+}
+
+android_library("xwalk_runtime_client_test_java") {
+  visibility = [ ":*" ]
+  testonly = true
+  java_files = [
+    "src/org/xwalk/runtime/client/test/CSPTest.java",
+    "src/org/xwalk/runtime/client/test/CrossOriginXhrTest.java",
+    "src/org/xwalk/runtime/client/test/EnableRemoteDebuggingTest.java",
+    "src/org/xwalk/runtime/client/test/ExternalExtensionTest.java",
+    "src/org/xwalk/runtime/client/test/GetVersionTest.java",
+    "src/org/xwalk/runtime/client/test/LoadAppFromManifestTest.java",
+    "src/org/xwalk/runtime/client/test/LoadAppFromUrlTest.java",
+    "src/org/xwalk/runtime/client/test/NativeExternalExtensionTest.java",
+    "src/org/xwalk/runtime/client/test/NativeFileSystemTest.java",
+    "src/org/xwalk/runtime/client/test/PauseResumeTest.java",
+    "src/org/xwalk/runtime/client/test/PresentationTest.java",
+    "src/org/xwalk/runtime/client/test/ScreenOrientationTest.java",
+    "src/org/xwalk/runtime/client/test/XWalkRuntimeClientTestBase.java",
+  ]
+  deps = [
+    "//base:base_java",
+    "//base:base_java_test_support",
+    "//content/public/test/android:content_java_test_support",
+    "//net/android:net_java_test_support",
+    "//xwalk/app/android/runtime_client:xwalk_app_runtime_java",
+    "//xwalk/app/android/runtime_client_shell:xwalk_runtime_client_shell_apk_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+    "//xwalk/test/android/util:xwalk_runtime_client_test_utils_java",
+  ]
+}
+
+android_assets("xwalk_runtime_client_test_apk_assets") {
+  visibility = [ ":*" ]
+  renaming_sources = [
+    "//xwalk/extensions/test/data/echo.html",
+    "//xwalk/test/android/data/displayAvailableTest.html",
+    "//xwalk/test/android/data/echo_binary_java.html",
+    "//xwalk/test/android/data/echo_java.html",
+    "//xwalk/test/android/data/echo_sync_java.html",
+    "//xwalk/test/android/data/native_file_system.html",
+    "//xwalk/test/android/data/screen_orientation.html",
+    "//xwalk/test/android/data/timer.html",
+  ]
+  renaming_destinations = [
+    "echo.html",
+    "displayAvailableTest.html",
+    "echo_binary_java.html",
+    "echo_java.html",
+    "echo_sync_java.html",
+    "native_file_system.html",
+    "screen_orientation.html",
+    "timer.html",
+  ]
+}

--- a/test/android/runtime_client_embedded/javatests/BUILD.gn
+++ b/test/android/runtime_client_embedded/javatests/BUILD.gn
@@ -1,0 +1,73 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+instrumentation_test_apk("xwalk_runtime_client_embedded_test_apk") {
+  apk_name = "XWalkRuntimeClientEmbeddedTest"
+  android_manifest = "AndroidManifest.xml"
+  apk_under_test = "//xwalk/app/android/runtime_client_embedded_shell:xwalk_runtime_client_embedded_shell_apk"
+  deps = [
+    ":xwalk_runtime_client_embedded_test_apk_assets",
+    ":xwalk_runtime_client_embedded_test_java",
+    "//tools/android/forwarder2:forwarder2",
+    "//tools/android/md5sum:md5sum",
+  ]
+  data_deps = [
+    "//xwalk/app/android/runtime_client_embedded_shell:xwalk_runtime_client_embedded_shell_apk",
+  ]
+}
+
+android_library("xwalk_runtime_client_embedded_test_java") {
+  testonly = true
+  visibility = [ ":*" ]
+  java_files = [
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/CSPTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/CrossOriginXhrTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/EnableRemoteDebuggingTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/ExternalExtensionTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/GetVersionTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/LoadAppFromManifestTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/LoadAppFromUrlTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/NativeExternalExtensionTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/NativeFileSystemTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PauseResumeTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/PresentationTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/ScreenOrientationTest.java",
+    "//xwalk/test/android/runtime_client_embedded/javatests/src/org/xwalk/runtime/client/embedded/test/XWalkRuntimeClientTestBase.java",
+  ]
+  deps = [
+    "//base:base_java_test_support",
+    "//content/public/test/android:content_java_test_support",
+    "//net/android:net_java_test_support",
+    "//xwalk/app/android/runtime_client:xwalk_app_runtime_java",
+    "//xwalk/app/android/runtime_client_embedded_shell:xwalk_runtime_client_embedded_shell_apk_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+    "//xwalk/test/android/util:xwalk_runtime_client_test_utils_java",
+  ]
+}
+
+android_assets("xwalk_runtime_client_embedded_test_apk_assets") {
+  visibility = [ ":*" ]
+  renaming_sources = [
+    "//xwalk/extensions/test/data/echo.html",
+    "//xwalk/test/android/data/displayAvailableTest.html",
+    "//xwalk/test/android/data/echo_binary_java.html",
+    "//xwalk/test/android/data/echo_java.html",
+    "//xwalk/test/android/data/echo_sync_java.html",
+    "//xwalk/test/android/data/native_file_system.html",
+    "//xwalk/test/android/data/screen_orientation.html",
+    "//xwalk/test/android/data/timer.html",
+  ]
+  renaming_destinations = [
+    "echo.html",
+    "displayAvailableTest.html",
+    "echo_binary_java.html",
+    "echo_java.html",
+    "echo_sync_java.html",
+    "native_file_system.html",
+    "screen_orientation.html",
+    "timer.html",
+  ]
+}

--- a/test/android/util/BUILD.gn
+++ b/test/android/util/BUILD.gn
@@ -1,0 +1,36 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+android_library("xwalk_test_util_java") {
+  testonly = true
+  java_files = [
+    "src/org/xwalk/test/util/OnTitleUpdatedHelper.java",
+    "src/org/xwalk/test/util/XWalkTestUtilBase.java",
+    "src/org/xwalk/test/util/XWalkTestUtilCallbacks.java",
+  ]
+  deps = [
+    "//content/public/test/android:content_java_test_support",
+    "//net/android:net_java_test_support",
+  ]
+}
+
+android_library("xwalk_runtime_client_test_utils_java") {
+  testonly = true
+  java_files = [
+    "runtime_client/src/com/example/extension/MyExtension.java",
+    "runtime_client/src/org/xwalk/test/util/ActivityToCausePause.java",
+    "runtime_client/src/org/xwalk/test/util/RuntimeClientApiTestBase.java",
+    "runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientTestGeneric.java",
+    "runtime_client/src/org/xwalk/test/util/XWalkRuntimeClientTestUtilBase.java",
+  ]
+  deps = [
+    ":xwalk_test_util_java",
+    "//content/public/test/android:content_java_test_support",
+    "//net/android:net_java_test_support",
+    "//xwalk/app/android/runtime_client:xwalk_app_runtime_java",
+    "//xwalk/runtime/android/core:xwalk_core_java",
+  ]
+}

--- a/third_party/lzma_sdk/BUILD.gn
+++ b/third_party/lzma_sdk/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+android_library("lzma_sdk_java") {
+  java_files = [
+    "src/SevenZip/Compression/LZ/BinTree.java",
+    "src/SevenZip/Compression/LZ/InWindow.java",
+    "src/SevenZip/Compression/LZ/OutWindow.java",
+    "src/SevenZip/Compression/LZMA/Base.java",
+    "src/SevenZip/Compression/LZMA/Decoder.java",
+    "src/SevenZip/Compression/LZMA/Encoder.java",
+    "src/SevenZip/Compression/RangeCoder/BitTreeDecoder.java",
+    "src/SevenZip/Compression/RangeCoder/BitTreeEncoder.java",
+    "src/SevenZip/Compression/RangeCoder/Decoder.java",
+    "src/SevenZip/Compression/RangeCoder/Encoder.java",
+    "src/SevenZip/CRC.java",
+    "src/SevenZip/ICodeProgress.java",
+    "src/SevenZip/LzmaAlone.java",
+    "src/SevenZip/LzmaBench.java",
+  ]
+}


### PR DESCRIPTION
    In this patch:
    1) Inits the GN build configuration for Crosswalk-Android.
    2) Build out all of the APKs.
    3) Make sure Instrumentation tests pass in GN.
    4) Generate xwalk_core_librarys, javadocs, AARs.
    
    TODO: xwalk_core_unittest. lzma support for download mode.
    
    BUG = XWALK-7285