### PR TITLE
[Android] Do not require certificate transparency

### DIFF
--- a/runtime/browser/runtime_url_request_context_getter.h
+++ b/runtime/browser/runtime_url_request_context_getter.h
@@ -49,6 +49,7 @@ class RuntimeURLRequestContextGetter : public net::URLRequestContextGetter {
   void UpdateAcceptLanguages(const std::string& accept_languages);
 
  private:
+  class XWalkCTDelegate;
   ~RuntimeURLRequestContextGetter() override;
 
   bool ignore_certificate_errors_;


### PR DESCRIPTION
Certificate transparency is a unique feature of Chrome but non-standard
SSL protocol. It aims to improve the security aloneside with CA. But
Crosswalk is based on content shell so the network connections initiated
by it do not support this certificate policy. This causes a SSL error
called ERT_STATUS_CERTIFICATE_TRANSPARENCY_REQUIRED and makes the app
continue to pop up the "SSL Certificate Error Alert" dialog.

This patch declares that Crosswalk doesn't require certificate
transparency to bypass the SSL error above.

BUG=XWALK-7398