### PR TITLE
[Android] Reflection generator supports the @Deprecated annotation

### DIFF
--- a/tools/reflection_generator/java_class.py
+++ b/tools/reflection_generator/java_class.py
@@ -263,8 +263,10 @@ class InternalJavaFileData(object):
   def ExtractMethods(self, java_content):
     constructor_re = re.compile(
         '(?P<method_doc>(\n\s*/\*\*.*\n(\s+\*(.)*\n)+\s+\*/\s*)?)\n'
+        '(?P<method_deprecated1>\s*@Deprecated\s*\n)?'
         '\s*@XWalkAPI\(?'
         '(?P<method_annotation>[a-zA-Z0-9\$\!%,\s\(\)\{\}\\\\;._"=]*)\)?'
+        '(?P<method_deprecated2>\s*@Deprecated\s*\n)?'
         '\s*public\s(?P<method_name>[a-zA-Z0-9]+)\('
         '(?P<method_params>[a-zA-Z0-9\s,\[\]\>\<]*)\)')
     for match in re.finditer(constructor_re, java_content):
@@ -272,12 +274,15 @@ class InternalJavaFileData(object):
       method_name = match.group('method_name')
       method_params = match.group('method_params')
       method_doc = match.group('method_doc')
+      method_deprecated1 = match.group('method_deprecated1')
+      method_deprecated2 = match.group('method_deprecated2')
       method = Method(
           self._class_name,
           self._class_loader,
           True, # is_constructor
           False, # is_static
           False, # is_abstract
+          method_deprecated1 != None or method_deprecated2 != None,
           method_name, None,
           method_params, method_annotation, method_doc)
       self._methods.append(method)
@@ -285,8 +290,10 @@ class InternalJavaFileData(object):
 
     method_re = re.compile(
         '(?P<method_doc>(\n\s*/\*\*.*\n(\s+\*(.)*\n)+\s+\*/\s*)?)\n'
+        '(?P<method_deprecated1>\s*@Deprecated\s*\n)?'
         '\s*@XWalkAPI\(?'
         '(?P<method_annotation>[a-zA-Z0-9%,\s\(\)\{\};._"=]*)\)?'
+        '(?P<method_deprecated2>\s*@Deprecated\s*\n)?'
         '\s*public\s+(?P<method_return>[a-zA-Z0-9]+(\<[a-zA-Z0-9]+,\s[a-zA-Z0-9]+\>)*(\[\s*\])*)\s+'
         '(?P<method_name>[a-zA-Z0-9]+)\('
         '(?P<method_params>[a-zA-Z0-9\s,\]\[\<\>]*)\)')
@@ -296,12 +303,15 @@ class InternalJavaFileData(object):
       method_params = match.group('method_params')
       method_return = match.group('method_return')
       method_doc = match.group('method_doc')
+      method_deprecated1 = match.group('method_deprecated1')
+      method_deprecated2 = match.group('method_deprecated2')
       method = Method(
           self._class_name,
           self._class_loader,
           False, # is_constructor
           False, # is_static
           False, # is_abstract
+          method_deprecated1 != None or method_deprecated2 != None,
           method_name, method_return, method_params,
           method_annotation, method_doc)
       self._methods.append(method)
@@ -326,6 +336,7 @@ class InternalJavaFileData(object):
           False, # is_constructor
           True, # is_static
           False, # is_abstract
+          False,
           method_name, method_return, method_params,
           method_annotation, method_doc)
       self._methods.append(method)
@@ -350,6 +361,7 @@ class InternalJavaFileData(object):
           False, # is_constructor
           False, # is_static
           True, # is_abstract
+          False,
           method_name, method_return, method_params,
           method_annotation, method_doc)
       self._methods.append(method)

--- a/tools/reflection_generator/java_method.py
+++ b/tools/reflection_generator/java_method.py
@@ -128,13 +128,14 @@ class Method(object):
   ANNOTATION_POST_BRIDGELINE = 'postBridgeLines'
 
   def __init__(self, class_name, class_loader,
-      is_constructor, is_static, is_abstract,
+      is_constructor, is_static, is_abstract, is_deprecated,
       method_name, method_return, params, annotation, doc=''):
     self._class_name = class_name
     self._class_loader = class_loader
     self._is_constructor = is_constructor
     self._is_static = is_static
     self._is_abstract = is_abstract
+    self._is_deprecated = is_deprecated
     self._is_delegate = False
     self._disable_reflect_method = False
     self._method_name = method_name
@@ -182,6 +183,10 @@ class Method(object):
   @property
   def is_abstract(self):
     return self._is_abstract
+
+  @property
+  def is_deprecated(self):
+    return self._is_deprecated
 
   @property
   def is_reservable(self):
@@ -747,7 +752,11 @@ ${PRE_WRAP_LINES}
         postWrapperMethod = new ReflectMethod(this,
                 \"post%s\");\n""" % self._method_declare_name)
 
-    value = {'DOC': self.GenerateDoc(self.method_doc),
+    doc_string = self.GenerateDoc(self.method_doc)
+    if self._is_deprecated :
+      doc_string += "\n    @Deprecated"
+
+    value = {'DOC': doc_string,
              'CLASS_NAME': self._class_java_data.wrapper_name,
              'PARAMS': self._wrapper_params_declare,
              'PRE_WRAP_LINES': pre_wrap_string}
@@ -811,10 +820,14 @@ ${DOC}
       return_state = 'return (%s) ' % ConvertPrimitiveTypeToObject(return_type)
       return_null = 'return %s;' % GetPrimitiveTypeDefaultValue(return_type)
 
+    doc_string = self.GenerateDoc(self.method_doc)
+    if self._is_deprecated :
+      doc_string += "\n    @Deprecated"
+
     value = {'RETURN_TYPE': self.method_return,
              'RETURN': return_state,
              'RETURN_NULL': return_null,
-             'DOC': self.GenerateDoc(self.method_doc),
+             'DOC': doc_string,
              'NAME': self.method_name,
              'PARAMS': self._wrapper_params_declare,
              'METHOD_DECLARE_NAME': self._method_declare_name,
@@ -927,10 +940,14 @@ ${PARAMS_PASSING}).toString());""" % self._method_return
     pre_wrap_string = self._method_annotations.get(
         self.ANNOTATION_PRE_WRAPLINE, '')
 
+    doc_string = self.GenerateDoc(self.method_doc)
+    if self._is_deprecated :
+      doc_string += "\n    @Deprecated"
+
     value = {'RETURN_TYPE': return_type,
              'RETURN': return_state,
              'RETURN_NULL': return_null,
-             'DOC': self.GenerateDoc(self.method_doc),
+             'DOC': doc_string,
              'NAME': self.method_name,
              'PARAMS': re.sub(r'ValueCallback<([A-Za-z]+)Internal>',
                   r'ValueCallback<\1>',self._wrapper_params_declare),


### PR DESCRIPTION
When generating the reflection layer, if a method that is marked as
@XWalkAPI is markd as @Deprecated as well, the @Deprecated annotation
will also appears in the new generated wrapper class. This will help to
make the javadoc display more precise method information.

BUG=XWALK-7384

(cherry picked from commit 96e0ad92a7ec9c3e7943b04dd97bd8720505de66)