### PR TITLE
gn: Make xwalk_shared_library depend on additional resource targets

### DIFF
--- a/runtime/android/core/BUILD.gn
+++ b/runtime/android/core/BUILD.gn
@@ -8,6 +8,7 @@ import("//third_party/icu/config.gni")
 import("//xwalk/build/android/generate_android_project.gni")
 import("//xwalk/build/android/maven_pom.gni")
 import("//xwalk/build/version.gni")
+import("//xwalk/runtime/android/core_internal/chromium_java_deps.gni")
 
 declare_args() {
   # Name of Crosswalk Maven artifacts used to generate their respective POM
@@ -140,6 +141,18 @@ generate_android_project("xwalk_shared_library") {
     "//xwalk/experimental/launch_screen/launch_screen_api.js",
     "//xwalk/experimental/wifidirect/wifidirect_api.js",
   ]
+
+  # This target does not depend on //xwalk/runtime/android/core_internal, but
+  # it does need access to some resources that xwalk_core_internal_java ends up
+  # pulling (XWALK-7366).
+  # Even though |core_internal_java_chromium_deps| depends on the *_java
+  # targets instead of the *_java_resources ones, this is fine for our use
+  # case, as we only pass the resource zips to generate_xwalk_core_library.py
+  # anyway.
+  # For the effects of not adding these dependencies, see XWALK-7350 as well as
+  # XWALK-7358.
+  deps += [ "//xwalk/runtime/android/core_internal:xwalk_core_strings_grd" ]
+  deps += core_internal_java_chromium_deps
 
   # We only need to exclude those classes because invoker.android_manifest
   # usually points to a manifest with the same package name (org.xwalk.core),

--- a/runtime/android/core_internal/BUILD.gn
+++ b/runtime/android/core_internal/BUILD.gn
@@ -5,21 +5,19 @@
 import("//build/config/android/rules.gni")
 import("//xwalk/build/version.gni")
 import("//xwalk/build/xwalk.gni")
+import("//xwalk/runtime/android/core_internal/chromium_java_deps.gni")
 
 reflection_gen_dir = "$root_gen_dir/xwalk_core_reflection_layer/"
 android_library("xwalk_core_internal_java") {
+  # ATTENTION: do NOT add dependencies on non-//xwalk targets below; they must
+  # be added to |core_internal_java_chromium_deps| instead. This variable is
+  # used here as well as in //xwalk/runtime/android/core:xwalk_shared_library.
   deps = [
     ":xwalk_core_internal_java_resources",
     ":xwalk_core_reflection_layer_gen",
-    "//base:base_java",
-    "//components/navigation_interception/android:navigation_interception_java",
-    "//components/web_contents_delegate_android:web_contents_delegate_android_java",
-    "//content/public/android:content_java",
-    "//media/base/android:media_java",
-    "//net/android:net_java",
-    "//ui/android:ui_java",
     "//xwalk/extensions/android:xwalk_core_extensions_java",
   ]
+  deps += core_internal_java_chromium_deps
   srcjars = [ "$reflection_gen_dir/bridge/bridge.srcjar" ]
   java_files = [
     "src/org/xwalk/core/internal/AndroidProtocolHandler.java",

--- a/runtime/android/core_internal/chromium_java_deps.gni
+++ b/runtime/android/core_internal/chromium_java_deps.gni
@@ -1,0 +1,20 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a list of non-//xwalk targets that the xwalk_core_internal_java
+# target depends on. It is used by both :xwalk_core_internal_java and
+# //xwalk/runtime/android/core:xwalk_shared_library. The latter only needs the
+# *_java_resource targets, not the *_java ones, but in practice
+# generate_android_project() and its calls to write_build_config() take care of
+# using only the *_java_resource ones that the *_java targets depend on.
+# It is a hack required as long as XWALK-7366 is not fixed.
+core_internal_java_chromium_deps = [
+  "//base:base_java",
+  "//components/navigation_interception/android:navigation_interception_java",
+  "//components/web_contents_delegate_android:web_contents_delegate_android_java",
+  "//content/public/android:content_java",
+  "//media/base/android:media_java",
+  "//net/android:net_java",
+  "//ui/android:ui_java",
+]


### PR DESCRIPTION
It is not clear if this is a bug or due to some odd design, but the
xwalk_shared_library Android project needs resources from both
`runtime/android/core_internal` (due to its usage of the reflection
layer wrapper classes) as well as resources from Chromium itself that
the core_internal code depends on.

These same dependencies are also part of `XWalkRuntimeLib` itself, so it
means we need to duplicate them.

For now, introduce a new variable, `core_internal_java_chromium_deps` to
make it clear that this is hopefully something provisional and add some
informative comments instructing people to not add non-//xwalk
dependencies to `xwalk_core_internal_java`s `deps` list.

BUG=XWALK-7350
BUG=XWALK-7358
RELATED BUG=XWALK-7366