### PR TITLE
[Android] Backport presented user data to Crosswalk-23

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -39,6 +39,65 @@
 
 namespace {
 
+const char kPreKitkatDataDirectory[] = "app_database";
+const char kKitkatDataDirectory[] = "app_webview";
+
+void ImportKitkatDataIfNecessary(const base::FilePath& old_data_dir,
+                                 const base::FilePath& profile) {
+  if (!base::DirectoryExists(old_data_dir))
+    return;
+
+  const char* possible_data_dir_names[] = {
+      "Cache",
+      "Cookies",
+      "Cookies-journal",
+      "IndexedDB",
+      "Local Storage",
+  };
+  for (size_t i = 0; i < arraysize(possible_data_dir_names); i++) {
+    base::FilePath dir = old_data_dir.Append(possible_data_dir_names[i]);
+    if (base::PathExists(dir)) {
+      if (!base::Move(dir, profile.Append(possible_data_dir_names[i]))) {
+        NOTREACHED() << "Failed to import previous user data: "
+                     << possible_data_dir_names[i];
+      }
+    }
+  }
+}
+
+void ImportPreKitkatDataIfNecessary(const base::FilePath& old_data_dir,
+                                    const base::FilePath& profile) {
+  if (!base::DirectoryExists(old_data_dir))
+    return;
+
+  // Local Storage.
+  base::FilePath local_storage_path = old_data_dir.Append("localstorage");
+  if (base::PathExists(local_storage_path)) {
+    if (!base::Move(local_storage_path, profile.Append("Local Storage"))) {
+      NOTREACHED() << "Failed to import previous user data: localstorage";
+    }
+  }
+}
+
+void MoveUserDataDirIfNecessary(const base::FilePath& user_data_dir,
+                                const base::FilePath& profile) {
+  if (base::DirectoryExists(profile))
+    return;
+
+  if (!base::CreateDirectory(profile))
+    return;
+
+  // Import pre-crosswalk-8 data.
+  ImportKitkatDataIfNecessary(user_data_dir, profile);
+  // Import Android Kitkat System webview data.
+  base::FilePath old_data_dir = user_data_dir.DirName().Append(
+      kKitkatDataDirectory);
+  ImportKitkatDataIfNecessary(old_data_dir, profile);
+  // Import pre-Kitkat System webview data.
+  old_data_dir = user_data_dir.DirName().Append(kPreKitkatDataDirectory);
+  ImportPreKitkatDataIfNecessary(old_data_dir, profile);
+}
+
 base::StringPiece PlatformResourceProvider(int key) {
   if (key == IDR_DIR_HEADER_HTML) {
     base::StringPiece html_data =
@@ -55,6 +114,12 @@ namespace xwalk {
 
 using content::BrowserThread;
 using extensions::XWalkExtension;
+
+void GetUserDataDir(base::FilePath* user_data_dir) {
+  if (!PathService::Get(base::DIR_ANDROID_APP_DATA, user_data_dir)) {
+    NOTREACHED() << "Failed to get app data directory for Android WebView";
+  }
+}
 
 XWalkBrowserMainPartsAndroid::XWalkBrowserMainPartsAndroid(
     const content::MainFunctionParams& parameters)
@@ -137,6 +202,15 @@ void XWalkBrowserMainPartsAndroid::PreMainMessageLoopRun() {
   content::RenderFrameHost::AllowInjectingJavaScriptForAndroidWebView();
 
   // Prepare the cookie store.
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kXWalkProfileName)) {
+      base::FilePath user_data_dir;
+      xwalk::GetUserDataDir(&user_data_dir);
+
+      base::FilePath profile = user_data_dir.Append(
+          command_line->GetSwitchValuePath(switches::kXWalkProfileName));
+      MoveUserDataDirIfNecessary(user_data_dir, profile);
+  }
 }
 
 void XWalkBrowserMainPartsAndroid::PostMainMessageLoopRun() {

--- a/runtime/browser/xwalk_browser_main_parts_android.h
+++ b/runtime/browser/xwalk_browser_main_parts_android.h
@@ -12,6 +12,8 @@
 
 namespace xwalk {
 
+void GetUserDataDir(base::FilePath* user_data_dir);
+
 class XWalkBrowserMainPartsAndroid : public XWalkBrowserMainParts {
  public:
   explicit XWalkBrowserMainPartsAndroid(


### PR DESCRIPTION
CookieManger isn't used at starting crosswalk, so the datas need to be
moved early.
https://codereview.chromium.org/71583002

BUG=XWALK-7368

(cherry picked from commit 22170137e73de48c0750810f663c9d0cf484e6e9)