### PR TITLE
Pin apk signature hash

### DIFF
--- a/runtime/android/core/src/org/xwalk/core/XWalkEnvironment.java
+++ b/runtime/android/core/src/org/xwalk/core/XWalkEnvironment.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-class XWalkEnvironment {
+public class XWalkEnvironment {
     private static final String TAG = "XWalkLib";
 
     private static final String META_XWALK_ENABLE_DOWNLOAD_MODE = "xwalk_enable_download_mode";


### PR DESCRIPTION
Add the ability to pin the sha-256 digest hash of the public key of your choice.
Therefore when you are in the crosswalk download mode, you can sign your crosswalkRuntimeLib.apk's  with the key of your choice, and pin the hash of those certificates in your app.
The changes are only in the crossswalkShared library, which is the one you embeed into your app.

This is useful on amazon store, as you are not affected by the fact that amazon changes the signature of your app.