### PR TITLE
[Android] Deprecate XWalkView.load() and split it into multiple methods

### DIFF
--- a/API_VERSION
+++ b/API_VERSION
@@ -1,2 +1,2 @@
-API=7
+API=8
 MIN_API=5

--- a/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkCoreProviderImpl.java
+++ b/app/android/runtime_client/src/org/xwalk/app/runtime/XWalkCoreProviderImpl.java
@@ -112,7 +112,7 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
 
     @Override
     public void loadAppFromUrl(String url) {
-        mXWalkView.load(url, null);
+        mXWalkView.loadUrl(url);
     }
 
     @Override
@@ -146,6 +146,6 @@ class XWalkCoreProviderImpl implements XWalkRuntimeViewProvider {
 
     @Override
     public void loadDataForTest(String data, String mimeType, boolean isBase64Encoded) {
-        mXWalkView.load("", data);
+        mXWalkView.loadData(data, mimeType, isBase64Encoded ? "base64" : null);
     }
 }

--- a/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkActivity.java
@@ -51,7 +51,7 @@ import android.os.Bundle;
  *     public void onXWalkReady() {
  *         // Do anyting with the embedding API
  *
- *         mXWalkView.load("https://crosswalk-project.org/", null);
+ *         mXWalkView.loadUrl("https://crosswalk-project.org/");
  *     }
  * }
  * </pre>

--- a/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkDialogManager.java
@@ -54,7 +54,7 @@ import java.util.ArrayList;
  *
  *     &#64;Override
  *     public void onXWalkReady() {
- *         mXWalkView.load("https://crosswalk-project.org/", null);
+ *         mXWalkView.loadUrl("https://crosswalk-project.org/");
  *     }
  * }
  * </pre>
@@ -128,7 +128,7 @@ import java.util.ArrayList;
  *
  *     &#64;Override
  *     public void onXWalkInitCompleted() {
- *         mXWalkView.load("https://crosswalk-project.org/", null);
+ *         mXWalkView.loadUrl("https://crosswalk-project.org/");
  *     }
  *
  *     &#64;Override

--- a/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkFileChooser.java
@@ -68,7 +68,7 @@ import java.util.Date;
  *
  *     &#64;Override
  *     protected void onXWalkReady() {
- *         mXWalkView.load("file:///android_asset/test.html", null);
+ *         mXWalkView.loadUrl("file:///android_asset/test.html");
  *     }
  *
  *     &#64;Override

--- a/runtime/android/core/src/org/xwalk/core/XWalkInitializer.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkInitializer.java
@@ -99,7 +99,7 @@ import org.xwalk.core.XWalkLibraryLoader.DecompressListener;
  *     public void onXWalkInitCompleted() {
  *         // Do anyting with the embedding API
  *
- *         mXWalkView.load("https://crosswalk-project.org/", null);
+ *         mXWalkView.loadUrl("https://crosswalk-project.org/");
  *     }
  *
  *     &#64;Override

--- a/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkUpdater.java
@@ -120,7 +120,7 @@ import org.xwalk.core.XWalkLibraryLoader.DownloadListener;
  *     public void onXWalkInitCompleted() {
  *         // Do anyting with the embedding API
  *
- *         mXWalkView.load("https://crosswalk-project.org/", null);
+ *         mXWalkView.loadUrl("https://crosswalk-project.org/");
  *     }
  *
  *     &#64;Override

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkContentsClientBridge.java
@@ -101,7 +101,7 @@ class XWalkContentsClientBridge extends XWalkContentsClient
                 final String fallbackUrl = mNavigationHandler.getFallbackUrl();
                 if (fallbackUrl != null) {
                     mNavigationHandler.resetFallbackUrl();
-                    mXWalkView.load(fallbackUrl, null);
+                    mXWalkView.loadUrl(fallbackUrl);
                 } else {
                     // Post a message to UI thread to notify the page is starting to load.
                     mContentsClient.getCallbackHelper().postOnPageStarted(url);

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPresentationHost.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkPresentationHost.java
@@ -254,7 +254,7 @@ class XWalkPresentationHost implements XWalkDisplayManager.DisplayListener {
         }
 
         public void loadUrl(final String url) {
-            mContentView.load(url, null);
+            mContentView.loadUrl(url);
         }
     }
 

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/XWalkPresentationContent.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/extension/api/presentation/XWalkPresentationContent.java
@@ -69,7 +69,7 @@ public class XWalkPresentationContent {
             };
             mContentView.setUIClient(xWalkUIClient);
         }
-        mContentView.load(url, null);
+        mContentView.loadUrl(url);
     }
 
     public int getPresentationId() {

--- a/runtime/android/core_internal_shell/src/org/xwalk/core/internal/xwview/shell/XWalkViewInternalShellActivity.java
+++ b/runtime/android/core_internal_shell/src/org/xwalk/core/internal/xwview/shell/XWalkViewInternalShellActivity.java
@@ -91,7 +91,7 @@ public class XWalkViewInternalShellActivity extends Activity {
 
                 if (bundle.containsKey("url")) {
                     String extra = bundle.getString("url");
-                    if (mView != null) mView.load(sanitizeUrl(extra), null);
+                    if (mView != null) mView.loadUrl(sanitizeUrl(extra));
                 }
             }
         };
@@ -143,7 +143,7 @@ public class XWalkViewInternalShellActivity extends Activity {
                 }
 
                 if (mView == null) return true;
-                mView.load(sanitizeUrl(mUrlTextView.getText().toString()), null);
+                mView.loadUrl(sanitizeUrl(mUrlTextView.getText().toString()));
                 mUrlTextView.clearFocus();
                 setKeyboardVisibilityForUrl(false);
                 return true;

--- a/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
+++ b/runtime/android/core_shell/src/org/xwalk/core/xwview/shell/XWalkViewShellActivity.java
@@ -163,7 +163,7 @@ public class XWalkViewShellActivity extends XWalkActivity
                 if (bundle.containsKey("url")) {
                     String extra = bundle.getString("url");
                     if (mActiveView != null)
-                        mActiveView.load(sanitizeUrl(extra), null);
+                        mActiveView.loadUrl(sanitizeUrl(extra));
                 }
             }
         };
@@ -214,7 +214,7 @@ public class XWalkViewShellActivity extends XWalkActivity
                 }
 
                 if (mActiveView == null) return true;
-                mActiveView.load(sanitizeUrl(mUrlTextView.getText().toString()), null);
+                mActiveView.loadUrl(sanitizeUrl(mUrlTextView.getText().toString()));
                 mUrlTextView.clearFocus();
                 setKeyboardVisibilityForUrl(false);
                 return true;

