### PR TITLE
[Android] Remove dead code of "xwalk_core_unittests_apk"

### DIFF
--- a/runtime/common/android/xwalk_core_tests.cc
+++ b/runtime/common/android/xwalk_core_tests.cc
@@ -1,9 +1,0 @@
-// Copyright (c) 2012 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-#include "base/test/test_suite.h"
-
-int main(int argc, char** argv) {
-  return base::TestSuite(argc, argv).Run();
-}

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -199,58 +199,6 @@
       'includes': [ '../build/java_apk.gypi' ],
     },
     {
-      'target_name': 'xwalk_core_unittests',
-      'type': '<(gtest_target_type)',
-      'dependencies': [
-        '../base/base.gyp:test_support_base',
-        '../net/net.gyp:net_test_support',
-        '../testing/android/native_test.gyp:native_test_native_code',
-        '../testing/gmock.gyp:gmock',
-        '../testing/gtest.gyp:gtest',
-      ],
-      'include_dirs': [
-        '..',
-      ],
-      'sources': [
-        'runtime/common/android/xwalk_core_tests.cc',
-      ],
-    },
-    {
-      'target_name': 'xwalk_core_unittests_java',
-      'type': 'none',
-      'dependencies': [
-      ],
-      'variables': {
-        'java_in_dir': 'test/android/unittestjava',
-      },
-      # TODO: supress gyp error: "'find ../cameo_webview/unittestjava  -name "*.java"' returned exit status 1"
-      # 'includes': [ '../build/java.gypi' ],
-    },
-    {
-      'target_name': 'xwalk_core_unittests_jni',
-      'type': 'none',
-      'sources': [
-      ],
-      'variables': {
-        'jni_gen_package': 'xwalk_core_unittests',
-      },
-      'includes': [ '../build/jni_generator.gypi' ],
-    },
-    {
-      'target_name': 'xwalk_core_unittests_apk',
-      'type': 'none',
-      'dependencies': [
-        'xwalk_core_unittests',
-        'xwalk_core_unittests_java',
-        'xwalk_core_unittests_jni',
-      ],
-      'variables': {
-        'test_suite_name': 'xwalk_core_unittests',
-        'input_shlib_path': '<(SHARED_LIB_DIR)/<(SHARED_LIB_PREFIX)xwalk_core_unittests<(SHARED_LIB_SUFFIX)',
-      },
-      'includes': [ '../build/apk_test.gypi' ],
-    },
-    {
       'target_name': 'xwalk_runtime_client_shell_apk',
       'type': 'none',
       'dependencies': [


### PR DESCRIPTION
The "xwalk_core_unittests" and "xwalk_core_unittests_apk" are totally
dead code, There is 'java_in_dir': 'test/android/unittestjava' in this
target,but we cannot find it in xwalk src project. Those targets are
not referenced at all.