### PR TITLE
gn: Copy //xwalk/VERSION to the build dir for generate_crosswalk_win_zip

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -563,53 +563,60 @@ group("xwalk_all_tests") {
   }
 }
 
-if (is_win) {
-  action("generate_crosswalk_win_zip") {
-    # The files and directories will be added with the same names to the
-    # generated zip file, with $root_out_dir stripped from the beginning.
-    dirs_to_package = [ "$root_out_dir/locales/xwalk" ]
-    files_to_package = [
-      "//xwalk/VERSION",
-      "$root_out_dir/d3dcompiler_47.dll",
-      "$root_out_dir/icudtl.dat",
-      "$root_out_dir/libEGL.dll",
-      "$root_out_dir/libGLESv2.dll",
-      "$root_out_dir/natives_blob.bin",
-      "$root_out_dir/osmesa.dll",
-      "$root_out_dir/snapshot_blob.bin",
-      "$root_out_dir/xwalk.exe",
-      "$root_out_dir/xwalk.pak",
-      "$root_out_dir/xwalk_100_percent.pak",
-      "$root_out_dir/xwalk_200_percent.pak",
-      "$root_out_dir/xwalk_300_percent.pak",
-      "$root_out_dir/xwalk_dotnet_bridge.dll",
-    ]
-    inputs = [
-      "//xwalk/VERSION",
-    ]
-    outputs = [
-      "$root_out_dir/crosswalk_win.zip",
-    ]
-    script = "//xwalk/build/win/generate_crosswalk_zip.py"
+# Copy xwalk/VERSION to the build directory for tools (such as
+# generate_crosswalk_zip.py) that assume all paths are under $root_out_dir.
+copy("VERSION") {
+  sources = [
+    "//xwalk/VERSION",
+  ]
+  outputs = [
+    "$root_out_dir/VERSION",
+  ]
+}
 
-    _rebased_dirs = rebase_path(dirs_to_package, root_out_dir)
-    _rebased_files = rebase_path(files_to_package, root_out_dir)
+action("generate_crosswalk_win_zip") {
+  # The files and directories will be added with the same names to the
+  # generated zip file, with $root_out_dir stripped from the beginning.
+  dirs_to_package = [ "$root_out_dir/locales/xwalk" ]
+  files_to_package = [
+    "$root_out_dir/VERSION",
+    "$root_out_dir/d3dcompiler_47.dll",
+    "$root_out_dir/icudtl.dat",
+    "$root_out_dir/libEGL.dll",
+    "$root_out_dir/libGLESv2.dll",
+    "$root_out_dir/natives_blob.bin",
+    "$root_out_dir/osmesa.dll",
+    "$root_out_dir/snapshot_blob.bin",
+    "$root_out_dir/xwalk.exe",
+    "$root_out_dir/xwalk.pak",
+    "$root_out_dir/xwalk_100_percent.pak",
+    "$root_out_dir/xwalk_200_percent.pak",
+    "$root_out_dir/xwalk_300_percent.pak",
+    "$root_out_dir/xwalk_dotnet_bridge.dll",
+  ]
+  outputs = [
+    "$root_out_dir/crosswalk_win.zip",
+  ]
+  script = "//xwalk/build/win/generate_crosswalk_zip.py"
 
-    args = [
-      "--build-dir",
-      rebase_path(root_out_dir),
-      "--dest",
-      rebase_path("$root_out_dir/crosswalk_win.zip"),
-      "--dirs=$_rebased_dirs",
-      "--files=$_rebased_files",
-    ]
-    deps = [
-      ":xwalk",
-      "//xwalk/resources:xwalk_locales",
-      "//xwalk/resources:xwalk_pak",
-      "//xwalk/resources:xwalk_resources_100_percent_pak",
-      "//xwalk/resources:xwalk_resources_200_percent_pak",
-      "//xwalk/resources:xwalk_resources_300_percent_pak",
-    ]
-  }
+  _rebased_dirs = rebase_path(dirs_to_package, root_out_dir)
+  _rebased_files = rebase_path(files_to_package, root_out_dir)
+
+  args = [
+    "--build-dir",
+    rebase_path(root_out_dir),
+    "--dest",
+    rebase_path("$root_out_dir/crosswalk_win.zip"),
+    "--dirs=$_rebased_dirs",
+    "--files=$_rebased_files",
+  ]
+  deps = [
+    ":VERSION",
+    ":xwalk",
+    "//xwalk/resources:xwalk_locales",
+    "//xwalk/resources:xwalk_pak",
+    "//xwalk/resources:xwalk_resources_100_percent_pak",
+    "//xwalk/resources:xwalk_resources_200_percent_pak",
+    "//xwalk/resources:xwalk_resources_300_percent_pak",
+  ]
 }

--- a/build/win/generate_crosswalk_zip.py
+++ b/build/win/generate_crosswalk_zip.py
@@ -23,6 +23,12 @@ sys.path.append(GYP_ANDROID_DIR)
 from util import build_utils
 
 
+def PathInZipArchive(fs_path, root_dir):
+  if os.path.commonprefix([os.path.abspath(fs_path), root_dir]) != root_dir:
+    raise Exception("%s must be under %s" % (fs_path, root_dir))
+  return os.path.relpath(fs_path, root_dir)
+
+
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--build-dir', required=True,
@@ -39,12 +45,12 @@ def main():
 
   with zipfile.ZipFile(args.dest, 'w', zipfile.ZIP_DEFLATED) as zip_file:
     for filename in args.files:
-      zip_file.write(filename, os.path.relpath(filename, args.build_dir))
+      zip_file.write(filename, PathInZipArchive(filename, args.build_dir))
     for dirname in args.dirs:
       for root, _, files in os.walk(dirname):
         for filename in files:
           filepath = os.path.join(root, filename)
-          zip_path = os.path.relpath(filepath, args.build_dir)
+          zip_path = PathInZipArchive(filepath, args.build_dir)
           zip_file.write(filepath, zip_path)
 
 


### PR DESCRIPTION
When GN support for Crosswalk on Windows was landed, I thought there
would be no need to mimic what gyp does and copy //xwalk/VERSION to
`$root_out_dir`.

It turns out this is necessary because `generate_crosswalk_zip.py`
assumes all paths it stores in the zip archive are inside the build
directory. This means the zip file being generated with GN so far had a
relative path inside for `VERSION` (`../../xwalk/VERSION`) which did not
play well with `unzip` and other tools that need to extract it.

A sanity check has been added to `generate_crosswalk_zip.py` to make
sure this does not happen in the future.

While here, drop the `is_win` check from the
`generate_crosswalk_win_zip` target: it just needlessly complicates the
code with a check and another level of indentation.

RELATED BUG=XWALK-7336