### PR TITLE
[Android] Clean up xwalk_core_{internal_}empty_embedder_apk

### DIFF
--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -139,8 +139,9 @@
         'resource_map_dir': '<(PRODUCT_DIR)/resource_map',
         'timestamp': '<(resource_map_dir)/gen.timestamp',
       },
-      'all_dependent_settings': {
+      'direct_dependent_settings': {
         'variables': {
+          'generated_src_dirs': ['<(resource_map_dir)'],
           'resource_map_gen_timestamp': '<(timestamp)',
         },
       },
@@ -176,9 +177,6 @@
         'java_in_dir': 'runtime/android/core_internal_empty',
         'is_test_apk': 1,
         'additional_input_paths': [ '>(resource_map_gen_timestamp)' ],
-        'generated_src_dirs': [
-           '<(PRODUCT_DIR)/resource_map',
-        ],
         'native_lib_target': 'libxwalkdummy',
         'additional_bundled_libs': [
           '<(PRODUCT_DIR)/lib/libxwalkcore.>(android_product_extension)',
@@ -196,12 +194,10 @@
       'type': 'none',
       'dependencies': [
         'xwalk_core_library',
-        'generate_resource_maps',
       ],
       'variables': {
         'apk_name': '<(core_empty_embedder_apk_name)',
         'java_in_dir': 'runtime/android/core_internal_empty',
-        'additional_input_paths': [ '>(resource_map_gen_timestamp)' ],
       },
       'includes': [ '../build/java_apk.gypi' ],
     },


### PR DESCRIPTION
* `generate_resource_maps`: Use `direct_dependent_settings` to set
  variables that should be available to targets, there is no reason to
  make the variables available to targets that depend on it indirectly.
  While here, define `generated_src_dirs` instead of leaving it up to
  targets that depend on it to take care of it.
* `xwalk_core_empty_embedder_apk`: Stop depending on
  `generate_resource_maps`, it's not used.