### PR TITLE
[Android] Do not include BUILD.gn in xwalk_app_template/

### DIFF
--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -33,7 +33,8 @@ def GenerateAppTemplate(build_dir, build_mode, output_dir, source_dir):
   )
 
   for src, dest in dirs:
-    shutil.copytree(src, dest)
+    # Make sure app/android/app_template's BUILD.gn is not included.
+    shutil.copytree(src, dest, ignore=shutil.ignore_patterns('*.gn'))
   for src, dest in files:
     try:
       os.makedirs(os.path.dirname(dest))


### PR DESCRIPTION
Since we do a simple shutil.copytree() to copy `app/android/app_template`
to `xwalk_app_template/template`, we end up including the `BUILD.gn`
present in the former.

Explicitly ignore `*.gn` files when copying to avoid that.