### PR TITLE
[Android] Fix the warnings when generating java docs

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java
@@ -101,6 +101,8 @@ public class XWalkFileChooser {
 
     /**
      * Create a file chooser using an activity.
+     *
+     * @param activity the activity to start file chooser
      */
     public XWalkFileChooser(Activity activity) {
         mActivity = activity;
@@ -115,6 +117,7 @@ public class XWalkFileChooser {
      *        with this file picker.
      * @param capture value of the 'capture' attribute of the input tag associated
      *        with this file picker
+     * @return true if file chooser is launched
      * @since 7.0
      */
     public boolean showFileChooser(ValueCallback<Uri> uploadFile, String acceptType,

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionContextClient.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExtensionContextClient.java
@@ -18,11 +18,15 @@ import android.os.Bundle;
 public interface XWalkExtensionContextClient {
     /**
      * Register an xwalk extension into context.
+     *
+     * @param extension the external extension to be registered
      */
     public void registerExtension(XWalkExternalExtension extension);
 
     /**
      * Unregister an xwalk extension with the given unique name from context.
+     *
+     * @param name the name of the external extension to be unregistered
      */
     public void unregisterExtension(String name);
 

--- a/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtension.java
+++ b/runtime/android/core/src/org/xwalk/core/extension/XWalkExternalExtension.java
@@ -144,6 +144,8 @@ public class XWalkExternalExtension {
 
     /**
      * Called when this app is onNewIntent.
+     *
+     * @param intent passed from android.app.Activity.onNewIntent()
      */
     public void onNewIntent(Intent intent) {
     }
@@ -163,6 +165,8 @@ public class XWalkExternalExtension {
 
     /**
      * Called when a new extension instance is created.
+     *
+     * @param instanceID the ID of the instance that is created
      */
     public void onInstanceCreated(int instanceID) {
         instanceHelpers.put(instanceID,
@@ -171,6 +175,8 @@ public class XWalkExternalExtension {
 
     /**
      * Called when a extension instance is destroyed.
+     *
+     * @param instanceID the ID of the instance that is destroyed
      */
     public void onInstanceDestroyed(int instanceID) {
         instanceHelpers.remove(instanceID);
@@ -213,6 +219,7 @@ public class XWalkExternalExtension {
      * message.
      * @param extensionInstanceID the ID of extension instance where the message came from.
      * @param message the message from JavaScript code.
+     * @return whether the message is handled
      */
     public String onSyncMessage(int extensionInstanceID, String message) {
         Object result = null;

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkCookieManagerInternal.java
@@ -96,7 +96,8 @@ public class XWalkCookieManagerInternal {
     }
 
     /**
-     *  Return true if there are stored cookies.
+     * Get whether there are stored cookies.
+     * @return true if there are stored cookies
      * @since 5.0
      */
     @XWalkAPI
@@ -123,7 +124,8 @@ public class XWalkCookieManagerInternal {
     }
 
     /**
-     * Whether cookies are accepted for file scheme URLs.
+     * Get whether cookies are accepted for file scheme URLs.
+     * @return true if cookies are accepted for file scheme URLs
      * @since 5.0
      */
     @XWalkAPI

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkResourceClientInternal.java
@@ -411,6 +411,9 @@ public class XWalkResourceClientInternal {
      * Construct an instance of XWalkWebResourceResponseInternal
      * for application usage.
      *
+     * @param mimeType the resource response's MIME type, for example text/html
+     * @param encoding the resource response's encoding
+     * @param data the input stream that provides the resource response's data
      * @return XWalkWebResourceResponseInternal.
      * @since 6.0
      */
@@ -424,6 +427,12 @@ public class XWalkResourceClientInternal {
      * Construct an instance of XWalkWebResourceResponseInternal
      * for application usage.
      *
+     * @param mimeType the resource response's MIME type, for example text/html
+     * @param encoding the resource response's encoding
+     * @param data the input stream that provides the resource response's data
+     * @param statusCode the status code needs to be in the ranges [100, 299], [400, 599]
+     * @param reasonPhrase the phrase describing the status code, for example "OK"
+     * @param responseHeaders the resource response's headers represented as a mapping of header
      * @return XWalkWebResourceResponseInternal.
      * @since 6.0
      */

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -372,6 +372,8 @@ public class XWalkSettingsInternal {
      * default. Note that this enables or disables file system access only.
      * Assets and resources are still accessible using file:///android_asset and
      * file:///android_res.
+     *
+     * @param allow whether file access is allowed
      * @since 7.0
      */
     @XWalkAPI
@@ -387,6 +389,7 @@ public class XWalkSettingsInternal {
      * Gets whether this XWalkView supports file access.
      *
      * @see #setAllowFileAccess
+     * @return true if this XWalkView supports file access.
      * @since 7.0
      */
     @XWalkAPI
@@ -400,6 +403,8 @@ public class XWalkSettingsInternal {
      * Enables or disables content URL access within XWalkView. Content URL
      * access allows XWalkView to load content from a content provider installed
      * in the system. The default is enabled.
+     *
+     * @param allow whether content URL access is allowed
      * @since 7.0
      */
     @XWalkAPI
@@ -415,6 +420,7 @@ public class XWalkSettingsInternal {
      * Gets whether this XWalkView supports content URL access.
      *
      * @see #setAllowContentAccess
+     * @return true if this XWalkView supports content URL access.
      * @since 7.0
      */
     @XWalkAPI
@@ -1000,6 +1006,8 @@ public class XWalkSettingsInternal {
 
     /**
      * Sets whether the XWalkView should save form data. The default is true.
+     *
+     * @param enable whether the XWalkView should save form data
      * @since 7.0
      */
     @XWalkAPI

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkUIClientInternal.java
@@ -164,6 +164,7 @@ public class XWalkUIClientInternal {
      * @param message the message to be shown.
      * @param defaultValue the default value string. Only valid for Prompt dialog.
      * @param result the callback to handle the result from caller.
+     * @return true if the client will handle the dialog
      * @since 1.0
      */
     @XWalkAPI

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewInternal.java
@@ -773,6 +773,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * <a href="http://developer.android.com/reference/android/app/Activity.html">
      * android.app.Activity.onNewIntent()</a>.
      * @param intent passed from android.app.Activity.onNewIntent().
+     * @return true if this intent is handled
      * @since 1.0
      */
     @XWalkAPI
@@ -790,6 +791,7 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
      * Save current internal state of this XWalkViewInternal. This can help restore this state
      * afterwards restoring.
      * @param outState the saved state for restoring.
+     * @return true if the state is saved
      * @since 1.0
      */
     @XWalkAPI
@@ -959,6 +961,8 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * This method is used by Cordova for hacking.
      * TODO(yongsheng): remove this and related test cases?
+     *
+     * @param networkUp whether network is available
      */
     @XWalkAPI
     public void setNetworkAvailable(boolean networkUp) {
@@ -1522,6 +1526,8 @@ public class XWalkViewInternal extends android.widget.FrameLayout {
     /**
      * Clears the client certificate preferences stored in response to
      * proceeding/cancelling client cert requests.
+     *
+     * @param callback a runnable to be invoked when client certs are cleared
      * @since 6.0
      */
     @XWalkAPI


### PR DESCRIPTION
This patch completes the method's descriptions that are missing the
field @param or @return.

BUG=XWALK-5643