### PR TITLE
Android: Fix lint warning in AndroidManifest.xml across the tree

### DIFF
--- a/app/android/app_hello_world/AndroidManifest.xml
+++ b/app/android/app_hello_world/AndroidManifest.xml
@@ -9,6 +9,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.app.hello.world">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:label="XWalkAppHelloWorld" android:hardwareAccelerated="true"
         android:icon="@drawable/crosswalk">
@@ -22,14 +32,4 @@
           </intent-filter>
         </activity>
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CAMERA"/>
-  <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/app/android/app_template/AndroidManifest.xml
+++ b/app/android/app_template/AndroidManifest.xml
@@ -10,6 +10,16 @@
     package="org.xwalk.app.template"
     android:installLocation="auto">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:label="XWalkAppTemplate" android:hardwareAccelerated="true"
         android:icon="@drawable/crosswalk">
@@ -23,14 +33,4 @@
           </intent-filter>
         </activity>
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CAMERA"/>
-  <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/app/android/runtime_client_embedded_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_embedded_shell/AndroidManifest.xml
@@ -9,6 +9,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.runtime.client.embedded.shell">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
     <application
         android:label="XWalkRuntimeClientEmbeddedShell" android:hardwareAccelerated="true">
         <activity android:name="org.xwalk.runtime.client.embedded.shell.XWalkRuntimeClientEmbeddedShellActivity"
@@ -27,17 +40,4 @@
         <activity android:name="org.xwalk.test.util.ActivityToCausePause">
         </activity>
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CAMERA"/>
-  <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 </manifest>

--- a/app/android/runtime_client_shell/AndroidManifest.xml
+++ b/app/android/runtime_client_shell/AndroidManifest.xml
@@ -9,6 +9,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.runtime.client.shell">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:label="XWalkRuntimeClientShell" android:hardwareAccelerated="true">
         <activity android:name="org.xwalk.runtime.client.shell.XWalkRuntimeClientShellActivity"
@@ -27,17 +40,4 @@
         <activity android:name="org.xwalk.test.util.ActivityToCausePause">
         </activity>
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CAMERA"/>
-  <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/runtime/android/core_internal_empty/AndroidManifest.xml
+++ b/runtime/android/core_internal_empty/AndroidManifest.xml
@@ -9,9 +9,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.core.library.empty">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+
     <application android:name="android.app.Application"
         android:label="XWalkCoreLibraryEmpty" android:hardwareAccelerated="true">
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 </manifest>

--- a/runtime/android/core_internal_shell/AndroidManifest.xml
+++ b/runtime/android/core_internal_shell/AndroidManifest.xml
@@ -9,6 +9,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.core.internal.xwview.shell">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application android:name="android.app.Application"
         android:label="XWalkCoreInternalShell" android:hardwareAccelerated="true">
         <activity android:name="org.xwalk.core.internal.xwview.shell.XWalkViewInternalShellActivity"
@@ -30,15 +41,4 @@
         <provider android:name="org.xwalk.core.internal.xwview.test.TestContentProvider"
             android:authorities="org.xwalk.core.internal.xwview.test.TestContentProvider" />
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CAMERA"/>
-  <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/runtime/android/core_shell/AndroidManifest.xml
+++ b/runtime/android/core_shell/AndroidManifest.xml
@@ -9,6 +9,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.core.xwview.shell">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:label="XWalkCoreShell" android:hardwareAccelerated="true">
         <activity android:name="org.xwalk.core.xwview.shell.XWalkViewShellActivity"
@@ -30,17 +43,4 @@
         <provider android:name="org.xwalk.core.xwview.test.TestContentProvider"
             android:authorities="org.xwalk.core.xwview.test.TestContentProvider" />
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-  <uses-permission android:name="android.permission.CAMERA"/>
-  <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/runtime/android/runtime_lib/AndroidManifest.xml
+++ b/runtime/android/runtime_lib/AndroidManifest.xml
@@ -9,9 +9,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.core">
 
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+
     <application
         android:label="XWalkCoreLibrary" android:hardwareAccelerated="true" android:icon="@drawable/crosswalk">
     </application>
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 </manifest>

--- a/test/android/core/javatests/AndroidManifest.xml
+++ b/test/android/core/javatests/AndroidManifest.xml
@@ -8,18 +8,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.core.xwview.test">
 
