### PR TITLE
crosswalk-23: [Android] Use depfiles when generating projects and AARs

### DIFF
--- a/build/android/generate_android_project.gni
+++ b/build/android/generate_android_project.gni
@@ -39,10 +39,7 @@ template("generate_xwalk_core_library") {
     forward_variables_from(invoker, [ "deps" ])
 
     script = "//xwalk/build/android/generate_xwalk_core_library.py"
-    inputs = [
-      "//build/android/gyp/package_resources.py",
-      "//build/android/gyp/util/build_utils.py",
-    ]
+    depfile = "$target_gen_dir/${target_name}.d"
     outputs = [
       "$target_gen_dir/${target_name}__generate.stamp",
     ]
@@ -51,12 +48,14 @@ template("generate_xwalk_core_library") {
                          root_build_dir)
 
     _rebased_build_config = rebase_path(_build_config, root_build_dir)
+    _rebased_depfile = rebase_path(depfile, root_build_dir)
     _rebased_js_bindings = rebase_path(_js_bindings, root_build_dir)
     _rebased_output_dir = rebase_path(_output_dir, root_build_dir)
     _rebased_template_dir = rebase_path(_template_dir, root_build_dir)
 
     args = [
       "--abi=$android_app_abi",
+      "--depfile=$_rebased_depfile",
       "--js-bindings=$_rebased_js_bindings",
       "--main-jar=@FileArg(${_rebased_build_config}:deps_info:jar_path)",
       "--output-dir=$_rebased_output_dir",
@@ -293,6 +292,7 @@ template("generate_android_project") {
       ":$_project_target",
     ]
     script = "//xwalk/build/android/generate_xwalk_core_library_aar.py"
+    depfile = "$target_gen_dir/${target_name}.d"
     outputs = [
       _aar_path,
     ]
@@ -303,6 +303,8 @@ template("generate_android_project") {
       rebase_path(_android_manifest, root_build_dir),
       "--classes-jar",
       rebase_path(_merged_jar_path, root_build_dir),
+      "--depfile",
+      rebase_path(depfile, root_build_dir),
       "--res-dir",
       rebase_path("$root_out_dir/$_target_name/res", root_build_dir),
       "--r-txt",
@@ -313,9 +315,8 @@ template("generate_android_project") {
       args += [
         "--jni-abi",
         android_app_abi,
-        "--jni-dir",
-        rebase_path("$root_out_dir/$_target_name/libs/$android_app_abi",
-                    root_build_dir),
+        "--native-libraries",
+        "@FileArg(${_rebased_build_config}:native:libraries)",
       ]
     }
   }

--- a/build/android/generate_xwalk_core_library_aar.py
+++ b/build/android/generate_xwalk_core_library_aar.py
@@ -15,6 +15,14 @@ import os
 import sys
 import zipfile
 
+GYP_ANDROID_DIR = os.path.join(os.path.dirname(__file__),
+                               os.pardir, os.pardir, os.pardir,
+                               'build',
+                               'android',
+                               'gyp')
+sys.path.append(GYP_ANDROID_DIR)
+from util import build_utils
+
 
 def AddDirectoryToAAR(aar_file, src_dir, dest_dir):
   """Adds |src_dir| to |aar_file| with the name |dest_dir|."""
@@ -27,6 +35,7 @@ def AddDirectoryToAAR(aar_file, src_dir, dest_dir):
 
 def main():
   parser = argparse.ArgumentParser()
+  build_utils.AddDepfileOption(parser)
   parser.add_argument('--aar-path', required=True,
                       help='Path to the AAR file that will be created.')
   parser.add_argument('--android-manifest', required=True,
@@ -35,28 +44,33 @@ def main():
                       help='Path to the JAR that will become classes.jar.')
   parser.add_argument('--jni-abi',
                       help='Android ABI name.')
-  parser.add_argument('--jni-dir',
-                      help='/path/to/<ABI> that will be copied to libs/.')
+  parser.add_argument('--native-libraries', default='',
+                      help='Architecture-specific libraries to copy.')
   parser.add_argument('--res-dir', required=True,
                       help='/path/to/res to copy to res/ in the AAR file.')
   parser.add_argument('--r-txt', required=True,
                       help='Path to the R.txt file to copy to the AAR file.')
 
-  options = parser.parse_args()
-  if bool(options.jni_abi) ^ bool(options.jni_dir):
-    print '--jni-abi and --jni-dir must be specified together.'
+  options = parser.parse_args(build_utils.ExpandFileArgs(sys.argv[1:]))
+  if bool(options.jni_abi) ^ bool(options.native_libraries):
+    print '--jni-abi and --native-libraries must be specified together.'
     return 1
 
+  options.native_libraries = build_utils.ParseGypList(options.native_libraries)
+
   with zipfile.ZipFile(options.aar_path, 'w', zipfile.ZIP_DEFLATED) as aar:
-    if options.jni_dir:
-      AddDirectoryToAAR(aar, options.jni_dir,
-                        os.path.join('jni', options.jni_abi))
+    for native_library in options.native_libraries:
+      aar.write(native_library,
+                os.path.join('jni', options.jni_abi, native_library))
     AddDirectoryToAAR(aar, options.res_dir, 'res')
 
     aar.write(options.android_manifest, 'AndroidManifest.xml')
     aar.write(options.classes_jar, 'classes.jar')
     aar.write(options.r_txt, 'R.txt')
 
+  # Write a depfile so that any native libraries also trigger a re-run of this
+  # script.
+  build_utils.WriteDepfile(options.depfile, options.native_libraries)
   return 0
 
 


### PR DESCRIPTION
Contrary to what one would expect, having a dependency on a shared
library target such as `libxwalkcore` does not cause an action to be
re-run whenever the aforementioned shared library changes -- the .ninja
file only depends on the library's .TOC file, so the action is called
only if the library's symbol list changes.

In practice, this means rebuilding `libxwalkcore.so` would not cause
`xwalk_core_library` and its respective AAR to be regenerated, leading
to all sorts of problems.

We work around the issue by adding `depfile`s to the GN actions, and
then adding those native libraries (as well as some other files like the
.js ones in xwalk_core_library) to them. GN can then use their contents
and trigger the actions when the files there change (in addition to the
ones regularly tracked by the build system).

BUG=XWALK-7433

(cherry picked from commit 0556777edf280ef272a8b894122489cf67781bdd)