### PR TITLE
gn: Rename a few targets to prepare for M53.

### DIFF
--- a/runtime/android/core/BUILD.gn
+++ b/runtime/android/core/BUILD.gn
@@ -7,7 +7,7 @@ import("//build/config/android/rules.gni")
 android_library("xwalk_core_java") {
   deps = [
     ":xwalk_core_java_resources",
-    "//xwalk/runtime/android/core_internal:xwalk_core_reflection_layer_java_gen",
+    "//xwalk/runtime/android/core_internal:xwalk_core_reflection_layer_gen",
     "//xwalk/third_party/lzma_sdk:lzma_sdk_java",
   ]
   srcjars =
@@ -52,11 +52,11 @@ android_resources("xwalk_core_java_resources") {
   resource_dirs = [ "res" ]
   custom_package = "org.xwalk.core"
   deps = [
-    ":xwalk_app_strings",
+    ":xwalk_app_strings_grd",
   ]
 }
 
-java_strings_grd("xwalk_app_strings") {
+java_strings_grd("xwalk_app_strings_grd") {
   grd_file = "strings/xwalk_app_strings.grd"
   outputs = [
     "values/xwalk_app_strings.xml",

--- a/runtime/android/core_internal/BUILD.gn
+++ b/runtime/android/core_internal/BUILD.gn
@@ -10,7 +10,7 @@ reflection_gen_dir = "$root_gen_dir/xwalk_core_reflection_layer/"
 android_library("xwalk_core_internal_java") {
   deps = [
     ":xwalk_core_internal_java_resources",
-    ":xwalk_core_reflection_layer_java_gen",
+    ":xwalk_core_reflection_layer_gen",
     "//base:base_java",
     "//components/navigation_interception/android:navigation_interception_java",
     "//components/web_contents_delegate_android:web_contents_delegate_android_java",
@@ -103,7 +103,7 @@ android_library("xwalk_core_internal_java") {
   ]
 }
 
-java_strings_grd("xwalk_core_strings") {
+java_strings_grd("xwalk_core_strings_grd") {
   grd_file = "strings/android_xwalk_strings.grd"
   outputs = [
     "values/android_xwalk_strings.xml",
@@ -114,11 +114,11 @@ android_resources("xwalk_core_internal_java_resources") {
   resource_dirs = [ "res" ]
   custom_package = "org.xwalk.core.internal"
   deps = [
-    ":xwalk_core_strings",
+    ":xwalk_core_strings_grd",
   ]
 }
 
-action("xwalk_core_reflection_layer_java_gen") {
+action("xwalk_core_reflection_layer_gen") {
   script = "//xwalk/tools/reflection_generator/reflection_generator.py"
   args = [
     "--input-dir",


### PR DESCRIPTION
Starting with M53, https://codereview.chromium.org/2109293003 enforces a
naming convention for certain Android targets, and if a target name
matches it's assumed to have a `.build_config` file with it.

* Rename `xwalk_app_strings` to `xwalk_app_strings_grd` so GN accepts it
  as a valid target that generates a `.build_config`.

* Rename `xwalk_core_reflection_layer_java_gen` to
  `xwalk_core_reflection_layer_gen` to achieve the opposite and have GN
  _stop_ assuming the target produces a `.build_config` (the "java" part
  was making it fall into a naming whitelist).