### PR TITLE
[Android] Directly depend on the .so's we want to strip

### DIFF
--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -228,6 +228,10 @@
           'variables': {
             'stripped_libraries_dir': '<(intermediate_dir)',
             'stamp': '<(intermediate_dir)/stamp',
+            'input_paths': [
+              '<(SHARED_LIB_DIR)/libxwalkcore.so',
+              '<(SHARED_LIB_DIR)/libxwalkdummy.so',
+            ],
           },
           'includes': ['../build/android/strip_native_libraries.gypi'],
         },


### PR DESCRIPTION
This fixes a regression introduced in commit 8f3c7d3 ("[Android] Stop
depending on xwalk_core_shell from xwalk_core_library"), where
`libxwalkdummy.so` and `libxwalkcore.so` were not being stripped and
added to `xwalk_core_library/` (which is then used for the AAR and
`xwalk_app_template`) in incremental builds, leading to outdated,
existing versions being used instead.

The bug was caused by us not explicitly depending on both unstripped
shared libraries in the action that includes
`strip_native_libraries.gypi`: we were previously only depending on
`native_libraries.json` being updated whenever those shared libraries
changed, but `write_ordered_libraries.py` only updates the JSON file if
its contents are actually different (if we started depending on other
shared libraries, for example).

BUG=XWALK-7335