### PR TITLE
[Windows] Remove unreferenced variables in the .NET bridge code

### DIFF
--- a/dotnet/xwalk_dotnet_bridge.cc
+++ b/dotnet/xwalk_dotnet_bridge.cc
@@ -385,7 +385,7 @@ void XWalkDotNetBridge::HandleMessage(XW_Instance instance,
               << "': HandleMessage method is not defined";
     return;
   }
-  Object^ returnValue = handle_message_method->Invoke(
+  handle_message_method->Invoke(
       ((Object^)*instance_object_ptr), gcnew array<Object^>(1){ message_str });
 }
 
@@ -404,7 +404,7 @@ void XWalkDotNetBridge::HandleSyncMessage(XW_Instance instance,
               << "': HandleMessage method is not defined";
     return;
   }
-  Object^ returnValue = handle_sync_message_method->Invoke(
+  handle_sync_message_method->Invoke(
       ((Object^)*instance_object_ptr), gcnew array<Object^>(1){ message_str });
 }
 


### PR DESCRIPTION
This avoids the following type of error when building the bridge code
with stricter flags (on by default with GN):

    xwalk_dotnet_bridge.cc(388): error C2220: warning treated as error -
    no 'object' file generated
    xwalk_dotnet_bridge.cc(388): warning C4189: 'returnValue': local
    variable initialized but not referenced

RELATED BUG=XWALK-7336