### PR TITLE
gn: Import //v8/gni/v8.gni, not //build_overrides/v8.gni

### DIFF
--- a/build/android.gni
+++ b/build/android.gni
@@ -21,5 +21,5 @@ import("//xwalk/build/common.gni")
 exclude_unwind_tables = true
 
 # Temporarily disable use of external snapshot files (XWALK-3516).
-# From //build_overrides/v8.gni
+# From //v8/gni/v8.gni
 v8_use_external_startup_data = false

--- a/runtime/android/core/BUILD.gn
+++ b/runtime/android/core/BUILD.gn
@@ -3,8 +3,8 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
-import("//build_overrides/v8.gni")
 import("//third_party/icu/config.gni")
+import("//v8/gni/v8.gni")
 import("//xwalk/build/android/generate_android_project.gni")
 import("//xwalk/build/android/maven_pom.gni")
 import("//xwalk/build/version.gni")

--- a/runtime/android/runtime_lib/BUILD.gn
+++ b/runtime/android/runtime_lib/BUILD.gn
@@ -3,8 +3,8 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
-import("//build_overrides/v8.gni")
 import("//third_party/icu/config.gni")
+import("//v8/gni/v8.gni")
 import("//xwalk/build/version.gni")
 
 android_apk("xwalk_runtime_lib_apk") {


### PR DESCRIPTION
We were importing the latter to access `v8_use_external_startup_data`.
However, we also had to import http://crrev.com/2058033002 in order to
override its value in `build/android.gni`, which means the value is
actually coming from `//v8/gni/v8.gni` instead.

Import the latter now to avoid errors in the M54 build.