### PR TITLE
[Android] Remove dependency on support_v13 xwalk_core_internal_shell_apk

### DIFF
--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -618,7 +618,6 @@
       'target_name': 'xwalk_core_internal_shell_apk',
       'type': 'none',
       'dependencies': [
-        '../third_party/android_tools/android_tools.gyp:android_support_v13_javalib',
         'libxwalkcore',
         'xwalk_core_extensions_java',
         'xwalk_core_internal_java',


### PR DESCRIPTION
Nothing in `runtime/android/core_internal_shell` seems to have ever
depended on Android's support-v13 library, so remove the dependency.