### PR TITLE
gn: Unify packing of xwalk{_100_percent}.pak into a single target

### DIFF
--- a/app/android/runtime_client_embedded_shell/BUILD.gn
+++ b/app/android/runtime_client_embedded_shell/BUILD.gn
@@ -15,7 +15,6 @@ android_apk("xwalk_runtime_client_embedded_shell_apk") {
   deps = [
     ":xwalk_runtime_client_embedded_shell_apk_assets",
     ":xwalk_runtime_client_embedded_shell_apk_java",
-    ":xwalk_runtime_client_embedded_shell_apk_pak",
     ":xwalk_runtime_client_embedded_shell_apk_resources",
     "//base:base_java",
     "//xwalk/extensions/test:echo_extension",
@@ -36,26 +35,11 @@ android_library("xwalk_runtime_client_embedded_shell_apk_java") {
   ]
 }
 
-android_assets("xwalk_runtime_client_embedded_shell_apk_pak") {
-  sources = [
-    "$root_out_dir/xwalk.pak",
-    "$root_out_dir/xwalk_100_percent.pak",
-  ]
-  deps = [
-    "//third_party/icu:icu_assets",
-    "//v8:v8_external_startup_data_assets",
-    "//xwalk/resources:xwalk_pak",
-    "//xwalk/resources:xwalk_resources_100_percent_pak",
-  ]
-  disable_compression = true
-}
-
 android_assets("xwalk_runtime_client_embedded_shell_apk_assets") {
   sources = []
   deps = [
     "//third_party/icu:icu_assets",
-    "//xwalk/resources:xwalk_pak",
-    "//xwalk/resources:xwalk_resources_100_percent_pak",
+    "//xwalk/resources:pak_file_assets",
   ]
   renaming_sources = [
     "//xwalk/test/android/data/manifest.json",

--- a/resources/BUILD.gn
+++ b/resources/BUILD.gn
@@ -6,6 +6,10 @@ import("//tools/grit/grit_rule.gni")
 import("//tools/grit/repack.gni")
 import("//xwalk/resources/locales.gni")
 
+if (is_android) {
+  import("//build/config/android/rules.gni")
+}
+
 repack("xwalk_pak") {
   output = "$root_out_dir/xwalk.pak"
   sources = [
@@ -108,6 +112,22 @@ repack("xwalk_resources_300_percent_pak") {
     sources +=
         [ "$root_gen_dir/ui/views/resources/views_resources_300_percent.pak" ]
     deps += [ "//ui/views/resources:resources_grd" ]
+  }
+}
+
+if (is_android) {
+  android_assets("pak_file_assets") {
+    sources = [
+      "$root_out_dir/xwalk.pak",
+      "$root_out_dir/xwalk_100_percent.pak",
+    ]
+    deps = [
+      ":xwalk_pak",
+      ":xwalk_resources_100_percent_pak",
+      "//third_party/icu:icu_assets",
+      "//v8:v8_external_startup_data_assets",
+    ]
+    disable_compression = true
   }
 }
 

--- a/runtime/android/core_internal_shell/BUILD.gn
+++ b/runtime/android/core_internal_shell/BUILD.gn
@@ -11,7 +11,6 @@ android_apk("xwalk_core_internal_shell_apk") {
   deps = [
     ":xwalk_core_internal_shell_apk_assets",
     ":xwalk_core_internal_shell_apk_java",
-    ":xwalk_core_internal_shell_apk_pak",
     ":xwalk_core_internal_shell_apk_resources",
     "//base:base_java",
     "//xwalk/runtime/app/android:libxwalkcore",
@@ -37,24 +36,8 @@ android_assets("xwalk_core_internal_shell_apk_assets") {
   renaming_sources = [ "//xwalk/test/android/data/index.html" ]
   renaming_destinations = [ "www/index.html" ]
   deps = [
-    "//xwalk/resources:xwalk_pak",
-    "//xwalk/resources:xwalk_resources_100_percent_pak",
+    "//xwalk/resources:pak_file_assets",
   ]
-}
-
-android_assets("xwalk_core_internal_shell_apk_pak") {
-  visibility = [ ":*" ]
-  sources = [
-    "$root_out_dir/xwalk.pak",
-    "$root_out_dir/xwalk_100_percent.pak",
-  ]
-  deps = [
-    "//third_party/icu:icu_assets",
-    "//v8:v8_external_startup_data_assets",
-    "//xwalk/resources:xwalk_pak",
-    "//xwalk/resources:xwalk_resources_100_percent_pak",
-  ]
-  disable_compression = true
 }
 
 android_resources("xwalk_core_internal_shell_apk_resources") {

--- a/runtime/android/core_shell/BUILD.gn
+++ b/runtime/android/core_shell/BUILD.gn
@@ -14,7 +14,6 @@ android_apk("xwalk_core_shell_apk") {
   deps = [
     ":xwalk_core_shell_apk_assets",
     ":xwalk_core_shell_apk_java",
-    ":xwalk_core_shell_apk_pak",
     ":xwalk_core_shell_apk_resources",
     "//base:base_java",
     "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
@@ -65,23 +64,8 @@ android_assets("xwalk_core_shell_apk_assets") {
     "jsapi/wifidirect_api.js",
   ]
   deps = [
-    "//xwalk/resources:xwalk_pak",
-    "//xwalk/resources:xwalk_resources_100_percent_pak",
+    "//xwalk/resources:pak_file_assets",
   ]
-}
-
-android_assets("xwalk_core_shell_apk_pak") {
-  sources = [
-    "$root_out_dir/xwalk.pak",
-    "$root_out_dir/xwalk_100_percent.pak",
-  ]
-  deps = [
-    "//third_party/icu:icu_assets",
-    "//v8:v8_external_startup_data_assets",
-    "//xwalk/resources:xwalk_pak",
-    "//xwalk/resources:xwalk_resources_100_percent_pak",
-  ]
-  disable_compression = true
 }
 
 android_resources("xwalk_core_shell_apk_resources") {

--- a/runtime/android/runtime_lib/BUILD.gn
+++ b/runtime/android/runtime_lib/BUILD.gn
@@ -32,10 +32,6 @@ android_resources("xwalk_runtime_lib_apk_resources") {
 
 android_assets("xwalk_runtime_lib_apk_assets") {
   visibility = [ ":*" ]
-  sources = [
-    "$root_out_dir/xwalk.pak",
-    "$root_out_dir/xwalk_100_percent.pak",
-  ]
   renaming_sources = [
     "//xwalk/experimental/launch_screen/launch_screen_api.js",
     "//xwalk/experimental/wifidirect/wifidirect_api.js",
@@ -47,7 +43,6 @@ android_assets("xwalk_runtime_lib_apk_assets") {
   deps = [
     "//third_party/icu:icu_assets",
     "//v8:v8_external_startup_data_assets",
-    "//xwalk/resources:xwalk_pak",
-    "//xwalk/resources:xwalk_resources_100_percent_pak",
+    "//xwalk/resources:pak_file_assets",
   ]
 }

--- a/runtime/android/sample/BUILD.gn
+++ b/runtime/android/sample/BUILD.gn
@@ -35,7 +35,6 @@ android_apk("xwalk_core_sample_apk") {
     "//xwalk/extensions/android:xwalk_core_extensions_java",
     "//xwalk/runtime/android/core:xwalk_core_java",
     "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
-    "//xwalk/runtime/android/core_shell:xwalk_core_shell_apk_pak",
     "//xwalk/runtime/app/android:libxwalkcore",
   ]
 }
@@ -78,5 +77,6 @@ android_assets("xwalk_core_sample_apk_assets") {
   deps = [
     "//third_party/icu:icu_assets",
     "//v8:v8_external_startup_data_assets",
+    "//xwalk/resources:pak_file_assets",
   ]
 }


### PR DESCRIPTION
Get rid of a lot of repetition in the Android `BUILD.gn`s. There were 4
targets doing the exact same thing: calling `android_assets()` to pack
`xwalk.pak` and `xwalk_100_percent.pak` along with ICU and V8 blobs.
Some of those targets were then being depended on in other files,
leading to a needless entanglement in the build system.

Additionally, many `*_apk` targets were duplicating the dependency on
the `xwalk_pak` and `xwalk_resources_100_percent_pak` targets that were
already part of the `*_assets` targets.

We now unify all those targets into `//xwalk/runtime:pak_file_assets`,
and only depend on it from the `*_assets` Android targets (which is also
what upstream does with its targets).