### PR TITLE
[gn] Rename xwalk_installer_package_deb to xwalk_installer_linux_debian

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -26,7 +26,7 @@ if (is_linux) {
   group("xwalk_installer") {
     testonly = true
     deps = [
-      "//xwalk/tools/installer:xwalk_installer_package_deb",
+      "//xwalk/tools/installer:xwalk_installer_linux_debian",
     ]
   }
 }

--- a/tools/installer/BUILD.gn
+++ b/tools/installer/BUILD.gn
@@ -1,3 +1,4 @@
+# Copyright (c) 2015 The Chromium Authors. All rights reserved.
 # Copyright (c) 2016 Intel Corporation. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -6,7 +7,7 @@
 import("//xwalk/build/version.gni")
 
 # Modified from template("linux_package") in //chrome/installer/linux/BUILD.gn
-action("xwalk_installer_package_deb") {
+action("xwalk_installer_linux_debian") {
   deps = [
     ":common_packaging_files",
     ":deb_packaging_files",


### PR DESCRIPTION
Use the same target name for the gyp and the GN versions, otherwise this
needlessly complicates the release build process and confuses everyone
trying to build Debian packages.

While here, add Chromium's missing copyright to `tools/installer/BUILD.gn`.

BUG=XWALK-7180