### PR TITLE
[Android] Back port the feature of preserving websql databases to Crosswalk 23

### DIFF
--- a/runtime/browser/xwalk_browser_main_parts_android.cc
+++ b/runtime/browser/xwalk_browser_main_parts_android.cc
@@ -53,6 +53,7 @@ void ImportKitkatDataIfNecessary(const base::FilePath& old_data_dir,
       "Cookies-journal",
       "IndexedDB",
       "Local Storage",
+      "databases",
   };
   for (size_t i = 0; i < arraysize(possible_data_dir_names); i++) {
     base::FilePath dir = old_data_dir.Append(possible_data_dir_names[i]);


### PR DESCRIPTION
SQLite Databases that are created using the window.openDatabase with
System WebVieware not accessible in Crosswalk, the databases need to
be moved to Crosswalk profile directory.

BUG=XWALK-7368 XWALK-4488

(cherry picked from commit 136cf6e6b6ffdaa308326366f5096e0853fd007b)