### PR TITLE
gn: Implement the "xwalk_runtime_lib_lzma_apk" target

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -41,6 +41,7 @@ group("xwalk_builder") {
       "runtime/android/core:xwalk_shared_library",
       "runtime/android/core:xwalk_shared_library_pom_gen",
       "runtime/android/runtime_lib:xwalk_runtime_lib_apk",
+      "runtime/android/runtime_lib:xwalk_runtime_lib_lzma_apk",
       "runtime/android/sample:xwalk_core_sample_apk",
     ]
   }

--- a/build/android/lzma_compress.py
+++ b/build/android/lzma_compress.py
@@ -5,11 +5,10 @@
 # found in the LICENSE file.
 # pylint: disable=F0401
 
-import optparse
+import argparse
 import os
 import shutil
 import sys
-import subprocess
 
 GYP_ANDROID_DIR = os.path.join(os.path.dirname(__file__),
                                os.pardir, os.pardir, os.pardir,
@@ -21,37 +20,24 @@ sys.path.append(GYP_ANDROID_DIR)
 from util import build_utils
 
 
-def DoCompress(dest_path, sources):
-  build_utils.DeleteDirectory(dest_path)
-  build_utils.MakeDirectory(dest_path)
-
-  for source in sources:
-    shutil.copy(source, dest_path)
-    file_to_compress = os.path.join(dest_path, os.path.basename(source))
-    subprocess.check_call(['lzma', '-f', file_to_compress])
-
-
-def DoShowOutputNames(dest_path, sources):
-  for source in sources:
-    print('%s.lzma' % os.path.join(dest_path, os.path.basename(source)))
-
-
 def main():
-  parser = optparse.OptionParser()
-  parser.add_option('--dest-path',
-                    help='Destination directory for compressed files')
-  parser.add_option('--mode', choices=('compress', 'show-output-names'),
-                    help='Whether to compress the files or show their '
-                    'compressed names')
-  parser.add_option('--sources', help='The list of files to be compressed')
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--dest-path', required=True,
+                      help='Destination directory for compressed files.')
+  parser.add_argument('--sources', required=True,
+                      help='The list of files to be compressed.')
 
-  options, _ = parser.parse_args(sys.argv)
-  sources = build_utils.ParseGypList(options.sources)
+  options = parser.parse_args()
+  options.sources = build_utils.ParseGypList(options.sources)
 
-  if options.mode == 'compress':
-    return DoCompress(options.dest_path, sources)
-  else:
-    return DoShowOutputNames(options.dest_path, sources)
+  with build_utils.TempDir() as temp_dir:
+    for source in options.sources:
+      shutil.copy2(source, temp_dir)
+      file_to_compress = os.path.join(temp_dir, os.path.basename(source))
+      build_utils.CheckOutput(['lzma', '-f', file_to_compress],
+                              print_stderr=True)
+    build_utils.DeleteDirectory(options.dest_path)
+    shutil.copytree(temp_dir, options.dest_path)
 
 
 if __name__ == '__main__':