--- a/runtime/android/sample/src/org/xwalk/core/sample/AnimatableXWalkViewActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/AnimatableXWalkViewActivity.java
@@ -61,7 +61,7 @@ public class AnimatableXWalkViewActivity extends XWalkBaseActivity {
         });
 
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
-        mXWalkView.load("http://www.baidu.com", null);
+        mXWalkView.loadUrl("http://www.baidu.com");
     }
 
     @Override

--- a/runtime/android/sample/src/org/xwalk/core/sample/ExtensionActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/ExtensionActivity.java
@@ -19,6 +19,6 @@ public class ExtensionActivity extends XWalkBaseActivity {
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         mExtension = new ExtensionEcho();
 
-        mXWalkView.load("file:///android_asset/echo_java.html", null);
+        mXWalkView.loadUrl("file:///android_asset/echo_java.html");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/MultiXWalkViewActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/MultiXWalkViewActivity.java
@@ -31,7 +31,7 @@ public class MultiXWalkViewActivity extends XWalkBaseActivity {
         mXWalkView2 = new XWalkView(this, this);
         parent.addView(mXWalkView2, params);
 
-        mXWalkView.load("http://www.intel.com", null);
-        mXWalkView2.load("http://www.baidu.com", null);
+        mXWalkView.loadUrl("http://www.intel.com");
+        mXWalkView2.loadUrl("http://www.baidu.com");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/MultiXWalkViewOverlayActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/MultiXWalkViewOverlayActivity.java
@@ -54,7 +54,7 @@ public class MultiXWalkViewOverlayActivity extends XWalkBaseActivity {
         parent.addView(mXWalkView2, params);
         mXWalkView2.setVisibility(View.INVISIBLE);
 
-        mXWalkView.load("http://www.intel.com", null);
-        mXWalkView2.load("http://www.baidu.com", null);
+        mXWalkView.loadUrl("http://www.intel.com");
+        mXWalkView2.loadUrl("http://www.baidu.com");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/OnCreateWindowRequestedActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/OnCreateWindowRequestedActivity.java
@@ -39,7 +39,7 @@ public class OnCreateWindowRequestedActivity extends XWalkBaseActivity {
         mParent.addView(mXWalkView);
         mXWalkViewHistory.add(mXWalkView);
 
-        mXWalkView.load("file:///android_asset/create_window_1.html", null);
+        mXWalkView.loadUrl("file:///android_asset/create_window_1.html");
     }
 
     private void setClient(XWalkView view) {

--- a/runtime/android/sample/src/org/xwalk/core/sample/OnHideOnShowActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/OnHideOnShowActivity.java
@@ -18,6 +18,6 @@ public class OnHideOnShowActivity extends XWalkBaseActivity {
 
         // The web page below will display a video.
         // When home button is pressed, the activity will be in background, and the video will be paused.
-        mXWalkView.load("http://www.w3.org/2010/05/video/mediaevents.html", null);
+        mXWalkView.loadUrl("http://www.w3.org/2010/05/video/mediaevents.html");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/OnReceivedIconActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/OnReceivedIconActivity.java
@@ -41,6 +41,6 @@ public class OnReceivedIconActivity extends XWalkBaseActivity {
             }
         });
 
-        mXWalkView.load("file:///android_asset/favicon.html", null);
+        mXWalkView.loadUrl("file:///android_asset/favicon.html");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/PauseTimersActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/PauseTimersActivity.java
@@ -42,6 +42,6 @@ public class PauseTimersActivity extends XWalkBaseActivity {
                 }
             }
         });
