### PR TITLE
tools/installer: Import ffmpeg_options.gni

### DIFF
--- a/tools/installer/BUILD.gn
+++ b/tools/installer/BUILD.gn
@@ -3,7 +3,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Simplified version based on //chrome/installer/linux
+# Simplified version based on //chrome/installer/linux.
+
+import("//third_party/ffmpeg/ffmpeg_options.gni")
 import("//xwalk/build/version.gni")
 
 # Modified from template("linux_package") in //chrome/installer/linux/BUILD.gn


### PR DESCRIPTION
`is_ffmpeg_component` is defined there, but we were not importing the
file, which leads to an error in M54.