### PR TITLE
Import ffmpeg_options.gni in more locations

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/config/features.gni")
 import("//build/config/ui.gni")
+import("//third_party/ffmpeg/ffmpeg_options.gni")
 import("//xwalk/build/version.gni")
 import("//xwalk/build/xwalk.gni")
 

--- a/extensions/test/BUILD.gn
+++ b/extensions/test/BUILD.gn
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//third_party/ffmpeg/ffmpeg_options.gni")
+
 executable("xwalk_extensions_unittest") {
   testonly = true
   sources = [

--- a/sysapps/BUILD.gn
+++ b/sysapps/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//third_party/ffmpeg/ffmpeg_options.gni")
 import("//tools/grit/grit_rule.gni")
 
 source_set("sysapps") {


### PR DESCRIPTION
The fix in ba159bc ("tools/installer: Import ffmpeg_options.gni") needs
to be extended to avoid breaking the upcoming M54 build -- that file
needs to be imported in all locations that make use of
`is_component_ffmpeg`.