-        mXWalkView.load("file:///android_asset/pause_timers.html", null);
+        mXWalkView.loadUrl("file:///android_asset/pause_timers.html");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/ResourceAndUIClientsActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/ResourceAndUIClientsActivity.java
@@ -101,6 +101,6 @@ public class ResourceAndUIClientsActivity extends XWalkBaseActivity {
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
         mXWalkView.setUIClient(new UIClient(mXWalkView));
-        mXWalkView.load("http://www.baidu.com", null);
+        mXWalkView.loadUrl("http://www.baidu.com");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/SupportZoomActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/SupportZoomActivity.java
@@ -77,13 +77,13 @@ public class SupportZoomActivity extends XWalkBaseActivity {
 
     void setAndLoadForBuiltInZoom(boolean flag) {
         mXWalkSettings.setBuiltInZoomControls(flag);
-        mXWalkView.load("file:///android_asset/builtinzoom.html", null);
+        mXWalkView.loadUrl("file:///android_asset/builtinzoom.html");
     }
 
     void setAndLoadForDoubleTapZoom(boolean flag) {
         // setUseWideViewPort() should be called at first.
         mXWalkSettings.setUseWideViewPort(flag);
         mXWalkSettings.setBuiltInZoomControls(flag);
-        mXWalkView.load("file:///android_asset/doubletapzoom.html", null);
+        mXWalkView.loadUrl("file:///android_asset/doubletapzoom.html");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkNavigationActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkNavigationActivity.java
@@ -62,7 +62,7 @@ public class XWalkNavigationActivity extends XWalkBaseActivity {
             }
         });
 
-        mXWalkView.load("http://www.baidu.com/", null);
+        mXWalkView.loadUrl("http://www.baidu.com/");
     }
 
     private void showNavigationItemInfo(XWalkNavigationItem navigationItem){

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkPreferencesActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkPreferencesActivity.java
@@ -21,6 +21,6 @@ public class XWalkPreferencesActivity extends XWalkBaseActivity {
         // You can debug the web content via PC chrome.
         XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
 
-        mXWalkView.load("http://www.baidu.com/", null);
+        mXWalkView.loadUrl("http://www.baidu.com/");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkVersionAndAPIVersion.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkVersionAndAPIVersion.java
@@ -20,6 +20,6 @@ public class XWalkVersionAndAPIVersion extends XWalkBaseActivity {
         String xwalkVersion = mXWalkView.getXWalkVersion();
         TextView text1 = (TextView) super.findViewById(R.id.text1);
         text1.setText("API Version: " + apiVersion + "; XWalk Version: " + xwalkVersion);
-        mXWalkView.load("", "");
+        mXWalkView.loadUrl("");
     }
 }

--- a/runtime/android/sample/src/org/xwalk/core/sample/XWalkViewWithLayoutActivity.java
+++ b/runtime/android/sample/src/org/xwalk/core/sample/XWalkViewWithLayoutActivity.java
@@ -15,6 +15,6 @@ public class XWalkViewWithLayoutActivity extends XWalkBaseActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.xwview_layout);
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
-        mXWalkView.load("http://www.baidu.com/", null);
+        mXWalkView.loadUrl("http://www.baidu.com/");
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/EnterAndLeaveFullscreenTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/EnterAndLeaveFullscreenTest.java
@@ -28,7 +28,7 @@ public class EnterAndLeaveFullscreenTest extends XWalkViewTestBase {
         String fileContent = getFileContent(name);
         int count = mOnFullscreenToggledHelper.getCallCount();
 
-        loadDataSync(name, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         assertFalse(hasEnteredFullscreen());
 
         clickOnElementId("enter_fullscreen", null);
@@ -48,7 +48,7 @@ public class EnterAndLeaveFullscreenTest extends XWalkViewTestBase {
         String fileContent = getFileContent(name);
         int count = mOnFullscreenToggledHelper.getCallCount();
 
-        loadDataSync(name, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         assertFalse(hasEnteredFullscreen());
 
         clickOnElementId("enter_fullscreen", null);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetTitleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/GetTitleTest.java
@@ -35,7 +35,7 @@ public class GetTitleTest extends XWalkViewTestBase {
         final String name = "index.html";
         final String fileContent = getFileContent(name);
 
-        loadDataSync(name, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         assertEquals(mTitle, getTitleOnUiThread());
     }
 }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/LoadTest.java
@@ -61,10 +61,7 @@ public class LoadTest extends XWalkViewTestBase {
         final String name = "index.html";
         String fileContent = getFileContent(name);
 
-        loadDataSync(null, fileContent, "text/html", false);
-        assertEquals(expectedLocalTitle, getTitleOnUiThread());
-
-        loadDataSync(name, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         assertEquals(expectedLocalTitle, getTitleOnUiThread());
     }
 
@@ -84,7 +81,7 @@ public class LoadTest extends XWalkViewTestBase {
     @SmallTest
     @Feature({"Load"})
     public void testEmpytUrlAndContent() throws Throwable {
-        loadDataAsync(null, null, "text/html", false);
+        loadDataAsync(null, "text/html", false);
         Thread.sleep(1000);
         assertNotNull(getTitleOnUiThread());
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnConsoleMessageTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnConsoleMessageTest.java
@@ -31,7 +31,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doDebug();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -44,7 +44,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doError();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -57,7 +57,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doInfo();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -70,7 +70,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doLog();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -83,7 +83,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doWarn();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -96,7 +96,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doDir();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -109,7 +109,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doDirxml();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -122,7 +122,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doTable();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -135,7 +135,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doClear();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -148,7 +148,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doTrace();");
         mOnConsoleMessageHelper.waitForCallback(count);
         assertEquals(1, mOnConsoleMessageHelper.getCallCount());
@@ -161,7 +161,7 @@ public class OnConsoleMessageTest extends XWalkViewTestBase {
         String fileContent = getFileContent("console_message.html");
         int count = mOnConsoleMessageHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         executeJavaScriptAndWaitForResult("doAll();");
         mOnConsoleMessageHelper.waitForCallback(count,NUM_OF_CONSOLE_CALL);
         assertEquals(NUM_OF_CONSOLE_CALL, mOnConsoleMessageHelper.getCallCount());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnCreateWindowRequestedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnCreateWindowRequestedTest.java
@@ -48,7 +48,7 @@ public class OnCreateWindowRequestedTest extends XWalkViewTestBase {
         String fileContent = getFileContent("create_window_1.html");
         int count = mOnCreateWindowRequestedHelper.getCallCount();
 
-        loadDataAsync(null, fileContent, "text/html", false);
+        loadDataAsync(fileContent, "text/html", false);
         clickOnElementId("new_window", null);
         mOnCreateWindowRequestedHelper.waitForCallback(count);
         assertNotNull(mOnCreateWindowRequestedHelper.getXWalkView());
@@ -62,13 +62,13 @@ public class OnCreateWindowRequestedTest extends XWalkViewTestBase {
 
         setSupportMultipleWindows(false);
         setJavaScriptCanOpenWindowsAutomatically(false);
-        loadDataAsync(null, fileContent, "text/html", false);
+        loadDataAsync(fileContent, "text/html", false);
         clickOnElementId("new_window", null);
         assertNull(mOnCreateWindowRequestedHelper.getXWalkView());
 
         setSupportMultipleWindows(true);
         setJavaScriptCanOpenWindowsAutomatically(true);
-        loadDataAsync(null, fileContent, "text/html", false);
+        loadDataAsync(fileContent, "text/html", false);
         clickOnElementId("new_window", null);
         mOnCreateWindowRequestedHelper.waitForCallback(count);
         assertNotNull(mOnCreateWindowRequestedHelper.getXWalkView());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnFullscreenToggledTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnFullscreenToggledTest.java
@@ -27,7 +27,7 @@ public class OnFullscreenToggledTest extends XWalkViewTestBase {
         String fileContent = getFileContent(name);
         int count = mOnFullscreenToggledHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         clickOnElementId("fullscreen_toggled", null);
         mOnFullscreenToggledHelper.waitForCallback(count);
         assertTrue(mOnFullscreenToggledHelper.getEnterFullscreen());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnJavascriptModalDialogTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnJavascriptModalDialogTest.java
@@ -34,7 +34,7 @@ public class OnJavascriptModalDialogTest extends XWalkViewTestBase {
         String fileContent = getFileContent(url);
         int count = mOnJavascriptModalDialogHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         clickOnElementId("js_modal_dialog", null);
         mOnJavascriptModalDialogHelper.waitForCallback(count);
         assertEquals("hello", mOnJavascriptModalDialogHelper.getMessage());
@@ -46,7 +46,7 @@ public class OnJavascriptModalDialogTest extends XWalkViewTestBase {
         String fileContent = getFileContent("js_modal_dialog.html");
         int count = mOnJsAlertHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         clickOnElementId("js_alert", null);
         mOnJsAlertHelper.waitForCallback(count);
         assertEquals(1, mOnJsAlertHelper.getCallCount());
@@ -59,7 +59,7 @@ public class OnJavascriptModalDialogTest extends XWalkViewTestBase {
         String fileContent = getFileContent("js_modal_dialog.html");
         int count = mOnJsConfirmHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         clickOnElementId("js_confirm", null);
         mOnJsConfirmHelper.waitForCallback(count);
         assertEquals(1, mOnJsConfirmHelper.getCallCount());
@@ -72,7 +72,7 @@ public class OnJavascriptModalDialogTest extends XWalkViewTestBase {
         String fileContent = getFileContent("js_modal_dialog.html");
         int count = mOnJsPromptHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         clickOnElementId("js_prompt", null);
         mOnJsPromptHelper.waitForCallback(count);
         assertEquals(1, mOnJsPromptHelper.getCallCount());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageFinishedTest.java
@@ -32,11 +32,9 @@ public class OnPageFinishedTest extends XWalkViewTestBase {
     public void testOnPageFinishedPassesCorrectUrl() throws Throwable {
         TestCallbackHelperContainer.OnPageFinishedHelper onPageFinishedHelper =
                 mTestHelperBridge.getOnPageFinishedHelper();
-
         String html = "<html><body>Simple page.</body></html>";
         int currentCallCount = onPageFinishedHelper.getCallCount();
-        loadDataAsync(null, html, "text/html", false);
-
+        loadDataWithBaseUrlAsync(html, "text/html", false, null, null);
         onPageFinishedHelper.waitForCallback(currentCallCount);
         assertEquals("about:blank", onPageFinishedHelper.getUrl());
     }
@@ -85,7 +83,7 @@ public class OnPageFinishedTest extends XWalkViewTestBase {
 
             assertEquals(0, onPageFinishedHelper.getCallCount());
             final int pageWithSubresourcesCallCount = onPageFinishedHelper.getCallCount();
-            loadDataAsync(null, "<html><iframe src=\"" + testUrl + "\" /></html>",
+            loadDataAsync("<html><iframe src=\"" + testUrl + "\" /></html>",
                           "text/html",
                           false);
 
@@ -116,7 +114,7 @@ public class OnPageFinishedTest extends XWalkViewTestBase {
         int currentCallCount = onPageFinishedHelper.getCallCount();
         assertEquals(0, currentCallCount);
 
-        loadDataAsync(null, html, "text/html", false);
+        loadDataWithBaseUrlAsync(html, "text/html", false, null, null);
         loadJavaScriptUrl("javascript: try { console.log('foo'); } catch(e) {};");
 
         onPageFinishedHelper.waitForCallback(currentCallCount);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageLoadStoppedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnPageLoadStoppedTest.java
@@ -73,8 +73,7 @@ public class OnPageLoadStoppedTest extends XWalkViewTestBase {
         final String name = "index.html";
         String fileContent = getFileContent(name);
         int currentCallCount = mOnPageFinishedHelper.getCallCount();
-        loadDataAsync(null, fileContent, "text/html", false);
-
+        loadDataWithBaseUrlAsync(fileContent, "text/html", false, null, null);
         mOnPageFinishedHelper.waitForCallback(currentCallCount);
         assertEquals("about:blank", mOnPageFinishedHelper.getUrl());
         assertEquals(LoadStatus.FINISHED, mTestHelperBridge.getLoadStatus());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnProgressChangedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnProgressChangedTest.java
@@ -39,7 +39,7 @@ public class OnProgressChangedTest extends XWalkViewTestBase {
         final String testPath = "/test.html";
         final String testUrl = mWebServer.setResponse(testPath, testHtml, null);
 
-        loadDataAsync(null, "<html><iframe src=\"" + testUrl + "\" /></html>",
+        loadDataAsync("<html><iframe src=\"" + testUrl + "\" /></html>",
                       "text/html",
                       false);
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedErrorTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedErrorTest.java
@@ -60,10 +60,7 @@ public class OnReceivedErrorTest extends XWalkViewTestBase {
                 mTestHelperBridge.getOnPageFinishedHelper();
 
         int currentCallCount = onPageFinishedHelper.getCallCount();
-        loadDataAsync("<html><iframe src=\"http//invalid.url.co/\" /></html>",
-                      null,
-                      "text/html",
-                      false);
+        loadUrlAsync("<html><iframe src=\"http//invalid.url.co/\" /></html>");
 
         onPageFinishedHelper.waitForCallback(currentCallCount);
         assertEquals(0, mOnReceivedErrorHelper.getCallCount());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedIconTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedIconTest.java
@@ -46,7 +46,7 @@ public class OnReceivedIconTest extends XWalkViewTestBase {
         String fileContent = getFileContent("favicon.html");
         int count = mOnReceivedIconHelper.getCallCount();
 
-        loadDataAsync(null, fileContent, "text/html", false);
+        loadDataAsync(fileContent, "text/html", false);
         mOnReceivedIconHelper.waitForCallback(count);
         assertNotNull(mOnReceivedIconHelper.getIcon());
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedTitleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnReceivedTitleTest.java
@@ -65,7 +65,7 @@ public class OnReceivedTitleTest extends XWalkViewTestBase {
         final String fileContent = getFileContent(name);
         int onReceivedTitleCallCount = mOnTitleUpdatedHelper.getCallCount();
 
-        loadDataSync(name, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         mOnTitleUpdatedHelper.waitForCallback(onReceivedTitleCallCount);
         assertNotNull(mOnTitleUpdatedHelper.getTitle());
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnScaleChangedTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnScaleChangedTest.java
@@ -27,7 +27,7 @@ public class OnScaleChangedTest extends XWalkViewTestBase {
         String fileContent = getFileContent(name);
         int count = mOnScaleChangedHelper.getCallCount();
 
-        loadDataAsync(null, fileContent, "text/html", false);
+        loadDataAsync(fileContent, "text/html", false);
         mOnScaleChangedHelper.waitForCallback(count);
         assertTrue(Float.compare(mOnScaleChangedHelper.getNewScale(), 0.0f) > 0);
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnUnhandledKeyEventTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OnUnhandledKeyEventTest.java
@@ -46,7 +46,7 @@ public class OnUnhandledKeyEventTest extends XWalkViewTestBase {
         final String name = "index.html";
         String fileContent = getFileContent(name);
         int count = mOverrideOrUnhandledKeyEventHelper.getCallCount();
-        loadDataAsync(null, fileContent, "text/html", false);
+        loadDataAsync(fileContent, "text/html", false);
         simulateKeyAction(KeyEvent.ACTION_UP);
         mOverrideOrUnhandledKeyEventHelper.waitForCallback(count);
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/OpenFileChooserTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/OpenFileChooserTest.java
@@ -27,7 +27,7 @@ public class OpenFileChooserTest extends XWalkViewTestBase {
         String fileContent = getFileContent(name);
         int count = mOpenFileChooserHelper.getCallCount();
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         clickOnElementId("upload_input", null);
         mOpenFileChooserHelper.waitForCallback(count);
         assertNotNull(mOpenFileChooserHelper.getCallback());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetInitialScaleTest.java
@@ -47,7 +47,7 @@ public class SetInitialScaleTest extends XWalkViewTestBase {
         // So we first change the scale to some non-default value, and then wait
         // until it gets back to 1.0.
         int onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
-        loadDataSync(null, pageScale4, "text/html", false);
+        loadDataSync(pageScale4, "text/html", false);
         mOnScaleChangedHelper.waitForCallback(onScaleChangedCallCount);
         assertEquals(4.0f, getScaleFactor());
 
@@ -55,7 +55,7 @@ public class SetInitialScaleTest extends XWalkViewTestBase {
         // page scale change may occur, and this makes the usual onScaleChanged-based workflow
         // flaky. So instead, we are just polling the scale until it becomes 1.0.
         setInitialScale(50);
-        loadDataSync(null, page, "text/html", false);
+        loadDataSync(page, "text/html", false);
         ensureScaleBecomes(1.0f);
     }
 
@@ -80,25 +80,25 @@ public class SetInitialScaleTest extends XWalkViewTestBase {
                 ).getResources().getDisplayMetrics().density;
 
         assertEquals(defaultScaleFactor, getScaleFactor(), .01f);
-        loadDataSync(null, page, "text/html", false);
+        loadDataSync(page, "text/html", false);
         assertEquals(defaultScale, getPixelScale(), .01f);
 
         int onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
         setInitialScale(60);
-        loadDataSync(null, page, "text/html", false);
+        loadDataSync(page, "text/html", false);
         mOnScaleChangedHelper.waitForCallback(onScaleChangedCallCount);
         assertEquals(0.6f, getPixelScale(), .01f);
 
         onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
         setInitialScale(500);
-        loadDataSync(null, page, "text/html", false);
+        loadDataSync(page, "text/html", false);
         mOnScaleChangedHelper.waitForCallback(onScaleChangedCallCount);
         assertEquals(5.0f, getPixelScale(), .01f);
 
         onScaleChangedCallCount = mOnScaleChangedHelper.getCallCount();
         // default min-scale will be used.
         setInitialScale(0);
-        loadDataSync(null, page, "text/html", false);
+        loadDataSync(page, "text/html", false);
         mOnScaleChangedHelper.waitForCallback(onScaleChangedCallCount);
         assertEquals(defaultScale, getPixelScale(), .01f);
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetUserAgentStringTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SetUserAgentStringTest.java
@@ -34,7 +34,7 @@ public class SetUserAgentStringTest extends XWalkViewTestBase {
 
     @SmallTest
     public void testSetUserAgentString() throws Throwable {
-        loadDataSync(null, EMPTY_PAGE, "text/html", false);
+        loadDataSync(EMPTY_PAGE, "text/html", false);
         String result = executeJavaScriptAndWaitForResult("navigator.userAgent;");
         assertEquals(EXPECTED_USER_AGENT, result);
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/SettingsTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/SettingsTest.java
@@ -173,7 +173,7 @@ public class SettingsTest extends XWalkViewTestBase {
                 + "</head><body onload=\"document.title='" + jsEnabledString
                 + "';\"></body></html>";
 
-        loadDataSync(null, testPageHtml, "text/html", false);
+        loadDataSync(testPageHtml, "text/html", false);
         assertEquals(jsEnabledString, getTitleOnUiThread());
     }
 
@@ -390,7 +390,7 @@ public class SettingsTest extends XWalkViewTestBase {
     public void testLoadsImagesAutomaticallyNoPageReload() throws Throwable {
         ImagePageGenerator generator = new ImagePageGenerator(0, false);
         setLoadsImagesAutomatically(false);
-        loadDataSync(null, generator.getPageSource(), "text/html", false);
+        loadDataSync(generator.getPageSource(), "text/html", false);
         assertEquals(ImagePageGenerator.IMAGE_NOT_LOADED_STRING,
                 getTitleOnUiThread());
         setLoadsImagesAutomatically(true);

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldOverrideKeyEventTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldOverrideKeyEventTest.java
@@ -28,7 +28,7 @@ public class ShouldOverrideKeyEventTest extends XWalkViewTestBase {
         String fileContent = getFileContent(name);
         int count = mOverrideOrUnhandledKeyEventHelper.getCallCount();
 
-        loadDataAsync(null, fileContent, "text/html", false);
+        loadDataAsync(fileContent, "text/html", false);
         simulateKeyAction(KeyEvent.ACTION_DOWN);
         mOverrideOrUnhandledKeyEventHelper.waitForCallback(count);
 

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldOverrideUrlLoadingTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ShouldOverrideUrlLoadingTest.java
@@ -113,9 +113,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     @SmallTest
     @Feature({"XWalkView", "Navigation"})
     public void testNotCalledOnLoadData() throws Throwable {
-        loadDataSync(null,
-                CommonResources.makeHtmlPageWithSimpleLinkTo(DATA_URL), "text/html", false);
-
+        loadDataSync(CommonResources.makeHtmlPageWithSimpleLinkTo(DATA_URL), "text/html", false);
         assertEquals(0, mShouldOverrideUrlLoadingHelper.getCallCount());
     }
 
@@ -157,7 +155,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     public void testCantBlockLoads() throws Throwable {
         setShouldOverrideUrlLoadingReturnValueOnUiThread(true);
 
-        loadDataSync(null,
+        loadDataSync(
                 CommonResources.makeHtmlPageWithSimpleLinkTo(getTestPageCommonHeaders(),
                         DATA_URL), "text/html", false);
 
@@ -169,7 +167,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     public void testCalledBeforeOnPageStarted() throws Throwable {
         OnPageStartedHelper onPageStartedHelper = mTestHelperBridge.getOnPageStartedHelper();
 
-        loadDataSync(null,
+        loadDataSync(
                 CommonResources.makeHtmlPageWithSimpleLinkTo(DATA_URL), "text/html", false);
 
         final int shouldOverrideUrlLoadingCallCount = mShouldOverrideUrlLoadingHelper.getCallCount();
@@ -187,7 +185,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
         OnReceivedErrorHelper onReceivedErrorHelper = mTestHelperBridge.getOnReceivedErrorHelper();
         final int onReceivedErrorCallCount = onReceivedErrorHelper.getCallCount();
 
-        loadDataSync(null,
+        loadDataSync(
                 CommonResources.makeHtmlPageWithSimpleLinkTo(DATA_URL), "text/html", false);
 
         final int shouldOverrideUrlLoadingCallCount = mShouldOverrideUrlLoadingHelper.getCallCount();
@@ -226,7 +224,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
                 CommonResources.makeHtmlPageWithSimpleLinkTo(anchorLinkUrl + "#anchor"));
 
         if (useLoadData) {
-            loadDataSync(null,
+            loadDataSync(
                     CommonResources.makeHtmlPageWithSimpleLinkTo("#anchor"), "text/html", false);
         } else {
             loadUrlSync(anchorLinkUrl);
@@ -248,7 +246,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     @Feature({"XWalkView", "Navigation"})
     public void testCalledWhenLinkClicked() throws Throwable {
         // We can't go to about:blank from here because we'd get a cross-origin error.
-        loadDataSync(null,
+        loadDataSync(
                 CommonResources.makeHtmlPageWithSimpleLinkTo(DATA_URL), "text/html", false);
 
         int callCount = mShouldOverrideUrlLoadingHelper.getCallCount();
@@ -282,7 +280,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     public void testCalledWhenNavigatingFromJavaScriptUsingAssign()
             throws Throwable {
         final String redirectTargetUrl = createRedirectTargetPage(mWebServer);
-        loadDataSync(null,
+        loadDataSync(
                 getHtmlForPageWithJsAssignLinkTo(redirectTargetUrl), "text/html", false);
 
         int callCount = mShouldOverrideUrlLoadingHelper.getCallCount();
@@ -297,7 +295,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     public void testCalledWhenNavigatingFromJavaScriptUsingReplace()
             throws Throwable {
         final String redirectTargetUrl = createRedirectTargetPage(mWebServer);
-        loadDataSync(null,
+        loadDataSync(
                 getHtmlForPageWithJsReplaceLinkTo(redirectTargetUrl), "text/html", false);
 
         int callCount = mShouldOverrideUrlLoadingHelper.getCallCount();
@@ -309,7 +307,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     @Feature({"XWalkView", "Navigation"})
     public void testPassesCorrectUrl() throws Throwable {
         final String redirectTargetUrl = createRedirectTargetPage(mWebServer);
-        loadDataSync(null,
+        loadDataSync(
                 CommonResources.makeHtmlPageWithSimpleLinkTo(redirectTargetUrl), "text/html", false);
 
         int callCount = mShouldOverrideUrlLoadingHelper.getCallCount();
@@ -361,7 +359,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
                 "data:text/html;base64," +
                 "PGh0bWw+PGhlYWQ+PHRpdGxlPmRhdGFVcmxUZXN0QmFzZTY0PC90aXRsZT48" +
                 "L2hlYWQ+PC9odG1sPg==";
-        loadDataSync(null,
+        loadDataSync(
                 CommonResources.makeHtmlPageWithSimpleLinkTo(dataUrl), "text/html", false);
 
         int callCount = mShouldOverrideUrlLoadingHelper.getCallCount();
@@ -378,7 +376,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
     @Feature({"XWalkView", "Navigation"})
     public void testCalledForUnsupportedSchemes() throws Throwable {
         final String unsupportedSchemeUrl = "foobar://resource/1";
-        loadDataSync(null,
+        loadDataSync(
                 CommonResources.makeHtmlPageWithSimpleLinkTo(unsupportedSchemeUrl), "text/html",
                         false);
 
@@ -574,7 +572,7 @@ public class ShouldOverrideUrlLoadingTest extends XWalkViewTestBase {
 
         // Do a double navigagtion, the second being an effective no-op, in quick succession (i.e.
         // without yielding the main thread inbetween).
-        loadDataSync(null,
+        loadDataSync(
                 CommonResources.makeHtmlPageWithSimpleLinkTo(DATA_URL), "text/html", false);
         loadJavaScriptUrl(jsUrl);
         assertEquals(0, mShouldOverrideUrlLoadingHelper.getCallCount());

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewAsynchronousFindApisTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewAsynchronousFindApisTest.java
@@ -20,14 +20,14 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindAllFinds() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(4, findAllAsyncOnUiThread("wood"));
     }
 
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindAllDouble() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         findAllAsyncOnUiThread("wood");
         assertEquals(4, findAllAsyncOnUiThread("chuck"));
     }
@@ -35,7 +35,7 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindAllDoubleNext() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(4, findAllAsyncOnUiThread("wood"));
         assertEquals(4, findAllAsyncOnUiThread("wood"));
         assertEquals(2, findNextOnUiThread(true));
@@ -44,28 +44,28 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindAllDoesNotFind() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(0, findAllAsyncOnUiThread("foo"));
     }
 
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindAllEmptyPage() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(0, findAllAsyncOnUiThread("foo"));
     }
 
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindAllEmptyString() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(0, findAllAsyncOnUiThread(""));
     }
 
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindNextForward() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(4, findAllAsyncOnUiThread("wood"));
 
         for (int i = 2; i <= 4; i++) {
@@ -77,7 +77,7 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindNextBackward() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(4, findAllAsyncOnUiThread("wood"));
 
         for (int i = 4; i >= 1; i--) {
@@ -89,7 +89,7 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindNextBig() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(4, findAllAsyncOnUiThread("wood"));
 
         assertEquals(1, findNextOnUiThread(true));
@@ -104,7 +104,7 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindAllEmptyNext() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(4, findAllAsyncOnUiThread("wood"));
         assertEquals(1, findNextOnUiThread(true));
         assertEquals(0, findAllAsyncOnUiThread(""));
@@ -117,7 +117,7 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testClearMatches() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(4, findAllAsyncOnUiThread("wood"));
         clearMatchesOnUiThread();
     }
@@ -125,7 +125,7 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testClearFindNext() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(4, findAllAsyncOnUiThread("wood"));
         clearMatchesOnUiThread();
         assertEquals(4, findAllAsyncOnUiThread("wood"));
@@ -135,7 +135,7 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindEmptyNext() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         assertEquals(0, findAllAsyncOnUiThread(""));
         assertEquals(0, findNextOnUiThread(true));
         assertEquals(4, findAllAsyncOnUiThread("wood"));
@@ -144,7 +144,7 @@ public class XWalkViewAsynchronousFindApisTest extends XWalkViewFindApisTestBase
     @SmallTest
     @Feature({"XWalkView", "FindInPage"})
     public void testFindNextFirst() throws Throwable {
-        loadDataSync(null, data, "text/html", false);
+        loadDataSync(data, "text/html", false);
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/XWalkViewTestBase.java
@@ -341,7 +341,6 @@ public class XWalkViewTestBase
         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();
         loadUrlAsync(url);
-
         pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);
     }
@@ -363,26 +362,47 @@ public class XWalkViewTestBase
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                mXWalkView.load(url, null);
+                mXWalkView.loadUrl(url);
             }
         });
     }
 
-    protected void loadDataSync(final String url, final String data, final String mimeType,
+    protected void loadDataSync(final String data, final String mimeType,
             final boolean isBase64Encoded) throws Exception {
         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();
-        loadDataAsync(url, data, mimeType, isBase64Encoded);
+        loadDataAsync(data, mimeType, isBase64Encoded);
         pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);
     }
 
-    protected void loadDataAsync(final String url, final String data, final String mimeType,
+    protected void loadDataAsync(final String data, final String mimeType,
              final boolean isBase64Encoded) throws Exception {
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                mXWalkView.load(url, data);
+                mXWalkView.loadData(data, mimeType, isBase64Encoded ? "base64" : null);
+            }
+        });
+    }
+
+    protected void loadDataWithBaseUrlSync(final String data, final String mimeType,
+            final boolean isBase64Encoded, final String baseUrl,
+            final String historyUrl) throws Throwable {
+        CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
+        int currentCallCount = pageFinishedHelper.getCallCount();
+        loadDataWithBaseUrlAsync(data, mimeType, isBase64Encoded, baseUrl, historyUrl);
+        pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
+    }
+
+    protected void loadDataWithBaseUrlAsync(final String data, final String mimeType,
+            final boolean isBase64Encoded, final String baseUrl, final String historyUrl) throws Throwable {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.loadDataWithBaseURL(
+                        baseUrl, data, mimeType, isBase64Encoded ? "base64" : null, historyUrl);
             }
         });
     }
@@ -393,7 +413,6 @@ public class XWalkViewTestBase
         CallbackHelper pageFinishedHelper = contentsClient.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();
         loadUrlAsyncByContent(xWalkContent, url);
-
         pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);
     }
@@ -406,7 +425,6 @@ public class XWalkViewTestBase
         int onErrorCallCount = onReceivedErrorHelper.getCallCount();
         int onFinishedCallCount = onPageFinishedHelper.getCallCount();
         loadUrlAsyncByContent(xWalkContent, url);
-
         onReceivedErrorHelper.waitForCallback(onErrorCallCount, 1, WAIT_TIMEOUT_MS,
                 TimeUnit.MILLISECONDS);
         onPageFinishedHelper.waitForCallback(onFinishedCallCount, 1, WAIT_TIMEOUT_MS,
@@ -418,7 +436,7 @@ public class XWalkViewTestBase
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                xWalkContent.load(url, null);
+                xWalkContent.loadUrl(url);
             }
         });
     }
@@ -496,16 +514,14 @@ public class XWalkViewTestBase
 
     protected void loadAssetFile(String fileName) throws Exception {
         String fileContent = getFileContent(fileName);
-        loadDataSync(fileName, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
     }
 
     public void loadAssetFileAndWaitForTitle(String fileName) throws Exception {
         CallbackHelper getTitleHelper = mTestHelperBridge.getOnTitleUpdatedHelper();
         int currentCallCount = getTitleHelper.getCallCount();
         String fileContent = getFileContent(fileName);
-
-        loadDataAsync(fileName, fileContent, "text/html", false);
-
+        loadDataAsync(fileContent, "text/html", false);
         getTitleHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);
     }
@@ -1090,7 +1106,7 @@ public class XWalkViewTestBase
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                view.load(null, data);
+                view.loadData(data, "text/html", null);
             }
         });
     }

--- a/test/android/core/javatests/src/org/xwalk/core/xwview/test/ZoomTest.java
+++ b/test/android/core/javatests/src/org/xwalk/core/xwview/test/ZoomTest.java
@@ -37,7 +37,7 @@ public class ZoomTest extends XWalkViewTestBase {
     @Feature({"Zoom test"})
     public void testZoomUsingMultiTouch() throws Throwable {
         XWalkSettings settings = getXWalkSettingsOnUiThreadByXWalkView(getXWalkView());
-        loadDataSync(null, getZoomableHtml(0.5f), "text/html", false);
+        loadDataSync(getZoomableHtml(0.5f), "text/html", false);
 
         assertTrue(settings.supportZoom());
         assertFalse(settings.getBuiltInZoomControls());

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/GeolocationPermissionTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/GeolocationPermissionTest.java
@@ -63,7 +63,7 @@ public class GeolocationPermissionTest extends XWalkViewInternalTestBase {
             }
         });
         String fileContent = getFileContent("geolocation.html");
-        loadDataSync("https://google.com/", fileContent, "text/html", false);
+        loadDataWithBaseUrlSync(fileContent, "text/html", false, "https://google.com/", null);
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/LoadTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/LoadTest.java
@@ -69,10 +69,10 @@ public class LoadTest extends XWalkViewInternalTestBase {
         final String name = "index.html";
         String fileContent = getFileContent(name);
 
-        loadDataSync(null, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         assertEquals(expectedLocalTitle, getTitleOnUiThread());
 
-        loadDataSync(name, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
         assertEquals(expectedLocalTitle, getTitleOnUiThread());
     }
 
@@ -92,7 +92,7 @@ public class LoadTest extends XWalkViewInternalTestBase {
     @SmallTest
     @Feature({"Load"})
     public void testEmpytUrlAndContent() throws Throwable {
-        loadDataAsync(null, null, "text/html", false);
+        loadDataWithBaseUrlAsync(null, "text/html", false, null, null);
         Thread.sleep(1000);
         assertNotNull(getTitleOnUiThread());
     }

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkJavascriptResultTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkJavascriptResultTest.java
@@ -95,7 +95,7 @@ public class XWalkJavascriptResultTest extends XWalkViewInternalTestBase {
     @SmallTest
     @Feature({"onJsAlert"})
     public void testOverrideAlertHandling() throws Throwable {
-        loadDataSync(null, EMPTY_PAGE, "text/html", false);
+        loadDataSync(EMPTY_PAGE, "text/html", false);
         executeJavaScriptAndWaitForResult("alert('" + ALERT_TEXT + "')");
         assertTrue(callbackCalled.get());
     }
@@ -103,7 +103,7 @@ public class XWalkJavascriptResultTest extends XWalkViewInternalTestBase {
     @SmallTest
     @Feature({"onJsPrompt"})
     public void testOverridePromptHandling() throws Throwable {
-        loadDataSync(null, EMPTY_PAGE, "text/html", false);
+        loadDataSync(EMPTY_PAGE, "text/html", false);
         String result = executeJavaScriptAndWaitForResult(
                 "prompt('" + PROMPT_TEXT + "','" + PROMPT_DEFAULT + "')");
         assertTrue(callbackCalled.get());
@@ -113,7 +113,7 @@ public class XWalkJavascriptResultTest extends XWalkViewInternalTestBase {
     @SmallTest
     @Feature({"onJsConfirm"})
     public void testOverrideConfirmHandlingConfirmed() throws Throwable {
-        loadDataSync(null, EMPTY_PAGE, "text/html", false);
+        loadDataSync(EMPTY_PAGE, "text/html", false);
         String result = executeJavaScriptAndWaitForResult(
                 "confirm('" + CONFIRM_TEXT + "')");
         assertTrue(callbackCalled.get());
@@ -124,7 +124,7 @@ public class XWalkJavascriptResultTest extends XWalkViewInternalTestBase {
     @Feature({"onJsConfirm"})
     public void testOverrideConfirmHandlingCancelled() throws Throwable {
         flagForConfirmCancelled = true;
-        loadDataSync(null, EMPTY_PAGE, "text/html", false);
+        loadDataSync(EMPTY_PAGE, "text/html", false);
         String result = executeJavaScriptAndWaitForResult(
                 "confirm('" + CONFIRM_TEXT + "')");
         assertTrue(callbackCalled.get());
@@ -134,10 +134,10 @@ public class XWalkJavascriptResultTest extends XWalkViewInternalTestBase {
     @SmallTest
     @Feature({"onJsConfirm(JAVASCRIPT_BEFOREUNLOAD)"})
     public void testOverrideBeforeUnloadHandling() throws Throwable {
-        loadDataSync(null, BEFORE_UNLOAD_URL, "text/html", false);
+        loadDataSync(BEFORE_UNLOAD_URL, "text/html", false);
 
         int callCount = jsBeforeUnloadHelper.getCallCount();
-        loadDataAsync(null, EMPTY_PAGE, "text/html", false);
+        loadDataAsync(EMPTY_PAGE, "text/html", false);
         jsBeforeUnloadHelper.waitForCallback(callCount);
     }
 }

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/XWalkViewInternalTestBase.java
@@ -255,7 +255,6 @@ public class XWalkViewInternalTestBase
         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();
         loadUrlAsync(url);
-
         pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);
     }
@@ -264,26 +263,47 @@ public class XWalkViewInternalTestBase
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                mXWalkViewInternal.load(url, null);
+                mXWalkViewInternal.loadUrl(url);
             }
         });
     }
 
-    protected void loadDataSync(final String url, final String data, final String mimeType,
+    protected void loadDataSync(final String data, final String mimeType,
             final boolean isBase64Encoded) throws Exception {
         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();
-        loadDataAsync(url, data, mimeType, isBase64Encoded);
+        loadDataAsync(data, mimeType, isBase64Encoded);
         pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);
     }
 
-    protected void loadDataAsync(final String url, final String data, final String mimeType,
+    protected void loadDataAsync(final String data, final String mimeType,
              final boolean isBase64Encoded) throws Exception {
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                mXWalkViewInternal.load(url, data);
+                mXWalkViewInternal.loadData(data, mimeType, isBase64Encoded ? "base64" : null);
+            }
+        });
+    }
+
+    protected void loadDataWithBaseUrlSync(final String data, final String mimeType,
+            final boolean isBase64Encoded, final String baseUrl,
+            final String historyUrl) throws Throwable {
+        CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
+        int currentCallCount = pageFinishedHelper.getCallCount();
+        loadDataWithBaseUrlAsync(data, mimeType, isBase64Encoded, baseUrl, historyUrl);
+        pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
+    }
+
+    protected void loadDataWithBaseUrlAsync(final String data, final String mimeType,
+            final boolean isBase64Encoded, final String baseUrl, final String historyUrl) throws Throwable {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkViewInternal.loadDataWithBaseURL(
+                        baseUrl, data, mimeType, isBase64Encoded ? "base64" : null, historyUrl);
             }
         });
     }
@@ -304,7 +324,7 @@ public class XWalkViewInternalTestBase
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                xWalkViewInternal.load(url, null);
+                xWalkViewInternal.loadUrl(url);
             }
         });
     }
@@ -406,7 +426,7 @@ public class XWalkViewInternalTestBase
 
     protected void loadAssetFile(String fileName) throws Exception {
         String fileContent = getFileContent(fileName);
-        loadDataSync(fileName, fileContent, "text/html", false);
+        loadDataSync(fileContent, "text/html", false);
     }
 
     public void loadAssetFileAndWaitForTitle(String fileName) throws Exception {
@@ -414,7 +434,7 @@ public class XWalkViewInternalTestBase
         int currentCallCount = getTitleHelper.getCallCount();
         String fileContent = getFileContent(fileName);
 
-        loadDataAsync(fileName, fileContent, "text/html", false);
+        loadDataAsync(fileContent, "text/html", false);
 
         getTitleHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);

--- a/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/ZoomTest.java
+++ b/test/android/core_internal/javatests/src/org/xwalk/core/internal/xwview/test/ZoomTest.java
@@ -39,7 +39,7 @@ public class ZoomTest extends XWalkViewInternalTestBase {
         setUseWideViewPortOnUiThreadByXWalkView(true, getXWalkView());
         assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
 
-        loadDataSync(null, getZoomableHtml(mPageMinimumScale), "text/html", false);
+        loadDataSync(getZoomableHtml(mPageMinimumScale), "text/html", false);
         waitForScaleToBecome(mPageMinimumScale);
         assertTrue("Should be able to zoom in", canZoomInOnUiThread());
         assertFalse("Should not be able to zoom out", canZoomOutOnUiThread());


### PR DESCRIPTION
Users are now expected to use `loadUrl()`, `loadData()` or
`loadDataWithBaseURL()`, which are the same names used by the default
Android WebView. `load()` has been deprecated, not removed, to keep
backwards compatibility (the `@Deprecated` tags will only show up in
`XWalkView.java` once XWALK-7384 is fixed though). `API_VERSION` has
been bumped accordingly.

`XWalkContent.load()` tried to be too smart and implement those 3
methods without having enough information to decide which one to run
when called. Specifically, there was no equivalent to `loadData()`,
which loads a request with a "data:" URL, so whenever one needed to load
some data into a XWalkView the code path mimicked the Android WebView's
`loadDataWithBaseURL()` instead. Not to mention that most users just
want to load a URL, and `load(<address>, null)` is more tedious and less
clean to write than `loadUrl(<address>)`.

The lack of a `loadData()` equivalent in `load()` was causing
`org.xwalk.core.internal.xwview.test.XWalkJavascriptResultTest#testOverrideBeforeUnloadHandling`
to fail in the upcoming Chromium M53 because of
http://crrev.com/1890493002.

We relied on `blink::FrameLoader::startLoad()` calling `shouldClose()`
to trigger the machinery that delivers the "onbeforeunload" JavaScript
event we depended on in that test. While
`blink::FrameLoader::shouldContinueForNavigationPolicy()` could end up
calling `decidePolicyForNavigation()` which would trigger this same
machinery, that function was bailing out earlier in the check for an
empty request URL, as `XWalkContent.doLoadUrl()` was calling
`LoadUrlParams.createLoadDataParamsWithBaseUrl()` to create a data
request. That function creates a request with an empty URL and the data
as Blink's `SubstituteData`. What we need is
`LoadUrlParams.createLoadDataParams()`, which just creates a request
with the data in the URL.

The previous `XWalkContent.doLoadUrl()` implementation was moved to
`XWalkViewInternal.load()`, as we need to preserve compatibility with
the old code in the deprecated functions. All the new code comes from
Chromium's `android_webview/`, which also inspired the changes to
`XWalkViewInternalTestBase.java` and `XWalkViewTestBase.java`.

RELATED BUG=XWALK-7325