### PR TITLE
gn: Use existing targets to manipulate icudtl.dat and V8 snapshots

### DIFF
--- a/app/android/runtime_client_embedded_shell/BUILD.gn
+++ b/app/android/runtime_client_embedded_shell/BUILD.gn
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
-import("//third_party/icu/config.gni")
 
 android_apk("xwalk_runtime_client_embedded_shell_apk") {
   apk_name = "XWalkRuntimeClientEmbeddedShell"
@@ -43,32 +42,21 @@ android_assets("xwalk_runtime_client_embedded_shell_apk_pak") {
     "$root_out_dir/xwalk_100_percent.pak",
   ]
   deps = [
+    "//third_party/icu:icu_assets",
+    "//v8:v8_external_startup_data_assets",
     "//xwalk/resources:xwalk_pak",
     "//xwalk/resources:xwalk_resources_100_percent_pak",
   ]
-  if (icu_use_data_file) {
-    sources += [ "$root_out_dir/icudtl.dat" ]
-    deps += [ "//third_party/icu:icudata" ]
-  }
-  if (v8_use_external_startup_data) {
-    sources += [
-      "$root_out_dir/natives_blob.bin",
-      "$root_out_dir/snapshot_blob.bin",
-    ]
-  }
   disable_compression = true
 }
 
 android_assets("xwalk_runtime_client_embedded_shell_apk_assets") {
   sources = []
   deps = [
+    "//third_party/icu:icu_assets",
     "//xwalk/resources:xwalk_pak",
     "//xwalk/resources:xwalk_resources_100_percent_pak",
   ]
-  if (icu_use_data_file) {
-    sources += [ "$root_out_dir/icudtl.dat" ]
-    deps += [ "//third_party/icu:icudata" ]
-  }
   renaming_sources = [
     "//xwalk/test/android/data/manifest.json",
     "//xwalk/test/android/data/index.html",

--- a/runtime/android/core_internal_shell/BUILD.gn
+++ b/runtime/android/core_internal_shell/BUILD.gn
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
-import("//third_party/icu/config.gni")
 
 android_apk("xwalk_core_internal_shell_apk") {
   apk_name = "XWalkCoreInternalShell"
@@ -50,19 +49,11 @@ android_assets("xwalk_core_internal_shell_apk_pak") {
     "$root_out_dir/xwalk_100_percent.pak",
   ]
   deps = [
+    "//third_party/icu:icu_assets",
+    "//v8:v8_external_startup_data_assets",
     "//xwalk/resources:xwalk_pak",
     "//xwalk/resources:xwalk_resources_100_percent_pak",
   ]
-  if (icu_use_data_file) {
-    sources += [ "$root_out_dir/icudtl.dat" ]
-    deps += [ "//third_party/icu:icudata" ]
-  }
-  if (v8_use_external_startup_data) {
-    sources += [
-      "$root_out_dir/natives_blob.bin",
-      "$root_out_dir/snapshot_blob.bin",
-    ]
-  }
   disable_compression = true
 }
 

--- a/runtime/android/core_shell/BUILD.gn
+++ b/runtime/android/core_shell/BUILD.gn
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
-import("//third_party/icu/config.gni")
 
 android_apk("xwalk_core_shell_apk") {
   apk_name = "XWalkCoreShell"
@@ -77,19 +76,11 @@ android_assets("xwalk_core_shell_apk_pak") {
     "$root_out_dir/xwalk_100_percent.pak",
   ]
   deps = [
+    "//third_party/icu:icu_assets",
+    "//v8:v8_external_startup_data_assets",
     "//xwalk/resources:xwalk_pak",
     "//xwalk/resources:xwalk_resources_100_percent_pak",
   ]
-  if (icu_use_data_file) {
-    deps += [ "//third_party/icu:icudata" ]
-    sources += [ "$root_out_dir/icudtl.dat" ]
-  }
-  if (v8_use_external_startup_data) {
-    sources += [
-      "$root_out_dir/natives_blob.bin",
-      "$root_out_dir/snapshot_blob.bin",
-    ]
-  }
   disable_compression = true
 }
 

--- a/runtime/android/runtime_lib/BUILD.gn
+++ b/runtime/android/runtime_lib/BUILD.gn
@@ -4,7 +4,6 @@
 
 import("//build/config/android/rules.gni")
 import("//xwalk/build/version.gni")
-import("//third_party/icu/config.gni")
 
 android_apk("xwalk_runtime_lib_apk") {
   apk_name = "XWalkRuntimeLib"
@@ -46,17 +45,9 @@ android_assets("xwalk_runtime_lib_apk_assets") {
     "jsapi/wifidirect_api.js",
   ]
   deps = [
+    "//third_party/icu:icu_assets",
+    "//v8:v8_external_startup_data_assets",
     "//xwalk/resources:xwalk_pak",
     "//xwalk/resources:xwalk_resources_100_percent_pak",
   ]
-  if (icu_use_data_file) {
-    deps += [ "//third_party/icu:icudata" ]
-    sources += [ "$root_out_dir/icudtl.dat" ]
-  }
-  if (v8_use_external_startup_data) {
-    sources += [
-      "$root_out_dir/natives_blob.bin",
-      "$root_out_dir/snapshot_blob.bin",
-    ]
-  }
 }

--- a/runtime/android/sample/BUILD.gn
+++ b/runtime/android/sample/BUILD.gn
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
-import("//third_party/icu/config.gni")
 
 android_apk("xwalk_core_sample_apk") {
   apk_name = "CrosswalkSample"
@@ -76,15 +75,8 @@ android_assets("xwalk_core_sample_apk_assets") {
     "echo_java.html",
   ]
   sources = []
-  deps = []
-  if (icu_use_data_file) {
-    sources += [ "$root_out_dir/icudtl.dat" ]
-    deps += [ "//third_party/icu:icudata" ]
-  }
-  if (v8_use_external_startup_data) {
-    sources += [
-      "$root_out_dir/natives_blob.bin",
-      "$root_out_dir/snapshot_blob.bin",
-    ]
-  }
+  deps = [
+    "//third_party/icu:icu_assets",
+    "//v8:v8_external_startup_data_assets",
+  ]
 }


### PR DESCRIPTION
Instead of repeating the same checks for `icu_use_data_file` and
`v8_use_external_startup_data` along with changes to `sources` and
`deps` in many different files, we can leverage the existing upstream
targets whose purpose is to do the exact same thing.