### PR TITLE
Clean up reflection_generator.py and make it work with GN.

### DIFF
--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -26,7 +26,7 @@ from util import build_utils
 
 
 # Classes list that have to generate bridge and wrap code.
-CLASSES_TO_BE_PROCESS = [
+CLASSES_TO_PROCESS = [
     'ClientCertRequestHandlerInternal',
     'ClientCertRequestInternal',
     'CustomViewCallbackHandlerInternal',
@@ -55,7 +55,7 @@ CLASSES_TO_BE_PROCESS = [
     'XWalkWebResourceResponseInternal',
 ]
 
-REFLECTION_HERLPER = [
+REFLECTION_HELPERS = [
     'ReflectMethod.java',
     'ReflectField.java',
     'ReflectConstructor.java',
@@ -69,13 +69,13 @@ def PerformSerialize(output_path, generator):
   file_name = generator.GetGeneratedClassFileName()
   with open(os.path.join(output_path, file_name), 'w') as f:
     f.write(generator.GetGeneratedCode())
-  print('%s has been generated!' % file_name)
+  print('Generated %s.' % file_name)
 
 
 def GenerateJavaBindingClass(input_dir, bridge_path, wrapper_path):
-  class_loader = JavaClassLoader(input_dir, CLASSES_TO_BE_PROCESS)
-  for input_class in CLASSES_TO_BE_PROCESS:
-    print('Generate bridge and wrapper code for %s' % input_class)
+  class_loader = JavaClassLoader(input_dir, CLASSES_TO_PROCESS)
+  for input_class in CLASSES_TO_PROCESS:
+    print('Generating bridge and wrapper code for %s.' % input_class)
     java_data = class_loader.GetJavaData(input_class)
     if java_data.class_type == 'interface':
       # Generate Interface code.
@@ -94,7 +94,7 @@ def GenerateJavaBindingClass(input_dir, bridge_path, wrapper_path):
 
 
 def GenerateJavaReflectClass(input_dir, wrapper_path):
-  for helper in REFLECTION_HERLPER:
+  for helper in REFLECTION_HELPERS:
     with open(os.path.join(wrapper_path, helper), 'w') as f:
       for line in open(os.path.join(input_dir, helper), 'r'):
         if line.startswith('package '):

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import optparse
+import argparse
 import os
 import shutil
 from string import Template
@@ -126,37 +126,25 @@ def GenerateJavaTemplateClass(template_dir, bridge_path, wrapper_path,
 
 
 def main(argv):
-  usage = """Usage: %prog [OPTIONS]
-This script can generate bridge and wrap source files for given directory.
-\'input_dir\' is provided as directory containing source files.
-  """
-  option_parser = optparse.OptionParser(usage=usage)
-  option_parser.add_option('--input-dir',
-                           help=('Input source file directory which contains '
-                                 'input files'))
-  option_parser.add_option('--template-dir',
-                           help=('Templates directory to generate java source '
-                                 'file'))
-  option_parser.add_option('--bridge-output',
-                           help=('Output directory where the bridge code is '
-                                 'placed.'))
-  option_parser.add_option('--wrapper-output',
-                           help=('Output directory where the wrap code is '
-                                 'placed.'))
-  option_parser.add_option('--stamp', help='the file to touch on success.')
-  option_parser.add_option('--api-version', help='API Version')
-  option_parser.add_option('--min-api-version', help='Min API Version')
-  option_parser.add_option('--verify-xwalk-apk', action='store_true',
-                           default=False,
-                           help='Verify Crosswalk library APK before loading')
-  option_parser.add_option('--xwalk-build-version', help='XWalk Build Version')
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--input-dir', required=True,
+                      help=('Input source file directory which contains input '
+                            'files'))
+  parser.add_argument('--template-dir',
+                      help='Templates directory to generate java source file')
+  parser.add_argument('--bridge-output', required=True,
+                      help='Output directory where the bridge code is placed.')
+  parser.add_argument('--wrapper-output', required=True,
+                      help='Output directory where the wrap code is placed.')
+  parser.add_argument('--stamp', help='the file to touch on success.')
+  parser.add_argument('--api-version', help='API Version')
+  parser.add_argument('--min-api-version', help='Min API Version')
+  parser.add_argument('--verify-xwalk-apk', action='store_true',
+                      default=False,
+                      help='Verify Crosswalk library APK before loading.')
+  parser.add_argument('--xwalk-build-version', help='XWalk Build Version')
 
-  options, _ = option_parser.parse_args(argv)
-  if (not options.input_dir or
-      not options.bridge_output or
-      not options.wrapper_output):
-    print('Error: Must specify input and output.')
-    return 1
+  options = parser.parse_args()
 
   if os.path.isdir(options.bridge_output):
     shutil.rmtree(options.bridge_output)

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -152,11 +152,11 @@ def main(argv):
     shutil.rmtree(options.wrapper_output)
 
   bridge_path = os.path.join(options.bridge_output,
-                             os.path.sep.join(BRIDGE_PACKAGE.split('.')))
+                             BRIDGE_PACKAGE.replace('.', os.path.sep))
   os.makedirs(bridge_path)
 
   wrapper_path = os.path.join(options.wrapper_output,
-                              os.path.sep.join(WRAPPER_PACKAGE.split('.')))
+                              WRAPPER_PACKAGE.replace('.', os.path.sep))
   os.makedirs(wrapper_path)
 
   if options.input_dir:

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -7,12 +7,12 @@
 import optparse
 import os
 import shutil
+from string import Template
 import sys
 
 from bridge_generator import BridgeGenerator
 from interface_generator import InterfaceGenerator
 from java_class import JavaClassLoader
-from string import Template
 from wrapper_generator import WrapperGenerator
 
 GYP_ANDROID_DIR = os.path.join(os.path.dirname(__file__),

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -64,9 +64,6 @@ REFLECTION_HERLPER = [
 WRAPPER_PACKAGE = 'org.xwalk.core'
 BRIDGE_PACKAGE = 'org.xwalk.core.internal'
 
-bridge_path = ''
-wrapper_path = ''
-
 
 def PerformSerialize(output_path, generator):
   file_name = generator.GetGeneratedClassFileName()
@@ -75,7 +72,7 @@ def PerformSerialize(output_path, generator):
   print('%s has been generated!' % file_name)
 
 
-def GenerateJavaBindingClass(input_dir):
+def GenerateJavaBindingClass(input_dir, bridge_path, wrapper_path):
   class_loader = JavaClassLoader(input_dir, CLASSES_TO_BE_PROCESS)
   for input_class in CLASSES_TO_BE_PROCESS:
     print('Generate bridge and wrapper code for %s' % input_class)
@@ -96,7 +93,7 @@ def GenerateJavaBindingClass(input_dir):
       PerformSerialize(wrapper_path, wrapper_generator)
 
 
-def GenerateJavaReflectClass(input_dir):
+def GenerateJavaReflectClass(input_dir, wrapper_path):
   for helper in REFLECTION_HERLPER:
     with open(os.path.join(wrapper_path, helper), 'w') as f:
       for line in open(os.path.join(input_dir, helper), 'r'):
@@ -106,8 +103,9 @@ def GenerateJavaReflectClass(input_dir):
           f.write(line)
 
 
-def GenerateJavaTemplateClass(template_dir, xwalk_build_version,
-    api_version, min_api_version, verify_xwalk_apk):
+def GenerateJavaTemplateClass(template_dir, bridge_path, wrapper_path,
+                              xwalk_build_version, api_version,
+                              min_api_version, verify_xwalk_apk):
   template_file = os.path.join(template_dir, 'XWalkCoreVersion.template')
   template = Template(open(template_file, 'r').read())
   value = {'API_VERSION': api_version,
@@ -165,23 +163,24 @@ This script can generate bridge and wrap source files for given directory.
   if os.path.isdir(options.wrapper_output):
     shutil.rmtree(options.wrapper_output)
 
-  global bridge_path
   bridge_path = os.path.join(options.bridge_output,
                              os.path.sep.join(BRIDGE_PACKAGE.split('.')))
   os.makedirs(bridge_path)
 
-  global wrapper_path
   wrapper_path = os.path.join(options.wrapper_output,
                               os.path.sep.join(WRAPPER_PACKAGE.split('.')))
   os.makedirs(wrapper_path)
 
   if options.input_dir:
-    GenerateJavaBindingClass(options.input_dir)
-    GenerateJavaReflectClass(options.input_dir)
+    GenerateJavaBindingClass(options.input_dir, bridge_path, wrapper_path)
+    GenerateJavaReflectClass(options.input_dir, wrapper_path)
 
   if options.template_dir:
-    GenerateJavaTemplateClass(options.template_dir, options.xwalk_build_version,
-        options.api_version, options.min_api_version, options.verify_xwalk_apk)
+    GenerateJavaTemplateClass(options.template_dir,
+                              bridge_path, wrapper_path,
+                              options.xwalk_build_version,
+                              options.api_version, options.min_api_version,
+                              options.verify_xwalk_apk)
 
   if options.stamp:
     build_utils.Touch(options.stamp)

--- a/tools/reflection_generator/reflection_generator.py
+++ b/tools/reflection_generator/reflection_generator.py
@@ -104,25 +104,17 @@ def GenerateJavaReflectClass(input_dir, wrapper_path):
 
 
 def GenerateJavaTemplateClass(template_dir, bridge_path, wrapper_path,
-                              xwalk_build_version, api_version,
-                              min_api_version, verify_xwalk_apk):
-  template_file = os.path.join(template_dir, 'XWalkCoreVersion.template')
-  template = Template(open(template_file, 'r').read())
-  value = {'API_VERSION': api_version,
-           'MIN_API_VERSION': min_api_version,
-           'XWALK_BUILD_VERSION': xwalk_build_version}
-  output_file = os.path.join(bridge_path, "XWalkCoreVersion.java")
-  with open(output_file, 'w') as f:
-    f.write(template.substitute(value))
-
-  template_file = os.path.join(template_dir, 'XWalkAppVersion.template')
-  template = Template(open(template_file, 'r').read())
-  value = {'API_VERSION': api_version,
-           'VERIFY_XWALK_APK': str(verify_xwalk_apk).lower(),
-           'XWALK_BUILD_VERSION': xwalk_build_version}
-  output_file = os.path.join(wrapper_path, "XWalkAppVersion.java")
-  with open(output_file, 'w') as f:
-    f.write(template.substitute(value))
+                              mapping):
+  with open(os.path.join(template_dir, 'XWalkAppVersion.template')) as f:
+    contents = f.read()
+    out_path = os.path.join(wrapper_path, 'XWalkAppVersion.java')
+    with open(out_path, 'w') as out_f:
+      out_f.write(Template(contents).substitute(mapping))
+  with open(os.path.join(template_dir, 'XWalkCoreVersion.template')) as f:
+    contents = f.read()
+    out_path = os.path.join(bridge_path, 'XWalkCoreVersion.java')
+    with open(out_path, 'w') as out_f:
+      out_f.write(Template(contents).substitute(mapping))
 
 
 def main(argv):
@@ -164,11 +156,14 @@ def main(argv):
     GenerateJavaReflectClass(options.input_dir, wrapper_path)
 
   if options.template_dir:
-    GenerateJavaTemplateClass(options.template_dir,
-                              bridge_path, wrapper_path,
-                              options.xwalk_build_version,
-                              options.api_version, options.min_api_version,
-                              options.verify_xwalk_apk)
+    mapping = {
+      'API_VERSION': options.api_version,
+      'MIN_API_VERSION': options.min_api_version,
+      'XWALK_BUILD_VERSION': options.xwalk_build_version,
+      'VERIFY_XWALK_APK': str(options.verify_xwalk_apk).lower(),
+    }
+    GenerateJavaTemplateClass(options.template_dir, bridge_path, wrapper_path,
+                              mapping)
 
   if options.stamp:
     build_utils.Touch(options.stamp)


### PR DESCRIPTION
This pull request contains several commits, but the main goal is to make
it work correctly with GN.

With gyp, we are just generating a lot of .java files in the build
directory and depending on the directory where they are written in
`xwalk_core_internal_java`. Depending on a directory does not work with
GN, depending on all those new files directly also fails [1], so we now
follow Chromium's approach of writing those files into zip files called
`.srcjar`s and making `xwalk_core_internal_java` depend on that instead.
This is done by introducing a `--use-srcjars` option (off by default)
while we have to support both gyp and GN.

[1] https://groups.google.com/a/chromium.org/forum/#!topic/gn-dev/GokFp6TorgI

All the commits before the one described above are cleanups to make the
script look saner and more Pythonic.

RELATED BUG=XWALK-3674