### PR TITLE
Add back an empty file to xwalk_{core,shared}_library/src

### DIFF
--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -239,6 +239,7 @@ def main(argv):
 
   # Create an empty src/.
   build_utils.MakeDirectory(os.path.join(options.output_dir, 'src'))
+  build_utils.Touch(os.path.join(options.output_dir, 'src', '.empty'))
 
   build_utils.Touch(options.stamp)
 


### PR DESCRIPTION
This is a regression introduced in 4b928d3 ("[Android] Rewrite
generate_xwalk_core_library.py"), where we stopped adding `README.md` to
the `src/` in the projects we create and just left `src/` as an empty
directory.

That works fine when calling app-tools and passing the
`xwalk_app_template` directory to it, but not when using a zipped
version, as app-tools does not create the empty directory and the build
fails like this:

    /Users/fbalestr/Devel/adt/sdk/tools/ant/build.xml:597: The following error occurred while executing this line:
    /Users/fbalestr/Devel/adt/sdk/tools/ant/build.xml:649: The following error occurred while executing this line:
    /Users/fbalestr/Devel/adt/sdk/tools/ant/build.xml:655: /private/var/folders/rv/6r78mqbs5cl8zysfzz_1vmp40000gp/T/NsLBXU/org.foo.bar/prj/android/xwalk_core_library/src does not exist.

BUG=XWALK-7332