### PR TITLE
[Android] Sync find_helper.{cc,h} copies with upstream

### DIFF
--- a/runtime/browser/android/find_helper.cc
+++ b/runtime/browser/android/find_helper.cc
@@ -24,6 +24,7 @@ FindHelper::FindHelper(WebContents* web_contents)
       async_find_started_(false),
       find_request_id_counter_(0),
       current_request_id_(0),
+      current_session_id_(0),
       last_match_count_(-1),
       last_active_ordinal_(-1) {
 }
@@ -41,7 +42,7 @@ void FindHelper::FindAllAsync(const base::string16& search_string) {
 
   async_find_started_ = true;
 
-  StartNewRequest(search_string);
+  StartNewSession(search_string);
 
   if (MaybeHandleEmptySearch(search_string))
     return;
@@ -58,7 +59,7 @@ void FindHelper::HandleFindReply(int request_id,
                                  int match_count,
                                  int active_ordinal,
                                  bool finished) {
-  if (!async_find_started_ || request_id != current_request_id_)
+  if (!async_find_started_ || request_id < current_session_id_)
     return;
 
   NotifyResults(active_ordinal, match_count, finished);
@@ -67,6 +68,8 @@ void FindHelper::HandleFindReply(int request_id,
 void FindHelper::FindNext(bool forward) {
   if (!async_find_started_)
     return;
+
+  current_request_id_ = find_request_id_counter_++;
 
   if (MaybeHandleEmptySearch(last_search_string_))
     return;
@@ -97,8 +100,9 @@ bool FindHelper::MaybeHandleEmptySearch(const base::string16& search_string) {
   return true;
 }
 
-void FindHelper::StartNewRequest(const base::string16& search_string) {
+void FindHelper::StartNewSession(const base::string16& search_string) {
   current_request_id_ = find_request_id_counter_++;
+  current_session_id_ = current_request_id_;
   last_search_string_ = search_string;
   last_match_count_ = -1;
   last_active_ordinal_ = -1;

--- a/runtime/browser/android/find_helper.h
+++ b/runtime/browser/android/find_helper.h
@@ -46,7 +46,7 @@ class FindHelper : public content::WebContentsObserver {
   void ClearMatches();
 
  private:
-  void StartNewRequest(const base::string16& search_string);
+  void StartNewSession(const base::string16& search_string);
   bool MaybeHandleEmptySearch(const base::string16& search_string);
   void NotifyResults(int active_ordinal, int match_count, bool finished);
 
@@ -56,10 +56,14 @@ class FindHelper : public content::WebContentsObserver {
   // Used to check the validity of FindNext operations.
   bool async_find_started_;
 
-  // Used to provide different ids to each request and for result
+  // Used to provide different IDs to each request and for result
   // verification in asynchronous calls.
   int find_request_id_counter_;
   int current_request_id_;
+
+  // Used to mark the beginning of the current find session. This is the ID of
+  // the first find request in the current session.
+  int current_session_id_;
 
   // Required by FindNext and the incremental find replies.
   base::string16 last_search_string_;


### PR DESCRIPTION
Incorporate changes that went into the upstream versions of
`find_helper.{cc,h}`:
* 1cfca29 Fix for problem with activating find-in-page match via find
  tickbar.
* c0b762b Implement a shell of FindRequestManager, and hook it up to
  WebContentsImpl.

In addition to reducing the delta to upstream and making updating the
code in the future easier, it actually makes the code work in debug
mode (we were hitting some DCHECKs because the code had not been
updated).

RELATED BUG=XWALK-7325