### PR TITLE
Depend on blink, not blink_headers, in the extensions target

### DIFF
--- a/extensions/BUILD.gn
+++ b/extensions/BUILD.gn
@@ -59,7 +59,7 @@ source_set("extensions") {
     "//base",
     "//content",
     "//ipc",
-    "//third_party/WebKit/public:blink_headers",
+    "//third_party/WebKit/public:blink",
     "//url",
     "//v8",
   ]

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -11,7 +11,7 @@
         '../../ipc/ipc.gyp:ipc',
         '../../url/url.gyp:url_lib',
         '../../v8/src/v8.gyp:v8',
-        '../../third_party/WebKit/public/blink_headers.gyp:blink_headers',
+        '../../third_party/WebKit/public/blink.gyp:blink',
         'extensions_resources.gyp:xwalk_extensions_resources',
       ],
       'includes': [


### PR DESCRIPTION
blink_headers is supposed to be used when targets only need access to
Blink structs and enums, which is not the case here, as
`xwalk_v8tools_module.cc` actually calls Blink code.

This was preventing `xwalk_extensions_unittest` from linking in debug
mode with GN and `is_component = true`. gyp was not affected because the
`xwalk_extensions` target there is always built as a static library, but
the code was updated there too for completeness.