### PR TITLE
gn: Implement project and AAR generation targets for Android

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -34,6 +34,8 @@ group("xwalk_builder") {
 
       # For external testing.
       "app/android/app_hello_world:xwalk_app_hello_world_apk",
+      "runtime/android/core:xwalk_core_library",
+      "runtime/android/core:xwalk_shared_library",
       "runtime/android/runtime_lib:xwalk_runtime_lib_apk",
       "runtime/android/sample:xwalk_core_sample_apk",
     ]

--- a/build/android/generate_android_project.gni
+++ b/build/android/generate_android_project.gni
@@ -1,0 +1,302 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/android/rules.gni")
+
+# Runs generate_xwalk_core_library.py.
+#
+# Args:
+#   binary_files [optional]
+#     List of additional binary data (icudtl.dat, for example) that will be
+#     added to res/raw.
+#   build_config [required]
+#     Path to a .build_config file with resource and native libraries
+#     information (generally, a build_config with the "android_apk" type).
+#   has_native_libraries [optional]
+#     Boolean indicating whether there are architecture-dependent shared
+#     libraries to copy to the project.
+#   js_bindings [required]
+#     List of Crosswalk extension bindings .js files to add to res/raw.
+#   output_dir [required]
+#     The project directory to be created. If it already exists, it will be
+#     erased.
+#   template_dir [required]
+#     Directory to the template directory containing a ant.properties,
+#     AndroidManifest.xml and others.
+template("generate_xwalk_core_library") {
+  assert(defined(invoker.build_config))
+  assert(defined(invoker.js_bindings))
+  assert(defined(invoker.output_dir))
+  assert(defined(invoker.template_dir))
+
+  _build_config = invoker.build_config
+  _js_bindings = invoker.js_bindings
+  _output_dir = invoker.output_dir
+  _template_dir = invoker.template_dir
+
+  action(target_name) {
+    forward_variables_from(invoker, [ "deps" ])
+
+    script = "//xwalk/build/android/generate_xwalk_core_library.py"
+    inputs = [
+      "//build/android/gyp/package_resources.py",
+      "//build/android/gyp/util/build_utils.py",
+    ]
+    outputs = [
+      "$target_gen_dir/${target_name}__generate.stamp",
+    ]
+
+    _stamp = rebase_path("$target_gen_dir/${target_name}__generate.stamp",
+                         root_build_dir)
+
+    _rebased_build_config = rebase_path(_build_config, root_build_dir)
+    _rebased_js_bindings = rebase_path(_js_bindings, root_build_dir)
+    _rebased_output_dir = rebase_path(_output_dir, root_build_dir)
+    _rebased_template_dir = rebase_path(_template_dir, root_build_dir)
+
+    args = [
+      "--abi=$android_app_abi",
+      "--js-bindings=$_rebased_js_bindings",
+      "--main-jar=@FileArg(${_rebased_build_config}:deps_info:jar_path)",
+      "--output-dir=$_rebased_output_dir",
+      "--resource-zips=@FileArg(${_rebased_build_config}:resources:dependency_zips)",
+      "--stamp=$_stamp",
+      "--template-dir=$_rebased_template_dir",
+    ]
+
+    if (defined(invoker.binary_files) && invoker.binary_files != []) {
+      binary_files = rebase_path(invoker.binary_files, root_build_dir)
+      args += [ "--binary-files=$binary_files" ]
+    }
+    if (defined(invoker.has_native_libraries) && invoker.has_native_libraries) {
+      args += [ "--native-libraries=@FileArg(${_rebased_build_config}:native:libraries)" ]
+    }
+  }
+}
+
+# Creates an empty Android project with Crosswalk ready for use as a library,
+# as well as an AAR archive derived from it.
+# The project will be created in $root_out_dir/$target_name; if the directory
+# already exists, it will be removed first.
+#
+# Args:
+#   android_manifest [required]
+#     Path to the AndroidManifest.xml that will be used when processing
+#     resources and creating the AAR archive.
+#   binary_files [optional]
+#     List of additional binary data (icudtl.dat, for example) that will be
+#     added to res/raw.
+#   js_bindings [required]
+#     List of Crosswalk extension bindings .js files to add to res/raw.
+#   native_libs [optional]
+#     List of architecture-dependent shared libraries to include in the
+#     project.
+#   resource_excluded_patterns [optional]
+#     A list that accepts fnmatch-style wildcards with resource classes that
+#     should be left out of the JARs being built.
+#   template_dir [required]
+#     Directory to the template directory containing a ant.properties,
+#     AndroidManifest.xml and others.
+template("generate_android_project") {
+  assert(defined(invoker.android_manifest))
+  assert(defined(invoker.js_bindings))
+  assert(defined(invoker.template_dir))
+
+  _base_path = "$target_gen_dir/$target_name"
+  _merged_jar_path = "${_base_path}.jar"
+  _r_file_path = "${_base_path}_R.txt"
+  _resource_jar_path = "${_base_path}_resources.jar"
+  _target_name = target_name
+
+  _native_libs = []
+  if (defined(invoker.native_libs)) {
+    _native_libs = invoker.native_libs
+  }
+
+  # Write a build_config file. Its contents are used by several other targets
+  # within this template via the "@FileArg" expansion. We are not really
+  # building an APK here, but the "android_apk" type generates a build config
+  # with all the information we need about dependencies (JARs and resource
+  # files).
+  _build_config_target = "${target_name}__build_config"
+  _build_config = _base_path + ".build_config"
+  _rebased_build_config = rebase_path(_build_config, root_build_dir)
+  write_build_config(_build_config_target) {
+    type = "android_apk"
+    deps = invoker.deps
+
+    build_config = _build_config
+    jar_path = _merged_jar_path
+    native_libs = _native_libs
+
+    # The following are required to write an android_apk build config file, but
+    # we do not use them for anything.
+    android_manifest = invoker.android_manifest
+    dex_path = _base_path + "__unused.dex"
+    resources_zip = _base_path + "__unused.resources.zip"
+  }
+
+  _srcjar_deps = []
+
+  # Process resources from all dependencies (obtained via the build config
+  # file) and generate a .srcjar file with all the generated R.java files, as
+  # well as an R.txt for the AAR.
+  _process_resources_target = "${target_name}__process_resources"
+  process_resources(_process_resources_target) {
+    android_manifest = invoker.android_manifest
+    build_config = _build_config
+    deps = [
+      ":$_build_config_target",
+    ]
+    r_text_path = _r_file_path
+    resource_dirs = [ "//build/android/ant/empty/res" ]
+    srcjar_path = "$target_gen_dir/$target_name.srcjar"
+
+    # Unused, but required.
+    zip_path = _base_path + "_reszip__unused.zip"
+  }
+  _srcjar_deps += [ ":$_process_resources_target" ]
+
+  # If we are shipping native libraries, we need to create a wrapper to be able
+  # to load them at runtime.
+  if (_native_libs != []) {
+    # TODO(rakuco): We may need an additional block adding libc++_shared.so for
+    # the is_component_build case. See the android_apk template in rules.gni.
+
+    java_cpp_template("${target_name}__native_libraries_java") {
+      package_name = "org/chromium/base/library_loader"
+      sources = [
+        "//base/android/java/templates/NativeLibraries.template",
+      ]
+      inputs = [
+        _build_config,
+      ]
+      deps = [
+        ":$_build_config_target",
+      ]
+      defines =
+          [ "NATIVE_LIBRARIES_LIST=" +
+            "@FileArg($_rebased_build_config:native:java_libraries_list)" ]
+    }
+    _srcjar_deps += [ ":${target_name}__native_libraries_java" ]
+
+    # We also need to generate BuildConfig.java, which some classes in //base
+    # may use.
+    # Note that this does not really depend on |_native_libs| at all, we are
+    # just relying on the fact that, so far, not having native libraries means
+    # we do not want any Chromium bits at all (i.e. we are building
+    # xwalk_shared_library).
+    java_cpp_template("${target_name}__build_config_java") {
+      package_name = "org/chromium/base"
+      sources = [
+        "//base/android/java/templates/BuildConfig.template",
+      ]
+    }
+    _srcjar_deps += [ ":${target_name}__build_config_java" ]
+  }
+
+  # Compile the files we have generated (the .srcjar containing the R.java's
+  # and the wrappers).
+  _java_target = "${target_name}__java"
+  java_library_impl(_java_target) {
+    android_manifest = "//build/android/AndroidManifest.xml"
+    deps = [
+      ":$_build_config_target",
+    ]
+    dex_path = _base_path + "__unused.dex.jar"
+    emma_never_instrument = true
+    if (defined(invoker.resource_excluded_patterns)) {
+      jar_excluded_patterns = invoker.resource_excluded_patterns
+    }
+    jar_path = _resource_jar_path
+    java_files = []
+    override_build_config = _build_config
+    requires_android = true
+    srcjar_deps = _srcjar_deps
+    supports_android = true
+  }
+
+  # Merge all JARs from the dependencies and the one we generated above into a
+  # single one.
+  _merge_target = "${target_name}__merge"
+  action(_merge_target) {
+    deps = [
+      ":$_java_target",
+    ]
+    script = "//xwalk/build/android/merge_jars.py"
+    args = [
+      "--output-jar",
+      rebase_path(_merged_jar_path, root_build_dir),
+      "@FileArg($_rebased_build_config:java:full_classpath)",
+      rebase_path(_resource_jar_path, root_build_dir),
+    ]
+    outputs = [
+      _merged_jar_path,
+    ]
+  }
+
+  # Call generate_xwalk_core_library to generate a project directory.
+  _project_target = "${target_name}__project"
+  generate_xwalk_core_library(_project_target) {
+    build_config = _build_config
+    deps = [
+      ":$_build_config_target",
+      ":$_merge_target",
+    ]
+    forward_variables_from(invoker,
+                           [
+                             "binary_files",
+                             "js_bindings",
+                             "template_dir",
+                           ])
+    output_dir = "$root_out_dir/$_target_name"
+
+    if (_native_libs != []) {
+      has_native_libraries = true
+    }
+  }
+
+  # Create an AAR archive.
+  _aar_target = "${target_name}__aar"
+  action(_aar_target) {
+    _aar_path = "$root_out_dir/${_target_name}.aar"
+
+    deps = [
+      ":$_project_target",
+    ]
+    script = "//xwalk/build/android/generate_xwalk_core_library_aar.py"
+    outputs = [
+      _aar_path,
+    ]
+    args = [
+      "--aar-path",
+      rebase_path(_aar_path, root_build_dir),
+      "--android-manifest",
+      rebase_path(invoker.android_manifest, root_build_dir),
+      "--classes-jar",
+      rebase_path(_merged_jar_path, root_build_dir),
+      "--res-dir",
+      rebase_path("$root_out_dir/$_target_name/res", root_build_dir),
+      "--r-txt",
+      rebase_path(_r_file_path, root_build_dir),
+    ]
+
+    if (_native_libs != []) {
+      args += [
+        "--jni-abi",
+        android_app_abi,
+        "--jni-dir",
+        rebase_path("$root_out_dir/$_target_name/libs/$android_app_abi",
+                    root_build_dir),
+      ]
+    }
+  }
+
+  group(target_name) {
+    public_deps = [
+      ":$_aar_target",
+      ":$_project_target",
+    ]
+  }
+}

