### PR TITLE
[Android] Fix crash on file chooser

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java
@@ -230,7 +230,9 @@ public class XWalkFileChooser {
                 deleteImageFile();
             }
 
-            Log.d(TAG, "Received file: " + results.toString());
+            if (results != null) {
+                Log.d(TAG, "Received file: " + results.toString());
+            }
             mFilePathCallback.onReceiveValue(results);
             mFilePathCallback = null;
         }

--- a/runtime/browser/android/xwalk_web_contents_delegate.cc
+++ b/runtime/browser/android/xwalk_web_contents_delegate.cc
@@ -121,18 +121,15 @@ void XWalkWebContentsDelegate::RunFileChooser(
     return;
   }
   int mode = static_cast<int>(params.mode);
-  jboolean overridden =
-      Java_XWalkWebContentsDelegate_shouldOverrideRunFileChooser(env,
-          java_delegate.obj(),
-          web_contents->GetRenderProcessHost()->GetID(),
-          web_contents->GetRenderViewHost()->GetRoutingID(),
-          mode,
-          ConvertUTF16ToJavaString(env,
-              base::JoinString(params.accept_types,
-                               base::ASCIIToUTF16(","))).obj(),
-          params.capture);
-  if (overridden == JNI_FALSE)
-    RuntimeFileSelectHelper::RunFileChooser(web_contents, params);
+  Java_XWalkWebContentsDelegate_shouldOverrideRunFileChooser(env,
+      java_delegate.obj(),
+      web_contents->GetRenderProcessHost()->GetID(),
+      web_contents->GetRenderViewHost()->GetRoutingID(),
+      mode,
+      ConvertUTF16ToJavaString(env,
+          base::JoinString(params.accept_types,
+                           base::ASCIIToUTF16(","))).obj(),
+      params.capture);
 }
 
 content::JavaScriptDialogManager*


### PR DESCRIPTION
- Fixed crash when no file is uploaded after the file chooser is launched.
- Do not invoke RuntimeFileSelectHelper when the uploaded file is null.

BUG=XWALK-7278
BUG=XWALK-7271