-    <application>
-        <uses-library android:name="android.test.runner" />
-    </application>
-
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-    <instrumentation android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="org.xwalk.core.xwview.shell"
-        android:label="Test for org.xwalk.core.xwview" />
     <uses-permission android:name="android.permission.RUN_INSTRUMENTATION" />
     <uses-permission android:name="android.permission.INJECT_EVENTS" />
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.READ_LOGS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application>
+        <uses-library android:name="android.test.runner" />
+    </application>
+
+    <instrumentation android:name="android.test.InstrumentationTestRunner"
+        android:targetPackage="org.xwalk.core.xwview.shell"
+        android:label="Test for org.xwalk.core.xwview" />
 </manifest>

--- a/test/android/core_internal/javatests/AndroidManifest.xml
+++ b/test/android/core_internal/javatests/AndroidManifest.xml
@@ -8,18 +8,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.core.internal.xwview.test">
 
-    <application>
-        <uses-library android:name="android.test.runner" />
-    </application>
-
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-    <instrumentation android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="org.xwalk.core.internal.xwview.shell"
-        android:label="Test for org.xwalk.core.internal.xwview" />
     <uses-permission android:name="android.permission.RUN_INSTRUMENTATION" />
     <uses-permission android:name="android.permission.INJECT_EVENTS" />
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.READ_LOGS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application>
+        <uses-library android:name="android.test.runner" />
+    </application>
+
+    <instrumentation android:name="android.test.InstrumentationTestRunner"
+        android:targetPackage="org.xwalk.core.internal.xwview.shell"
+        android:label="Test for org.xwalk.core.internal.xwview" />
 </manifest>

--- a/test/android/runtime_client/javatests/AndroidManifest.xml
+++ b/test/android/runtime_client/javatests/AndroidManifest.xml
@@ -8,16 +8,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.runtime.client.test">
 
-    <application>
-        <uses-library android:name="android.test.runner" />
-        <provider android:name="org.xwalk.runtime.client.test.TestContentProvider"
-            android:authorities="org.xwalk.runtime.client.test.TestContentProvider" />
-    </application>
-
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-    <instrumentation android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="org.xwalk.runtime.client.shell"
-        android:label="Test for org.xwalk.runtime.client" />
     <uses-permission android:name="android.permission.RUN_INSTRUMENTATION" />
     <uses-permission android:name="android.permission.INJECT_EVENTS" />
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
@@ -26,4 +17,14 @@
     <uses-permission android:name="android.permission.READ_LOGS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
+
+    <application>
+        <uses-library android:name="android.test.runner" />
+        <provider android:name="org.xwalk.runtime.client.test.TestContentProvider"
+            android:authorities="org.xwalk.runtime.client.test.TestContentProvider" />
+    </application>
+
+    <instrumentation android:name="android.test.InstrumentationTestRunner"
+        android:targetPackage="org.xwalk.runtime.client.shell"
+        android:label="Test for org.xwalk.runtime.client" />
 </manifest>

--- a/test/android/runtime_client_embedded/javatests/AndroidManifest.xml
+++ b/test/android/runtime_client_embedded/javatests/AndroidManifest.xml
@@ -8,16 +8,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xwalk.runtime.client.embedded.test">
 
-    <application>
-        <uses-library android:name="android.test.runner" />
-        <provider android:name="org.xwalk.runtime.client.test.TestContentProvider"
-            android:authorities="org.xwalk.runtime.client.embedded.test.TestContentProvider" />
-    </application>
-
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-    <instrumentation android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="org.xwalk.runtime.client.embedded.shell"
-        android:label="Test for org.xwalk.runtime.client.embedded" />
     <uses-permission android:name="android.permission.RUN_INSTRUMENTATION" />
     <uses-permission android:name="android.permission.INJECT_EVENTS" />
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
@@ -26,4 +17,14 @@
     <uses-permission android:name="android.permission.READ_LOGS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
+
+    <application>
+        <uses-library android:name="android.test.runner" />
+        <provider android:name="org.xwalk.runtime.client.test.TestContentProvider"
+            android:authorities="org.xwalk.runtime.client.embedded.test.TestContentProvider" />
+    </application>
+
+    <instrumentation android:name="android.test.InstrumentationTestRunner"
+        android:targetPackage="org.xwalk.runtime.client.embedded.shell"
+        android:label="Test for org.xwalk.runtime.client.embedded" />
 </manifest>


### PR DESCRIPTION
When building the APK with stricter options (default in GN), the
following lint warning is shown:

    AndroidManifest.xml:26 `<uses-sdk>` tag appears after `<application>` tag: ManifestOrder [warning]
      <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />

Fix it by reordering the tags in the files.