--- a/build/android/merge_jars.py
+++ b/build/android/merge_jars.py
@@ -97,15 +97,19 @@ def ValidateKnownSkippedJars(jar_list):
 
 def main():
   parser = argparse.ArgumentParser()
-  parser.add_argument('--jars', help='The jars to merge.')
+  parser.add_argument('jars', nargs=argparse.REMAINDER,
+                      help='The jars to merge.')
   parser.add_argument('--output-jar', help='Name of the merged JAR file.')
   parser.add_argument('--validate-skipped-jars-list', action='store_true',
                       help='Whether to validate KNOWN_SKIPPED_JARS by making '
                       'sure it matches all the jars passed in --jars that are '
                       'being skipped.')
 
-  options = parser.parse_args()
-  options.jars = build_utils.ParseGypList(options.jars)
+  options = parser.parse_args(build_utils.ExpandFileArgs(sys.argv[1:]))
+  jars = []
+  for j in options.jars:
+    jars.extend(build_utils.ParseGypList(j))
+  options.jars = jars
 
   if options.validate_skipped_jars_list:
     extra, missing = ValidateKnownSkippedJars(options.jars)

--- a/runtime/android/core/BUILD.gn
+++ b/runtime/android/core/BUILD.gn
@@ -3,6 +3,9 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
+import("//build_overrides/v8.gni")
+import("//third_party/icu/config.gni")
+import("//xwalk/build/android/generate_android_project.gni")
 
 android_library("xwalk_core_java") {
   deps = [
@@ -61,4 +64,85 @@ java_strings_grd("xwalk_app_strings_grd") {
   outputs = [
     "values/xwalk_app_strings.xml",
   ]
+}
+
+generate_android_project("xwalk_core_library") {
+  android_manifest =
+      "//xwalk/runtime/android/core_internal_empty/AndroidManifest.xml"
+  deps = [
+    ":xwalk_core_java",
+    "//base:base_java",
+    "//third_party/icu:icudata",
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+    "//xwalk/runtime/android/core_internal:xwalk_core_internal_java",
+    "//xwalk/runtime/android/dummy_lib:libxwalkdummy",
+    "//xwalk/runtime/app/android:libxwalkcore",
+  ]
+  binary_files = [
+    "$root_out_dir/xwalk.pak",
+    "$root_out_dir/xwalk_100_percent.pak",
+  ]
+  js_bindings = [
+    "//xwalk/experimental/launch_screen/launch_screen_api.js",
+    "//xwalk/experimental/wifidirect/wifidirect_api.js",
+  ]
+  native_libs = [
+    "$root_out_dir/libxwalkdummy.so",
+    "$root_out_dir/libxwalkcore.so",
+  ]
+
+  # We only need to exclude those classes because invoker.android_manifest
+  # usually points to a manifest with the same package name (org.xwalk.core),
+  # leading to the resources being processed again by Ant when building with
+  # app-tools and dex complaining of multiple definitions of
+  # org.xwalk.core.R.
+  # TODO(rakuco): Check if we should fix the manifest instead.
+  resource_excluded_patterns = [
+    "*/org/xwalk/core/R.class",
+    "*/org/xwalk/core/R##*.class",
+    "*/org/xwalk/core/library/empty/R.class",
+    "*/org/xwalk/core/library/empty/R##*.class",
+  ]
+  template_dir = "//xwalk/build/android/xwalkcore_library_template"
+
+  if (icu_use_data_file) {
+    binary_files += [ "$root_out_dir/icudtl.dat" ]
+  }
+
+  if (v8_use_external_startup_data) {
+    binary_files += [
+      "$root_out_dir/natives_blob.bin",
+      "$root_out_dir/snapshot_blob.bin",
+    ]
+    deps += [ "//v8" ]
+  }
+}
+
+generate_android_project("xwalk_shared_library") {
+  android_manifest =
+      "//xwalk/runtime/android/core_internal_empty/AndroidManifest.xml"
+  deps = [
+    ":xwalk_core_java",
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+  ]
+  js_bindings = [
+    "//xwalk/experimental/launch_screen/launch_screen_api.js",
+    "//xwalk/experimental/wifidirect/wifidirect_api.js",
+  ]
+
+  # We only need to exclude those classes because invoker.android_manifest
+  # usually points to a manifest with the same package name (org.xwalk.core),
+  # leading to the resources being processed again by Ant when building with
+  # app-tools and dex complaining of multiple definitions of
+  # org.xwalk.core.R.
+  # TODO(rakuco): Check if we should fix the manifest instead.
+  resource_excluded_patterns = [
+    "*/org/xwalk/core/R.class",
+    "*/org/xwalk/core/R##*.class",
+    "*/org/xwalk/core/library/empty/R.class",
+    "*/org/xwalk/core/library/empty/R##*.class",
+  ]
+  template_dir = "//xwalk/build/android/xwalk_shared_library_template"
 }

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -125,8 +125,8 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--jars=>(input_jars_paths)',
             '--output-jar=<(jar_final_path)',
+            '>(input_jars_paths)',
           ],
         },
       ],
