### PR TITLE
Android: Fix lint warning in app_hello_world's AndroidManifest.xml

### DIFF
--- a/app/android/app_hello_world/AndroidManifest.xml
+++ b/app/android/app_hello_world/AndroidManifest.xml
@@ -9,6 +9,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.app.hello.world">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:label="XWalkAppHelloWorld" android:hardwareAccelerated="true"
         android:icon="@drawable/crosswalk">
@@ -22,14 +32,4 @@
           </intent-filter>
         </activity>
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CAMERA"/>
-  <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
When building the APK with stricter options (default in GN), the
following lint warning is shown:

    AndroidManifest.xml:26 `<uses-sdk>` tag appears after `<application>` tag: ManifestOrder [warning]
      <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />

Fix it by reordering the tags in the file.