### PR TITLE
[Windows] Add a msbuild.gypi and clean up the MSBuild Python wrapper

### DIFF
--- a/build/msbuild.gypi
+++ b/build/msbuild.gypi
@@ -1,0 +1,81 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file is meant to be included into a target in order to invoke MSBuild,
+# generate an extension .dll and its respective accompanying bridge DLL from a
+# number of C# source files.
+# The actions below generate two files in |output_dir|: "<output_name>.dll" and
+# "<output_name>_bridge.dll".
+#
+# Usage:
+# {
+#   'target_name': 'my_dotnet_extension',
+#   'variables': {
+#     'output_dir': '<(PRODUCT_DIR)/my_dotnet_extension',
+#     'output_name': 'dotnet_extension',
+#     'project_path': '<(DEPTH)/xwalk/path/to/my_dotnet_extension/project.csproj',
+#     'sources': ['foo.cs', 'bar.cs'],
+#   },
+#   'includes': ['<(DEPTH)/xwalk/msbuild.gypi'],
+# }
+#
+# Required variables:
+#  output_dir - Path where the DLLs will be generated.
+#  output_name - Name of the generated DLL (without ".dll" at the end).
+#  project_path - Full path to the .csproj that MSBuild will use.
+#  sources - List of C# source files.
+
+{
+  'type': 'none',
+  'dependencies': [
+    '<(DEPTH)/xwalk/dotnet/dotnet_bridge.gyp:xwalk_dotnet_bridge',
+  ],
+  'actions': [
+    {
+      'action_name': 'msbuild_<(_target_name)',
+      'message': 'Building <(_target_name)',
+      'inputs': [
+        '<(DEPTH)/xwalk/tools/msbuild_dotnet.py',
+        '<@(sources)',
+      ],
+      'outputs': [
+        '<(output_name).dll',
+      ],
+      'variables': {
+        'conditions': [
+          ['CONFIGURATION_NAME=="Debug" or CONFIGURATION_NAME=="Debug_x64"', {
+            'build_type': 'Debug',
+          }, {
+            'build_type': 'Release',
+          }],
+        ],
+      },
+      'action': [
+        'python', '<(DEPTH)/xwalk/tools/msbuild_dotnet.py',
+        '--build-type', '<(build_type)',
+        '--project', '<(project_path)',
+        '--output-dir', '<(output_dir)',
+      ],
+    },
+    {
+      'action_name': 'rename_bridge_<(_target_name)',
+      'message': 'Renaming bridge for <(_target_name)',
+      'inputs': [
+        '<(DEPTH)/xwalk/tools/copy_rename.py',
+        '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
+        '<(output_name).dll',
+      ],
+      'outputs': [
+        '<(output_name)_bridge.dll',
+      ],
+      'action': [
+        'python', '<(DEPTH)/xwalk/tools/copy_rename.py',
+        '--source-dir', '<(PRODUCT_DIR)',
+        '--input-file', 'xwalk_dotnet_bridge.dll',
+        '--output-file', '<(output_name)_bridge.dll',
+        '--destination-dir', '<(output_dir)/',
+      ],
+    },
+  ],
+}

--- a/experimental/wifidirect/wifidirect_extension.gyp
+++ b/experimental/wifidirect/wifidirect_extension.gyp
@@ -2,49 +2,17 @@
   'targets': [
     {
       'target_name': 'wifidirect_extension',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_wifidirect_extension',
-          'inputs': [
-            'XWalkExtension.cs',
-            'XWalkExtensionInstance.cs',
-          ],
-          'outputs': [
-            'wifidirect_extension.dll',
-          ],
-          'action': ['python',
-                     '../../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)',
-                     '--project', '../../../experimental/wifidirect/wifidirect_extension.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_wifidirect_extension_bridge',
-      'type': 'none',
-      'dependencies': [
-        'wifidirect_extension',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_wifidirect_extension',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'wifidirect_extension_bridge.dll',
-          ],
-          'action': ['python',
-                     '../../tools/copy_rename.py',
-                     '--source-dir', '<(PRODUCT_DIR)',
-                     '--input-file', 'xwalk_dotnet_bridge.dll',
-                     '--output-file', 'wifidirect_extension_bridge.dll',
-                     '--destination-dir', '<(PRODUCT_DIR)/',
-          ],
-        },
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)',
+        'output_name': 'wifidirect_extension',
+        'project_path': '<(DEPTH)/xwalk/experimental/wifidirect/wifidirect_extension.csproj',
+        'sources': [
+          'XWalkExtension.cs',
+          'XWalkExtensionInstance.cs',
+        ],
+      },
+      'includes': [
+        '../../build/msbuild.gypi',
       ],
     },
   ],