--- a/runtime/android/runtime_lib/BUILD.gn
+++ b/runtime/android/runtime_lib/BUILD.gn
@@ -3,6 +3,8 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
+import("//build_overrides/v8.gni")
+import("//third_party/icu/config.gni")
 import("//xwalk/build/version.gni")
 
 android_apk("xwalk_runtime_lib_apk") {
@@ -44,5 +46,94 @@ android_assets("xwalk_runtime_lib_apk_assets") {
     "//third_party/icu:icu_assets",
     "//v8:v8_external_startup_data_assets",
     "//xwalk/resources:pak_file_assets",
+  ]
+}
+
+# The code for generating XWalkRuntimeLibLzma.apk below is definitely not
+# beautiful: the fact that it compresses a dex class from another APK prevents
+# it from looking minimally nice. We have to keep a list of .lzma files we
+# generate because android_assets() expects a list of files instead of a
+# directory, so we keep a hardcoded list of assets we want to compress.
+
+template("compressed_android_assets") {
+  assert(defined(invoker.deps))
+  assert(defined(invoker.sources))
+
+  _compressed_assets_dir = "$target_gen_dir/compressed_assets"
+  _compressed_assets = []
+
+  # Transform the list of sources into $_compressed_assets_dir/$file.lzma.
+  foreach(source, invoker.sources) {
+    _source_file = get_path_info(source, "file")
+    assert(_source_file != "")
+    _compressed_assets += [ "$_compressed_assets_dir/$_source_file.lzma" ]
+  }
+
+  _compress_target = "${target_name}__compress"
+  action(_compress_target) {
+    forward_variables_from(invoker, [ "deps" ])
+
+    _rebased_sources = rebase_path(invoker.sources, root_out_dir)
+
+    script = "//xwalk/build/android/lzma_compress.py"
+    outputs = _compressed_assets
+    args = [
+      "--dest-path",
+      rebase_path(_compressed_assets_dir, root_out_dir),
+      "--sources",
+      "$_rebased_sources",
+    ]
+  }
+
+  android_assets(target_name) {
+    deps = [
+      ":$_compress_target",
+    ]
+    sources = _compressed_assets
+    disable_compression = true
+  }
+}
+
+compressed_android_assets("xwalk_runtime_lib_lzma_assets") {
+  _runtime_apk_target = ":xwalk_runtime_lib_apk"
+  _runtime_apk_name = get_label_info(_runtime_apk_target, "name")
+  _runtime_apk_gen_dir = get_label_info(_runtime_apk_target, "target_gen_dir")
+
+  deps = [
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+    "//xwalk/runtime/app/android:libxwalkcore",
+    _runtime_apk_target,
+  ]
+  sources = [
+    "$_runtime_apk_gen_dir/$_runtime_apk_name/classes.dex",
+    "$root_out_dir/libxwalkcore.so",
+    "$root_out_dir/xwalk.pak",
+    "$root_out_dir/xwalk_100_percent.pak",
+  ]
+
+  if (icu_use_data_file) {
+    deps += [ "//third_party/icu:icudata" ]
+    sources += [ "$root_out_dir/icudtl.dat" ]
+  }
+
+  if (v8_use_external_startup_data) {
+    deps += [ "//v8" ]
+    sources += [
+      "$root_out_dir/natives_blob.bin",
+      "$root_out_dir/snapshot_blob.bin",
+    ]
+  }
+}
+
+android_apk("xwalk_runtime_lib_lzma_apk") {
+  apk_name = "XWalkRuntimeLibLzma"
+  android_manifest = "AndroidManifest.xml"
+  java_files = []
+  version_name = xwalk_version
+  version_code = xwalk_version_code
+  deps = [
+    ":xwalk_runtime_lib_apk_resources",
+    ":xwalk_runtime_lib_lzma_assets",
   ]
 }

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -307,12 +307,14 @@
             '<@(build_system_inputs)',
           ],
           'outputs': [
-            "<!@(['python', 'build/android/lzma_compress.py', '--mode=show-output-names', \
-                  '--sources=<(lzma_compress_inputs)', '--dest-path=<(assets_dir)'])",
+            '<(assets_dir)/classes.dex',
+            '<(assets_dir)/icudtl.dat.lzma',
+            '<(assets_dir)/libxwalkcore.so.lzma',
+            '<(assets_dir)/xwalk.pak.lzma',
+            '<(assets_dir)/xwalk_100_percent.pak.lzma',
           ],
           'action': [
             'python', 'build/android/lzma_compress.py',
-            '--mode=compress',
             '--dest-path=<(assets_dir)',
             '--sources=<(lzma_compress_inputs)',
           ],


### PR DESCRIPTION
This was hopefully the last missing Android target in the gyp->GN
conversion, and it is an ugly one: we are forced to keep a hardcoded
list of all the files we want to compress and ship as assets, which
makes the change to `runtime/android/runtime_lib/BUILD.gn` bigger than
usual.

Since `android_assets()` in GN requires a list of all files being
shipped as assets, we can simplify `lzma_compress.py` and get rid of its
different operation modes: instead of passing `--mode=show-output-names`
we just list all files that are being compressed in gyp.

While here, also use a temporary directory to perform the compressions
in `lzma_compress.py`, as it's then removed automatically in case
something goes wrong and we are not left with dangling files in the
build tree.

BUG=XWALK-7285