### PR TITLE
tools: Disable gclient syntax validation when fetching dependencies.

### DIFF
--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -50,6 +50,9 @@ class DepsFetcher(object):
                    '--delete_unversioned_trees']
     gclient_cmd.append('--gclientfile=%s' %
                        os.path.basename(self._new_gclient_file))
+    # As of revision 454e53abae6e4d68ee992b0a93a4174b75519393,
+    # src/xwalk/buildtools does not pass gclient's syntax validation.
+    gclient_cmd.append('--disable-syntax-validation')
     gclient_utils.CheckCallAndFilterAndHeader(gclient_cmd,
         always=self._options.verbose, cwd=self._root_dir)
 


### PR DESCRIPTION
As per
https://groups.google.com/a/chromium.org/d/msg/infra-dev/Cwc6jsitAEA/Dwy3xweSAAAJ,
gclient has recently started validating the syntax of DEPS files.

This is a problem for us because src/xwalk/buildtools, which we fetch from
upstream, is at a revision that does not pass gclient's validation and
breaks the checkout process.

For now, just disable syntax validation to get things back to where they
were before.

BUG=XWALK-7528