### PR TITLE
gn: Use the AndroidManifest.xml from the template when creating AARs

### DIFF
--- a/build/android/generate_android_project.gni
+++ b/build/android/generate_android_project.gni
@@ -262,6 +262,12 @@ template("generate_android_project") {
   action(_aar_target) {
     _aar_path = "$root_out_dir/${_target_name}.aar"
 
+    # Curiously enough, the AARs should use the AndroidManifest.xml present in
+    # the template directory, not the one passed via invoker.android_manifest.
+    # The latter contains additional fields that conflict with the manifest
+    # generated when building Cordova apps (XWALK-7348).
+    _android_manifest = invoker.template_dir + "/AndroidManifest.xml"
+
     deps = [
       ":$_project_target",
     ]
@@ -273,7 +279,7 @@ template("generate_android_project") {
       "--aar-path",
       rebase_path(_aar_path, root_build_dir),
       "--android-manifest",
-      rebase_path(invoker.android_manifest, root_build_dir),
+      rebase_path(_android_manifest, root_build_dir),
       "--classes-jar",
       rebase_path(_merged_jar_path, root_build_dir),
       "--res-dir",


### PR DESCRIPTION
We were previously creating the Android AARs using the
`AndroidManifest.xml` specified via `invoker.android_manifest`.

While that is correct for all other usages in the
`generate_android_project` template, using it in the AARs we create is
wrong, as the manifest specified via `invoker.android_manifest` is
generally the one in `//xwalk/runtime/android/core_internal_empty`
instead of the one
`//xwalk/build/android/xwalk{core,_shared}_library_template`. The ones
in `build/` specify a different package name and don't have an
`<application>` tag. This tag conflicts with the ones in the manifest
generated by Cordova when building an app, meaning Android GN builds
were not working with Cordova at all.

BUG=XWALK-7348