### PR TITLE
Fix: Unexpected os.arch: armv8l

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkEnvironment.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkEnvironment.java
@@ -218,6 +218,7 @@ class XWalkEnvironment {
                         break;
                     case "aarch64":
                     case "armv8":
+                    case "armv8l":
                     case "arm64":
                         if (is64bitDevice()) {
                             sRuntimeAbi = "arm64-v8a";


### PR DESCRIPTION
Error happened when user clicks Get Crosswalk button on Crosswalk dialog.