@@ -154,8 +154,8 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--jars=>(input_jars_paths)',
             '--output-jar=<(jar_final_path)',
+            '>(input_jars_paths)',
           ],
         },
       ],
@@ -184,12 +184,12 @@
           ],
           'action': [
             'python', 'build/android/merge_jars.py',
-            '--jars=>(input_jars_paths)',
             '--output-jar=<(jar_final_path)',
             # This argument is important for this final JAR we are creating, as
             # it validates that we are filtering out the right JARs when doing
             # the merge.
             '--validate-skipped-jars-list',
+            '>(input_jars_paths)',
           ],
         },
       ],


### PR DESCRIPTION
In gyp, they are `xwalk_core_library`, `xwalk_shared_library`,
`xwalk_core_library_aar` and `xwalk_shared_library_aar`.

The GN implementation requires more lines of code, but is hopefully a
lot easier to understand: developers only have to care about the
`xwalk_{core,shared}_library` targets. Everything else is internal to
their implementation.

Thanks to GN's architecture, we can use `build_config` files to write
down a lot of dependency information for each target and use that file's
contents when specifying which resources we want or certain JARs we want
to work or generate. For example, we do not need to manually specify any
of the zipped resource files we use, nor their corresponding paths in
the source tree; we also do not have to hardcode paths to certain JARs,
such as `xwalk_app_runtime_java.jar`.

