### PR TITLE
M53 gardening: adapt to https://codereview.chromium.org/2067843003

### DIFF
--- a/runtime/browser/runtime_url_request_context_getter.cc
+++ b/runtime/browser/runtime_url_request_context_getter.cc
@@ -24,6 +24,8 @@
 #include "content/public/common/content_switches.h"
 #include "content/public/common/url_constants.h"
 #include "net/cert/cert_verifier.h"
+#include "net/cert/ct_policy_enforcer.h"
+#include "net/cert/multi_log_ct_verifier.h"
 #include "net/cookies/cookie_monster.h"
 #include "net/dns/host_resolver.h"
 #include "net/dns/mapped_host_resolver.h"
@@ -156,6 +158,10 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
     storage_->set_cert_verifier(net::CertVerifier::CreateDefault());
     storage_->set_transport_security_state(
         base::WrapUnique(new net::TransportSecurityState));
+    storage_->set_cert_transparency_verifier(
+        base::WrapUnique(new net::MultiLogCTVerifier));
+    storage_->set_ct_policy_enforcer(
+        base::WrapUnique(new net::CTPolicyEnforcer));
 #if defined(OS_ANDROID)
     // Android provides a local HTTP proxy that handles all the proxying.
     // Create the proxy without a resolver since we rely
@@ -192,6 +198,10 @@ net::URLRequestContext* RuntimeURLRequestContextGetter::GetURLRequestContext() {
         url_request_context_->cert_verifier();
     network_session_params.transport_security_state =
         url_request_context_->transport_security_state();
+    network_session_params.cert_transparency_verifier =
+        url_request_context_->cert_transparency_verifier();
+    network_session_params.ct_policy_enforcer =
+        url_request_context_->ct_policy_enforcer();
     network_session_params.channel_id_service =
         url_request_context_->channel_id_service();
     network_session_params.proxy_service =


### PR DESCRIPTION
Add some missing verifiers for TLS/QUIC sockets, following what upstream
has done.

This makes
org.xwalk.core.xwview.test.ClearSslPreferenceTest#testDeniedRequestForSslError
as well as regular SSL connections to websites on any platform (Android
and others) stop crashing.

RELATED BUG=XWALK-7325