### PR TITLE
[Android] Depend on the native library targets when generating a project

### DIFF
--- a/build/android/generate_android_project.gni
+++ b/build/android/generate_android_project.gni
@@ -262,9 +262,9 @@ template("generate_android_project") {
   generate_xwalk_core_library(_project_target) {
     build_config = _build_config
     deps = [
-      ":$_build_config_target",
-      ":$_merge_target",
-    ]
+             ":$_build_config_target",
+             ":$_merge_target",
+           ] + _native_libs_deps
     forward_variables_from(invoker,
                            [
                              "binary_files",


### PR DESCRIPTION
This fixes a regression introduced in 02104a7 ("Roll Chromium
53.0.2785.143"). Specifically, when the code in `build/android` was
updated due to https://codereview.chromium.org/2082453003 upstream
callers of `generate_android_project` no longer needed to have targets
such as `libxwalkcore` in `deps`, but the `generate_android_project`
itself was not depending on them at all. In practice, this could lead to
failures where `generate_xwalk_core_library.py` would try to operate on
shared libraries that had not yet been built.