### PR TITLE
Implement --unlimited-storage switch for crosswalk

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -277,6 +277,8 @@ source_set("xwalk_runtime") {
     "runtime/browser/xwalk_runner.h",
     "runtime/browser/xwalk_runner_win.cc",
     "runtime/browser/xwalk_runner_win.h",
+    "runtime/browser/xwalk_special_storage_policy.cc",
+    "runtime/browser/xwalk_special_storage_policy.h",
     "runtime/browser/xwalk_ssl_host_state_delegate.cc",
     "runtime/browser/xwalk_ssl_host_state_delegate.h",
     "runtime/common/android/xwalk_globals_android.cc",

--- a/runtime/browser/xwalk_browser_context.cc
+++ b/runtime/browser/xwalk_browser_context.cc
@@ -36,6 +36,7 @@
 #include "xwalk/runtime/browser/xwalk_permission_manager.h"
 #include "xwalk/runtime/browser/xwalk_pref_store.h"
 #include "xwalk/runtime/browser/xwalk_runner.h"
+#include "xwalk/runtime/browser/xwalk_special_storage_policy.h"
 #include "xwalk/runtime/common/xwalk_paths.h"
 #include "xwalk/runtime/common/xwalk_switches.h"
 
@@ -212,6 +213,12 @@ XWalkBrowserContext::GetGuestManager() {
 }
 
 storage::SpecialStoragePolicy* XWalkBrowserContext::GetSpecialStoragePolicy() {
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kUnlimitedStorage)) {
+    if (!special_storage_policy_.get())
+      special_storage_policy_ = new XWalkSpecialStoragePolicy();
+    return special_storage_policy_.get();
+  }
   return NULL;
 }
 

--- a/runtime/browser/xwalk_browser_context.h
+++ b/runtime/browser/xwalk_browser_context.h
@@ -22,6 +22,7 @@
 #include "content/public/browser/content_browser_client.h"
 #include "xwalk/runtime/browser/runtime_url_request_context_getter.h"
 #include "xwalk/runtime/browser/xwalk_form_database_service.h"
+#include "xwalk/runtime/browser/xwalk_special_storage_policy.h"
 #include "xwalk/runtime/browser/xwalk_ssl_host_state_delegate.h"
 
 #if defined(OS_ANDROID)
@@ -146,6 +147,7 @@ class XWalkBrowserContext
   PartitionPathContextGetterMap context_getters_;
   std::unique_ptr<XWalkSSLHostStateDelegate> ssl_host_state_delegate_;
   std::unique_ptr<content::PermissionManager> permission_manager_;
+  scoped_refptr<XWalkSpecialStoragePolicy> special_storage_policy_;
 
   DISALLOW_COPY_AND_ASSIGN(XWalkBrowserContext);
 };

--- a/runtime/browser/xwalk_special_storage_policy.cc
+++ b/runtime/browser/xwalk_special_storage_policy.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Medic Mobile, Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xwalk/runtime/browser/xwalk_special_storage_policy.h"
+
+using namespace xwalk;
+
+XWalkSpecialStoragePolicy::XWalkSpecialStoragePolicy(void) {}
+
+XWalkSpecialStoragePolicy::~XWalkSpecialStoragePolicy() {}
+
+bool XWalkSpecialStoragePolicy::IsStorageProtected(const GURL& origin) {
+  // Prevent data being removed by the browsing data remover.
+  return true;
+}
+
+bool XWalkSpecialStoragePolicy::IsStorageUnlimited(const GURL& origin) {
+  // Prevent data being affected by quota or storage pressure eviction.
+  return true;
+}
+
+bool XWalkSpecialStoragePolicy::IsStorageDurable(const GURL& origin) {
+  // Prevent storage pressure eviction.
+  return true;
+}
+
+bool XWalkSpecialStoragePolicy::CanQueryDiskSize(const GURL& origin) {
+  // Let anything query remaining disk size.  This could potentially allow for
+  // fingerprinting of a user, but seems less of a risk in a crosswalk app than
+  // it would in a more general browser.
+  return true;
+}
+
+bool XWalkSpecialStoragePolicy::HasIsolatedStorage(const GURL& origin) {
+  // I don't actually know if Crosswalk can guarantee if there is isolated
+  // storage or not.  Chrome seems to implement this through a special plugin,
+  // so it seems safe to say that we can't guarantee that storage is isolated.
+  return false;
+}
+
+bool XWalkSpecialStoragePolicy::IsStorageSessionOnly(const GURL& origin) {
+  // As per HasSessionOnlyOrigins(), no origins are session-only.
+  return false;
+}
+
+bool XWalkSpecialStoragePolicy::HasSessionOnlyOrigins() {
+  // Do not allow any origins to have session-only storage.
+  return false;
+}

--- a/runtime/browser/xwalk_special_storage_policy.h
+++ b/runtime/browser/xwalk_special_storage_policy.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2016 Medic Mobile, Ltd All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_RUNTIME_BROWSER_XWALK_SPECIAL_STORAGE_POLICY_H_
+#define XWALK_RUNTIME_BROWSER_XWALK_SPECIAL_STORAGE_POLICY_H_
+
+#include "storage/browser/quota/special_storage_policy.h"
+
+namespace xwalk {
+
+class XWalkSpecialStoragePolicy : public storage::SpecialStoragePolicy {
+ public:
+  XWalkSpecialStoragePolicy();
+
+  // storage::SpecialStoragePolicy methods used by storage subsystems and the
+  // browsing data remover. These methods are safe to call on any thread.
+  bool IsStorageProtected(const GURL& origin) override;
+  bool IsStorageUnlimited(const GURL& origin) override;
+  bool IsStorageSessionOnly(const GURL& origin) override;
+  bool CanQueryDiskSize(const GURL& origin) override;
+  bool HasIsolatedStorage(const GURL& origin) override;
+  bool HasSessionOnlyOrigins() override;
+  bool IsStorageDurable(const GURL& origin) override;
+
+ protected:
+  ~XWalkSpecialStoragePolicy() override;
+};
+
+}  // namespace xwalk
+
+#endif // XWALK_RUNTIME_BROWSER_XWALK_SPECIAL_STORAGE_POLICY_H_

--- a/runtime/common/xwalk_switches.cc
+++ b/runtime/common/xwalk_switches.cc
@@ -65,4 +65,8 @@ const char kPpapiFlashVersion[] = "ppapi-flash-version";
 // all of its state.
 const char kUserDataDir[] = "user-data-dir";
 
+// Overrides per-origin quota settings to unlimited storage for all
+// apps/origins.
+const char kUnlimitedStorage[] = "unlimited-storage";
+
 }  // namespace switches

--- a/runtime/common/xwalk_switches.h
+++ b/runtime/common/xwalk_switches.h
@@ -35,6 +35,8 @@ extern const char kPpapiFlashVersion[];
 
 extern const char kUserDataDir[];
 
+extern const char kUnlimitedStorage[];
+
 }  // namespace switches
 
 #endif  // XWALK_RUNTIME_COMMON_XWALK_SWITCHES_H_


### PR DESCRIPTION
When this switch is added to the crosswalk command-line, a SpecialStoragePolicy
is enabled which allows crosswalk to use the total free space available on the
device, instead of Chromium's standard of 10% of available space.

BUG=XWALK-7413

Ref https://github.com/crosswalk-project/crosswalk/pull/3958#issuecomment-264468574