### PR TITLE
[Android] Temporary disable the unified media pipeline by default

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -21,6 +21,7 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/common/content_switches.h"
 #include "content/public/common/result_codes.h"
+#include "media/base/media_switches.h"
 #include "net/android/network_change_notifier_factory_android.h"
 #include "net/base/network_change_notifier.h"
 #include "net/base/net_module.h"
@@ -84,6 +85,8 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopStart() {
   command_line->AppendSwitch(switches::kXWalkDisableExtensionProcess);
   // Enable viewport.
   command_line->AppendSwitch(switches::kEnableViewport);
+  // Temporary fix for XWALK-7231
+  command_line->AppendSwitch(switches::kDisableUnifiedMediaPipeline);
 
   // Only force to enable WebGL for Android for IA platforms because
   // we've tested the WebGL conformance test. For other platforms, just


### PR DESCRIPTION
Chromium start use desktop media pipeline on Android from version 52,
see the background: http://crbug.com/507834 and
https://docs.google.com/document/d/1QB4RVu0zT54Bys7dUHU6QeR3DyjOs-wk-MN9tjEzquQ/edit?usp=sharing

Currently, we still can use this patch to disable unified media pipeline,
that means use WebMediaPlayerAndroid instead of WebMediaPlayer_Impl, and
not use FFmpeg for demuxing and audio decoding.

However, this is just a temporary workaground, need to continue working
on find the final solution before Chromium make unified media pipeline
as the only code path.

BUG=XWALK-7231