The biggest piece of code is the `generate_android_project` template in
the newly-added `build/android/generate_android_project.gni. It performs
all the steps required to have a working project directory:
* Processing resources (`res/`) of all the specified dependencies.
* Generating a `NativeLibraries.java` wrapper for any native libraries
  listed as dependencies (e.g. `libxwalkcore.so`) to be loaded at
  runtime.
* Building a separate JAR with the code generated in the above steps.
* Merging this JAR with all the other JARs generated by the target's
  dependencies.
* Actually calling `generate_xwalk_core_library.py`.
* Generating an AAR file (via `generate_xwalk_core_library_aar.py`).

In gyp, the maze made of `xwalk_core_empty_embedder_apk`,
`xwalk_core_internal_empty_embedder_apk`, `xwalk_core_library_java`,
`xwalk_core_library_java_app_part` and
`xwalk_core_library_java_library_part` was used only to perform the
first 2 steps described above by creating empty, unused APKs and using
some of the byproducts of the APK's build.

With GN, we no longer need to pass either `--resource-zip-sources` or
`--resource-strings` to `generate_xwalk_core_library.py`, as all the
resource files are specified together in the build_config and the paths
are all derived from the original source locations. We can also separate
string and non-string resources based on their file names, as all string
targets end in `_grd`, and so do their zips.

Compared to `xwalk_core_library_java.jar` and `xwalk_core_library.aar`
from gyp, the GN versions have a few differences in what is packaged:
* We now ship `org.chromium.base.BuildConfig`, which is not really used
  by any of our code paths but may become required in the future.
* There are fewer `R$foo.class` files in both
  `org/chromium/components/web_contents_delegate_android` and
  `org/xwalk/core/internal` (seemingly with no adverse effects).
* We ship fewer Mojo classes, simply because the targets in `content`
  do not depend on all the Mojo targets the gyp version does.
* We no longer ship `org/xwalk/core/library/empty/R*.class`, as they are
  not used anywhere and are just a byproduct of the AndroidManifest.xml
  we pass when processing resources.

Compared to `xwalk_core_library_java_app_part.jar` and
`xwalk_shared_library.aar` from gyp, the GN versions differ in one aspect:
* They do not contain any resources coming from Chromium targets: they
  are also present in `XWalkRuntimeLibrary`, and that is where they
  should come from in shared mode (which is what uses the aforementioned
  JAR).

Finally, the existing Python scripts had to be modified slightly:
* Since some arguments to the scripts are passed in GN via the
  "@FileArg" expansion, we need to call `build_utils.ExpandFileArgs()`.
  There are no side-effects to gyp.
* `merge_jars.py` now takes the JARs to merge as positional arguments
  due to a limitation in the `ExpandFileArgs()` function mentioned
  above (it cannot expand multiple `@FileArg()` calls as a list value to
  a single argument).