### PR TITLE
[Android]Fix thread unsafety in accessing Java side getters

### DIFF
--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkSettingsInternal.java
@@ -783,6 +783,7 @@ public class XWalkSettingsInternal {
     @CalledByNative
     private boolean getAppCacheEnabled() {
         // When no app cache path is set, use chromium default cache path.
+        assert Thread.holdsLock(mXWalkSettingsLock);
         return mAppCacheEnabled;
     }
 
@@ -945,6 +946,7 @@ public class XWalkSettingsInternal {
 
     @CalledByNative
     private String getUserAgentLocked() {
+        assert Thread.holdsLock(mXWalkSettingsLock);
         return mUserAgent;
     }
 
@@ -1041,11 +1043,13 @@ public class XWalkSettingsInternal {
 
     @CalledByNative
     private String getAcceptLanguagesLocked() {
+        assert Thread.holdsLock(mXWalkSettingsLock);
         return mAcceptLanguages;
     }
 
     @CalledByNative
     private boolean getSaveFormDataLocked() {
+        assert Thread.holdsLock(mXWalkSettingsLock);
         return mAutoCompleteEnabled;
     }
 


### PR DESCRIPTION
Add assertions on holding the lock into getters called from native code.

BUG=XWALK-5635