--- a/extensions/dotnet_extension_sample.gyp
+++ b/extensions/dotnet_extension_sample.gyp
@@ -1,701 +1,190 @@
 {
+  'variables': {
+    'extension_prefix': '<(DEPTH)/xwalk/extensions/test/win'
+  },
   'targets': [
     {
       'target_name': 'dotnet_echo_extension',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_echo_extension',
-          'inputs': [
-            'test/win/echo_extension/XWalkExtension.cs',
-            'test/win/echo_extension/XWalkExtensionInstance.cs',
-          ],
-          'outputs': [
-            'echo_extension.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/echo_extension',
-                     '--project', 'echo_extension/echo_extension.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_echo_extension_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_echo_extension',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_echo_extension',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'echo_extension_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/echo_extension',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'echo_extension_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/echo_extension',
+        'output_name': 'echo_extension',
+        'project_path': '<(extension_prefix)/echo_extension/echo_extension.csproj',
+        'sources': [
+          'test/win/echo_extension/XWalkExtension.cs',
+          'test/win/echo_extension/XWalkExtensionInstance.cs',
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_1',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_1',
-          'inputs': [
-            'test/win/invalid_extension_1/Bla.cs'
-          ],
-          'outputs': [
-            'invalid_extension_1.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_1',
-                     '--project', 'invalid_extension_1/invalid_extension_1.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_1_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_1',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_1',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_1_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_1',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_1_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_1',
+        'output_name': 'invalid_extension_1',
+        'project_path': '<(extension_prefix)/invalid_extension_1/invalid_extension_1.csproj',
+        'sources': [
+          'test/win/invalid_extension_1/Bla.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_2',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_2',
-          'inputs': [
-            'test/win/invalid_extension_2/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_2.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_2',
-                     '--project', 'invalid_extension_2/invalid_extension_2.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_2_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_2',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_2',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_2_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_2',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_2_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_2',
+        'output_name': 'invalid_extension_2',
+        'project_path': '<(extension_prefix)/invalid_extension_2/invalid_extension_2.csproj',
+        'sources': [
+          'test/win/invalid_extension_2/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_3',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_3',
-          'inputs': [
-            'test/win/invalid_extension_3/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_3.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_3',
-                     '--project', 'invalid_extension_3/invalid_extension_3.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_3_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_3',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_3',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_3_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_3',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_3_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_3',
+        'output_name': 'invalid_extension_3',
+        'project_path': '<(extension_prefix)/invalid_extension_3/invalid_extension_3.csproj',
+        'sources': [
+          'test/win/invalid_extension_3/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_4',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_4',
-          'inputs': [
-            'test/win/invalid_extension_4/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_4.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_4',
-                     '--project', 'invalid_extension_4/invalid_extension_4.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_4_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_4',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_4',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_4_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_4',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_4_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_4',
+        'output_name': 'invalid_extension_4',
+        'project_path': '<(extension_prefix)/invalid_extension_4/invalid_extension_4.csproj',
+        'sources': [
+          'test/win/invalid_extension_4/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_5',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_5',
-          'inputs': [
-            'test/win/invalid_extension_5/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_5.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_5',
-                     '--project', 'invalid_extension_5/invalid_extension_5.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_5_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_5',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_5',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_5_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_5',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_5_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_5',
+        'output_name': 'invalid_extension_5',
+        'project_path': '<(extension_prefix)/invalid_extension_5/invalid_extension_5.csproj',
+        'sources': [
+          'test/win/invalid_extension_5/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_6',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_6',
-          'inputs': [
-            'test/win/invalid_extension_6/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_6.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_6',
-                     '--project', 'invalid_extension_6/invalid_extension_6.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_6_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_6',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_6',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_6_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_6',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_6_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_6',
+        'output_name': 'invalid_extension_6',
+        'project_path': '<(extension_prefix)/invalid_extension_6/invalid_extension_6.csproj',
+        'sources': [
+          'test/win/invalid_extension_6/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_7',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_7',
-          'inputs': [
-            'test/win/invalid_extension_7/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_7.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_7',
-                     '--project', 'invalid_extension_7/invalid_extension_7.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_7_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_7',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_7',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_7_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_7',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_7_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_7',
+        'output_name': 'invalid_extension_7',
+        'project_path': '<(extension_prefix)/invalid_extension_7/invalid_extension_7.csproj',
+        'sources': [
+          'test/win/invalid_extension_7/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_8',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_8',
-          'inputs': [
-            'test/win/invalid_extension_8/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_8.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_8',
-                     '--project', 'invalid_extension_8/invalid_extension_8.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_8_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_8',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_8',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_8_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_8',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_8_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_8',
+        'output_name': 'invalid_extension_8',
+        'project_path': '<(extension_prefix)/invalid_extension_8/invalid_extension_8.csproj',
+        'sources': [
+          'test/win/invalid_extension_8/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_9',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_9',
-          'inputs': [
-            'test/win/invalid_extension_9/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_9.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_9',
-                     '--project', 'invalid_extension_9/invalid_extension_9.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_9_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_9',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_9',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_9_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_9',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_9_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_9',
+        'output_name': 'invalid_extension_9',
+        'project_path': '<(extension_prefix)/invalid_extension_9/invalid_extension_9.csproj',
+        'sources': [
+          'test/win/invalid_extension_9/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_10',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_10',
-          'inputs': [
-            'test/win/invalid_extension_10/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_10.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_10',
-                     '--project', 'invalid_extension_10/invalid_extension_10.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_10_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_10',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_10',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_10_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_10',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_10_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_10',
+        'output_name': 'invalid_extension_10',
+        'project_path': '<(extension_prefix)/invalid_extension_10/invalid_extension_10.csproj',
+        'sources': [
+          'test/win/invalid_extension_10/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_11',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_11',
-          'inputs': [
-            'test/win/invalid_extension_11/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_11.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_11',
-                     '--project', 'invalid_extension_11/invalid_extension_11.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_11_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_11',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_11',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_11_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_11',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_11_bridge.dll',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_11',
+        'output_name': 'invalid_extension_11',
+        'project_path': '<(extension_prefix)/invalid_extension_11/invalid_extension_11.csproj',
+        'sources': [
+          'test/win/invalid_extension_11/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_invalid_extension_12',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_invalid_extension_12',
-          'inputs': [
-            'test/win/invalid_extension_12/XWalkExtension.cs'
-          ],
-          'outputs': [
-            'invalid_extension_12.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_12',
-                     '--project', 'invalid_extension_12/invalid_extension_12.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'copy_invalid_extension_12_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_invalid_extension_12',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_and_rename_bridge_invalid_extension_12',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'invalid_extension_12_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_12',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'invalid_extension_12_bridge.dll',
-          ],
-        },
-      ],
-    },
-    {
-      'target_name': 'dotnet_echo_extension2',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_echo_extension2',
-          'inputs': [
-            'test/win/echo_extension2/XWalkExtension.cs',
-            'test/win/echo_extension2/XWalkExtensionInstance.cs',
-          ],
-          'outputs': [
-            'echo_extension2.dll',
-          ],
-          'action': ['python',
-                     '../tools/msbuild_dotnet.py',
-                     '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
-                     '--project', 'echo_extension2/echo_extension2.csproj',
-                     '--build-type', 'Debug',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/invalid_extension_12',
+        'output_name': 'invalid_extension_12',
+        'project_path': '<(extension_prefix)/invalid_extension_12/invalid_extension_12.csproj',
+        'sources': [
+          'test/win/invalid_extension_12/XWalkExtension.cs'
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
       'target_name': 'dotnet_echo_extension1',
-      'type': 'none',
-      'actions': [
-        {
-          'action_name': 'build_dotnet_test_echo_extension1',
-          'inputs': [
-            'test/win/echo_extension1/XWalkExtension.cs',
-            'test/win/echo_extension1/XWalkExtensionInstance.cs',
-          ],
-          'outputs': [
-            'echo_extension1.dll',
-          ],
-          'action': ['python',
-                      '../tools/msbuild_dotnet.py',
-                      '--output-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
-                      '--project', 'echo_extension1/echo_extension1.csproj',
-                      '--build-type', 'Debug',
-          ],
-        },
-      ],
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
+        'output_name': 'echo_extension1',
+        'project_path': '<(extension_prefix)/echo_extension1/echo_extension1.csproj',
+        'sources': [
+          'test/win/echo_extension1/XWalkExtension.cs',
+          'test/win/echo_extension1/XWalkExtensionInstance.cs',
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
     {
-      'target_name': 'copy_echo_extension2_bridge',
-      'type': 'none',
-      'dependencies': [
-        'copy_echo_extension1_bridge',
-        'dotnet_echo_extension2',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_echo_extension2_bridge',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'dependencies': [
-            'copy_echo_extension1_bridge',
-          ],
-          'outputs': [
-            'echo_extension2_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'echo_extension2_bridge.dll',
-          ],
-        },
-      ],
-     },
-     {
-      'target_name': 'copy_echo_extension1_bridge',
-      'type': 'none',
-      'dependencies': [
-        'dotnet_echo_extension1',
-      ],
-      'actions': [
-        {
-          'action_name': 'copy_echo_extension1_bridge',
-          'inputs': [
-            '<(PRODUCT_DIR)/xwalk_dotnet_bridge.dll',
-          ],
-          'outputs': [
-            'echo_extension1_bridge.dll',
-          ],
-          'action': ['python',
-                      '../tools/copy_rename.py',
-                      '--source-dir', '<(PRODUCT_DIR)',
-                      '--destination-dir', '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
-                      '--input-file', 'xwalk_dotnet_bridge.dll',
-                      '--output-file', 'echo_extension1_bridge.dll',
-          ],
-        },
-      ],
+      'target_name': 'dotnet_echo_extension2',
+      'variables': {
+        'output_dir': '<(PRODUCT_DIR)/tests/dotnet_extension/multiple_extension',
+        'output_name': 'echo_extension2',
+        'project_path': '<(extension_prefix)/echo_extension2/echo_extension2.csproj',
+        'sources': [
+          'test/win/echo_extension2/XWalkExtension.cs',
+          'test/win/echo_extension2/XWalkExtensionInstance.cs',
+        ],
+      },
+      'includes': ['../build/msbuild.gypi'],
     },
   ],
 }

--- a/tools/msbuild_dotnet.py
+++ b/tools/msbuild_dotnet.py
@@ -6,49 +6,42 @@
 msbuild_dotnet.py -- Invoke MSBuild for .NET project.
 """
 
-import logging
-import optparse
+import argparse
 import os
 import subprocess
 import sys
 
 
 def LaunchMSBuild(options):
-  if not options.output_dir:
-    print('You must specify the output-dir')
-    return 1
-  if not options.project:
-    print('You have not specified the project you want to build')
-    return 1
-  if not options.build_type:
-    print('You have not specified the build-type')
-    return 1
+  params = [
+    'Platform=AnyCPU',
+    'Configuration=%s' % options.build_type,
+    'OutDir=%s' % options.output_dir,
+    'BaseIntermediateOutputPath=%s\\' % options.output_dir,
+  ]
+  cmd = [
+    'msbuild',
+    '/nologo',
+    '/p:%s' % ','.join(params),
+    '/verbosity:quiet',
+    options.project,
+  ]
+  subprocess.check_call(cmd)
 
-  output_dir = os.path.abspath(options.output_dir)
-  tools_dir = os.path.dirname(os.path.abspath(__file__))
-  xwalk_dir = os.path.dirname(tools_dir)
-  extensions_dir = os.path.join(xwalk_dir, 'extensions')
-  extensions_test_dir = os.path.join(extensions_dir, 'test')
-  extensions_win_test_dir = os.path.join(extensions_test_dir,
-                                         'win' + os.path.sep)
-
-  output = subprocess.call(['msbuild', extensions_win_test_dir
-      + options.project, '/p:Platform=AnyCPU,Configuration='
-      + options.build_type + ',OutDir=' + output_dir
-      + ',BaseIntermediateOutputPath=' + output_dir + os.path.sep],
-      cwd=extensions_win_test_dir)
-  if output != 0:
-    return output
 
 def main():
-  option_parser = optparse.OptionParser()
-  option_parser.add_option('--output-dir',
-                           help='Set the output dir for MSBuild.')
-  option_parser.add_option('--project',
-                           help='The project to build with MSBuild.')
-  option_parser.add_option('--build-type',
-                           help='The type of build : Release/Debug.')
-  options, _ = option_parser.parse_args()
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--output-dir', required=True,
+                      help='Set the output dir for MSBuild.')
+  parser.add_argument('--project', required=True,
+                      help='The project to build with MSBuild.')
+  parser.add_argument('--build-type', required=True,
+                      choices=('Debug', 'Release'),
+                      help='The type of build : Release/Debug.')
+  options = parser.parse_args()
+  # We need to call os.path.abspath() because MSBuild seems consider the
+  # project directory the root of a relative path, not the build directory.
+  options.output_dir = os.path.abspath(options.output_dir)
   LaunchMSBuild(options)
 
 


### PR DESCRIPTION
Instead of manually calling `msbuild_dotnet.py` and then renaming
`xwalk_dotnet_bridge.dll` every time one wants to build a .NET
extension, do that only once in `msbuild.gypi`: the other targets just
need to define a few variables and include the new gypi file, which then
takes care of doing all the rest.

This considerably reduces the size of the other gyp files and avoids a
lot of duplication.

Clean up `msbuild_dotnet.py` itself a little:
* Stop invoking `MSBuild` from `//xwalk/extensions/test/win`, which
  creates some needless complications in the WiFi Direct gyp code.
  Instead, just invoke it from the root of the build directory (the
  default).
* Use `argparse` instead of `optparse` to avoid having to manually
  validate required arguments.
* Pass `/nologo` and `/verbosity:quiet` to `MSBuild` to make it quieter.
* Split MSBuild's parameters into a separate variable to make the code
  easier to understand.

RELATED BUG=XWALK-7336