### PR TITLE
gn: Add xwalk_{core,shared}_library_pom_gen

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -36,7 +36,9 @@ group("xwalk_builder") {
       "app/android/app_hello_world:xwalk_app_hello_world_apk",
       "app/android/app_template:xwalk_app_template",
       "runtime/android/core:xwalk_core_library",
+      "runtime/android/core:xwalk_core_library_pom_gen",
       "runtime/android/core:xwalk_shared_library",
+      "runtime/android/core:xwalk_shared_library_pom_gen",
       "runtime/android/runtime_lib:xwalk_runtime_lib_apk",
       "runtime/android/sample:xwalk_core_sample_apk",
     ]

--- a/build/android/maven_pom.gni
+++ b/build/android/maven_pom.gni
@@ -1,0 +1,50 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//chrome/version.gni")
+
+# This template provides a target to generate a Maven POM XML file that can
+# later be used in Maven repositories.
+# It takes a template POM and substitutes the values @ARTIFACT_ID@ and
+# @ARTIFACT_VERSION@ with the variables provided to this file.
+#
+# Arguments:
+#   artifact_id [required]
+#     Value for the <artifactId> field in the POM file.
+#   artifact_version [required]
+#     Value for the <version> field in the POM file.
+#   pom_input [required]
+#     Path to the POM file that will be processed.
+#   pom_output [required]
+#     Path to the generated POM file.
+#
+# Example:
+#   maven_pom("my_artifact_pom_gen") {
+#     artifact_id = "foo_bar_canary"
+#     artifact_version = "1.2.3.4"
+#     pom_input = "//path/to/my_artifact.pom.xml.in"
+#     pom_output = "$target_gen_dir/my_artifact.pom.xml"
+#   }
+template("maven_pom") {
+  assert(defined(invoker.artifact_id))
+  assert(defined(invoker.artifact_version))
+  assert(defined(invoker.pom_input))
+  assert(defined(invoker.pom_output))
+
+  _artifact_id = invoker.artifact_id
+  _artifact_version = invoker.artifact_version
+
+  process_version(target_name) {
+    forward_variables_from(invoker, [ "deps" ])
+    template_file = invoker.pom_input
+    output = invoker.pom_output
+    extra_args = [
+      "-e",
+      "ARTIFACT_ID='$_artifact_id'",
+      "-e",
+      "ARTIFACT_VERSION='$_artifact_version'",
+    ]
+    process_only = true
+  }
+}

--- a/build/xwalk.gni
+++ b/build/xwalk.gni
@@ -11,9 +11,4 @@ declare_args() {
   # Android: whether the integrity of the Crosswalk runtime library should
   # be verified when Crosswalk is run in shared mode.
   verify_xwalk_apk = false
-
-  # Name of Crosswalk Maven artifacts used to generate their respective POM
-  # files.
-  xwalk_core_library_artifact_id = "xwalk_core_library_canary"
-  xwalk_shared_library_artifact_id = "xwalk_shared_library_canary"
 }

--- a/runtime/android/core/BUILD.gn
+++ b/runtime/android/core/BUILD.gn
@@ -6,6 +6,15 @@ import("//build/config/android/rules.gni")
 import("//build_overrides/v8.gni")
 import("//third_party/icu/config.gni")
 import("//xwalk/build/android/generate_android_project.gni")
+import("//xwalk/build/android/maven_pom.gni")
+import("//xwalk/build/version.gni")
+
+declare_args() {
+  # Name of Crosswalk Maven artifacts used to generate their respective POM
+  # files.
+  xwalk_core_library_artifact_id = "xwalk_core_library_canary"
+  xwalk_shared_library_artifact_id = "xwalk_shared_library_canary"
+}
 
 android_library("xwalk_core_java") {
   deps = [
@@ -145,4 +154,18 @@ generate_android_project("xwalk_shared_library") {
     "*/org/xwalk/core/library/empty/R##*.class",
   ]
   template_dir = "//xwalk/build/android/xwalk_shared_library_template"
+}
+
+maven_pom("xwalk_core_library_pom_gen") {
+  artifact_id = xwalk_core_library_artifact_id
+  artifact_version = xwalk_version
+  pom_input = "//xwalk/runtime/android/maven/xwalk_core_library.pom.xml.in"
+  pom_output = "$root_out_dir/xwalk_core_library.pom.xml"
+}
+
+maven_pom("xwalk_shared_library_pom_gen") {
+  artifact_id = xwalk_shared_library_artifact_id
+  artifact_version = xwalk_version
+  pom_input = "//xwalk/runtime/android/maven/xwalk_shared_library.pom.xml.in"
+  pom_output = "$root_out_dir/xwalk_shared_library.pom.xml"
 }


### PR DESCRIPTION
Port maven_pom.gypi to a GN template, `maven_pom`, which takes care of
calling `version.py` with the appropriate values.

While here, move the declaration of
`xwalk_{core,shared}_library_artifact_id` to
`runtime/android/core/BUILD.gn` which is the only place they are used.
This makes it follow GN's style more closely.