### PR TITLE
[Android] Remove DCHECK from CookieManager

### DIFF
--- a/runtime/browser/android/cookie_manager.cc
+++ b/runtime/browser/android/cookie_manager.cc
@@ -231,12 +231,8 @@ CookieManager::~CookieManager() {
 void CookieManager::ExecCookieTask(const CookieTask& task,
                                    const bool wait_for_completion) {
   base::WaitableEvent completion(false, false);
-
-  DCHECK(cookie_store_.get());
-
   cookie_store_task_runner_->PostTask(FROM_HERE,
       base::Bind(task, wait_for_completion ? &completion : nullptr));
-
   if (wait_for_completion) {
     ScopedAllowWaitForLegacyWebViewApi wait;
     completion.Wait();


### PR DESCRIPTION
Another file copied from upstream, another crash in debug mode. This
`DCHECK` was removed from the android_webview version of `CookieManager`
in 2013 (commit 23dc0bb, "Android WebView: Allow CookieManager to be
used without starting Chromium").

Since then the upstream version has undergone several modifications
while ours remained mostly unchanged. After so many years it's very
likely the `DCHECK` is just wrong and can be removed, otherwise the
following the `CookieManager` Android tests crash in debug mode.