### PR TITLE
[Android] Dispatch a mouse event when faking a click in the tests

### DIFF
--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -769,7 +769,6 @@ public class XWalkViewTestBase
             str = "document.getElementById('" + id + "')";
         }
         final String script1 = str + " != null";
-        final String script2 = str + ".dispatchEvent(evObj);";
         CriteriaHelper.pollInstrumentationThread(new Criteria() {
             @Override
             public boolean isSatisfied() {
@@ -785,10 +784,10 @@ public class XWalkViewTestBase
         }, WAIT_TIMEOUT_MS, CHECK_INTERVAL);
 
         try {
-            loadJavaScriptUrl("javascript:var evObj = document.createEvent('Events'); " +
-                "evObj.initEvent('click', true, false); " +
-                script2 +
-                "console.log('element with id [" + id + "] clicked');");
+            loadJavaScriptUrl(
+                "javascript:var evObj = new MouseEvent('click', {bubbles: true}); "
+                        + "document.getElementById('" + id + "').dispatchEvent(evObj);"
+                        + "console.log('element with id [" + id + "] clicked');");
         } catch (Throwable t) {
             t.printStackTrace();
         }


### PR DESCRIPTION
This is a backport of the same android_webview commit from
M53 (afc3aed86 in Chromium, "Fix android webview unit tests to dispatch
correct click event"). It is being landed separately into M52 to reduce
the size of the M53 pull request and to make it easier to identify in
the history that this is being done.

Starting with M53, creating a generic event will not cause a click to be
generated as per Chromium bug 520519, so adjust the code to create a
`MouseEvent` instead.

RELATED BUG=XWALK-7325