### PR TITLE
gn: Implement the xwalk_app_template target

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -34,6 +34,7 @@ group("xwalk_builder") {
 
       # For external testing.
       "app/android/app_hello_world:xwalk_app_hello_world_apk",
+      "app/android/app_template:xwalk_app_template",
       "runtime/android/core:xwalk_core_library",
       "runtime/android/core:xwalk_shared_library",
       "runtime/android/runtime_lib:xwalk_runtime_lib_apk",

--- a/app/android/app_template/BUILD.gn
+++ b/app/android/app_template/BUILD.gn
@@ -31,3 +31,49 @@ android_resources("xwalk_app_template_apk_resources") {
   resource_dirs = [ "res" ]
   custom_package = "org.xwalk.app.template"
 }
+
+action("xwalk_app_template") {
+  # Use xwalk_app_runtime_java's build_config to derive the path to the JAR.
+  _app_runtime_target =
+      "//xwalk/app/android/runtime_client:xwalk_app_runtime_java"
+  _app_runtime_gen_dir = get_label_info(_app_runtime_target, "target_gen_dir")
+  _app_runtime_name = get_label_info(_app_runtime_target, "name")
+  _app_runtime_build_config =
+      rebase_path("$_app_runtime_gen_dir/$_app_runtime_name.build_config",
+                  root_build_dir)
+
+  script = "//xwalk/build/android/generate_app_packaging_tool.py"
+  deps = [
+    "//xwalk/runtime/android/core:xwalk_core_library",
+    "//xwalk/runtime/android/core:xwalk_shared_library",
+    _app_runtime_target,
+  ]
+  sources = [
+    "//xwalk/API_VERSION",
+    "//xwalk/VERSION",
+  ]
+
+  _stamp = "$target_gen_dir/$target_name.stamp"
+  outputs = [
+    _stamp,
+  ]
+
+  _rebased_sources = rebase_path(sources, root_build_dir)
+
+  args = [
+    "--android-template",
+    rebase_path("//xwalk/app/android/app_template", root_build_dir),
+    "--core-library-dir",
+    rebase_path("$root_out_dir/xwalk_core_library", root_build_dir),
+    "--extra-files",
+    "$_rebased_sources",
+    "--output-dir",
+    rebase_path("$root_out_dir/xwalk_app_template", root_build_dir),
+    "--shared-library-dir",
+    rebase_path("$root_out_dir/xwalk_shared_library", root_build_dir),
+    "--stamp",
+    rebase_path(_stamp, root_build_dir),
+    "--xwalk-runtime-jar",
+    "@FileArg($_app_runtime_build_config:deps_info:jar_path)",
+  ]
+}

--- a/build/android/generate_app_packaging_tool.py
+++ b/build/android/generate_app_packaging_tool.py
@@ -35,7 +35,7 @@ def main():
   parser.add_argument('--xwalk-runtime-jar', required=True,
                       help='Path to the Crosswalk runtime JAR.')
 
-  args = parser.parse_args()
+  args = parser.parse_args(build_utils.ExpandFileArgs(sys.argv[1:]))
 
   build_utils.DeleteDirectory(args.output_dir)
   build_utils.MakeDirectory(args.output_dir)


### PR DESCRIPTION
This is fairly simple after commit cadbd11 ("[Android] Rewrite
generate_app_packaging_tool.py"): we just need to depend on the
recently-added `xwalk_core_library` and `xwalk_shared_library` targets
and specify the paths to everything we want to copy.

We also leverage GN's build_configs to determine the path to the runtime
JAR without having to hardcode it anywhere.