### PR TITLE
reflection_generator: Stop requiring an int for a boolean option.

### DIFF
--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -120,7 +120,7 @@ def GenerateJavaTemplateClass(template_dir, xwalk_build_version,
   template_file = os.path.join(template_dir, 'XWalkAppVersion.template')
   template = Template(open(template_file, 'r').read())
   value = {'API_VERSION': api_version,
-           'VERIFY_XWALK_APK': 'true' if verify_xwalk_apk == 1 else 'false',
+           'VERIFY_XWALK_APK': str(verify_xwalk_apk).lower(),
            'XWALK_BUILD_VERSION': xwalk_build_version}
   output_file = os.path.join(wrapper_path, "XWalkAppVersion.java")
   with open(output_file, 'w') as f:
@@ -148,8 +148,9 @@ This script can generate bridge and wrap source files for given directory.
   option_parser.add_option('--stamp', help='the file to touch on success.')
   option_parser.add_option('--api-version', help='API Version')
   option_parser.add_option('--min-api-version', help='Min API Version')
-  option_parser.add_option('--verify-xwalk-apk', default=0, type='int',
-      help='Verify Crosswalk library APK before loading')
+  option_parser.add_option('--verify-xwalk-apk', action='store_true',
+                           default=False,
+                           help='Verify Crosswalk library APK before loading')
   option_parser.add_option('--xwalk-build-version', help='XWalk Build Version')
 
   options, _ = option_parser.parse_args(argv)

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -72,6 +72,7 @@
           '>!@(find <(template_dir) -name "*.template")'
         ],
         'timestamp': '<(reflection_java_dir)/gen.timestamp',
+        'extra_reflection_args': [],
       },
       'all_dependent_settings': {
         'variables': {
@@ -79,6 +80,13 @@
           'reflection_gen_dir': '<(reflection_java_dir)',
         },
       },
+      'conditions': [
+        ['verify_xwalk_apk==1', {
+          'variables': {
+            'extra_reflection_args': ['--verify-xwalk-apk'],
+          },
+        }],
+      ],
       'actions': [
         {
           'action_name': 'generate_reflection',
@@ -103,8 +111,8 @@
             '--stamp', '<(timestamp)',
             '--api-version=<(api_version)',
             '--min-api-version=<(min_api_version)',
-            '--verify-xwalk-apk=<(verify_xwalk_apk)',
             '--xwalk-build-version=<(xwalk_version)',
+            '<@(extra_reflection_args)',
           ],
         },
       ],


### PR DESCRIPTION
`reflection_generator.py` expects to receive an integer for the
`--verify-xwalk-apk` argument, which does not make sense. It was likely
added as a shortcut because gyp uses 1 and 0 instead of booleans, so one
could just do `--verify-xwalk-apk=<(my_int_var)` in gyp. Unfortunately,
that does not integrate so well with GN, so revamp how the argument is
handled:
* Turn the `--verify-xwalk-apk` into a boolean argument that does not
  require a value; if it is passed in the command line, its value is
  true, otherwise it is false.
* Adapt xwalk_android.gypi to follow suit and only pass that argument
  when `verify_xwalk_apk` is on.